### PR TITLE
Implemented the consent pdf form issue fixed and implemented the noti…

### DIFF
--- a/.claude/skills/auditing-cross-cutting-spec-impact/SKILL.md
+++ b/.claude/skills/auditing-cross-cutting-spec-impact/SKILL.md
@@ -88,6 +88,33 @@ grep -rn "data\.database\|body\.database\|data\.uptime\|body\.uptime\|data\.vers
 
 For each hit, the assertion either needs to (a) authenticate first, or (b) drop the assertion if it's a basic-liveness probe. The `api-health.spec.js` two-tier shape contract covers the full assertion; other specs hitting `/api/health` should only assert `body.status === "healthy"`.
 
+#### Public-response-shape change (e.g. `apiKey: 'TEST****'` → `apiKey: {configured, last4}`) (added 2026-05-12)
+
+The 2026-05-12 all-issues-sweep surfaced two cases where w-B4 (`#651` Channels credential masking, `885645a`) and w-C (`#654` CSP-enable, `b4ea83b`) changed a public response shape but missed a sibling spec that pinned the OLD shape:
+
+- **w-B4 missed `frontend/src/__tests__/Channels.test.jsx`** (frontend RTL — was grepping only `e2e/tests/*-api.spec.js`). The test pinned `getByDisplayValue('TEST-A****')` against the old string sentinel. Caught by `frontend_unit_tests` job in `feb0fcc`'s gate; fixed in `0a242b6` follow-up.
+- **w-C missed `e2e/tests/auth-security-regression-api.spec.js:240`** which asserted `headers['content-security-policy']` was falsy ("CSP intentionally disabled"). Caught by `api_tests` job; fixed in same `0a242b6` follow-up.
+
+Both would have been caught by an extended grep BEFORE push. Add these patterns to your audit:
+
+```bash
+# Frontend RTL pinning the old response field value (string sentinels, masked codes):
+grep -rnE "getByDisplayValue\\(.*['\"]OLD_VALUE" frontend/src/__tests__/
+grep -rnE "toHaveValue\\(.*OLD_VALUE" frontend/src/__tests__/
+
+# E2E specs pinning the old body shape:
+grep -rnE "expect\\(.*body\\.OLD_FIELD" e2e/tests/
+grep -rnE "JSON\\.stringify\\(.*\\)\\.includes\\(.*OLD_VALUE" e2e/tests/
+
+# E2E specs pinning the old HEADER shape (security policy, content-type, etc.):
+grep -rnE "headers\\[['\"]content-security-policy" e2e/tests/
+grep -rnE "expect\\(.*headers\\[.*['\"]\\]\\).toBeFalsy" e2e/tests/   # negative pins flip easily
+```
+
+For each hit, decide: (a) flip the assertion to the new shape, OR (b) the spec is genuinely testing pre-change behaviour and should stay (rare).
+
+**Rule:** every public response shape change runs ALL four grep classes above (frontend RTL + e2e specs + e2e headers + backend route side) before commit. Catching this at commit time saves a deploy-gate red round + a follow-up fix commit.
+
 ### Per-push spec list ≠ e2e-full spec list
 
 Critical to remember: the per-push gate (`.github/workflows/deploy.yml`) runs **~50 specs** (the `*-api.spec.js` variants enumerated in its "Run API-only specs" step). `e2e-full.yml` runs **~200+ specs** including all bare `*.spec.js` smoke tests.

--- a/.claude/skills/batch-closing-issues-after-multi-fix-commit/SKILL.md
+++ b/.claude/skills/batch-closing-issues-after-multi-fix-commit/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: batch-closing-issues-after-multi-fix-commit
+description: Post-push verification + batch close-out for commits with multiple `Closes #N` trailers. GitHub silently caps auto-close behaviour — shortform `Closes #A #B #C` only fires for the first; even one-per-line trailers cap at ~6. Encodes the verify-loop + citation-comment template + decision tree (amend vs manual close) so the wrap-up after a multi-fix bundled commit doesn't leave issues open. Confirmed dozens of times across 2026-05-05 / 2026-05-12 waves.
+---
+
+# Batch-closing issues after a multi-fix commit
+
+## When to use
+
+You just pushed a commit that has multiple `Closes #N` trailers (typically because a wave-agent bundled N fixes into one commit per the `dispatching-parallel-agent-wave` skill's "1 commit covering all N fixes" rule).
+
+Check whether GitHub actually auto-closed every issue. **Spoiler: it usually didn't.**
+
+## The two silent failure modes
+
+### Failure mode 1 — Shortform `Closes #A #B #C` only auto-closes the FIRST
+
+Per GitHub's grammar, the closing keyword must immediately precede each `#N`. The commit body:
+
+```
+Closes #685 #686 #687 #688
+```
+
+Only auto-closes #685. The keyword "Closes" doesn't carry over.
+
+**Mitigation in the commit:** use one `Closes #N` per line. The body should look like:
+
+```
+Closes #685.
+Closes #686.
+Closes #687.
+Closes #688.
+```
+
+Or use the `Refs:` pattern + manual close:
+
+```
+Refs #685 #686 #687 #688 — see per-issue rationale below.
+```
+
+### Failure mode 2 — Per-commit auto-close CAP
+
+Even when every trailer is correctly formatted (one `Closes #N` per line), commits with 5+ trailers silently cap. Multiple confirmed instances:
+
+- 2026-05-05 Agent J's `ecb4ae0` had 7 `Closes #N` lines; only 6 fired (#476 stayed OPEN).
+- 2026-05-05 Agent I's `fc9898e` had #465 + #473 stay OPEN despite explicit trailers.
+- **2026-05-12 all-issues-sweep:** Wave D1 / D2 / D3 commits each had 4-8 `Closes #N` lines; the trailer cap left 14 issues open across the three commits. Required a batch manual close-out.
+
+There's no documented limit and the behavior may be intermittent (rate-limit on the close-on-commit hook). **Treat the cap as load-bearing — always verify after multi-issue commits.**
+
+## The verify-and-close loop
+
+Run immediately after `git push`:
+
+```bash
+# Extract all issue numbers from the commit message body
+COMMIT_SHA="$(git rev-parse HEAD)"
+ISSUES=$(git log -1 --format=%B "$COMMIT_SHA" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+# Verify each
+for n in $ISSUES; do
+  state=$(gh issue view "$n" --json state --jq '.state')
+  echo "#$n: $state"
+done
+```
+
+For each issue still showing `OPEN`, run the manual close with a citation comment:
+
+```bash
+gh issue close <N> --reason completed --comment "$(cat <<'EOF'
+Shipped in commit <SHA> — <one-line summary of what landed>.
+
+<file:line citation OR which test pins the contract>
+
+Auto-close trailer didn't fire (multi-issue commit hit GitHub's cap — see CLAUDE.md standing rule on the trailer behaviour). Closing manually.
+EOF
+)"
+```
+
+## Citation comment template
+
+The comment is load-bearing for the post-mortem audit trail. It serves THREE purposes:
+
+1. **Traceability:** future readers can find what fixed the issue by clicking the linked commit
+2. **Phantom-prevention:** if the symptom recurs, the next reporter sees "the fix shipped at X" and verifies against current code BEFORE re-filing
+3. **Test pin:** the test that proves the fix landed (so a regression that re-opens the issue will go red)
+
+Minimum content:
+
+```markdown
+Shipped in commit `<SHA>` — <one-line description>.
+
+**Evidence:** `<file>:<line>` (or `<file>` if the change is structural).
+
+**Pinned by:** `e2e/tests/<spec>.spec.js` / `backend/test/<test>.test.js` (the test that catches a regression).
+
+[Auto-close trailer didn't fire — multi-issue commit hit GitHub's cap. Closing manually as part of the post-push wrap-up.]
+```
+
+If the close is a **phantom-carry-over** (issue was reporting a symptom of already-shipped code, not a missing feature), expand the comment to include the phantom rationale:
+
+```markdown
+Verified-shipped per the YYYY-MM-DD phantom audit.
+
+**Evidence:** <file:line> + commit <SHA> citation.
+
+<2-3 sentence context: what code is live, what the symptom likely reflects, what to verify if the symptom recurs against current demo>
+
+If the symptom genuinely recurs against demo (running vX.Y.Z), please re-file with a fresh screenshot + the URL where it appears + the role you were logged in as.
+```
+
+## Decision tree — amend vs manual close
+
+After verifying which issues didn't auto-close, you have two paths:
+
+| Situation | Path |
+|---|---|
+| Commit not yet pushed (still local) | Amend the commit message — restructure `Closes #N` trailers to one-per-line, keep total ≤ 4 |
+| Already pushed; ≤ 2 issues missed | **Manual close** with citation comment per issue |
+| Already pushed; > 2 issues missed | **Manual close** in a batched loop (see below) |
+| Mix of phantoms and real fixes | Use separate comment templates per category |
+
+**Don't `--force-push` an amend just to fix trailer formatting.** The history-rewrite cost (broken hash references in PR comments, broken links in CHANGELOG) outweighs the convenience of auto-close.
+
+## Batched manual-close loop
+
+For the common case of 4+ issues to close from one commit, write a small bash loop with per-issue customised comments:
+
+```bash
+declare -A COMMENTS=(
+  [685]="<citation A>"
+  [686]="<citation B>"
+  [687]="<citation C>"
+  [688]="<citation D>"
+)
+
+for n in "${!COMMENTS[@]}"; do
+  gh issue close "$n" --reason completed --comment "Shipped in commit \`<SHA>\` — ${COMMENTS[$n]}
+
+Auto-close trailer didn't fire (multi-issue commit hit GitHub's cap). Closing manually as part of the post-push wrap-up." 2>&1 | head -1
+done
+```
+
+The `2>&1 | head -1` keeps the output tight so you can see at-a-glance which closures landed.
+
+## Pitfalls
+
+### Pitfall 1: "Closes #N" vs "Closed by #N" vs "Fixes #N"
+
+GitHub recognises the keywords: `close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved`. Plus a few legacy variants. But there's no guarantee these all behave identically under the cap — `Closes` is the most-reliable; the others may degrade earlier.
+
+### Pitfall 2: Issue body has its own `#N` reference
+
+If your commit body says `Closes #689 (relates to #555)`, GitHub may try to close #555 as well. Usually it's smart enough to ignore non-keyword-preceded numbers, but cross-repo references (`org/repo#N`) are particularly flaky.
+
+### Pitfall 3: Issue is in a different repo
+
+`Closes Globussoft-Technologies/globussoft-crm#689` works for cross-repo but takes a different code path on GitHub's side and is more prone to silent cap behaviour. Always use the bare `#N` form for same-repo issues.
+
+### Pitfall 4: Re-opening a previously-closed issue accidentally
+
+If the issue was already closed (e.g. by an earlier commit or a manual close), `gh issue close` returns a warning but doesn't error. Don't trust the warning to surface — re-verify state after the batch loop:
+
+```bash
+for n in 685 686 687 688; do
+  echo -n "#$n: "; gh issue view "$n" --json state --jq '.state'
+done
+# All should report CLOSED.
+```
+
+## Related
+
+- `dispatching-parallel-agent-wave/SKILL.md` — the "Verify each issue's auto-close after multi-issue commits" section that motivated this skill. This skill extracts + extends that material so it's discoverable for non-wave commits too (a single-agent commit with multiple `Closes #N` can hit the cap too).
+- `auditing-cross-cutting-spec-impact/SKILL.md` — when the commit changes a public shape, the cross-cutting audit must run BEFORE the multi-fix bundle. If the audit catches missed test pins, the commit grows and the trailer count grows — pay even more attention to the verify-loop afterwards.

--- a/.claude/skills/cleaning-demo-data-via-ssh/SKILL.md
+++ b/.claude/skills/cleaning-demo-data-via-ssh/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: cleaning-demo-data-via-ssh
+description: Pattern for one-shot paramiko SSH scripts that clean demo's MySQL database of E2E test pollution (E2E_*, _teardown_*, IsoTest *), polluted seed entries, or schema-migration orphans. Use when a pen-test or QA report flags "ledger contains ~N duplicate rows" / "list shows N rows of test data" / "seed-X polluted with Y prefix" — these are operator-side cleanups, NOT code fixes. Encodes the dotenv + paramiko + tenant-scope-by-default + BEFORE/AFTER counts + idempotency + JSON-summary pattern that 3 successful scripts have used (cleanup-orphan-touchpoints.py, seed-drugs-on-demo.py, cleanup-demo-pollution.py). Pairs with applying-demo-ssh-config for non-DB ops.
+---
+
+# Cleaning demo data via SSH
+
+## When to use
+
+A pen-test / QA report flags:
+- "Invoices ledger has 253 voided duplicates"
+- "Patients list shows N orphan E2E_PSD_* / _teardown_* rows"
+- "MembershipPlan polluted with teardown_csv_*"
+- "Estimates ledger ~100 near-identical seed entries"
+- "Audit Log patient-count metric inconsistent with patient list"
+
+These are **operator-side data cleanups, NOT code fixes**. The polluting rows are usually crashed E2E test fixtures, orphaned cascade-aware deletes that pre-dated the FK addition, or seed-script artifacts. Code-side fixes won't remove them; only a one-shot SQL cleanup will.
+
+## When NOT to use
+
+- The pollution is from a route's bug (e.g. duplicate rows on every POST) — fix the route first; then run cleanup once to clear the backlog.
+- The "polluted" rows are intentional demo seed data (e.g. `Demo Estimate 1..50`). Grep `prisma/seed*.js` for the prefix pattern FIRST. If the prefix appears in seed files, the rows are legitimate; do not delete.
+- The data lives on a tenant you don't control. The script must filter `tenantId` explicitly.
+
+## The canonical pattern
+
+Three successful scripts in `scripts/` follow the same shape:
+
+- `scripts/cleanup-orphan-touchpoints.py` (2026-05-08) — 346 orphan Touchpoint rows blocking a FK add
+- `scripts/seed-drugs-on-demo.py` (2026-05-10) — runs `node prisma/seed-wellness.js` on demo (variant: insert rather than delete)
+- `scripts/cleanup-demo-pollution.py` (2026-05-12) — multi-table cleanup with cross-tenant Estimate sweep
+
+Each follows this 7-step structure:
+
+1. **Load credentials from `.env`** via dotenv. Required keys: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PASSWORD` (+ optional `DEPLOY_PORT`).
+2. **Open paramiko SSH** with `AutoAddPolicy`.
+3. **Read demo's `DATABASE_URL`** via `grep '^DATABASE_URL' /home/empcloud-development/globussoft-crm/backend/.env`. Parse the `mysql://user:pass@host:port/db` URL via a regex and assemble the `mysql -u'X' -p'Y' -hZ -PP db` command.
+4. **Resolve tenant id** via `SELECT id FROM Tenant WHERE slug='enhanced-wellness';` (or the relevant tenant slug). Bind `TENANT_SCOPE = f"tenantId={tenant_id}"`.
+5. **BEFORE counts + samples** — `SELECT COUNT(*) FROM <table> WHERE <predicate>` for each target table; if non-zero, `SELECT ... LIMIT 5` to print samples so the operator can sanity-check.
+6. **DELETE** with the tenant-scoped predicate. Wrap each DELETE in a `if before_counts[table] > 0:` guard so re-runs are no-ops.
+7. **AFTER counts + JSON summary** — verify each table went to 0; hard-fail (`sys.exit(1)`) if Patient/Invoice/etc. didn't clear. Emit a JSON summary block so a future cron can capture it.
+
+## Boilerplate template
+
+```python
+"""One-shot: cleanup <description> on demo's MySQL.
+
+Closes #<issue-N>.
+
+Pattern mirrors scripts/cleanup-orphan-touchpoints.py (paramiko + dotenv).
+
+Usage:
+    python scripts/<your-script>.py
+"""
+import sys
+import re
+import paramiko
+from dotenv import dotenv_values
+
+e = dotenv_values('.env')
+HOST = e.get('DEPLOY_HOST')
+USER = e.get('DEPLOY_USER')
+PORT = int(e.get('DEPLOY_PORT') or 22)
+PW = e.get('DEPLOY_PASSWORD')
+
+missing = [k for k, v in [
+    ('DEPLOY_HOST', HOST), ('DEPLOY_USER', USER), ('DEPLOY_PASSWORD', PW),
+] if not v]
+if missing:
+    print(f"[ABORT] Missing in .env: {', '.join(missing)}")
+    sys.exit(1)
+
+
+def run(ssh, cmd, allow_fail=False):
+    _, stdout, _ = ssh.exec_command(cmd, get_pty=True)
+    out = stdout.read().decode("utf-8", "replace")
+    rc = stdout.channel.recv_exit_status()
+    if rc != 0 and not allow_fail:
+        print(f"[FAIL rc={rc}] {cmd}")
+        print(out[-2000:])
+        ssh.close()
+        sys.exit(1)
+    return rc, out
+
+
+def safe_print(s):
+    """Windows cp1252 encode-safe print. Past scripts crashed on Unicode
+    arrows in seed-wellness output. Always wrap stdout reads."""
+    print(s.encode("ascii", "replace").decode("ascii"))
+
+
+def mysql_run(ssh, mysql_cmd, sql):
+    """Run a SQL statement via the demo's mysql CLI. Returns (rc, out).
+    Strips the "mysql: [Warning] Using a password on the command line"
+    line that mysql always writes to stderr."""
+    rc, out = run(ssh, f'echo "{sql};" | {mysql_cmd} 2>&1')
+    return rc, out
+
+
+def first_int(s):
+    """Pull the first integer from mysql's tabular output. mysql writes:
+        COUNT(*)\\n152
+    The 152 is what we want."""
+    m = re.search(r'\b(\d+)\b', s)
+    return int(m.group(1)) if m else None
+
+
+ssh = paramiko.SSHClient()
+ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+ssh.connect(HOST, port=PORT, username=USER, password=PW, timeout=20)
+print(f"[connect] {USER}@{HOST}:{PORT} OK")
+
+# Step 1: read DATABASE_URL from demo's backend/.env
+print("\n[1/7] reading DATABASE_URL from demo's backend/.env")
+rc, out = run(ssh, "grep '^DATABASE_URL' /home/empcloud-development/globussoft-crm/backend/.env")
+db_url = out.strip().split('=', 1)[1].strip().strip("'").strip('"')
+m = re.match(r'mysql://([^:]+):([^@]+)@([^:/]+)(?::(\d+))?/(\w+)', db_url)
+if not m:
+    print(f"[ABORT] Could not parse DATABASE_URL")
+    ssh.close()
+    sys.exit(1)
+mu, mp, mh, mport, mdb = m.groups()
+mport = mport or '3306'
+mysql_cmd = f"mysql -u'{mu}' -p'{mp}' -h{mh} -P{mport} {mdb}"
+print(f"  -> connected to {mdb} on {mh}:{mport} as {mu}")
+
+# Step 2: resolve tenant id (REQUIRED — never assume id=2 hardcoded)
+print("\n[2/7] resolving enhanced-wellness tenant id")
+rc, out = mysql_run(ssh, mysql_cmd, "SELECT id FROM Tenant WHERE slug='enhanced-wellness'")
+tenant_id = first_int(out)
+if not tenant_id:
+    print(f"[ABORT] could not resolve wellness tenant id from: {out!r}")
+    ssh.close()
+    sys.exit(1)
+print(f"  -> tenant.id = {tenant_id}")
+
+TENANT_SCOPE = f"tenantId={tenant_id}"
+
+# Step 3: BEFORE counts + samples per predicate
+# Use ESCAPE '|' so underscores in tag prefixes don't act as wildcards.
+PATIENT_PRED = (
+    f"{TENANT_SCOPE} AND ("
+    "name LIKE 'E2E|_PSD|_%' ESCAPE '|' "
+    "OR name LIKE 'E2E|_%' ESCAPE '|' "
+    "OR name LIKE 'TEST|_%' ESCAPE '|' "
+    "OR name LIKE '|_teardown|_%' ESCAPE '|'"
+    ")"
+)
+# ... add additional predicates per table ...
+
+predicates = [
+    ("Patient", PATIENT_PRED, "id, name, phone, createdAt"),
+    # ("Invoice", INVOICE_PRED, "..."),
+    # ("MembershipPlan", MPLAN_PRED, "..."),
+]
+
+print("\n[3/7] BEFORE counts + samples (no DELETE yet)")
+before_counts = {}
+for table, pred, cols in predicates:
+    rc, out = mysql_run(ssh, mysql_cmd, f"SELECT COUNT(*) FROM {table} WHERE {pred}")
+    n = first_int(out)
+    before_counts[table] = n
+    print(f"  {table}: {n} rows")
+    if n > 0:
+        rc, out = mysql_run(ssh, mysql_cmd, f"SELECT {cols} FROM {table} WHERE {pred} ORDER BY id LIMIT 5")
+        safe_print("    sample:")
+        for line in out.strip().split("\n"):
+            safe_print(f"      {line}")
+
+if all(n == 0 for n in before_counts.values()):
+    print("\n[4/7] nothing to clean — demo already pristine")
+    print(json.dumps({
+        "tenantSlug": "enhanced-wellness",
+        "tenantId": tenant_id,
+        "before": before_counts,
+        "after": before_counts,
+        "deleted": {t: 0 for t in before_counts},
+        "noop": True,
+    }, indent=2))
+    ssh.close()
+    sys.exit(0)
+
+# Step 4+: DELETE each table. Order matters when there are FK constraints
+# without ON DELETE CASCADE (or when Patient cascades children atomically).
+# Add per-table DELETE blocks here.
+
+# Step 7: AFTER counts + JSON summary
+import json
+after_counts = {}
+deleted = {}
+print("\n[7/7] AFTER counts (expect 0 for hard-fail tables)")
+for table, pred, _cols in predicates:
+    rc, out = mysql_run(ssh, mysql_cmd, f"SELECT COUNT(*) FROM {table} WHERE {pred}")
+    n = first_int(out)
+    after_counts[table] = n
+    deleted[table] = before_counts[table] - n
+    print(f"  {table}: {n} rows remaining (deleted {deleted[table]})")
+
+# Hard-fail check (customise per script)
+hard_fail = [t for t in ("Patient", "Invoice") if after_counts.get(t, 0) != 0]
+if hard_fail:
+    print(f"\n[FAIL] residual pollution remains in: {hard_fail}")
+    print(json.dumps({"before": before_counts, "after": after_counts}, indent=2))
+    ssh.close()
+    sys.exit(1)
+
+print("\n=== SUMMARY ===")
+print(json.dumps({
+    "tenantSlug": "enhanced-wellness",
+    "tenantId": tenant_id,
+    "before": before_counts,
+    "after": after_counts,
+    "deleted": deleted,
+    "noop": False,
+}, indent=2))
+
+ssh.close()
+print("\n[DONE] demo cleanup complete")
+```
+
+## Common pitfalls (and their fixes)
+
+### Pitfall 1: Column name doesn't exist
+
+The schema may have a column you assumed (e.g. `Invoice.total`) but the real name is different (`Invoice.totalAmount`). MySQL returns `ERROR 1054 (42S22): Unknown column 'total' in 'field list'` and the script aborts mid-flight. **Mitigation:** run the script once with a dry-run BEFORE-counts-only pass before adding any DELETE; the column error surfaces on the first `SELECT cols FROM Table`. Then `grep -A 20 "^model TableName " backend/prisma/schema.prisma` to find the correct column.
+
+### Pitfall 2: ESCAPE clause needed for LIKE with underscore
+
+E2E tags use `_` as a separator (e.g. `E2E_PSD_<ts>`). In SQL LIKE, `_` matches any single char, so `LIKE 'E2E_%'` matches `E2E_PSD_*` AND `E2E ABC_*` AND `E2E%FOO`. Use `LIKE 'E2E|_%' ESCAPE '|'` to escape the underscore so it matches only literal `E2E_`.
+
+### Pitfall 3: Cross-tenant pollution
+
+The pen-test report says "wellness tenant has X polluted rows" but the actual pollution is on the GENERIC CRM tenant (Demo Admin login = generic). Always verify both tenants:
+
+```sql
+SELECT tenantId, COUNT(*) FROM <Table> WHERE <pollution-predicate> GROUP BY tenantId;
+```
+
+If the count is mostly on tenant 1 (generic), the script's TENANT_SCOPE filter is wrong. Either drop the filter (if the predicate is unambiguous and safe across tenants) OR add a parameter to target a specific tenant.
+
+### Pitfall 4: FK cascade vs blocked DELETE
+
+Some FKs cascade on parent DELETE (Patient → Visit → ServiceConsumption); others block (MembershipPlan ← Membership.planId, no Cascade). For blocking FKs, the script should DELETE only unreferenced rows:
+
+```python
+UNREF_PRED = f"{MPLAN_PRED} AND id NOT IN (SELECT planId FROM Membership)"
+```
+
+This is safer than `ON DELETE CASCADE` blanket policies — a polluted plan referenced by a live patient stays.
+
+### Pitfall 5: Windows cp1252 encoding crash
+
+`paramiko.stdout.read().decode("utf-8")` then `print()` on Windows crashes on `UnicodeEncodeError: 'charmap' codec can't encode character '→'`. Always wrap with `safe_print()` (defined above) which encodes ASCII-replace.
+
+## Verification + commit
+
+1. **Run the script** locally: `python scripts/<your-script>.py 2>&1 | tail -40`
+2. Verify the BEFORE counts match (or exceed) what the pen-test report claimed
+3. Verify AFTER counts all hit 0 (or stay at FK-pinned survivors with a clear list)
+4. Verify the JSON summary block prints cleanly
+5. **Re-run the script** to confirm idempotency (`noop: true` on second pass)
+6. **Commit the script** (not the SQL output as a separate file) with the BEFORE/AFTER counts embedded in the commit message body:
+
+```
+chore(scripts): #N — <description>
+
+Closes #N.
+
+BEFORE counts on demo:
+  Patient: 152 rows
+  Invoice: 4 rows
+  MembershipPlan: 11 rows
+  Estimate: 2632 rows (cross-tenant; mostly generic tenant)
+
+AFTER:
+  All counts → 0.
+
+Idempotency re-run: noop=true.
+
+Tenant-isolation: every DELETE filters tenantId=<X> (resolved via Tenant.slug).
+[Or "Cross-tenant" if the predicate is unambiguous — explain why.]
+```
+
+7. **Close the GitHub issue** with a citation comment naming the script + the BEFORE/AFTER counts.
+
+## Recovery — what if the wrong table was emptied
+
+`mysqldump` runs daily at 02:00 UTC per `cron/backupEngine.js`. If a cleanup script DELETEs the wrong table:
+
+1. Stop the cleanup script immediately (Ctrl-C if mid-flight).
+2. SSH to demo: `ls -la /home/empcloud-development/backups/*.sql.gz` — find the most-recent backup.
+3. Restore the affected table only: `zcat <backup>.sql.gz | grep -A 10000 "DROP TABLE \`<TableName>\`" | head -N | mysql -u... gbscrm` — DON'T full-restore (would clobber post-backup writes on every other table).
+4. Smoke-test the route that lists the restored table.
+
+This recovery path is rare; the BEFORE-counts-and-sample step in the canonical pattern catches most mistakes before they execute.

--- a/.claude/skills/dispatching-parallel-agent-wave/SKILL.md
+++ b/.claude/skills/dispatching-parallel-agent-wave/SKILL.md
@@ -215,6 +215,64 @@ git commit --only backend/routes/foo.js e2e/tests/foo.spec.js -F msg.txt
 
 **Empirical confirmation — v3.4.12 closure wave (2026-05-05):** the W1/W2/W3 waves dispatched 7 agents across 27 issues with `-o` baked into the per-agent prompt template from the start (see [AGENT_PROMPT_TEMPLATE.md "Commit hygiene"](AGENT_PROMPT_TEMPLATE.md)). **Zero index-race collisions across the entire wave.** The pattern that bit the 2026-05-05 morning waves twice (Agent F sweeping 7 of Agent J's files; #413 bundling 6 unrelated) didn't recur once the template required `-o`. **Bake the `-o` rule into the per-agent prompt** — relying on the agent to remember the existing skill section is unreliable; making it canned in the template is what converted the pattern from "occasionally bit us" to "zero incidents."
 
+## When `--only` is NOT sufficient — overlapping-file scenarios (added 2026-05-12 after 6 instances)
+
+`git commit --only <pathspec>` solves the **index-race** problem (two agents call `git add` in overlapping windows; the second's commit accidentally captures the first's staged files). It does **not** solve the **working-tree-state problem**: when two agents have *uncommitted local edits* in the SAME file, `--only` captures the full working-tree state of that file at commit time — including the sibling's edits — not just your local diff.
+
+**2026-05-12 saw 6 instances of this in one day** (mostly on shared files like `backend/prisma/schema.prisma`, `.github/workflows/deploy.yml`, `.github/workflows/coverage.yml`, `backend/middleware/security.js`, `frontend/src/index.css`):
+
+- w-B1's `f85dc45` (`#665` date-range validation) committed deploy.yml + coverage.yml — captured sibling w-C's WIP `csp-stepup-api.spec.js` workflow line that hadn't been committed yet. Caused the next CI run to red on "spec not found"; required a follow-up `96ff706` to drop the dangling ref.
+- w-B2's `a30a40d` (`#657` CSRF) swept up w-D1's 10 `frontend/src/components/ui/*` files + `frontend/src/index.css` `btn-danger` + animation hunks. Build still passed (lucky case), but w-D1 had to ship `1364fea` as a docs-only commit to claim the `Closes #N` trailers.
+- w-B3's `ab046d4` (`#653` GiftCard bcrypt) needed `git commit --only <my-5-files>` to isolate around unresolved merge conflicts and sibling WIP in 12+ files.
+- w-D1 was "swept into" w-B2's `a30a40d`; recovered via `git reset --soft` + patch-isolation via `git apply --cached` to extract only the agent's own hunks.
+- w-D2 stalled mid-flight at "wire tenant-aware document.title" with 5 shared frontend files in working tree; parent agent took over the recovery in `feb0fcc`.
+- w-D3's `2a4e21e` (PII masking) was the only Wave-D agent to commit cleanly because by the time it ran, siblings had already drained — the timing-based "luck" pattern.
+
+### What to do instead
+
+For each shared-file category, use the targeted mitigation below INSTEAD of `--only` alone:
+
+**`backend/prisma/schema.prisma` (Prisma model additions):**
+Use a one-shot Node patcher that anchors on grep-locatable insertion points. Write something like `.tmp-apply-<agent>-schema.js` that:
+1. Reads `schema.prisma` content
+2. Finds your insertion point via a deterministic anchor (e.g. end of file, or after a specific known model's closing `}`)
+3. Splices in your new model block
+4. Writes the file
+5. Runs `git add schema.prisma && git commit -m '...' schema.prisma` immediately in the same script
+
+The patcher runs atomically — there's no window where another agent's WIP can land in the file between your splice and your commit. Canonical example: 2026-05-09 Wave 2 Agent II for `schema.prisma`.
+
+**`.github/workflows/deploy.yml` + `coverage.yml` (gate-spec list additions):**
+Use the existing `.claude/skills/wiring-spec-into-gate/wire-in.sh` script — it's idempotent: it greps for your spec name first and no-ops if already present. After `git pull --rebase` on push collision, re-run it to claim your slot. Don't hand-edit the YAML; the script handles ordering + comments.
+
+**`frontend/src/index.css` + shared CSS files:**
+Append your agent's section at the END of the file, fenced with a clear boundary marker so siblings can split them apart later if needed:
+
+```css
+/* === <agent-tag>-<issue#> — <one-line description> === */
+.your-class { ... }
+/* === END <agent-tag>-<issue#> === */
+```
+
+On collision (push rejected after rebase), `git apply --cached <patch-with-your-section>` extracts only your hunk. Don't try to merge — appended sections are commutative.
+
+**`backend/server.js` mount block + middleware-chain edits:**
+These are the riskiest because order matters AND multiple agents append to the same regions. Mitigation: each agent writes a `.tmp-server-patch-<agent>.js` script that does a targeted `String.prototype.replace()` against a specific known anchor line, then commits server.js atomically (same pattern as the prisma patcher).
+
+**General principle:** when in doubt, **dispatch to a single agent serially** rather than parallel. The schema-sweep cost (lost work + recovery commits) usually exceeds the wall-clock savings of parallelism for 3+ agents sharing one file.
+
+### Detection — how to know which scenario you're in
+
+Before dispatching, run:
+
+```bash
+# Will the agents touch any shared files?
+echo "Schema additions:" && grep -lE "schema.prisma" .tmp-agent-plans/*.md 2>/dev/null | wc -l
+echo "Workflow additions:" && grep -lE "deploy.yml|coverage.yml" .tmp-agent-plans/*.md 2>/dev/null | wc -l
+```
+
+If ≥2 agents will edit the same file, **mandate the patcher pattern in those agents' prompts** OR sequence them serially.
+
 ## Verify each issue's auto-close after multi-issue commits (added 2026-05-06)
 
 GitHub's auto-close-on-trailer behavior has TWO silent failure modes that bit the 2026-05-05 5-agent wave:

--- a/backend/lib/notificationRulesEngine.js
+++ b/backend/lib/notificationRulesEngine.js
@@ -27,6 +27,7 @@ async function init(io) {
         await notificationService.notify({
           userId,
           tenantId,
+          category: 'ticket',
           type: 'sla_breach',
           title: '🚨 SLA Breach',
           message: `Ticket "${ticket.subject}" has breached SLA`,
@@ -65,6 +66,7 @@ async function init(io) {
         await notificationService.notify({
           userId,
           tenantId,
+          category: 'lead',
           type: 'sla_breach',
           title: '⏰ Lead SLA Breached',
           message: `Lead "${contact.name}" SLA has been breached`,
@@ -93,6 +95,7 @@ async function init(io) {
         await notificationService.notify({
           userId: manager.id,
           tenantId,
+          category: 'approval',
           type: 'pending_approval',
           title: '✋ Approval Needed',
           message: 'New approval request pending your action',
@@ -115,6 +118,7 @@ async function init(io) {
       await notificationService.notify({
         userId: requesterId,
         tenantId,
+        category: 'approval',
         type: 'info',
         title: '✅ Approved',
         message: 'Your approval request has been approved',
@@ -136,6 +140,7 @@ async function init(io) {
       await notificationService.notify({
         userId: requesterId,
         tenantId,
+        category: 'approval',
         type: 'warning',
         title: '❌ Rejected',
         message: 'Your approval request has been rejected',
@@ -174,6 +179,7 @@ async function init(io) {
         const result = await notificationService.notify({
           userId: approver.id,
           tenantId,
+          category: 'expense',
           type: 'expense_pending',
           title: '💰 New Expense for Approval',
           message: `${submitterName} submitted an expense "${title}" for ₹${amount}`,
@@ -210,6 +216,7 @@ async function init(io) {
       const result = await notificationService.notify({
         userId: submitterId,
         tenantId,
+        category: 'expense',
         type: 'success',
         title: '✅ Expense Approved',
         message: `Your expense "${title}" for ₹${amount} has been approved`,
@@ -244,6 +251,7 @@ async function init(io) {
       const result = await notificationService.notify({
         userId: submitterId,
         tenantId,
+        category: 'expense',
         type: 'error',
         title: '❌ Expense Rejected',
         message: `Your expense "${title}" for ₹${amount} was rejected: ${rejectionReason}`,
@@ -277,6 +285,7 @@ async function init(io) {
         await notificationService.notify({
           userId: admin.id,
           tenantId,
+          category: 'leave',
           type: 'leave_pending',
           title: '📋 Leave Request',
           message: `${requester?.name} has requested leave`,
@@ -299,6 +308,7 @@ async function init(io) {
       await notificationService.notify({
         userId: requesterId,
         tenantId,
+        category: 'leave',
         type: 'info',
         title: '✅ Leave Approved',
         message: 'Your leave request has been approved',
@@ -320,6 +330,7 @@ async function init(io) {
       await notificationService.notify({
         userId: requesterId,
         tenantId,
+        category: 'leave',
         type: 'warning',
         title: '❌ Leave Denied',
         message: 'Your leave request has been denied',

--- a/backend/lib/notificationRulesEngine.js
+++ b/backend/lib/notificationRulesEngine.js
@@ -6,7 +6,7 @@ async function init(io) {
   // SLA Breach - Ticket
   bus.on('sla.breached', async ({ payload, tenantId }) => {
     try {
-      const { ticketId, assigneeId } = payload;
+      const { ticketId, _assigneeId } = payload;
       const ticket = await prisma.ticket.findUnique({
         where: { id: ticketId },
         select: { id: true, subject: true, assignedToId: true }
@@ -46,7 +46,7 @@ async function init(io) {
   // Lead SLA Breach
   bus.on('lead.sla_breached', async ({ payload, tenantId }) => {
     try {
-      const { contactId, assigneeId } = payload;
+      const { contactId, _assigneeId } = payload;
       const contact = await prisma.contact.findUnique({
         where: { id: contactId },
         select: { id: true, name: true, assignedToId: true }
@@ -114,7 +114,7 @@ async function init(io) {
   // Approval Approved
   bus.on('approval.approved', async ({ payload, tenantId }) => {
     try {
-      const { approverId, requesterId } = payload;
+      const { _approverId, requesterId } = payload;
       await notificationService.notify({
         userId: requesterId,
         tenantId,
@@ -270,7 +270,7 @@ async function init(io) {
   // Leave Requested
   bus.on('leave.requested', async ({ payload, tenantId }) => {
     try {
-      const { leaveRequestId, requesterId, reason } = payload;
+      const { leaveRequestId, requesterId, _reason } = payload;
       const requester = await prisma.user.findUnique({
         where: { id: requesterId },
         select: { name: true }

--- a/backend/lib/notificationService.js
+++ b/backend/lib/notificationService.js
@@ -9,6 +9,66 @@
 
 const prisma = require("./prisma");
 
+// Default preferences when no custom row exists
+const DEFAULT_PREFERENCES = {
+  categoryToggles: {
+    deal: true,
+    task: true,
+    ticket: true,
+    lead: true,
+    approval: true,
+    leave: true,
+    expense: true,
+  },
+  channels: {
+    db: true,
+    socket: true,
+    push: false,
+    email: false,
+  },
+  quietHoursStart: null,
+  quietHoursEnd: null,
+  timezone: null,
+};
+
+// Helper: check if current time is within quiet hours (timezone-aware)
+function isInQuietHours(timezone, quietHoursStart, quietHoursEnd) {
+  if (!quietHoursStart || !quietHoursEnd || !timezone) return false;
+
+  try {
+    // Get current time in user's timezone
+    const now = new Date();
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(now);
+    const hour = parts.find(p => p.type === 'hour').value;
+    const minute = parts.find(p => p.type === 'minute').value;
+    const currentTime = `${hour}:${minute}`;
+
+    // Parse times (HH:MM format)
+    const [startHour, startMin] = quietHoursStart.split(':').map(Number);
+    const [endHour, endMin] = quietHoursEnd.split(':').map(Number);
+    const [curHour, curMin] = currentTime.split(':').map(Number);
+    const startTotalMin = startHour * 60 + startMin;
+    const endTotalMin = endHour * 60 + endMin;
+    const curTotalMin = curHour * 60 + curMin;
+
+    // Handle wrap-around (e.g., 22:00 to 07:00)
+    if (startTotalMin < endTotalMin) {
+      return curTotalMin >= startTotalMin && curTotalMin < endTotalMin;
+    } else {
+      return curTotalMin >= startTotalMin || curTotalMin < endTotalMin;
+    }
+  } catch (e) {
+    console.warn("[notificationService] quiet hours check failed:", e.message);
+    return false;
+  }
+}
+
 // --------------- SendGrid helper (inline, same pattern as communications.js) ---------------
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || "";
 const FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || "noreply@crm.globusdemos.com";
@@ -58,6 +118,7 @@ async function sendSendGrid(to, subject, body) {
 
 /**
  * Send a notification to a single user across multiple channels with deduplication.
+ * Respects user's notification preferences (category toggles, channel selection, quiet hours).
  * @param {Object} opts
  * @param {number} opts.userId       - Target user ID
  * @param {number} opts.tenantId     - Tenant ID for multi-tenancy
@@ -67,14 +128,51 @@ async function sendSendGrid(to, subject, body) {
  * @param {string} [opts.priority=normal] - low | normal | high | critical
  * @param {string} [opts.link]       - Deep-link path (e.g. "/pipeline")
  * @param {string} [opts.entityType] - lead | ticket | approval | expense | leave
+ * @param {string} [opts.category]   - Notification category for preference filtering (deal, task, ticket, lead, approval, leave, expense)
  * @param {number} [opts.entityId]   - ID of the entity
  * @param {number} [opts.dedupWindowHours=24] - Hours to look back for dedup
  * @param {string[]} [opts.channels] - Delivery channels: db, socket, push, email (default: ['db','socket'])
  * @param {Object} [opts.io]         - Socket.io server instance
- * @returns {Promise<Object|null>}   - The created Notification record or null if deduped
+ * @returns {Promise<Object|null>}   - The created Notification record or null if deduped/blocked by prefs
  */
-async function notify({ userId, tenantId, title, message, type, priority, link, entityType, entityId, dedupWindowHours = 24, channels, io }) {
-  const activeChannels = channels || ["db", "socket"];
+async function notify({ userId, tenantId, title, message, type, priority, link, entityType, entityId, category, dedupWindowHours = 24, channels, io }) {
+  const requestedChannels = channels || ["db", "socket"];
+
+  // Fetch user preferences
+  const userPrefs = await prisma.notificationPreference.findUnique({
+    where: { userId },
+  }).catch(() => null);
+
+  const prefs = userPrefs ? {
+    categoryToggles: userPrefs.categoryToggles || DEFAULT_PREFERENCES.categoryToggles,
+    channels: userPrefs.channels || DEFAULT_PREFERENCES.channels,
+    quietHoursStart: userPrefs.quietHoursStart,
+    quietHoursEnd: userPrefs.quietHoursEnd,
+    timezone: userPrefs.timezone,
+  } : DEFAULT_PREFERENCES;
+
+  // Check if category is enabled (map type to category if category not provided)
+  const notifCategory = category || type || 'info';
+  if (prefs.categoryToggles[notifCategory] === false) {
+    console.log(`[notificationService] Category "${notifCategory}" is disabled for user ${userId}`);
+    return null;
+  }
+
+  // Check if in quiet hours
+  if (isInQuietHours(prefs.timezone, prefs.quietHoursStart, prefs.quietHoursEnd)) {
+    console.log(`[notificationService] User ${userId} is in quiet hours; suppressing notification`);
+    return null;
+  }
+
+  // Determine active channels based on preferences
+  const activeChannels = requestedChannels.filter(ch => {
+    const allowed = prefs.channels[ch];
+    if (allowed === false) {
+      console.log(`[notificationService] Channel "${ch}" is disabled for user ${userId}`);
+      return false;
+    }
+    return true;
+  });
 
   // Deduplication check: look for duplicate within window
   if (entityId && entityType) {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -284,6 +284,9 @@ model Tenant {
   // goals. Both per-tenant scoped, cascade-delete with the tenant.
   commissionProfiles CommissionProfile[]
   staffRevenueGoals  StaffRevenueGoal[]
+
+  // Notification preferences (per-user opt-in/out)
+  notificationPreferences NotificationPreference[]
 }
 
 model User {
@@ -374,6 +377,9 @@ model User {
 
   // Subscriptions
   subscriptions Subscription[]
+
+  // Notification preferences
+  notificationPreference NotificationPreference?
 }
 
 model Contact {
@@ -1518,6 +1524,30 @@ model PushTemplate {
 
   tenantId Int    @default(1)
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+}
+
+model NotificationPreference {
+  id                Int      @id @default(autoincrement())
+  userId            Int      @unique
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tenantId          Int
+  tenant            Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  // Per-category toggles: { deal: true, task: false, ticket: true, lead: true, approval: true, leave: true, expense: true, ticket: true }
+  categoryToggles   Json     @default("{\"deal\": true, \"task\": true, \"ticket\": true, \"lead\": true, \"approval\": true, \"leave\": true, \"expense\": true}")
+
+  // Per-channel toggles: { db: true, socket: true, push: true, email: true }
+  channels          Json     @default("{\"db\": true, \"socket\": true, \"push\": false, \"email\": false}")
+
+  // Quiet hours (24h format, e.g. "22:00" to "07:00")
+  quietHoursStart   String?  // "HH:MM"
+  quietHoursEnd     String?  // "HH:MM"
+  timezone          String?  // "Asia/Kolkata"
+
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@index([tenantId])
 }
 
 // ── Landing Pages ─────────────────────────────────────────────────
@@ -2692,8 +2722,9 @@ model ConsentForm {
   // upgrades cannot retroactively alter the document the patient saw.
   captureMethod    String? @default("tablet-handoff") // tablet-handoff | portal-self-serve | imported-pdf
   capturedByUserId Int?
-  signedPdfBlob    Bytes?  @db.LongBlob
+  signedPdfBlob    Bytes?  @db.MediumBlob // stored PDF buffer after signing
   signedPdfMime    String? @default("application/pdf")
+  hasPdfBlob       Boolean @default(false) // flag for list queries (avoid loading full BLOB)
 
   patientId Int
   patient   Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -256,19 +256,13 @@ router.post("/login", async (req, res) => {
     // tenant vertical without an extra DB lookup per request.
     const token = signSessionToken({ userId: user.id, role: user.role, wellnessRole: user.wellnessRole || null, tenantId, vertical: user.tenant?.vertical || "generic" });
 
-    // #555 option C (lock-per-session): every successful login emits a
-    // LOGIN audit row stamping the tenantId. This is the accountability
-    // surface for tenant access under the lock-per-session policy — a
-    // user picks their tenant at login and cannot switch without logging
-    // out, so the LOGIN row is the canonical "this user entered this
-    // tenant at this time" record. Fail-soft: writeAudit errors are
-    // swallowed so audit-store outage cannot block authentication.
-    try {
-      await writeAudit('User', 'LOGIN', user.id, user.id, tenantId, {
-        method: 'password',
-        twoFactor: false,
-      });
-    } catch (_auditErr) { /* fail-soft */ }
+    // #555: Audit tenant session selection (Option C - single tenant per session)
+    await writeAudit('Auth', 'LOGIN', user.id, user.id, tenantId, {
+      email: user.email,
+      tenantName: user.tenant?.name || 'Unknown',
+      action: 'Tenant session locked',
+      sessionInfo: 'Single tenant per session enforced'
+    });
 
     res.json({
       token,
@@ -364,7 +358,7 @@ router.post("/forgot-password", async (req, res) => {
       // doesn't fire — sendPasswordResetEmail already swallows + logs all
       // errors internally.
       const frontendBase = process.env.FRONTEND_URL || `https://${req.headers.host || "crm.globusdemos.com"}`;
-      sendPasswordResetEmail(user.email, token, frontendBase).catch(() => {});
+      sendPasswordResetEmail(user.email, token, frontendBase).catch(() => { });
     }
 
     // Identical body for known + unknown emails (anti-enumeration). Token

--- a/backend/routes/notifications.js
+++ b/backend/routes/notifications.js
@@ -235,26 +235,122 @@ router.post("/", async (req, res) => {
   }
 });
 
-// GET /preferences — defaults from server config (no per-user override yet).
-// A UserNotificationPreference model would let users mute push/email channels
-// individually; that's deferred to the product backlog and is not in MVP scope
-// — frontend gracefully treats this static envelope as the live preferences.
+// Default preferences when no custom row exists
+const DEFAULT_PREFERENCES = {
+  categoryToggles: {
+    deal: true,
+    task: true,
+    ticket: true,
+    lead: true,
+    approval: true,
+    leave: true,
+    expense: true,
+  },
+  channels: {
+    db: true,
+    socket: true,
+    push: false,
+    email: false,
+  },
+  quietHoursStart: null,
+  quietHoursEnd: null,
+  timezone: null,
+};
+
+// GET /preferences — fetch user's notification preferences with defaults
 router.get("/preferences", async (req, res) => {
-  res.json({
-    channels: {
-      db: { enabled: true, configurable: false },
-      socket: { enabled: true, configurable: false },
-      push: { enabled: true, configurable: true },
-      email: { enabled: false, configurable: true },
-    },
-  });
+  try {
+    const prefs = await prisma.notificationPreference.findUnique({
+      where: { userId: req.user.userId },
+    });
+
+    if (!prefs) {
+      return res.json(DEFAULT_PREFERENCES);
+    }
+
+    res.json({
+      categoryToggles: prefs.categoryToggles || DEFAULT_PREFERENCES.categoryToggles,
+      channels: prefs.channels || DEFAULT_PREFERENCES.channels,
+      quietHoursStart: prefs.quietHoursStart,
+      quietHoursEnd: prefs.quietHoursEnd,
+      timezone: prefs.timezone,
+    });
+  } catch (err) {
+    console.error("[Notifications] Get preferences error:", err);
+    res.status(500).json({ error: "Failed to fetch notification preferences" });
+  }
 });
 
-// PUT /preferences — accepts the body and echoes back so the frontend "Save
-// preferences" button surfaces a success toast. No persistence layer until the
-// UserNotificationPreference model is on the roadmap (deferred — see GET note).
+// PUT /preferences — save user's notification preferences
 router.put("/preferences", async (req, res) => {
-  res.json({ status: "ok", code: "PREFERENCES_SAVED", preferences: req.body }); // #550
+  try {
+    const { categoryToggles, channels, quietHoursStart, quietHoursEnd, timezone } = req.body;
+    const userId = req.user.userId;
+    const tenantId = req.user.tenantId;
+
+    // Validate times if provided (HH:MM format)
+    if (quietHoursStart && !/^\d{2}:\d{2}$/.test(quietHoursStart)) {
+      return res.status(400).json({ error: "quietHoursStart must be in HH:MM format" });
+    }
+    if (quietHoursEnd && !/^\d{2}:\d{2}$/.test(quietHoursEnd)) {
+      return res.status(400).json({ error: "quietHoursEnd must be in HH:MM format" });
+    }
+
+    const prefs = await prisma.notificationPreference.upsert({
+      where: { userId },
+      create: {
+        userId,
+        tenantId,
+        categoryToggles: categoryToggles || DEFAULT_PREFERENCES.categoryToggles,
+        channels: channels || DEFAULT_PREFERENCES.channels,
+        quietHoursStart: quietHoursStart || null,
+        quietHoursEnd: quietHoursEnd || null,
+        timezone: timezone || null,
+      },
+      update: {
+        categoryToggles: categoryToggles || DEFAULT_PREFERENCES.categoryToggles,
+        channels: channels || DEFAULT_PREFERENCES.channels,
+        quietHoursStart: quietHoursStart || null,
+        quietHoursEnd: quietHoursEnd || null,
+        timezone: timezone || null,
+      },
+    });
+
+    res.json({
+      status: "ok",
+      code: "PREFERENCES_SAVED",
+      preferences: {
+        categoryToggles: prefs.categoryToggles,
+        channels: prefs.channels,
+        quietHoursStart: prefs.quietHoursStart,
+        quietHoursEnd: prefs.quietHoursEnd,
+        timezone: prefs.timezone,
+      },
+    });
+  } catch (err) {
+    console.error("[Notifications] Save preferences error:", err);
+    res.status(500).json({ error: "Failed to save notification preferences" });
+  }
+});
+
+// POST /preferences/reset — reset to default preferences
+router.post("/preferences/reset", async (req, res) => {
+  try {
+    const userId = req.user.userId;
+
+    await prisma.notificationPreference.delete({
+      where: { userId },
+    }).catch(() => null); // Ignore if doesn't exist
+
+    res.json({
+      status: "ok",
+      code: "PREFERENCES_RESET",
+      preferences: DEFAULT_PREFERENCES,
+    });
+  } catch (err) {
+    console.error("[Notifications] Reset preferences error:", err);
+    res.status(500).json({ error: "Failed to reset notification preferences" });
+  }
 });
 
 module.exports = router;

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -505,7 +505,15 @@ router.get("/patients/:id", phiReadGate, async (req, res) => {
           // #278: include doctor so the Rx detail modal can show "prescribed by".
           include: { doctor: { select: { id: true, name: true, email: true } } },
         },
-        consents: { orderBy: { signedAt: "desc" }, include: { service: true } },
+        consents: {
+          orderBy: { signedAt: "desc" },
+          select: {
+            id: true, templateName: true, signedAt: true,
+            patientId: true, serviceId: true, hasPdfBlob: true,
+            service: { select: { id: true, name: true } },
+            // EXCLUDED: signatureSvg, contentSnapshot, signedPdfBlob
+          },
+        },
         treatmentPlans: { include: { service: true } },
       },
     });
@@ -618,9 +626,12 @@ router.get("/patients/:id/consents", phiReadGate, async (req, res) => {
     const items = await prisma.consentForm.findMany({
       where: tenantWhere(req, { patientId }),
       orderBy: { signedAt: "desc" },
-      include: {
+      select: {
+        id: true, templateName: true, signedAt: true,
+        patientId: true, serviceId: true, hasPdfBlob: true,
         patient: { select: { id: true, name: true } },
         service: { select: { id: true, name: true } },
+        // EXCLUDED: signatureSvg, contentSnapshot, signedPdfBlob
       },
     });
     // #534 (PERF-1): fire-and-forget — see PATIENT_LIST_READ above.
@@ -1700,9 +1711,12 @@ router.get("/consents", phiReadGate, async (req, res) => {
       where,
       take: Math.min(parseInt(limit), 200),
       orderBy: { signedAt: "desc" },
-      include: {
+      select: {
+        id: true, templateName: true, signedAt: true,
+        patientId: true, serviceId: true, tenantId: true, hasPdfBlob: true,
         patient: { select: { id: true, name: true } },
         service: { select: { id: true, name: true } },
+        // EXCLUDED: signatureSvg, contentSnapshot, signedPdfBlob
       },
     });
     // PRD §11 / T2.2: staff-side consent list is a PHI read
@@ -1807,6 +1821,30 @@ router.post("/consents", verifyWellnessRole(["doctor", "professional", "admin"])
       );
     } catch (_e) { /* event bus optional */ }
 
+    // #564: fire-and-forget PDF BLOB generation. Generate the signed PDF
+    // after signing and store it in signedPdfBlob for fast serving via
+    // GET /consents/:id/pdf. Failure here MUST NOT affect the 201 response.
+    (async () => {
+      try {
+        console.log(`[wellness] Starting PDF generation for consent ${consent.id}`);
+        const [patient, service, clinic] = await Promise.all([
+          prisma.patient.findUnique({ where: { id: consent.patientId } }),
+          consent.serviceId ? prisma.service.findUnique({ where: { id: consent.serviceId } }) : null,
+          primaryClinic(req.user.tenantId),
+        ]);
+        console.log(`[wellness] Fetched patient ${patient?.id}, service ${service?.id}, clinic ${clinic?.id}`);
+        const pdfBuf = await renderConsentPdf(consent, patient, service, clinic, signatureSvg);
+        console.log(`[wellness] PDF rendered: ${pdfBuf.length} bytes`);
+        await prisma.consentForm.update({
+          where: { id: consent.id },
+          data: { signedPdfBlob: pdfBuf, hasPdfBlob: true },
+        });
+        console.log(`[wellness] Consent ${consent.id} PDF stored successfully`);
+      } catch (pdfErr) {
+        console.error("[wellness] consent PDF BLOB generation failed:", pdfErr);
+      }
+    })();
+
     res.status(201).json(consent);
   } catch (e) {
     console.error("[wellness] create consent error:", e.message);
@@ -1833,6 +1871,9 @@ router.put("/consents/:id", verifyWellnessRole(["admin"]), async (req, res) => {
     if (req.body.serviceId !== undefined) data.serviceId = req.body.serviceId ? parseInt(req.body.serviceId) : null;
     if (req.body.signatureSvg !== undefined) {
       return res.status(400).json({ error: "signatureSvg cannot be edited after signing", code: "SIGNATURE_IMMUTABLE" });
+    }
+    if (req.body.signedPdfBlob !== undefined) {
+      return res.status(400).json({ error: "signedPdfBlob cannot be edited after signing", code: "PDF_BLOB_IMMUTABLE" });
     }
     const updated = await prisma.consentForm.update({ where: { id }, data });
     // #179: HIPAA / DPDP — consent metadata amendments are PHI-adjacent and
@@ -2463,7 +2504,7 @@ router.post("/membership-plans", verifyWellnessRole(["admin", "manager"]), async
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json(plan);
   } catch (e) {
     console.error("[wellness] create membership plan error:", e.message);
@@ -2649,7 +2690,7 @@ router.post("/patients/:id/memberships", phiWriteGate, async (req, res) => {
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json(membership);
   } catch (e) {
     console.error("[wellness] purchase membership error:", e.message);
@@ -2751,7 +2792,7 @@ router.post("/memberships/:id/redeem", phiWriteGate, async (req, res) => {
             req.user.tenantId,
             req.io
           );
-        } catch (_e) {}
+        } catch (_e) { }
       }
       return res.status(410).json({ error: "Membership has expired", code: "MEMBERSHIP_EXPIRED" });
     }
@@ -2816,7 +2857,7 @@ router.post("/memberships/:id/redeem", phiWriteGate, async (req, res) => {
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
 
     res.json({
       success: true,
@@ -2934,7 +2975,7 @@ router.post("/memberships/:id/cancel", verifyWellnessRole(["admin", "manager"]),
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.json({ success: true, membership: updated });
   } catch (e) {
     console.error("[wellness] cancel membership error:", e.message);
@@ -4622,11 +4663,11 @@ function sanitizeUtmInput(utm, referrer) {
   };
   if (utm && typeof utm === "object") {
     const trim = (v) => (v == null ? null : String(v).replace(/[\x00-\x1f\x7f]/g, "").slice(0, 191).trim() || null);
-    out.utmSource   = trim(utm.utmSource   ?? utm.source);
-    out.utmMedium   = trim(utm.utmMedium   ?? utm.medium);
+    out.utmSource = trim(utm.utmSource ?? utm.source);
+    out.utmMedium = trim(utm.utmMedium ?? utm.medium);
     out.utmCampaign = trim(utm.utmCampaign ?? utm.campaign);
-    out.utmTerm     = trim(utm.utmTerm     ?? utm.term);
-    out.utmContent  = trim(utm.utmContent  ?? utm.content);
+    out.utmTerm = trim(utm.utmTerm ?? utm.term);
+    out.utmContent = trim(utm.utmContent ?? utm.content);
   }
   if (referrer != null) {
     out.referrer = String(referrer).replace(/[\x00-\x1f\x7f]/g, "").slice(0, 2000).trim() || null;
@@ -4960,6 +5001,9 @@ router.get("/prescriptions/:id/pdf", async (req, res) => {
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader("Content-Disposition", `inline; filename="rx-${id}.pdf"`);
     res.setHeader("Content-Length", buf.length);
+    res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    res.setHeader("Pragma", "no-cache");
+    res.setHeader("Expires", "0");
     res.send(buf);
   } catch (e) {
     console.error("[wellness] prescription pdf error:", e.message);
@@ -4976,16 +5020,19 @@ router.get("/consents/:id/pdf", async (req, res) => {
     });
     if (!consent) return res.status(404).json({ error: "Consent not found" });
 
-    // #564 v3.7.3 — prefer the frozen BLOB if /archive has already been
-    // called. The BLOB is the canonical bytes the patient saw at archive
-    // time; rendering on-demand is the legacy/back-compat path for rows
-    // signed before BLOB archival shipped. The branch is decided per-row.
+    // #564: serve from stored BLOB if available (fast path), otherwise
+    // generate on-demand (old records pre-BLOB storage).
     let buf;
-    let servedFromBlob = false;
+    console.log(`[wellness] GET /consents/${id}/pdf: hasPdfBlob=${consent.hasPdfBlob}, blobSize=${consent.signedPdfBlob?.length || 0}`);
     if (consent.signedPdfBlob && consent.signedPdfBlob.length > 0) {
-      buf = consent.signedPdfBlob;
-      servedFromBlob = true;
+      // Prisma Bytes type may not be a proper Buffer; ensure conversion
+      buf = Buffer.isBuffer(consent.signedPdfBlob)
+        ? consent.signedPdfBlob
+        : Buffer.from(consent.signedPdfBlob);
+      console.log(`[wellness] Using stored BLOB: ${buf.length} bytes`);
     } else {
+      // Fallback: old records without stored PDF
+      console.log(`[wellness] No BLOB found, generating on-demand for consent ${id}`);
       const clinic = await primaryClinic(req.user.tenantId);
       buf = await renderConsentPdf(
         consent,
@@ -4994,6 +5041,7 @@ router.get("/consents/:id/pdf", async (req, res) => {
         clinic,
         consent.signatureSvg,
       );
+      console.log(`[wellness] On-demand PDF generated: ${buf.length} bytes`);
     }
     // PRD §11: consent PDF export carries patient PII + signature image; log it.
     try {
@@ -5010,6 +5058,11 @@ router.get("/consents/:id/pdf", async (req, res) => {
     res.setHeader("Content-Type", consent.signedPdfMime || "application/pdf");
     res.setHeader("Content-Disposition", `inline; filename="consent-${id}.pdf"`);
     res.setHeader("Content-Length", buf.length);
+    res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    res.setHeader("Pragma", "no-cache");
+    res.setHeader("Expires", "0");
+    console.log(`[wellness] Sending PDF response: ${buf.length} bytes, type=${buf instanceof Buffer ? 'Buffer' : typeof buf}`);
+    console.log(`[wellness] PDF header check: ${buf.toString('utf8', 0, 4)}`);
     res.send(buf);
   } catch (e) {
     console.error("[wellness] consent pdf error:", e.message);
@@ -6545,7 +6598,7 @@ router.post("/wallet/:walletId/credit", verifyRole(["ADMIN"]), async (req, res) 
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json(tx);
   } catch (e) {
     console.error("[wellness] wallet credit error:", e.message);
@@ -6589,7 +6642,7 @@ router.post("/wallet/:walletId/debit", verifyRole(["ADMIN"]), async (req, res) =
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json(tx);
   } catch (e) {
     console.error("[wellness] wallet debit error:", e.message);
@@ -6699,7 +6752,7 @@ router.post("/giftcards", verifyRole(["ADMIN", "MANAGER"]), async (req, res) => 
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     // Return the plaintext ONCE in the response as `code` (back-compat with
     // 48 existing spec assertions) + `oneTimeCode` (explicit alias making
     // the disclosure semantics obvious to API consumers).
@@ -6808,7 +6861,7 @@ router.post("/giftcards/redeem", phiReadGate, async (req, res) => {
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json({ giftCard: updated, transaction: tx });
   } catch (e) {
     console.error("[wellness] giftcard redeem error:", e.message);
@@ -7178,7 +7231,7 @@ router.post("/visits/:id/apply-cashback", phiWriteGate, async (req, res) => {
         req.user.tenantId,
         req.io
       );
-    } catch (_e) {}
+    } catch (_e) { }
     res.status(201).json({ applied: true, earn: result.earn, ruleId: result.ruleId, transaction: tx });
   } catch (e) {
     console.error("[wellness] cashback apply error:", e.message);

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -5023,12 +5023,14 @@ router.get("/consents/:id/pdf", async (req, res) => {
     // #564: serve from stored BLOB if available (fast path), otherwise
     // generate on-demand (old records pre-BLOB storage).
     let buf;
+    let servedFromBlob = false;
     console.log(`[wellness] GET /consents/${id}/pdf: hasPdfBlob=${consent.hasPdfBlob}, blobSize=${consent.signedPdfBlob?.length || 0}`);
     if (consent.signedPdfBlob && consent.signedPdfBlob.length > 0) {
       // Prisma Bytes type may not be a proper Buffer; ensure conversion
       buf = Buffer.isBuffer(consent.signedPdfBlob)
         ? consent.signedPdfBlob
         : Buffer.from(consent.signedPdfBlob);
+      servedFromBlob = true;
       console.log(`[wellness] Using stored BLOB: ${buf.length} bytes`);
     } else {
       // Fallback: old records without stored PDF

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -34,7 +34,7 @@ const { writeAudit, diffFields } = require("../lib/audit");
 // row.
 const {
   shouldMaskForViewer,
-  maskRow,
+  _maskRow,
   maskRows,
   auditDisclosureDetails,
 } = require("../lib/piiMask");
@@ -758,6 +758,7 @@ function validatePatientInput(body, { isUpdate = false } = {}) {
   // invalid", not silent mutation. Tag-shaped HTML stays as silent-scrub
   // (preserves the long-standing #213 contract + the explicit "scrub is
   // silent" e2e contract test).
+  // eslint-disable-next-line no-control-regex
   if (body.name != null && /[\x00-\x1F\x7F]/.test(String(body.name))) {
     return { status: 400, error: "name contains invalid control characters", code: "INVALID_NAME" };
   }
@@ -4662,6 +4663,7 @@ function sanitizeUtmInput(utm, referrer) {
     utmTerm: null, utmContent: null, referrer: null,
   };
   if (utm && typeof utm === "object") {
+    // eslint-disable-next-line no-control-regex
     const trim = (v) => (v == null ? null : String(v).replace(/[\x00-\x1f\x7f]/g, "").slice(0, 191).trim() || null);
     out.utmSource = trim(utm.utmSource ?? utm.source);
     out.utmMedium = trim(utm.utmMedium ?? utm.medium);
@@ -4670,6 +4672,7 @@ function sanitizeUtmInput(utm, referrer) {
     out.utmContent = trim(utm.utmContent ?? utm.content);
   }
   if (referrer != null) {
+    // eslint-disable-next-line no-control-regex
     out.referrer = String(referrer).replace(/[\x00-\x1f\x7f]/g, "").slice(0, 2000).trim() || null;
   }
   return out;

--- a/e2e/tests/notifications-api.spec.js
+++ b/e2e/tests/notifications-api.spec.js
@@ -132,7 +132,7 @@ test.afterAll(async ({ request }) => {
   const { token } = await getAdmin(request);
   if (!token) return;
   for (const id of createdNotificationIds) {
-    await del(request, token, `/api/notifications/${id}`).catch(() => {});
+    await del(request, token, `/api/notifications/${id}`).catch(() => { });
   }
 });
 

--- a/e2e/tests/wellness-clinical-api.spec.js
+++ b/e2e/tests/wellness-clinical-api.spec.js
@@ -1665,6 +1665,93 @@ test.describe('Wellness API — Consents', () => {
     );
     expect(res.status()).toBe(404);
   });
+
+  // #564: PDF BLOB storage tests
+  test('GET /consents/:id/pdf returns valid PDF with embedded signature', async ({ request }) => {
+    const postRes = await authPost(
+      request,
+      '/api/wellness/consents',
+      {
+        patientId: consentPatientId,
+        templateName: `${RUN_TAG} Consent PDF`,
+        signatureSvg: FAKE_SIG_PAYLOAD,
+      },
+      'drharsh',
+    );
+    expect(postRes.status()).toBe(201);
+    const consent = await postRes.json();
+    const pdfRes = await authGet(request, `/api/wellness/consents/${consent.id}/pdf`);
+    expect(pdfRes.status()).toBe(200);
+    expect(pdfRes.headers()['content-type']).toMatch(/application\/pdf/);
+    const pdfBody = await pdfRes.arrayBuffer();
+    expect(pdfBody.byteLength).toBeGreaterThan(0);
+    // PDF files start with %PDF magic bytes
+    expect(new Uint8Array(pdfBody).slice(0, 4).toString()).toMatch(/37,80,68,70/); // %PDF
+  });
+
+  test('GET /consents list excludes heavy fields (signatureSvg, contentSnapshot, signedPdfBlob)', async ({ request }) => {
+    const res = await authGet(request, `/api/wellness/consents?patientId=${consentPatientId}&limit=5`);
+    expect(res.status()).toBe(200);
+    const items = await res.json();
+    for (const c of items) {
+      expect(c).not.toHaveProperty('signatureSvg');
+      expect(c).not.toHaveProperty('contentSnapshot');
+      expect(c).not.toHaveProperty('signedPdfBlob');
+      expect(c).toHaveProperty('hasPdfBlob');
+      expect(typeof c.hasPdfBlob).toBe('boolean');
+    }
+  });
+
+  test('GET /patients/:id includes consents without heavy fields', async ({ request }) => {
+    const res = await authGet(request, `/api/wellness/patients/${consentPatientId}`);
+    expect(res.status()).toBe(200);
+    const patient = await res.json();
+    expect(Array.isArray(patient.consents)).toBe(true);
+    for (const c of patient.consents) {
+      expect(c).not.toHaveProperty('signatureSvg');
+      expect(c).not.toHaveProperty('contentSnapshot');
+      expect(c).not.toHaveProperty('signedPdfBlob');
+      expect(c).toHaveProperty('hasPdfBlob');
+    }
+  });
+
+  test('PUT /consents/:id with signedPdfBlob returns 400 PDF_BLOB_IMMUTABLE', async ({ request }) => {
+    const postRes = await authPost(
+      request,
+      '/api/wellness/consents',
+      {
+        patientId: consentPatientId,
+        templateName: `${RUN_TAG} Consent Immutable`,
+        signatureSvg: FAKE_SIG_PAYLOAD,
+      },
+      'drharsh',
+    );
+    expect(postRes.status()).toBe(201);
+    const consent = await postRes.json();
+    const res = await authPut(
+      request,
+      `/api/wellness/consents/${consent.id}`,
+      { signedPdfBlob: 'tampered' },
+      'admin',
+    );
+    expect(res.status()).toBe(400);
+    const err = await res.json();
+    expect(err.code).toBe('PDF_BLOB_IMMUTABLE');
+  });
+
+  test('GET /consents/:id/pdf works for seeded consents without BLOB (fallback)', async ({ request }) => {
+    // Seeded consents have signedPdfBlob = null, test on-demand fallback
+    const listRes = await authGet(request, '/api/wellness/consents?limit=5');
+    expect(listRes.status()).toBe(200);
+    const items = await listRes.json();
+    // Find any seeded consent (they'll have hasPdfBlob: false or id < 1000 depending on seed order)
+    if (items.length > 0) {
+      const anyConsent = items[0];
+      const pdfRes = await authGet(request, `/api/wellness/consents/${anyConsent.id}/pdf`);
+      expect(pdfRes.status()).toBe(200);
+      expect(pdfRes.headers()['content-type']).toMatch(/application\/pdf/);
+    }
+  });
 });
 
 // =====================================================================

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -40,6 +40,7 @@ const Marketing = lazy(() => import("./pages/Marketing"));
 const Reports = lazy(() => import("./pages/Reports"));
 const AgentReports = lazy(() => import("./pages/AgentReports"));
 const Settings = lazy(() => import("./pages/Settings"));
+const UserSettings = lazy(() => import("./pages/UserSettings"));
 const Developer = lazy(() => import("./pages/Developer"));
 const Portal = lazy(() => import("./pages/Portal"));
 const Marketplace = lazy(() => import("./pages/Marketplace"));
@@ -666,6 +667,7 @@ export default function App() {
                     />
                     <Route path="profile" element={<Profile />} />
                     <Route path="profile/2fa" element={<Profile2FA />} />
+                    <Route path="notification-settings" element={<UserSettings />} />
                     {/* #589: Audit Log is ADMIN-only (mirrors Sidebar's
                         adminOnly visibility + the "System Admin Required"
                         toast text). Pre-fix, USER + MANAGER navigation to

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -18,37 +18,62 @@ import { AuthContext } from '../App';
 import { fetchApi } from '../utils/api';
 import { setupPush } from '../utils/pushSetup';
 
-// #555 (HI-06) — lock-per-session policy.
-//
-// Pre-fix, the SPA's tenant context could flip silently based on URL
-// pathname — no switcher in the chrome, no audit trail, localStorage
-// could disagree with the rendered shell (pen-test privilege-confusion
-// surface). The earlier fix shipped an explicit switcher widget; v3.7.2
-// disposition reset the policy to lock-per-session — pick the tenant at
-// login and log out to switch. This component is now a READ-ONLY chip
-// showing the active tenant prominently; there is no in-session switch
-// path. The backend `/api/auth/tenant-switch` endpoint now returns
-// 410 Gone with code TENANT_SWITCH_DISABLED.
+// #555: Simple tenant display chip showing organization name and lock icon
 function TenantChip({ tenant }) {
-  if (!tenant?.name) return null;
-  const isWellness = tenant?.vertical === 'wellness';
   return (
     <div
-      data-testid="tenant-chip"
-      title="Tenant is locked for this session. Log out and log back in to switch."
       style={{
         display: 'flex', alignItems: 'center', gap: '6px',
-        background: 'transparent', border: '1px solid var(--border-color)',
+        background: 'var(--accent-bg, #f0f4ff)', border: '1px solid var(--accent-color)',
         color: 'var(--text-primary)', borderRadius: 8,
-        padding: '6px 10px', fontSize: '0.85rem',
+        padding: '6px 12px', fontSize: '0.85rem',
+        fontWeight: 500,
       }}
     >
-      <Building2 size={14} aria-hidden="true" />
-      <span>{tenant.name}</span>
-      {isWellness && (
-        <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
-          (wellness)
-        </span>
+      <Building2 size={14} style={{ color: 'var(--accent-color)' }} />
+      <span>{tenant?.name || 'Organization'}</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--accent-color)', marginLeft: '4px' }}>🔒</span>
+    </div>
+  );
+}
+
+// #555: Option C — Lock to single tenant per session. Users cannot switch
+// tenants without logging out. The tenant is locked for the entire session.
+// To switch tenants, user must logout and login again. Tenant name displayed
+// prominently in header with lock icon to indicate no-switching policy.
+function TenantSwitcher({ tenant, setTenant, setUser, setToken }) {
+  const navigate = useNavigate();
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <div data-testid="tenant-switcher" style={{ position: 'relative' }}>
+      <div
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '6px',
+          background: 'var(--accent-bg, #f0f4ff)', border: '1px solid var(--accent-color)',
+          color: 'var(--text-primary)', borderRadius: 8,
+          padding: '6px 12px', cursor: 'default', fontSize: '0.85rem',
+          fontWeight: 500, position: 'relative',
+        }}
+      >
+        <Building2 size={14} style={{ color: 'var(--accent-color)' }} />
+        <span>{tenant?.name || 'Organization'}</span>
+        <span style={{ fontSize: '0.7rem', color: 'var(--accent-color)', marginLeft: '4px' }}>🔒</span>
+      </div>
+      {showTooltip && (
+        <div
+          style={{
+            position: 'absolute', top: 'calc(100% + 8px)', right: 0,
+            background: 'var(--surface-color)', border: '1px solid var(--border-color)',
+            borderRadius: 6, padding: '8px 12px', fontSize: '0.8rem',
+            whiteSpace: 'nowrap', boxShadow: '0 4px 12px rgba(0,0,0,0.15)', zIndex: 50,
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Locked to {tenant?.name || 'this tenant'} for session
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -875,6 +875,14 @@ function renderWellnessNav({
           <Link to="/settings" icon={Settings} label="Settings" />
         </>
       )}
+
+      {/* User Notification Settings — only for regular users, not admin/manager */}
+      {!isAdmin && !isManager && (
+        <>
+          <div style={labelStyle}>User</div>
+          <Link to="/notification-settings" icon={Settings} label="Notification Settings" />
+        </>
+      )}
     </>
   );
 }
@@ -1058,6 +1066,22 @@ function renderGenericNav({
           }}
         >
           <Link to="/settings" icon={Settings} label="Settings" />
+        </div>
+      )}
+
+      {/* User Notification Settings — only for regular users, not admin/manager */}
+      {!isAdmin && !isManager && (
+        <div
+          style={{
+            paddingTop: "0.75rem",
+            marginTop: "0.5rem",
+            borderTop: "1px solid var(--border-color)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.25rem",
+          }}
+        >
+          <Link to="/notification-settings" icon={Settings} label="Notification Settings" />
         </div>
       )}
     </>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { Shield, UserPlus, Trash2, Key, Sun, Moon, Plus, ArrowUp, ArrowDown, Layers, Building2, Image as ImageIcon, Palette, Monitor, Mail, FileSignature } from 'lucide-react';
+import { Shield, UserPlus, Trash2, Key, Sun, Moon, Plus, ArrowUp, ArrowDown, Layers, Building2, Image as ImageIcon, Palette, Monitor, Mail, FileSignature, Bell } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../utils/api';
 import { useNotify } from '../utils/notify';
 import { ThemeContext, AuthContext } from '../App';
@@ -630,6 +630,9 @@ export default function Settings() {
              <button type="submit" className="btn-primary" style={{ gridColumn: '1 / -1' }}>Send Invitation & Create Account</button>
           </form>
         </div>
+
+        {/* Notification Preferences Card */}
+        <NotificationPreferencesCard notify={notify} />
         </div>
 
       </div>
@@ -738,6 +741,208 @@ function ConsentTemplatesCard({ notify }) {
           <Plus size={16} /> {creating ? 'Adding…' : 'Add Template'}
         </button>
       </form>
+    </div>
+  );
+}
+
+// Notification Preferences — per-user opt-in/out of categories, channels, and quiet hours
+function NotificationPreferencesCard({ notify }) {
+  const [prefs, setPrefs] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Category and channel options
+  const categoryOptions = [
+    { key: 'deal', label: 'Deals & Opportunities' },
+    { key: 'task', label: 'Tasks' },
+    { key: 'ticket', label: 'Support Tickets' },
+    { key: 'lead', label: 'Leads' },
+    { key: 'approval', label: 'Approvals' },
+    { key: 'leave', label: 'Leave Requests' },
+    { key: 'expense', label: 'Expense Reports' },
+  ];
+
+  const channelOptions = [
+    { key: 'db', label: 'In-App Bell' },
+    { key: 'socket', label: 'Real-Time Updates' },
+    { key: 'push', label: 'Browser Push' },
+    { key: 'email', label: 'Email' },
+  ];
+
+  // Timezone list
+  const timezones = [
+    'UTC', 'Asia/Kolkata', 'Asia/Dubai', 'Asia/Bangkok', 'Asia/Singapore', 'Asia/Hong_Kong',
+    'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+    'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Australia/Sydney'
+  ];
+
+  const load = async () => {
+    try {
+      const data = await fetchApi('/api/notifications/preferences');
+      setPrefs(data);
+    } catch (err) {
+      console.error('Failed to load preferences:', err);
+      notify.error('Failed to load notification preferences');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCategoryToggle = (category) => {
+    setPrefs({
+      ...prefs,
+      categoryToggles: {
+        ...prefs.categoryToggles,
+        [category]: !prefs.categoryToggles[category],
+      },
+    });
+  };
+
+  const handleChannelToggle = (channel) => {
+    setPrefs({
+      ...prefs,
+      channels: {
+        ...prefs.channels,
+        [channel]: !prefs.channels[channel],
+      },
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await fetchApi('/api/notifications/preferences', {
+        method: 'PUT',
+        body: JSON.stringify(prefs),
+      });
+      notify.success('Notification preferences saved');
+    } catch (err) {
+      notify.error('Failed to save notification preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!await notify.confirm('Reset notification preferences to defaults?')) return;
+    setSaving(true);
+    try {
+      await fetchApi('/api/notifications/preferences/reset', { method: 'POST' });
+      load();
+      notify.success('Preferences reset to defaults');
+    } catch (err) {
+      notify.error('Failed to reset preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div className="card" style={{ padding: '1.5rem' }}>Loading preferences…</div>;
+  if (!prefs) return null;
+
+  return (
+    <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
+      <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <Bell size={20} color="var(--accent-color)" /> Notification Preferences
+      </h3>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Notification Categories</h4>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Choose which types of notifications you want to receive.</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
+          {categoryOptions.map(cat => (
+            <label key={cat.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+              <input
+                type="checkbox"
+                checked={prefs.categoryToggles[cat.key] !== false}
+                onChange={() => handleCategoryToggle(cat.key)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span style={{ fontSize: '0.9rem' }}>{cat.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Delivery Channels</h4>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Select how you want to receive notifications.</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
+          {channelOptions.map(ch => (
+            <label key={ch.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+              <input
+                type="checkbox"
+                checked={prefs.channels[ch.key] !== false}
+                onChange={() => handleChannelToggle(ch.key)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span style={{ fontSize: '0.9rem' }}>{ch.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Quiet Hours</h4>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Suppress notifications during these times in your timezone.</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 150px), 1fr))', gap: '1rem' }}>
+          <div style={{ minWidth: 0 }}>
+            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Timezone</label>
+            <select
+              className="input-field"
+              value={prefs.timezone || ''}
+              onChange={(e) => setPrefs({ ...prefs, timezone: e.target.value || null })}
+              style={{ background: 'var(--input-bg)', minWidth: 0 }}
+            >
+              <option value="">—</option>
+              {timezones.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+            </select>
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Start Time (HH:MM)</label>
+            <input
+              type="time"
+              className="input-field"
+              value={prefs.quietHoursStart || ''}
+              onChange={(e) => setPrefs({ ...prefs, quietHoursStart: e.target.value || null })}
+              style={{ minWidth: 0 }}
+            />
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>End Time (HH:MM)</label>
+            <input
+              type="time"
+              className="input-field"
+              value={prefs.quietHoursEnd || ''}
+              onChange={(e) => setPrefs({ ...prefs, quietHoursEnd: e.target.value || null })}
+              style={{ minWidth: 0 }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleSave}
+          disabled={saving}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+        >
+          {saving ? 'Saving…' : 'Save Preferences'}
+        </button>
+        <button
+          type="button"
+          className="btn-secondary"
+          onClick={handleReset}
+          disabled={saving}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+        >
+          Reset to Defaults
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/UserSettings.jsx
+++ b/frontend/src/pages/UserSettings.jsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect } from 'react';
+import { Bell } from 'lucide-react';
+import { fetchApi } from '../utils/api';
+import { useNotify } from '../utils/notify';
+
+export default function UserSettings() {
+  const notify = useNotify();
+  const [prefs, setPrefs] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Category and channel options
+  const categoryOptions = [
+    { key: 'deal', label: 'Deals & Opportunities' },
+    { key: 'task', label: 'Tasks' },
+    { key: 'ticket', label: 'Support Tickets' },
+    { key: 'lead', label: 'Leads' },
+    { key: 'approval', label: 'Approvals' },
+    { key: 'leave', label: 'Leave Requests' },
+    { key: 'expense', label: 'Expense Reports' },
+  ];
+
+  const channelOptions = [
+    { key: 'db', label: 'In-App Bell' },
+    { key: 'socket', label: 'Real-Time Updates' },
+    { key: 'push', label: 'Browser Push' },
+    { key: 'email', label: 'Email' },
+  ];
+
+  // Timezone list
+  const timezones = [
+    'UTC', 'Asia/Kolkata', 'Asia/Dubai', 'Asia/Bangkok', 'Asia/Singapore', 'Asia/Hong_Kong',
+    'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+    'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Australia/Sydney'
+  ];
+
+  const load = async () => {
+    try {
+      const data = await fetchApi('/api/notifications/preferences');
+      setPrefs(data);
+    } catch (err) {
+      console.error('Failed to load preferences:', err);
+      notify.error('Failed to load notification preferences');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCategoryToggle = (category) => {
+    setPrefs({
+      ...prefs,
+      categoryToggles: {
+        ...prefs.categoryToggles,
+        [category]: !prefs.categoryToggles[category],
+      },
+    });
+  };
+
+  const handleChannelToggle = (channel) => {
+    setPrefs({
+      ...prefs,
+      channels: {
+        ...prefs.channels,
+        [channel]: !prefs.channels[channel],
+      },
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await fetchApi('/api/notifications/preferences', {
+        method: 'PUT',
+        body: JSON.stringify(prefs),
+      });
+      notify.success('Notification preferences saved');
+    } catch (err) {
+      notify.error('Failed to save notification preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!await notify.confirm('Reset notification preferences to defaults?')) return;
+    setSaving(true);
+    try {
+      await fetchApi('/api/notifications/preferences/reset', { method: 'POST' });
+      load();
+      notify.success('Preferences reset to defaults');
+    } catch (err) {
+      notify.error('Failed to reset preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div style={{ padding: '2rem' }}>Loading preferences…</div>;
+  if (!prefs) return null;
+
+  return (
+    <div style={{ padding: 'clamp(1rem, 4vw, 2rem)', height: '100%', overflowY: 'auto', animation: 'fadeIn 0.5s ease-out' }}>
+      <header style={{ marginBottom: '2.5rem' }}>
+        <h1 style={{ fontSize: '2rem', fontWeight: 'bold' }}>Notification Settings</h1>
+        <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>Manage how and when you receive notifications.</p>
+      </header>
+
+      <div style={{ maxWidth: '800px' }}>
+        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
+          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Bell size={20} color="var(--accent-color)" /> Notification Preferences
+          </h3>
+
+          <div style={{ marginBottom: '2rem' }}>
+            <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Notification Categories</h4>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Choose which types of notifications you want to receive.</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
+              {categoryOptions.map(cat => (
+                <label key={cat.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+                  <input
+                    type="checkbox"
+                    checked={prefs.categoryToggles[cat.key] !== false}
+                    onChange={() => handleCategoryToggle(cat.key)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                  <span style={{ fontSize: '0.9rem' }}>{cat.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ marginBottom: '2rem' }}>
+            <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Delivery Channels</h4>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Select how you want to receive notifications.</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
+              {channelOptions.map(ch => (
+                <label key={ch.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+                  <input
+                    type="checkbox"
+                    checked={prefs.channels[ch.key] !== false}
+                    onChange={() => handleChannelToggle(ch.key)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                  <span style={{ fontSize: '0.9rem' }}>{ch.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ marginBottom: '2rem' }}>
+            <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Quiet Hours</h4>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Suppress notifications during these times in your timezone.</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 150px), 1fr))', gap: '1rem' }}>
+              <div style={{ minWidth: 0 }}>
+                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Timezone</label>
+                <select
+                  className="input-field"
+                  value={prefs.timezone || ''}
+                  onChange={(e) => setPrefs({ ...prefs, timezone: e.target.value || null })}
+                  style={{ background: 'var(--input-bg)', minWidth: 0 }}
+                >
+                  <option value="">—</option>
+                  {timezones.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+                </select>
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Start Time (HH:MM)</label>
+                <input
+                  type="time"
+                  className="input-field"
+                  value={prefs.quietHoursStart || ''}
+                  onChange={(e) => setPrefs({ ...prefs, quietHoursStart: e.target.value || null })}
+                  style={{ minWidth: 0 }}
+                />
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>End Time (HH:MM)</label>
+                <input
+                  type="time"
+                  className="input-field"
+                  value={prefs.quietHoursEnd || ''}
+                  onChange={(e) => setPrefs({ ...prefs, quietHoursEnd: e.target.value || null })}
+                  style={{ minWidth: 0 }}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSave}
+              disabled={saving}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+            >
+              {saving ? 'Saving…' : 'Save Preferences'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={handleReset}
+              disabled={saving}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+            >
+              Reset to Defaults
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/wellness/PatientDetail.jsx
+++ b/frontend/src/pages/wellness/PatientDetail.jsx
@@ -680,6 +680,31 @@ function ConsentTab({ patient, services, onSaved }) {
   // server stores a blank "signature" — a legal/compliance issue (#118).
   const [hasStrokes, setHasStrokes] = useState(false);
 
+  const [downloadingId, setDownloadingId] = useState(null);
+
+  const downloadConsentPdf = async (c) => {
+    setDownloadingId(c.id);
+    try {
+      const token = getAuthToken();
+      const res = await fetch(`/api/wellness/consents/${c.id}/pdf`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      console.log(`[PDF Download] Status: ${res.status}, Content-Type: ${res.headers.get('content-type')}`);
+      if (!res.ok) throw new Error(`PDF download failed (${res.status})`);
+      const blob = await res.blob();
+      console.log(`[PDF Download] Blob size: ${blob.size} bytes, type: ${blob.type}`);
+      if (blob.size === 0) throw new Error('PDF blob is empty');
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank', 'noopener');
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } catch (err) {
+      console.error('[PDF Download Error]', err);
+      notify.error(err.message || 'Failed to download consent PDF.');
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
   const startDraw = (e) => {
     setIsDrawing(true);
     setHasStrokes(true);
@@ -705,10 +730,13 @@ function ConsentTab({ patient, services, onSaved }) {
   };
   const endDraw = () => setIsDrawing(false);
   const getCoords = (e) => {
-    const rect = canvasRef.current.getBoundingClientRect();
+    const canvas = canvasRef.current;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const clientY = e.touches ? e.touches[0].clientY : e.clientY;
-    return { x: clientX - rect.left, y: clientY - rect.top };
+    return { x: (clientX - rect.left) * scaleX, y: (clientY - rect.top) * scaleY };
   };
   const clearSig = () => {
     const c = canvasRef.current;
@@ -807,6 +835,23 @@ function ConsentTab({ patient, services, onSaved }) {
                     <span style={{ color: 'var(--text-secondary)' }}>{c.service.name}</span>
                   </>
                 )}
+                <button
+                  type="button"
+                  onClick={() => downloadConsentPdf(c)}
+                  disabled={downloadingId === c.id}
+                  title="Download signed consent PDF"
+                  style={{
+                    marginLeft: 'auto', background: 'transparent',
+                    border: '1px solid var(--primary-color, var(--accent-color))',
+                    color: 'var(--primary-color, var(--accent-color))',
+                    padding: '0.2rem 0.6rem', borderRadius: 6, fontSize: '0.75rem',
+                    cursor: downloadingId === c.id ? 'wait' : 'pointer',
+                    display: 'flex', alignItems: 'center', gap: '0.3rem',
+                  }}
+                >
+                  <Download size={12} />
+                  {downloadingId === c.id ? 'Downloading...' : 'PDF'}
+                </button>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
2. ✅ CLOSED v3.7.3 — https://github.com/Globussoft-Technologies/globussoft-crm/issues/555 tenant-switcher UX

Decision received — option C lock-per-session shipped at https://github.com/Globussoft-Technologies/globussoft-crm/commit/32a4bd9c70fbfc1978b7238d3b536a479734785e
Status: Backend is fine — the tenantId on the JWT scopes everything correctly. Pen-test flagged that on URL switching alone (between Default Org and Enhanced Wellness) there's no visual indicator, no audit row, no confirmation. Privilege-confusion surface.

Why not autonomous: UX decision. Engineering shouldn't pick between three different ergonomic patterns without product input — each has different implications for the people who actually use the CRM multi-tenant.

4. ✅ CLOSED v3.7.3 — https://github.com/Globussoft-Technologies/globussoft-crm/issues/564 wellness consent-form / signature surface

Workflow choice received — option B staff-tablet handoff

Storage choice received — DB BLOB (signedPdfBlob @db.LongBlob)
Status: ConsentForm Prisma model exists. pdfRenderer.js already renders consent PDFs with embedded signatures. PatientDetail page has a Consent canvas tab. The gap is the workflow — when consent appears, who signs, where the signed PDF lives, how staff collect signatures.


Area: Notification preferences

Symptom: There is no Settings panel where a user can opt-in/out of notification categories, choose channels (email / push / in-app / WhatsApp), or set quiet hours. Currently the user receives whatever the backend emits with no opt-out.

User Impact:

Power users get notification fatigue and disable the bell entirely.
No GDPR-compatible "unsubscribe from category X" path.
Suggested fix:

Add /settings/notifications page with per-category toggles and per-channel toggles.
Add quiet-hours per user TZ.
Backend respects preferences before sending.
Filed as part of the consolidated audit — Medium Notifications (3 / 3).