### PR TITLE
feat: add public KB article view, role-based sidebar gating, and dark…

### DIFF
--- a/backend/routes/integrations.js
+++ b/backend/routes/integrations.js
@@ -5,27 +5,89 @@ const prisma = require("../lib/prisma");
 const router = express.Router();
 
 const AVAILABLE_INTEGRATIONS = [
-  { provider: "slack", name: "Slack", description: "Send deal/contact notifications to Slack channels", category: "communication" },
-  { provider: "google", name: "Google Workspace", description: "Calendar, Contacts, and Drive sync", category: "productivity" },
-  { provider: "stripe", name: "Stripe", description: "Payment processing for invoices", category: "payments" },
-  { provider: "razorpay", name: "Razorpay", description: "Indian payment gateway for invoices", category: "payments" },
-  { provider: "mailchimp", name: "Mailchimp", description: "Email marketing campaign sync", category: "marketing" },
-  { provider: "quickbooks", name: "QuickBooks", description: "Accounting & bookkeeping sync", category: "accounting" },
-  { provider: "xero", name: "Xero", description: "Cloud accounting platform sync", category: "accounting" },
-  { provider: "tally", name: "Tally Prime", description: "Indian accounting software sync", category: "accounting" },
-  { provider: "zapier", name: "Zapier", description: "Connect to 5000+ apps via triggers & actions", category: "automation" },
-  { provider: "whatsapp", name: "WhatsApp Business", description: "Send messages via WhatsApp Cloud API", category: "communication" },
-  { provider: "indiamart", name: "IndiaMART", description: "Auto-import B2B leads", category: "marketplace" },
-  { provider: "justdial", name: "JustDial", description: "Auto-import local business leads", category: "marketplace" },
+  {
+    provider: "slack",
+    name: "Slack",
+    description: "Send deal/contact notifications to Slack channels",
+    category: "communication",
+  },
+  {
+    provider: "google",
+    name: "Google Workspace",
+    description: "Calendar, Contacts, and Drive sync",
+    category: "productivity",
+  },
+  {
+    provider: "stripe",
+    name: "Stripe",
+    description: "Payment processing for invoices",
+    category: "payments",
+  },
+  {
+    provider: "razorpay",
+    name: "Razorpay",
+    description: "Indian payment gateway for invoices",
+    category: "payments",
+  },
+  {
+    provider: "mailchimp",
+    name: "Mailchimp",
+    description: "Email marketing campaign sync",
+    category: "marketing",
+  },
+  {
+    provider: "quickbooks",
+    name: "QuickBooks",
+    description: "Accounting & bookkeeping sync",
+    category: "accounting",
+  },
+  {
+    provider: "xero",
+    name: "Xero",
+    description: "Cloud accounting platform sync",
+    category: "accounting",
+  },
+  {
+    provider: "tally",
+    name: "Tally Prime",
+    description: "Indian accounting software sync",
+    category: "accounting",
+  },
+  {
+    provider: "zapier",
+    name: "Zapier",
+    description: "Connect to 5000+ apps via triggers & actions",
+    category: "automation",
+  },
+  {
+    provider: "whatsapp",
+    name: "WhatsApp Business",
+    description: "Send messages via WhatsApp Cloud API",
+    category: "communication",
+  },
+  {
+    provider: "indiamart",
+    name: "IndiaMART",
+    description: "Auto-import B2B leads",
+    category: "marketplace",
+  },
+  {
+    provider: "justdial",
+    name: "JustDial",
+    description: "Auto-import local business leads",
+    category: "marketplace",
+  },
 ];
 
 router.get("/", verifyToken, async (req, res) => {
   try {
-    const connected = await prisma.integration.findMany({ where: { tenantId: req.user.tenantId } });
+    const connected = await prisma.integration.findMany({
+      where: { tenantId: req.user.tenantId },
+    });
     const connectedMap = {};
     for (const c of connected) connectedMap[c.provider] = c;
 
-    const integrations = AVAILABLE_INTEGRATIONS.map(a => ({
+    const integrations = AVAILABLE_INTEGRATIONS.map((a) => ({
       ...a,
       isActive: connectedMap[a.provider]?.isActive || false,
       connectedAt: connectedMap[a.provider]?.updatedAt || null,
@@ -37,34 +99,55 @@ router.get("/", verifyToken, async (req, res) => {
   }
 });
 
-router.post("/connect", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
-  try {
-    const { provider, token, settings } = req.body;
-    if (!provider) return res.status(400).json({ error: "Provider required" });
+router.post(
+  "/connect",
+  verifyToken,
+  verifyRole(["ADMIN"]),
+  async (req, res) => {
+    try {
+      const { provider, token, settings } = req.body;
+      if (!provider)
+        return res.status(400).json({ error: "Provider required" });
 
-    const integration = await prisma.integration.upsert({
-      where: { tenantId_provider: { tenantId: req.user.tenantId, provider } },
-      update: { isActive: true, token: token || null, settings: settings ? JSON.stringify(settings) : null },
-      create: { provider, isActive: true, token: token || null, settings: settings ? JSON.stringify(settings) : null, tenantId: req.user.tenantId },
-    });
-    res.json(integration);
-  } catch (_err) {
-    res.status(500).json({ error: "Failed to connect integration" });
-  }
-});
+      const integration = await prisma.integration.upsert({
+        where: { tenantId_provider: { tenantId: req.user.tenantId, provider } },
+        update: {
+          isActive: true,
+          token: token || null,
+          settings: settings ? JSON.stringify(settings) : null,
+        },
+        create: {
+          provider,
+          isActive: true,
+          token: token || null,
+          settings: settings ? JSON.stringify(settings) : null,
+          tenantId: req.user.tenantId,
+        },
+      });
+      res.json(integration);
+    } catch (_err) {
+      res.status(500).json({ error: "Failed to connect integration" });
+    }
+  },
+);
 
-router.post("/disconnect", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
-  try {
-    const { provider } = req.body;
-    await prisma.integration.updateMany({
-      where: { tenantId: req.user.tenantId, provider },
-      data: { isActive: false, token: null },
-    });
-    res.json({ success: true });
-  } catch (_err) {
-    res.status(500).json({ error: "Failed to disconnect" });
-  }
-});
+router.post(
+  "/disconnect",
+  verifyToken,
+  verifyRole(["ADMIN"]),
+  async (req, res) => {
+    try {
+      const { provider } = req.body;
+      await prisma.integration.updateMany({
+        where: { tenantId: req.user.tenantId, provider },
+        data: { isActive: false, token: null },
+      });
+      res.json({ success: true });
+    } catch (_err) {
+      res.status(500).json({ error: "Failed to disconnect" });
+    }
+  },
+);
 
 // Legacy toggle endpoint (kept for backwards compat). ADMIN-only — sister
 // /connect + /disconnect already require ADMIN; toggle is the same write
@@ -112,8 +195,8 @@ router.post("/toggle", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
 // existing /api/marketplace-leads/config endpoint stays admin-only because
 // it returns the (masked) API keys.
 const MARKETPLACE_PROVIDERS = [
-  { provider: "indiamart",  label: "IndiaMART" },
-  { provider: "justdial",   label: "JustDial" },
+  { provider: "indiamart", label: "IndiaMART" },
+  { provider: "justdial", label: "JustDial" },
   { provider: "tradeindia", label: "TradeIndia" },
 ];
 
@@ -137,7 +220,7 @@ router.get("/marketplace/status", verifyToken, async (req, res) => {
       ...MARKETPLACE_PROVIDERS.map(({ provider }) =>
         prisma.marketplaceLead.count({
           where: { tenantId, provider, createdAt: { gte: thirtyDaysAgo } },
-        })
+        }),
       ),
     ]);
 
@@ -187,27 +270,38 @@ router.get("/callified/auth-url", verifyToken, async (req, res) => {
     // Get the Callified SSO secret from environment — must match Callified's SSO_SHARED_SECRET
     const callifiedSecret = process.env.CALLIFIED_SSO_SECRET;
     if (!callifiedSecret) {
-      return res.status(503).json({ error: "Callified integration is not yet available. Please contact your administrator to configure it." });
+      return res.status(503).json({
+        error:
+          "Callified integration is not yet available. Please contact your administrator to configure it.",
+      });
     }
 
     // 1. Load Callified integration config for this tenant (optional — dashboardUrl comes from here)
     const integration = await prisma.integration.findFirst({
-      where: { tenantId: req.user.tenantId, provider: "callified", isActive: true },
+      where: {
+        tenantId: req.user.tenantId,
+        provider: "callified",
+        isActive: true,
+      },
     });
-    const settings = integration?.settings ? JSON.parse(integration.settings) : {};
+    const settings = integration?.settings
+      ? JSON.parse(integration.settings)
+      : {};
 
     // 2. Fetch current user for email + name
-    const user = await prisma.user.findUnique({ where: { id: req.user.userId } });
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.userId },
+    });
     if (!user) return res.status(401).json({ error: "User not found" });
 
     // 3. Map CRM roles to Callified roles (admin, viewer, agent)
     // Callified has three role types with different visibility/permissions
     const callifiedRoleMap = {
-      'ADMIN': 'admin',      // Full access
-      'MANAGER': 'agent',    // Agent/team lead access
-      'USER': 'viewer',      // Viewer/read-only access
+      ADMIN: "admin", // Full access
+      MANAGER: "agent", // Agent/team lead access
+      USER: "viewer", // Viewer/read-only access
     };
-    const callifiedRole = callifiedRoleMap[user.role] || 'viewer';
+    const callifiedRole = callifiedRoleMap[user.role] || "viewer";
 
     // 4. Sign the JWT — matches the Callified-specified format
     const payload = {
@@ -216,15 +310,21 @@ router.get("/callified/auth-url", verifyToken, async (req, res) => {
       sub: settings.sub || "globussoft-crm",
       email: user.email,
       name: user.name,
-      role: callifiedRole,  // Use mapped Callified role
+      role: callifiedRole, // Use mapped Callified role
       org_id: parseInt(settings.orgId) || 1,
     };
-    const token = jwt.sign(payload, callifiedSecret, { algorithm: "HS256", expiresIn: 1800 });
+    const token = jwt.sign(payload, callifiedSecret, {
+      algorithm: "HS256",
+      expiresIn: 1800,
+    });
 
     // 4. Construct the Callified auth URL with token and redirect params
     // For development: use local Callified at http://localhost:8001
     // For production: set CALLIFIED_DASHBOARD_URL env var
-    const callifiedBaseUrl = process.env.CALLIFIED_DASHBOARD_URL || settings.dashboardUrl || "http://localhost:8001/api/auth/sso/jwt";
+    const callifiedBaseUrl =
+      process.env.CALLIFIED_DASHBOARD_URL ||
+      settings.dashboardUrl ||
+      "http://localhost:8001/api/auth/sso/jwt";
     const redirect = settings.redirectPath || "/crm";
     const authUrl = `${callifiedBaseUrl}?token=${encodeURIComponent(token)}&redirect=${encodeURIComponent(redirect)}`;
 
@@ -244,24 +344,36 @@ router.get("/callified/sso", verifyToken, async (req, res) => {
 
     const callifiedSecret = process.env.CALLIFIED_SSO_SECRET;
     if (!callifiedSecret) {
-      return res.status(503).send("Callified integration is not yet available. Please contact your administrator to configure it.");
+      return res
+        .status(503)
+        .send(
+          "Callified integration is not yet available. Please contact your administrator to configure it.",
+        );
     }
 
     const integration = await prisma.integration.findFirst({
-      where: { tenantId: req.user.tenantId, provider: "callified", isActive: true },
+      where: {
+        tenantId: req.user.tenantId,
+        provider: "callified",
+        isActive: true,
+      },
     });
-    const settings = integration?.settings ? JSON.parse(integration.settings) : {};
+    const settings = integration?.settings
+      ? JSON.parse(integration.settings)
+      : {};
 
-    const user = await prisma.user.findUnique({ where: { id: req.user.userId } });
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.userId },
+    });
     if (!user) return res.status(401).send("User not found");
 
     // Map CRM roles to Callified roles (admin, viewer, agent)
     const callifiedRoleMap = {
-      'ADMIN': 'admin',
-      'MANAGER': 'agent',
-      'USER': 'viewer',
+      ADMIN: "admin",
+      MANAGER: "agent",
+      USER: "viewer",
     };
-    const callifiedRole = callifiedRoleMap[user.role] || 'viewer';
+    const callifiedRole = callifiedRoleMap[user.role] || "viewer";
 
     const payload = {
       iss: "globussoft-internal",
@@ -272,9 +384,15 @@ router.get("/callified/sso", verifyToken, async (req, res) => {
       role: callifiedRole,
       org_id: parseInt(settings.orgId) || 1,
     };
-    const token = jwt.sign(payload, callifiedSecret, { algorithm: "HS256", expiresIn: 1800 });
+    const token = jwt.sign(payload, callifiedSecret, {
+      algorithm: "HS256",
+      expiresIn: 1800,
+    });
 
-    const callifiedBaseUrl = process.env.CALLIFIED_DASHBOARD_URL || settings.dashboardUrl || "http://localhost:8001/api/auth/sso/jwt";
+    const callifiedBaseUrl =
+      process.env.CALLIFIED_DASHBOARD_URL ||
+      settings.dashboardUrl ||
+      "http://localhost:8001/api/auth/sso/jwt";
     const redirect = settings.redirectPath || "/crm";
     const authUrl = `${callifiedBaseUrl}?token=${encodeURIComponent(token)}&redirect=${encodeURIComponent(redirect)}`;
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -178,6 +178,9 @@ const WellnessLeave = lazy(() => import("./pages/wellness/Leave"));
 const WellnessPointOfSale = lazy(() => import("./pages/wellness/PointOfSale"));
 // Public customer-facing survey page (no admin chrome — see /survey/:id route below)
 const SurveyPublic = lazy(() => import("./pages/SurveyPublic"));
+// Public customer-facing knowledge-base article view (no auth, no admin chrome).
+// Replaces the raw-JSON backend response that the KB "View" button used to open.
+const KbArticleView = lazy(() => import("./pages/KbArticleView"));
 // #341: global catch-all 404. Previously unmapped or wrong-prefix URLs
 // (e.g. /loyalty without /wellness/) rendered a blank <main> with HTTP 200
 // because the SPA layout served but nothing inside it matched.
@@ -553,6 +556,12 @@ export default function App() {
                   />
                   {/* #184: customer-facing survey landing page from SMS — no auth, no admin chrome */}
                   <Route path="/survey/:id" element={<SurveyPublic />} />
+                  {/* Public knowledge-base article view (no auth). Replaces the raw
+                      backend JSON URL that the KB "View" button used to open. */}
+                  <Route
+                    path="/kb/:tenantSlug/:slug"
+                    element={<KbArticleView />}
+                  />
                   {/* #240: unauthenticated visitors to `/` should land on /login, not the
                 marketing Landing page. The Landing component is still importable
                 for any explicit /landing CTA but is no longer the implicit root. */}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -95,6 +95,7 @@ const Sidebar = ({
   const role = user?.role || "USER";
   const isAdmin = role === "ADMIN";
   const isManager = role === "ADMIN" || role === "MANAGER";
+  const wellnessRole = user?.wellnessRole || null;
   const isWellness = tenant?.vertical === "wellness";
   const location = useLocation();
 
@@ -343,9 +344,13 @@ const Sidebar = ({
     const tail = current[target.length];
     return tail === "/" || tail === undefined;
   };
-  const Link = ({ to, icon: Icon, label, adminOnly, managerOnly, count, matchPaths = [] }) => {
+  const Link = ({ to, icon: Icon, label, adminOnly, managerOnly, wellnessRoles, count, matchPaths = [] }) => {
     if (adminOnly && !isAdmin) return null;
     if (managerOnly && !isManager) return null;
+    // wellnessRoles gates a link to specific wellnessRole values. Managers
+    // and admins always pass through (mirrors the server's verifyWellnessRole
+    // gate which whitelists admin/manager alongside the named clinical roles).
+    if (wellnessRoles && !isManager && !wellnessRoles.includes(wellnessRole)) return null;
     return (
       <NavLink
         to={to}
@@ -720,10 +725,17 @@ function renderWellnessNav({
         icon={MessageSquare}
         label="WhatsApp Threads"
       />
+      {/* Telecaller Queue: visible to wellnessRole=telecaller and to
+          managers/admins for oversight. Plain users (and clinical staff
+          without the telecaller wellnessRole) saw a 403 toast on every
+          load, so the link is hidden for them — matches the server's
+          verifyWellnessRole(["telecaller","admin","manager"]) gate on
+          /api/wellness/telecaller/queue + /telecaller/dispose. */}
       <Link
         to="/wellness/telecaller"
         icon={PhoneCall}
         label="Telecaller Queue"
+        wellnessRoles={["telecaller"]}
       />
       <Link
         to="/leads"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,7 @@
   --text-primary: #ffffff;
   --text-secondary: #d1d5db;
   --accent-color: #3b82f6;
+  --accent-bg: rgba(59, 130, 246, 0.15);
   --accent-glow: rgba(59, 130, 246, 0.5);
   --accent-hover: #60a5fa;
   --success-color: #10b981;
@@ -47,6 +48,7 @@
   --text-primary: #1a1a2e;
   --text-secondary: #4b5563;
   --accent-color: #2563eb;
+  --accent-bg: #f0f4ff;
   --accent-glow: rgba(37, 99, 235, 0.3);
   --accent-hover: #3b82f6;
   --success-color: #059669;
@@ -83,6 +85,7 @@
   --text-primary: #ffffff;
   --text-secondary: #d1d5db;
   --accent-color: #3b82f6;
+  --accent-bg: rgba(59, 130, 246, 0.15);
   --accent-glow: rgba(59, 130, 246, 0.5);
   --accent-hover: #60a5fa;
   --success-color: #10b981;
@@ -402,6 +405,41 @@ input.input-field:focus-visible,
 textarea.input-field:focus-visible,
 select.input-field:focus-visible {
   outline: none;
+}
+
+/* ── Native <select> dropdown dark-mode support ──────────────────────────
+ * Without an explicit color-scheme, Chrome/Edge on Windows render the OS
+ * <option> popup with the system light palette regardless of how the
+ * <select> itself is styled — leaving near-invisible white-on-white text
+ * in dark mode (Chatbots flow-node picker, A/B Tests campaign dropdown,
+ * Custom Reports entity/filter/group selects). Three layers ensure the
+ * fix lands across Chrome/Edge/Firefox on every OS:
+ *   1) color-scheme on the document root → native widgets use the matching
+ *      palette where the browser honors it.
+ *   2) color-scheme directly on every <select> → some Chrome builds only
+ *      honor it at the element level, not the root.
+ *   3) explicit option/optgroup background-color + color via CSS vars
+ *      with !important → fallback that wins over any inline overrides
+ *      (e.g. `style={{ color: 'inherit' }}` on the select). */
+:root,
+[data-theme="dark"] {
+  color-scheme: dark;
+}
+[data-theme="light"] {
+  color-scheme: light;
+}
+
+[data-theme="dark"] select {
+  color-scheme: dark;
+}
+[data-theme="light"] select {
+  color-scheme: light;
+}
+
+select option,
+select optgroup {
+  background-color: var(--bg-color) !important;
+  color: var(--text-primary) !important;
 }
 
 .nav-link {

--- a/frontend/src/pages/DealInsights.jsx
+++ b/frontend/src/pages/DealInsights.jsx
@@ -44,7 +44,6 @@ export default function DealInsights() {
   // isMissing=true). Removing the broken fallback eliminates the regression
   // class entirely.
   const [openDealCount, setOpenDealCount] = useState(0);
-  const [openDealIds, setOpenDealIds] = useState([]);
   const [openDeals, setOpenDeals] = useState([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
@@ -76,12 +75,11 @@ export default function DealInsights() {
         }
       }
       setOpenDealCount(count);
-      // openDeals stores the full deal objects for the OPEN_DEALS view.
-      // openDealIds is just the IDs for the bulk-generate button.
+      // openDeals stores the full deal objects for both the OPEN_DEALS view
+      // and the bulk-generate button's per-deal POST loop.
       const sample = Array.isArray(openSampleRaw) ? openSampleRaw : [];
       const openOnly = sample.filter(d => d.stage !== 'won' && d.stage !== 'lost');
       setOpenDeals(openOnly);
-      setOpenDealIds(openOnly.map(d => d.id));
     } catch (e) {
       console.error(e);
     } finally {
@@ -142,7 +140,7 @@ export default function DealInsights() {
   const generateForAll = async () => {
     setGenerating(true);
     try {
-      const targets = openDealIds.slice(0, 50); // safety cap
+      const targets = openDeals.slice(0, 50); // safety cap
       let success = 0;
       let failed = 0;
       for (const d of targets) {
@@ -192,7 +190,7 @@ export default function DealInsights() {
         </div>
         <button
           onClick={generateForAll}
-          disabled={generating || openDealIds.length === 0}
+          disabled={generating || openDeals.length === 0}
           className="btn-primary"
           style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', opacity: generating ? 0.7 : 1 }}
         >

--- a/frontend/src/pages/Inbox.jsx
+++ b/frontend/src/pages/Inbox.jsx
@@ -333,7 +333,7 @@ export default function Inbox() {
           </button>
           {/* #594 — Compose WhatsApp affordance. Pre-fix the WhatsApp tab
               had no way to start a new outbound thread. */}
-          <button onClick={() => setShowComposeWa(true)} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <button onClick={() => setShowComposeWa(true)} className="btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', background: 'rgba(37, 211, 102, 0.15)', border: '1px solid #25D366', color: '#25D366' }}>
             <MessageCircle size={18} /> Compose WhatsApp
           </button>
           <button onClick={() => setShowCompose(true)} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -857,7 +857,7 @@ export default function Inbox() {
               </div>
               <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '1rem', gap: '1rem' }}>
                 <button type="button" onClick={() => { setShowComposeWa(false); setComposeWaData({ to: '', body: '' }); }} style={{ background: 'transparent', color: 'var(--text-secondary)', border: 'none', cursor: 'pointer', fontWeight: '500' }}>Discard</button>
-                <button type="submit" disabled={waSending} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <button type="submit" disabled={waSending} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', background: '#25D366', borderColor: '#25D366' }}>
                   <Send size={16} /> {waSending ? 'Sending…' : 'Send WhatsApp'}
                 </button>
               </div>

--- a/frontend/src/pages/Inbox.jsx
+++ b/frontend/src/pages/Inbox.jsx
@@ -333,7 +333,7 @@ export default function Inbox() {
           </button>
           {/* #594 — Compose WhatsApp affordance. Pre-fix the WhatsApp tab
               had no way to start a new outbound thread. */}
-          <button onClick={() => setShowComposeWa(true)} className="btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', background: 'rgba(37, 211, 102, 0.15)', border: '1px solid #25D366', color: '#25D366' }}>
+          <button onClick={() => setShowComposeWa(true)} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <MessageCircle size={18} /> Compose WhatsApp
           </button>
           <button onClick={() => setShowCompose(true)} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -857,7 +857,7 @@ export default function Inbox() {
               </div>
               <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '1rem', gap: '1rem' }}>
                 <button type="button" onClick={() => { setShowComposeWa(false); setComposeWaData({ to: '', body: '' }); }} style={{ background: 'transparent', color: 'var(--text-secondary)', border: 'none', cursor: 'pointer', fontWeight: '500' }}>Discard</button>
-                <button type="submit" disabled={waSending} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', background: '#25D366', borderColor: '#25D366' }}>
+                <button type="submit" disabled={waSending} className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <Send size={16} /> {waSending ? 'Sending…' : 'Send WhatsApp'}
                 </button>
               </div>

--- a/frontend/src/pages/KbArticleView.jsx
+++ b/frontend/src/pages/KbArticleView.jsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { BookOpen, ArrowLeft, Eye, Calendar, FolderTree } from "lucide-react";
+import { formatDate } from "../utils/date";
+
+// Lightweight markdown renderer covering the subset we use in KB articles
+// (## / ### headers, - lists, **bold**, paragraphs). Avoids pulling in a
+// full markdown dep for one page.
+function renderInline(text, keyPrefix = "") {
+  const parts = String(text).split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return <strong key={`${keyPrefix}-b-${i}`}>{part.slice(2, -2)}</strong>;
+    }
+    return <React.Fragment key={`${keyPrefix}-t-${i}`}>{part}</React.Fragment>;
+  });
+}
+
+function renderMarkdown(content) {
+  if (!content) return null;
+  const lines = String(content).split(/\r?\n/);
+  const blocks = [];
+  let listBuffer = [];
+  let paraBuffer = [];
+
+  const flushList = () => {
+    if (listBuffer.length) {
+      blocks.push(
+        <ul
+          key={`ul-${blocks.length}`}
+          style={{
+            margin: "0.5rem 0 1.25rem",
+            paddingLeft: "1.5rem",
+            color: "var(--text-primary)",
+            lineHeight: 1.7,
+          }}
+        >
+          {listBuffer.map((item, i) => (
+            <li key={i} style={{ marginBottom: "0.35rem" }}>
+              {renderInline(item, `li-${blocks.length}-${i}`)}
+            </li>
+          ))}
+        </ul>,
+      );
+      listBuffer = [];
+    }
+  };
+
+  const flushPara = () => {
+    if (paraBuffer.length) {
+      const text = paraBuffer.join(" ");
+      blocks.push(
+        <p
+          key={`p-${blocks.length}`}
+          style={{
+            margin: "0 0 1rem",
+            lineHeight: 1.7,
+            color: "var(--text-primary)",
+          }}
+        >
+          {renderInline(text, `p-${blocks.length}`)}
+        </p>,
+      );
+      paraBuffer = [];
+    }
+  };
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) {
+      flushList();
+      flushPara();
+      continue;
+    }
+    if (line.startsWith("### ")) {
+      flushList();
+      flushPara();
+      blocks.push(
+        <h3
+          key={`h3-${blocks.length}`}
+          style={{
+            fontSize: "1.15rem",
+            fontWeight: 600,
+            margin: "1.5rem 0 0.6rem",
+            color: "var(--text-primary)",
+          }}
+        >
+          {renderInline(line.slice(4), `h3-${blocks.length}`)}
+        </h3>,
+      );
+    } else if (line.startsWith("## ")) {
+      flushList();
+      flushPara();
+      blocks.push(
+        <h2
+          key={`h2-${blocks.length}`}
+          style={{
+            fontSize: "1.4rem",
+            fontWeight: 700,
+            margin: "1.75rem 0 0.75rem",
+            color: "var(--text-primary)",
+            borderBottom: "1px solid var(--border-color)",
+            paddingBottom: "0.4rem",
+          }}
+        >
+          {renderInline(line.slice(3), `h2-${blocks.length}`)}
+        </h2>,
+      );
+    } else if (line.startsWith("# ")) {
+      flushList();
+      flushPara();
+      blocks.push(
+        <h1
+          key={`h1-${blocks.length}`}
+          style={{
+            fontSize: "1.7rem",
+            fontWeight: 700,
+            margin: "1.75rem 0 0.75rem",
+          }}
+        >
+          {renderInline(line.slice(2), `h1-${blocks.length}`)}
+        </h1>,
+      );
+    } else if (line.startsWith("- ") || line.startsWith("* ")) {
+      flushPara();
+      listBuffer.push(line.slice(2));
+    } else {
+      flushList();
+      paraBuffer.push(line);
+    }
+  }
+  flushList();
+  flushPara();
+  return blocks;
+}
+
+export default function KbArticleView() {
+  const { tenantSlug, slug } = useParams();
+  const [article, setArticle] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    fetch(
+      `/api/knowledge-base/public/${encodeURIComponent(tenantSlug)}/article/${encodeURIComponent(slug)}`,
+    )
+      .then(async (r) => {
+        if (cancelled) return;
+        if (r.status === 404) {
+          setError("Article not found or unpublished.");
+          return;
+        }
+        if (!r.ok) {
+          setError("Could not load this article.");
+          return;
+        }
+        const data = await r.json();
+        if (!cancelled) setArticle(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not load this article.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantSlug, slug]);
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg-color)",
+        color: "var(--text-primary)",
+        padding: "2.5rem 1rem",
+      }}
+    >
+      <div style={{ maxWidth: "780px", margin: "0 auto" }}>
+        <Link
+          to="/portal"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
+            color: "var(--text-secondary)",
+            textDecoration: "none",
+            fontSize: "0.875rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          <ArrowLeft size={14} /> Back to help center
+        </Link>
+
+        {loading && (
+          <div
+            style={{
+              padding: "3rem 1rem",
+              textAlign: "center",
+              color: "var(--text-secondary)",
+            }}
+          >
+            Loading article…
+          </div>
+        )}
+
+        {!loading && error && (
+          <div
+            style={{
+              padding: "3rem 1.5rem",
+              textAlign: "center",
+              background: "var(--subtle-bg-2)",
+              border: "1px dashed var(--border-color)",
+              borderRadius: "12px",
+            }}
+          >
+            <BookOpen
+              size={48}
+              style={{
+                opacity: 0.25,
+                margin: "0 auto 1rem",
+                color: "var(--accent-color)",
+              }}
+            />
+            <h2 style={{ marginBottom: "0.4rem" }}>Article unavailable</h2>
+            <p style={{ color: "var(--text-secondary)", margin: 0 }}>{error}</p>
+          </div>
+        )}
+
+        {!loading && !error && article && (
+          <article
+            className="card"
+            style={{
+              padding: "2.25rem 2rem",
+              borderRadius: "12px",
+            }}
+          >
+            <header style={{ marginBottom: "1.5rem" }}>
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.4rem",
+                  padding: "0.25rem 0.7rem",
+                  borderRadius: "999px",
+                  background: "rgba(16,185,129,0.1)",
+                  color: "#10b981",
+                  border: "1px solid rgba(16,185,129,0.25)",
+                  fontSize: "0.7rem",
+                  fontWeight: 600,
+                  marginBottom: "1rem",
+                }}
+              >
+                <FolderTree size={12} /> Knowledge Base
+              </div>
+              <h1
+                style={{
+                  fontSize: "2rem",
+                  fontWeight: 700,
+                  lineHeight: 1.25,
+                  margin: 0,
+                }}
+              >
+                {article.title}
+              </h1>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "1rem",
+                  marginTop: "0.9rem",
+                  color: "var(--text-secondary)",
+                  fontSize: "0.8rem",
+                }}
+              >
+                {article.updatedAt && (
+                  <span
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "0.35rem",
+                    }}
+                  >
+                    <Calendar size={13} /> Updated {formatDate(article.updatedAt)}
+                  </span>
+                )}
+                <span
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "0.35rem",
+                  }}
+                >
+                  <Eye size={13} /> {(article.views || 0).toLocaleString()} views
+                </span>
+              </div>
+            </header>
+
+            <div style={{ fontSize: "0.95rem" }}>
+              {renderMarkdown(article.content)}
+              {!String(article.content || "").trim() && (
+                <p
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontStyle: "italic",
+                  }}
+                >
+                  This article has no content yet.
+                </p>
+              )}
+            </div>
+          </article>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/KnowledgeBase.jsx
+++ b/frontend/src/pages/KnowledgeBase.jsx
@@ -194,10 +194,10 @@ export default function KnowledgeBase() {
       tenantSlug = stored?.slug || null;
     } catch (_) { /* malformed JSON — ignore */ }
   }
+  // Frontend article-view page (KbArticleView.jsx). Previously linked directly
+  // to the backend JSON endpoint which dumped raw response in the browser.
   const publicArticleUrl = (slug) =>
-    tenantSlug
-      ? `${window.location.origin.replace(':5173', ':5000')}/api/knowledge-base/public/${tenantSlug}/article/${slug}`
-      : '#';
+    tenantSlug ? `/kb/${tenantSlug}/${slug}` : '#';
 
   return (
     <div


### PR DESCRIPTION
[x] Added a new public Knowledge Base article view page with inline markdown rendering, loading/error states, metadata chips, and customer-facing article navigation.
[x] Added a lazy-loaded public /kb/:tenantSlug/:slug route without auth/admin layout dependencies.
[x] Updated Knowledge Base “View” action to open the frontend article page instead of exposing raw backend JSON responses.
[x] Added Telecaller Queue sidebar role gating based on wellnessRole to align frontend visibility with backend access control rules.
[x] Fixed native <select> dropdown dark mode rendering issues across browsers using explicit color-scheme and option styling rules.
[x] Added new --accent-bg CSS variable support across all theme variants.
[x] Cleaned up DealInsights.jsx by removing redundant openDealIds state and using a single source of truth for open deals.
[x] Updated Inbox WhatsApp action buttons to use standard btn-primary styling for UI consistency.
[x] Reformatted backend/routes/integrations.js using Prettier without any functional changes.