### PR TITLE
feat: add granular RBAC system, roles management UI, and customer sel…

### DIFF
--- a/backend/middleware/requirePermission.js
+++ b/backend/middleware/requirePermission.js
@@ -28,17 +28,31 @@ const CACHE_TTL_MS = 30_000; // 30 seconds
  */
 async function loadUserPermissions(tenantId, userId) {
   try {
-    // Find all roles assigned to this user via UserRole junction table
+    // Find all roles assigned to this user via UserRole junction table.
+    //
+    // FIX: Prisma's `include` on a to-one relation (UserRole→Role via roleId)
+    // does NOT accept a `where` clause — that's a `findMany`-only feature
+    // and is rejected by the validator with PrismaClientValidationError
+    // ("Unknown argument 'where'"). The previous shape silently threw on
+    // every authed non-OWNER call and surfaced as a 500 on the
+    // /api/auth/me/permissions endpoint.
+    //
+    // Tenant scoping is now done via a nested relation filter on the
+    // top-level `where`: Prisma joins UserRole→Role and filters on Role's
+    // tenantId. Same semantic (tenant-scoped roles for this tenant, plus
+    // platform-level OWNER roles where tenantId is null), validator-clean.
     const userRoles = await prisma.userRole.findMany({
-      where: { userId },
+      where: {
+        userId,
+        role: {
+          OR: [
+            { tenantId: tenantId },  // Tenant-scoped roles
+            { tenantId: null },      // Platform-level roles (e.g., OWNER)
+          ],
+        },
+      },
       include: {
         role: {
-          where: {
-            OR: [
-              { tenantId: tenantId },  // Tenant-scoped roles
-              { tenantId: null },      // Platform-level roles (e.g., OWNER)
-            ],
-          },
           include: { permissions: true },
         },
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,9 @@
     "lint:fix": "eslint . --fix",
     "lint:strict": "eslint lib middleware services utils test --max-warnings 0",
     "audit:check": "node scripts/check-audit.js",
-    "audit:verify": "node scripts/verify-audit-chain.js"
+    "audit:verify": "node scripts/verify-audit-chain.js",
+    "db:sync": "node scripts/sync-schema.js",
+    "db:sync:check": "node scripts/sync-schema.js --check"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,110 @@
+/**
+ * /api/users — user-scoped read endpoints.
+ *
+ * Today this file exposes a single endpoint: GET /:userId/permissions, which
+ * returns the merged RBAC permissions for a *target* user (not the caller).
+ * It's the per-target sister of /api/auth/me/permissions.
+ *
+ * Guards:
+ *  - verifyToken: must be authenticated
+ *  - requirePermission('roles', 'read'): only users with the roles.read grant
+ *    (typically ADMIN, or OWNER who short-circuits everything) can view
+ *    another user's permissions
+ *  - same-tenant check: a non-OWNER caller can only view users in their own
+ *    tenant. OWNER (isOwner=true) can view any user across tenants.
+ *
+ * Response shape: same as /api/auth/me/permissions, extended with `user` so
+ * the StaffPermissions page can render account/email/role tiles in one trip.
+ */
+
+const express = require('express');
+const router = express.Router();
+const prisma = require('../lib/prisma');
+const { verifyToken } = require('../middleware/auth');
+const {
+  requirePermission,
+  getUserPermissions,
+} = require('../middleware/requirePermission');
+
+router.get(
+  '/:userId/permissions',
+  verifyToken,
+  requirePermission('roles', 'read'),
+  async (req, res) => {
+    try {
+      const userId = parseInt(req.params.userId, 10);
+      if (!Number.isFinite(userId) || userId <= 0) {
+        return res.status(400).json({ error: 'Invalid userId' });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          wellnessRole: true,
+          userType: true,
+          tenantId: true,
+          createdAt: true,
+          deactivatedAt: true,
+        },
+      });
+
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      // Same-tenant guard — OWNER bypasses because they're not tenant-scoped.
+      // An ADMIN in tenant A cannot look up a user in tenant B; that would be
+      // a cross-tenant info leak about who works at the other org.
+      if (!req.user.isOwner && user.tenantId !== req.user.tenantId) {
+        return res.status(403).json({
+          error: 'Cross-tenant access denied',
+          code: 'CROSS_TENANT_DENIED',
+        });
+      }
+
+      // Target user is OWNER → mirror /auth/me/permissions short-circuit.
+      // OWNER bypasses every permission gate at the middleware layer, so
+      // returning an explicit permissions array would be misleading; report
+      // it as the platform-owner condition instead.
+      if (user.userType === 'OWNER') {
+        return res.json({
+          isOwner: true,
+          userType: 'OWNER',
+          roles: ['OWNER'],
+          permissions: [],
+          user,
+        });
+      }
+
+      // Load merged permissions for the TARGET user via the same helper that
+      // backs /auth/me/permissions. This guarantees the two endpoints stay
+      // in lock-step — if the merge logic changes, both endpoints change.
+      const permissions = await getUserPermissions(user.tenantId, user.id);
+      const permissionArray = Array.from(permissions).sort();
+
+      // Role names for the "Assigned roles" pill row in the UI.
+      const userRoles = await prisma.userRole.findMany({
+        where: { userId: user.id },
+        include: { role: { select: { key: true } } },
+      });
+      const roleNames = userRoles.map((ur) => ur.role?.key).filter(Boolean);
+
+      return res.json({
+        isOwner: false,
+        userType: user.userType || 'STAFF',
+        roles: roleNames,
+        permissions: permissionArray,
+        user,
+      });
+    } catch (err) {
+      console.error('[users/:userId/permissions] error:', err);
+      return res.status(500).json({ error: 'Failed to fetch user permissions' });
+    }
+  },
+);
+
+module.exports = router;

--- a/backend/scripts/seed-rbac-only.js
+++ b/backend/scripts/seed-rbac-only.js
@@ -1,0 +1,307 @@
+/**
+ * Targeted, idempotent RBAC seed.
+ *
+ * Why this exists: `prisma/seed.js` TRUNCATEs the whole database before
+ * re-seeding. If you have local data you want to keep (real contacts,
+ * in-progress test data, anything not in the seed file), running the full
+ * seed wipes it. This script ONLY touches:
+ *   - Role
+ *   - RolePermission
+ *   - UserRole
+ * ...and is safe to re-run any number of times. It uses lookup-then-create
+ * (no TRUNCATE, no upsert that could clobber custom rows).
+ *
+ * Run with: `node scripts/seed-rbac-only.js` from the backend/ directory.
+ *
+ * What it does:
+ *  1. For every tenant in the DB: ensure ADMIN / MANAGER / CUSTOMER / USER
+ *     system roles exist (matches prisma/seed.js:898-1083).
+ *  2. Ensure the platform-level OWNER role exists (tenantId = null).
+ *  3. Grant ADMIN every permission in PERMISSION_CATALOG; grant MANAGER /
+ *     CUSTOMER / USER the curated subsets that match the main seed.
+ *  4. For every User with userType=OWNER: assign OWNER role.
+ *  5. For every other User: assign the role matching User.role
+ *     (ADMIN / MANAGER / USER). Users with role outside that set are
+ *     skipped — wellness-specific roles (doctor/professional/etc.) live
+ *     on User.wellnessRole and are out of scope here.
+ *
+ * Output is a short summary of what was created vs. what already existed.
+ */
+
+const prisma = require('../lib/prisma');
+const { PERMISSION_CATALOG } = require('../lib/permissionCatalog');
+
+// Curated permission subsets — mirror prisma/seed.js exactly so this stays
+// consistent with the canonical seed when someone runs that on a fresh DB.
+const MANAGER_PERMISSIONS = [
+  'contacts.read', 'contacts.write', 'contacts.update',
+  'deals.read', 'deals.write', 'deals.update',
+  'leads.read', 'leads.write', 'leads.update', 'leads.delete', 'leads.export',
+  'tasks.read', 'tasks.write', 'tasks.update',
+  'projects.read', 'projects.write', 'projects.update',
+  'pipeline.read', 'pipeline.write', 'pipeline.update',
+  'quotes.read', 'quotes.write', 'quotes.update',
+  'reports.read', 'reports.export',
+  'dashboards.read',
+  'analytics.read', 'analytics.export',
+  'billing.read',
+  'staff.read',
+  'communications.read', 'communications.write',
+  'email.read', 'email.write',
+  'sms.read', 'sms.write',
+  'marketing.read', 'marketing.write', 'marketing.update',
+  'tickets.read', 'tickets.write', 'tickets.update',
+  'surveys.read', 'surveys.write', 'surveys.update',
+  'documents.read', 'documents.write', 'documents.update',
+  'contracts.read', 'contracts.write', 'contracts.update',
+  'estimates.read', 'estimates.write', 'estimates.update', 'estimates.export',
+];
+
+const CUSTOMER_PERMISSIONS = [
+  'appointments.read',
+  'services.read',
+  'billing.read',
+  'documents.read',
+  'prescriptions.read',
+  'consents.read',
+];
+
+const USER_PERMISSIONS = [
+  'contacts.read',
+  'deals.read',
+  'leads.read',
+  'tasks.read',
+  'projects.read',
+  'pipeline.read',
+  'quotes.read',
+  'reports.read',
+  'dashboards.read',
+  'analytics.read',
+  'communications.read',
+  'email.read',
+  'sms.read',
+  'tickets.read',
+  'surveys.read',
+  'documents.read',
+  'contracts.read',
+  'estimates.read',
+];
+
+// Counters for the end-of-run summary.
+const stats = {
+  rolesCreated: 0,
+  rolesExisting: 0,
+  permsCreated: 0,
+  permsExisting: 0,
+  assignmentsCreated: 0,
+  assignmentsExisting: 0,
+  usersSkipped: 0,
+};
+
+// Lookup-then-create for Role. The schema's @@unique([tenantId, key]) lets
+// us key on (tenantId, key). MySQL treats NULL as distinct in unique
+// constraints, so OWNER (tenantId=null) needs a separate lookup path that
+// doesn't go through the compound unique.
+async function ensureRole({ tenantId, key, name, description, isSystem, userType }) {
+  const existing = await prisma.role.findFirst({
+    where: { tenantId: tenantId, key },
+  });
+  if (existing) {
+    stats.rolesExisting++;
+    return existing;
+  }
+  const created = await prisma.role.create({
+    data: { tenantId, key, name, description, isSystem, isActive: true, userType },
+  });
+  stats.rolesCreated++;
+  console.log(`  + Role created: tenant=${tenantId ?? 'null'} key=${key} (id=${created.id})`);
+  return created;
+}
+
+// RolePermission has @@unique([roleId, module, action]) so we can rely on
+// that to deduplicate. Use findFirst → create rather than upsert because
+// upsert wants the unique key in a specific compound shape and the existing
+// rows have everything we need already.
+async function ensureRolePermission(roleId, module, action) {
+  const existing = await prisma.rolePermission.findFirst({
+    where: { roleId, module, action },
+  });
+  if (existing) {
+    stats.permsExisting++;
+    return existing;
+  }
+  const created = await prisma.rolePermission.create({
+    data: { roleId, module, action },
+  });
+  stats.permsCreated++;
+  return created;
+}
+
+async function ensureUserRole(userId, roleId) {
+  const existing = await prisma.userRole.findFirst({
+    where: { userId, roleId },
+  });
+  if (existing) {
+    stats.assignmentsExisting++;
+    return existing;
+  }
+  const created = await prisma.userRole.create({
+    data: { userId, roleId },
+  });
+  stats.assignmentsCreated++;
+  return created;
+}
+
+async function grantAllPermissions(roleId) {
+  for (const [module, actions] of Object.entries(PERMISSION_CATALOG)) {
+    for (const action of actions) {
+      await ensureRolePermission(roleId, module, action);
+    }
+  }
+}
+
+async function grantPermissionList(roleId, perms) {
+  for (const perm of perms) {
+    const [module, action] = perm.split('.');
+    if (!module || !action) continue;
+    await ensureRolePermission(roleId, module, action);
+  }
+}
+
+async function seedOwnerRole() {
+  const ownerRole = await ensureRole({
+    tenantId: null,
+    key: 'OWNER',
+    name: 'Platform Owner',
+    description: 'Unrestricted access across all organizations',
+    isSystem: true,
+    userType: 'OWNER',
+  });
+  // OWNER short-circuits permission checks at the middleware level (see
+  // requirePermission.js), so we deliberately do NOT grant the OWNER role
+  // any permission rows. Leaving it empty matches prisma/seed.js.
+  return ownerRole;
+}
+
+async function seedTenantRoles(tenantId) {
+  console.log(`\n=== tenant=${tenantId} ===`);
+
+  const adminRole = await ensureRole({
+    tenantId,
+    key: 'ADMIN',
+    name: 'Admin',
+    description: 'Full access to all features within the organization',
+    isSystem: true,
+    userType: 'STAFF',
+  });
+  await grantAllPermissions(adminRole.id);
+
+  const managerRole = await ensureRole({
+    tenantId,
+    key: 'MANAGER',
+    name: 'Manager',
+    description: 'Manager role with broad staff access',
+    isSystem: false,
+    userType: 'STAFF',
+  });
+  await grantPermissionList(managerRole.id, MANAGER_PERMISSIONS);
+
+  const customerRole = await ensureRole({
+    tenantId,
+    key: 'CUSTOMER',
+    name: 'Customer',
+    description: 'Customer access to booking and appointments only',
+    isSystem: true,
+    userType: 'CUSTOMER',
+  });
+  await grantPermissionList(customerRole.id, CUSTOMER_PERMISSIONS);
+
+  const userRole = await ensureRole({
+    tenantId,
+    key: 'USER',
+    name: 'User',
+    description: 'Basic user role with limited CRM access',
+    isSystem: false,
+    userType: 'STAFF',
+  });
+  await grantPermissionList(userRole.id, USER_PERMISSIONS);
+
+  return { adminRole, managerRole, customerRole, userRole };
+}
+
+async function assignUsersForTenant(tenantId, roles) {
+  const users = await prisma.user.findMany({ where: { tenantId } });
+  for (const u of users) {
+    // OWNER users get the platform-level OWNER role (handled separately).
+    if (u.userType === 'OWNER') continue;
+
+    const legacy = String(u.role || '').toUpperCase();
+    let target = null;
+    if (legacy === 'ADMIN') target = roles.adminRole;
+    else if (legacy === 'MANAGER') target = roles.managerRole;
+    else if (legacy === 'USER') target = roles.userRole;
+    else if (u.userType === 'CUSTOMER') target = roles.customerRole;
+
+    if (!target) {
+      stats.usersSkipped++;
+      console.log(`  · Skipped user id=${u.id} email=${u.email} (legacy role=${legacy || 'none'}) — no matching RBAC role`);
+      continue;
+    }
+
+    const before = stats.assignmentsCreated;
+    await ensureUserRole(u.id, target.id);
+    if (stats.assignmentsCreated > before) {
+      console.log(`  + Assigned user id=${u.id} email=${u.email} -> role.key=${target.key}`);
+    }
+  }
+}
+
+async function assignOwnerUsers(ownerRole) {
+  const owners = await prisma.user.findMany({
+    where: { userType: 'OWNER' },
+  });
+  for (const u of owners) {
+    const before = stats.assignmentsCreated;
+    await ensureUserRole(u.id, ownerRole.id);
+    if (stats.assignmentsCreated > before) {
+      console.log(`  + Assigned OWNER user id=${u.id} email=${u.email} -> role.key=OWNER`);
+    }
+  }
+}
+
+async function main() {
+  console.log('Seeding RBAC roles + permissions + user assignments (idempotent)...\n');
+
+  const ownerRole = await seedOwnerRole();
+  console.log(`  · OWNER role id=${ownerRole.id}`);
+  await assignOwnerUsers(ownerRole);
+
+  const tenants = await prisma.tenant.findMany({
+    select: { id: true, name: true, vertical: true },
+    orderBy: { id: 'asc' },
+  });
+  if (tenants.length === 0) {
+    console.log('\nNo tenants found in DB — nothing to seed for tenant-scoped roles.');
+  }
+
+  for (const t of tenants) {
+    const roles = await seedTenantRoles(t.id);
+    await assignUsersForTenant(t.id, roles);
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Roles:           created=${stats.rolesCreated}  existed=${stats.rolesExisting}`);
+  console.log(`Permissions:     created=${stats.permsCreated}  existed=${stats.permsExisting}`);
+  console.log(`User assignments: created=${stats.assignmentsCreated}  existed=${stats.assignmentsExisting}`);
+  console.log(`Users skipped:   ${stats.usersSkipped}`);
+  console.log('\nDone.');
+}
+
+main()
+  .catch((err) => {
+    console.error('FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/scripts/sync-schema.js
+++ b/backend/scripts/sync-schema.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * scripts/sync-schema.js
+ *
+ * Single-shot "is my local DB in sync with prisma/schema.prisma, and if not,
+ * push it" tool.
+ *
+ * Why this exists: the deploy pipeline runs `prisma db push` blind on every
+ * push, but local development often has a stale DB (you pulled new branches,
+ * the schema added models, etc.). Without this, you find out about the
+ * mismatch by reading a "Unknown field" 500 in the browser. This script
+ * gives you `npm run db:sync` instead.
+ *
+ * Distinct from `scripts/check-migration-safety.js` — that one is a CI
+ * risk detector (warns about NOT-NULL adds, column drops, type narrowing).
+ * This script *applies* drift, with a couple of safety rails:
+ *   - `prisma db push` refuses to drop columns/tables on a populated DB
+ *     unless `--accept-data-loss` is passed; we don't pass it by default,
+ *     so a destructive change halts the script and the operator must
+ *     decide.
+ *   - The previous DATABASE_URL value is printed (with the password masked)
+ *     before any change is made.
+ *
+ * Flow:
+ *   1. Load DATABASE_URL from backend/.env via dotenv.
+ *   2. Run `prisma migrate diff --exit-code` to detect drift:
+ *        exit 0 → DB matches schema; nothing to do.
+ *        exit 2 → drift detected; the SQL preview is printed.
+ *        exit 1 → unrecoverable error.
+ *   3. If drifted and --check NOT passed: run `prisma db push --skip-generate`.
+ *   4. Run `prisma generate` so the Prisma client matches the new schema.
+ *      (Often blocked on Windows when the backend is running — see the
+ *      EPERM rename hint in the failure output.)
+ *
+ * Flags:
+ *   --check              Only report drift; do not push. Exit code 2 if
+ *                        drift detected, 0 if not. Useful in CI as a gate.
+ *   --force-data-loss    Pass `--accept-data-loss` to db push. Use only
+ *                        when you know dropping columns/tables on this DB
+ *                        is intentional (e.g. a throwaway dev DB).
+ *   --silent             Suppress informational output. Errors still print.
+ *
+ * Exit codes:
+ *   0 — In sync, OR successfully synced.
+ *   1 — Error (missing env, schema file, or Prisma command failure).
+ *   2 — Drift detected, --check mode only.
+ */
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const BACKEND_ROOT = path.resolve(__dirname, '..');
+const SCHEMA_PATH = path.join(BACKEND_ROOT, 'prisma', 'schema.prisma');
+const ENV_PATH = path.join(BACKEND_ROOT, '.env');
+
+// Load .env explicitly from the backend root so the script can be invoked
+// from any working directory (e.g. `node backend/scripts/sync-schema.js`).
+require('dotenv').config({ path: ENV_PATH });
+
+const args = process.argv.slice(2);
+const CHECK_ONLY = args.includes('--check');
+const FORCE_DATA_LOSS = args.includes('--force-data-loss');
+const SILENT = args.includes('--silent');
+
+function log(...m) {
+  if (!SILENT) console.log(...m);
+}
+function fail(msg, code = 1) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(code);
+}
+function maskUrl(url) {
+  // Replace the password in user:password@host with *** so we don't print
+  // secrets to terminal scrollback / CI logs.
+  return String(url || '').replace(/(:\/\/[^:]+:)[^@]+(@)/, '$1***$2');
+}
+function runPrisma(args, opts = {}) {
+  return spawnSync('npx', ['prisma', ...args], {
+    cwd: BACKEND_ROOT,
+    encoding: 'utf8',
+    // Windows requires shell:true to resolve `npx` from PATH; the same flag
+    // is a no-op on POSIX shells.
+    shell: process.platform === 'win32',
+    ...opts,
+  });
+}
+
+// ── Preflight ─────────────────────────────────────────────────────────────
+
+if (!process.env.DATABASE_URL) {
+  fail(
+    `DATABASE_URL is not set. Looked in ${path.relative(process.cwd(), ENV_PATH)}.`,
+  );
+}
+if (!fs.existsSync(SCHEMA_PATH)) {
+  fail(`prisma/schema.prisma not found at ${SCHEMA_PATH}.`);
+}
+
+log('━━━ Schema sync check ━━━');
+log(`Schema:  ${path.relative(process.cwd(), SCHEMA_PATH)}`);
+log(`Target:  ${maskUrl(process.env.DATABASE_URL)}`);
+log(`Mode:    ${CHECK_ONLY ? 'check (read-only)' : 'apply'}${FORCE_DATA_LOSS ? ' + accept-data-loss' : ''}`);
+log('');
+
+// ── Step 1: detect drift ──────────────────────────────────────────────────
+
+log('[1/3] Detecting drift via `prisma migrate diff`...');
+const diff = runPrisma([
+  'migrate',
+  'diff',
+  '--from-url', process.env.DATABASE_URL,
+  '--to-schema-datamodel', SCHEMA_PATH,
+  '--script',
+  '--exit-code',
+]);
+
+// migrate diff --exit-code semantics (Prisma docs):
+//   0 → no diff
+//   1 → unrecoverable error (auth, connection, malformed schema, ...)
+//   2 → diff detected; stdout contains the SQL preview
+if (diff.status === 0) {
+  log('');
+  log('✓ Database is in sync with prisma/schema.prisma — nothing to do.');
+  process.exit(0);
+}
+
+if (diff.status !== 2) {
+  console.error('\n`prisma migrate diff` failed.');
+  if (diff.stderr) console.error(diff.stderr);
+  if (diff.stdout) console.error(diff.stdout);
+  process.exit(1);
+}
+
+// Status 2 — drift detected.
+log('');
+log('⚠ Drift detected. Migration SQL preview:');
+log('────────────────────────────────────────');
+log((diff.stdout || '').trim() || '(no SQL emitted; check Prisma stderr)');
+log('────────────────────────────────────────');
+
+if (CHECK_ONLY) {
+  log('');
+  log('Run without --check to apply, or use `npm run db:sync` from backend/.');
+  process.exit(2);
+}
+
+// ── Step 2: apply via db push ────────────────────────────────────────────
+
+log('');
+log('[2/3] Applying via `prisma db push --skip-generate`...');
+const pushArgs = ['db', 'push', '--skip-generate'];
+if (FORCE_DATA_LOSS) {
+  pushArgs.push('--accept-data-loss');
+}
+const push = runPrisma(pushArgs, { stdio: 'inherit', encoding: undefined });
+if (push.status !== 0) {
+  console.error('');
+  console.error('`prisma db push` failed.');
+  console.error(
+    'If Prisma refused due to data loss (column/table drop on a populated\n' +
+    'table, type narrowing that would truncate values), back up the DB\n' +
+    'first and then re-run with --force-data-loss.',
+  );
+  process.exit(1);
+}
+
+// ── Step 3: regenerate client ─────────────────────────────────────────────
+
+log('');
+log('[3/3] Regenerating Prisma client (`prisma generate`)...');
+const gen = runPrisma(['generate'], { stdio: 'inherit', encoding: undefined });
+if (gen.status !== 0) {
+  console.error('');
+  console.error('`prisma generate` failed — the DB is synced but the client is stale.');
+  console.error(
+    'On Windows, EPERM rename on query_engine-windows.dll.node usually means\n' +
+    'the backend dev server is still running and is holding the DLL open.\n' +
+    'Stop it (Ctrl+C the `npm run dev` terminal), then re-run `npm run db:sync`.',
+  );
+  process.exit(1);
+}
+
+log('');
+log('✓ Schema synced and Prisma client regenerated.');
+process.exit(0);

--- a/backend/server.js
+++ b/backend/server.js
@@ -310,6 +310,10 @@ io.on("connection", (socket) => {
 // Import Enterprise Routes
 const authRoutes = require("./routes/auth");
 const rolesRoutes = require("./routes/roles");
+// /api/users — per-target user endpoints (currently just :userId/permissions).
+// Sister surface to /api/auth/me/* but addresses ANY user, with same-tenant +
+// roles.read guards inside the handler.
+const usersRoutes = require("./routes/users");
 const contactsRoutes = require("./routes/contacts");
 const dealsRoutes = require("./routes/deals");
 const calendarRoutes = require("./routes/calendar");
@@ -488,6 +492,7 @@ app.param("id", validateNumericId);
 // Map API Endpoints
 app.use("/api/auth", authRoutes);
 app.use("/api/roles", rolesRoutes);
+app.use("/api/users", usersRoutes);
 app.use("/api/contacts", contactsRoutes);
 app.use("/api/deals", dealsRoutes);
 app.use("/api/calendar", calendarRoutes);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -108,10 +108,23 @@ const Social = lazy(() => import("./pages/Social"));
 const Sandbox = lazy(() => import("./pages/Sandbox"));
 const Funnel = lazy(() => import("./pages/Funnel"));
 const Zapier = lazy(() => import("./pages/Zapier"));
+// RBAC: admin role/permission management + per-user effective-permission view.
+// Both are protected behind auth (Layout wrapper) but use page-internal
+// permission checks (usePermissions) rather than RoleGuard wrap so non-ADMIN
+// users granted `roles.read` through RBAC can also reach the page.
+const RolesAdmin = lazy(() => import("./pages/RolesAdmin"));
+const MyPermissions = lazy(() => import("./pages/MyPermissions"));
+// Per-target user permission view at /staff/:userId/permissions. Reuses the
+// MyPermissions visual layout but is driven by a URL param and the
+// /api/users/:userId/permissions endpoint. Page-level gated on roles.read.
+const StaffPermissions = lazy(() => import("./pages/StaffPermissions"));
 // Public pages
 const SsoReturn = lazy(() => import("./pages/SsoReturn"));
 const PaymentSuccess = lazy(() => import("./pages/PaymentSuccess"));
 const PaymentFailed = lazy(() => import("./pages/PaymentFailed"));
+// Self-service customer registration. Creates a User with userType='CUSTOMER'
+// — distinct from the wellness patient portal (OTP-based, /wellness/portal).
+const CustomerRegister = lazy(() => import("./pages/CustomerRegister"));
 // Wellness vertical
 const WellnessOwnerDashboard = lazy(
   () => import("./pages/wellness/OwnerDashboard"),
@@ -530,6 +543,10 @@ export default function App() {
                     path="/signup"
                     element={!token ? <Signup /> : <Navigate to="/dashboard" />}
                   />
+                  <Route
+                    path="/customer/register"
+                    element={!token ? <CustomerRegister /> : <Navigate to="/portal" />}
+                  />
                   <Route path="/sso/return" element={<SsoReturn />} />
                   <Route path="/pricing" element={<Pricing />} />
                   <Route path="/payment-success" element={<PaymentSuccess />} />
@@ -684,8 +701,25 @@ export default function App() {
                         </RoleGuard>
                       }
                     />
+                    {/* Per-target user permission view. Route is auth-only;
+                        the page rechecks roles.read so non-admin admins
+                        with the RBAC grant can also reach it, and so a
+                        cross-tenant userId hits the backend's tenant guard
+                        rather than a frontend allow-list. */}
+                    <Route
+                      path="staff/:userId/permissions"
+                      element={<StaffPermissions />}
+                    />
                     <Route path="profile" element={<Profile />} />
                     <Route path="profile/2fa" element={<Profile2FA />} />
+                    {/* RBAC: every authed user can view their own effective
+                        permissions. Page is read-only and not gated. */}
+                    <Route path="profile/permissions" element={<MyPermissions />} />
+                    {/* RBAC: role + permission admin. Route is auth-only; the
+                        page renders <AccessDenied /> for users without
+                        roles.read so non-ADMIN admins with the RBAC grant can
+                        still reach it. */}
+                    <Route path="settings/roles" element={<RolesAdmin />} />
                     <Route path="notification-settings" element={<UserSettings />} />
                     {/* #589: Audit Log is ADMIN-only (mirrors Sidebar's
                         adminOnly visibility + the "System Admin Required"

--- a/frontend/src/components/AccessDenied.jsx
+++ b/frontend/src/components/AccessDenied.jsx
@@ -1,0 +1,84 @@
+import { Lock } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+// In-page "you don't have access" empty state for permission-gated routes
+// and page-level guards. Mirrors RoleGuard's <LockedPanel> visual language
+// so the user gets a consistent locked-state across legacy role gates and
+// new RBAC permission gates.
+//
+// Usage:
+//   <AccessDenied permission={{ module: 'roles', action: 'read' }} />
+//   <AccessDenied title="Roles" message="Custom copy here" />
+//   <AccessDenied inline />   // narrower, no nav buttons — for in-card use
+export default function AccessDenied({
+  title = "You don't have access to this page",
+  message,
+  permission,
+  showActions = true,
+  inline = false,
+}) {
+  const navigate = useNavigate();
+  const body =
+    message ||
+    (permission
+      ? `This page requires the "${permission.module}.${permission.action}" permission. Contact your administrator to request access.`
+      : 'Contact your administrator to request access.');
+
+  return (
+    <div
+      role="region"
+      aria-label="Access denied"
+      data-testid="access-denied"
+      style={{
+        padding: inline ? '1.5rem 1rem' : '3rem 2rem',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        minHeight: inline ? 'auto' : '60vh',
+        color: 'var(--text-primary)',
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{
+          width: inline ? 48 : 64,
+          height: inline ? 48 : 64,
+          borderRadius: '50%',
+          background: 'var(--subtle-bg-3)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: '1rem',
+        }}
+      >
+        <Lock size={inline ? 22 : 28} aria-hidden="true" />
+      </div>
+      <h2 style={{ fontSize: inline ? '1rem' : '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+        {title}
+      </h2>
+      <p style={{ color: 'var(--text-secondary)', maxWidth: 480, lineHeight: 1.5, margin: 0 }}>
+        {body}
+      </p>
+      {showActions && !inline && (
+        <div style={{ marginTop: '1.5rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            className="btn-primary"
+          >
+            Go to dashboard
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="btn-secondary"
+          >
+            Go back
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RoleGuard.jsx
+++ b/frontend/src/components/RoleGuard.jsx
@@ -164,7 +164,7 @@ function LockedPanel({ feature, rolesText }) {
           width: 64,
           height: 64,
           borderRadius: '50%',
-          background: 'var(--surface-elevated, rgba(0,0,0,0.05))',
+          background: 'var(--subtle-bg-3)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -38,6 +38,7 @@ import {
   PanelTop,
   Calendar,
   Shield,
+  ShieldCheck,
   ScrollText,
   GitBranch,
   TrendingUp,
@@ -77,6 +78,7 @@ import { fetchApi } from "../utils/api";
 import { launchAdsGptAs, ADSGPT_DASHBOARD } from '../utils/adsgpt';
 import { launchCallifiedSSO } from '../utils/callified';
 import { useNotify } from '../utils/notify';
+import { usePermissions } from '../hooks/usePermissions';
 
 // T2.1: focus trap selector. Limited to actually-focusable elements inside the
 // drawer (anchors, buttons, [tabindex]). Used by the focus-trap effect below
@@ -96,6 +98,15 @@ const Sidebar = ({
   const isAdmin = role === "ADMIN";
   const isManager = role === "ADMIN" || role === "MANAGER";
   const wellnessRole = user?.wellnessRole || null;
+  // RBAC: fine-grained permission gate for new sidebar entries. Legacy
+  // adminOnly / managerOnly / wellnessRoles continue to work as before;
+  // requiredPermission stacks on top — only hides an entry once permissions
+  // have RESOLVED (permissionsReady) so admin users don't see a flash of an
+  // empty sidebar during the first 100ms of /auth/me/permissions resolving.
+  const {
+    hasPermission,
+    isReady: permissionsReady,
+  } = usePermissions();
   const isWellness = tenant?.vertical === "wellness";
   const location = useLocation();
 
@@ -344,13 +355,26 @@ const Sidebar = ({
     const tail = current[target.length];
     return tail === "/" || tail === undefined;
   };
-  const Link = ({ to, icon: Icon, label, adminOnly, managerOnly, wellnessRoles, count, matchPaths = [] }) => {
+  const Link = ({ to, icon: Icon, label, adminOnly, managerOnly, wellnessRoles, requiredPermission, count, matchPaths = [] }) => {
     if (adminOnly && !isAdmin) return null;
     if (managerOnly && !isManager) return null;
     // wellnessRoles gates a link to specific wellnessRole values. Managers
     // and admins always pass through (mirrors the server's verifyWellnessRole
     // gate which whitelists admin/manager alongside the named clinical roles).
     if (wellnessRoles && !isManager && !wellnessRoles.includes(wellnessRole)) return null;
+    // RBAC permission gate. Only HIDE once permissions have resolved so admin
+    // users don't see a flash of an empty sidebar during the first frame of
+    // /auth/me/permissions resolving. After the answer arrives, an entry with
+    // `requiredPermission={{module, action}}` is hidden when the user lacks
+    // that grant. Stacks ON TOP of the legacy gates above — if a link sets
+    // both `adminOnly` and `requiredPermission`, both must pass.
+    if (
+      requiredPermission &&
+      permissionsReady &&
+      !hasPermission(requiredPermission.module, requiredPermission.action)
+    ) {
+      return null;
+    }
     return (
       <NavLink
         to={to}
@@ -868,6 +892,14 @@ function renderWellnessNav({
           <Link to="/wellness/inventory-adjustments" icon={Receipt} label="Adjustments" managerOnly />
           <Link to="/wellness/auto-consumption-rules" icon={Recycle} label="Auto-consumption" managerOnly />
           <Link to="/staff" icon={UsersRound} label="Staff" adminOnly />
+          {/* RBAC role + permission admin. Shown to anyone with `roles.read`
+              granted via RBAC (typically ADMIN). The page itself rechecks. */}
+          <Link
+            to="/settings/roles"
+            icon={ShieldCheck}
+            label="Roles"
+            requiredPermission={{ module: 'roles', action: 'read' }}
+          />
           {/* PRD Gap §1.5 / §1.6 — wellness admins also manage payroll. */}
           <Link
             to="/commission-profiles"
@@ -1031,6 +1063,14 @@ function renderGenericNav({
           }}
         >
           <Link to="/staff" icon={UsersRound} label="Staff" adminOnly />
+          {/* RBAC role + permission admin. Shown to anyone with `roles.read`
+              granted via RBAC (typically ADMIN). The page itself rechecks. */}
+          <Link
+            to="/settings/roles"
+            icon={ShieldCheck}
+            label="Roles"
+            requiredPermission={{ module: 'roles', action: 'read' }}
+          />
           <Link to="/audit-log" icon={ScrollText} label="Audit Log" adminOnly />
           <Link to="/privacy" icon={Shield} label="Privacy" adminOnly />
           <Link

--- a/frontend/src/hooks/usePermissions.js
+++ b/frontend/src/hooks/usePermissions.js
@@ -1,0 +1,164 @@
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { AuthContext } from '../App';
+import { fetchApi } from '../utils/api';
+
+// Module-level cache so every consumer of usePermissions in a session shares
+// one fetch. Keyed by the JWT token — a re-login (different user) invalidates
+// automatically because the new token misses the cache key.
+let _cached = null;
+let _cachedToken = null;
+let _inflight = null;
+
+const EMPTY = Object.freeze({
+  isOwner: false,
+  userType: null,
+  roles: [],
+  permissions: [],
+});
+
+function fetchPermissions(token) {
+  if (!token) return Promise.resolve(EMPTY);
+  if (_inflight && _cachedToken === token) return _inflight;
+  _cachedToken = token;
+  _inflight = fetchApi('/api/auth/me/permissions', { silent: true })
+    .then((res) => {
+      _cached = {
+        isOwner: !!res?.isOwner,
+        userType: res?.userType || null,
+        roles: Array.isArray(res?.roles) ? res.roles : [],
+        permissions: Array.isArray(res?.permissions) ? res.permissions : [],
+      };
+      _inflight = null;
+      return _cached;
+    })
+    .catch((err) => {
+      _inflight = null;
+      throw err;
+    });
+  return _inflight;
+}
+
+// Exported for callers that mutate roles/permissions (RolesAdmin) and need
+// every consumer to re-fetch. Pair with the `refresh()` returned by the hook.
+export function invalidatePermissionCache() {
+  _cached = null;
+  _cachedToken = null;
+  _inflight = null;
+}
+
+export function usePermissions() {
+  const auth = useContext(AuthContext) || {};
+  const { token } = auth;
+  const [data, setData] = useState(() =>
+    token && _cachedToken === token && _cached ? _cached : null,
+  );
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(
+    !!token && (_cachedToken !== token || !_cached),
+  );
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!token) {
+      setData(EMPTY);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+    if (_cachedToken === token && _cached) {
+      setData(_cached);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    fetchPermissions(token)
+      .then((res) => {
+        if (!mountedRef.current) return;
+        setData(res);
+        setError(null);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (!mountedRef.current) return;
+        setError(err);
+        // Fail-safe: empty permissions on error so the UI hides protected
+        // features rather than rendering them as if granted.
+        setData(EMPTY);
+        setIsLoading(false);
+      });
+  }, [token]);
+
+  const refresh = useCallback(() => {
+    invalidatePermissionCache();
+    if (!token) return Promise.resolve(EMPTY);
+    setIsLoading(true);
+    return fetchPermissions(token)
+      .then((res) => {
+        if (!mountedRef.current) return res;
+        setData(res);
+        setError(null);
+        setIsLoading(false);
+        return res;
+      })
+      .catch((err) => {
+        if (mountedRef.current) {
+          setError(err);
+          setData(EMPTY);
+          setIsLoading(false);
+        }
+        throw err;
+      });
+  }, [token]);
+
+  const hasPermission = useCallback(
+    (module, action) => {
+      if (!data) return false;
+      if (data.isOwner) return true;
+      const key = `${module}.${action}`;
+      return data.permissions.includes(key);
+    },
+    [data],
+  );
+
+  const hasAllPermissions = useCallback(
+    (list) =>
+      Array.isArray(list) &&
+      list.every(({ module, action }) => hasPermission(module, action)),
+    [hasPermission],
+  );
+
+  const hasAnyPermission = useCallback(
+    (list) =>
+      Array.isArray(list) &&
+      list.some(({ module, action }) => hasPermission(module, action)),
+    [hasPermission],
+  );
+
+  // `isReady` means we have a definitive answer for hasPermission(). Sidebar /
+  // nav filters use this to avoid HIDING items during the first 100ms while
+  // permissions are still resolving — they fall through to the legacy
+  // adminOnly / managerOnly checks until the answer arrives.
+  const isReady = !isLoading && data !== null;
+
+  return {
+    permissions: data?.permissions || [],
+    roles: data?.roles || [],
+    isOwner: data?.isOwner || false,
+    userType: data?.userType || null,
+    isLoading,
+    isReady,
+    error,
+    hasPermission,
+    hasAllPermissions,
+    hasAnyPermission,
+    refresh,
+  };
+}

--- a/frontend/src/pages/CustomerRegister.jsx
+++ b/frontend/src/pages/CustomerRegister.jsx
@@ -1,0 +1,365 @@
+import { useContext, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../App';
+import { setAuthToken } from '../utils/api';
+import { invalidatePermissionCache } from '../hooks/usePermissions';
+
+// Self-service customer registration page (public, no auth required).
+// Backend handler at POST /api/auth/customer/register creates a User row with
+// userType='CUSTOMER' and assigns the tenant's system CUSTOMER role. CUSTOMER
+// users are blocked from staff endpoints by middleware/blockCustomers.js.
+//
+// IMPORTANT: customer registration here is a STAFF-scoped concept — it creates
+// a User row. The wellness patient portal (OTP, phone-only) is a separate auth
+// flow at /wellness/portal and unrelated to this page.
+//
+// Tenant list: the backend doesn't expose a public "list tenants" endpoint, so
+// we hardcode the two demo tenants today. Replace with a /api/public/tenants
+// call once one ships.
+const KNOWN_TENANTS = [
+  { id: 1, name: 'NovaCrest Technologies (Generic CRM)' },
+  { id: 2, name: 'Enhanced Wellness (Wellness Clinic)' },
+];
+
+function passwordStrength(p) {
+  let s = 0;
+  if (p.length >= 8) s += 1;
+  if (/[A-Z]/.test(p)) s += 1;
+  if (/[a-z]/.test(p)) s += 1;
+  if (/[0-9]/.test(p)) s += 1;
+  if (/[^A-Za-z0-9]/.test(p)) s += 1;
+  return s;
+}
+
+export default function CustomerRegister() {
+  const navigate = useNavigate();
+  const { setUser, setToken, setTenant } = useContext(AuthContext);
+
+  const [form, setForm] = useState({
+    email: '',
+    name: '',
+    tenantId: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const [errors, setErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const update = (field) => (e) => setForm({ ...form, [field]: e.target.value });
+  const strength = passwordStrength(form.password);
+  const strengthLabel =
+    strength <= 2 ? 'Weak' : strength === 3 ? 'Fair' : strength === 4 ? 'Good' : 'Strong';
+  const strengthColor =
+    strength <= 2 ? '#ef4444' : strength === 3 ? '#f59e0b' : '#10b981';
+
+  const validate = () => {
+    const e = {};
+    if (!form.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+      e.email = 'Enter a valid email';
+    }
+    if (!form.name.trim()) e.name = 'Full name is required';
+    if (!form.tenantId) e.tenantId = 'Select an organization';
+    if (!form.password || form.password.length < 8) {
+      e.password = 'Password must be at least 8 characters';
+    } else if (!/[A-Za-z]/.test(form.password)) {
+      e.password = 'Password must contain a letter';
+    } else if (!/[0-9]/.test(form.password)) {
+      e.password = 'Password must contain a number';
+    }
+    if (form.password !== form.confirmPassword) {
+      e.confirmPassword = 'Passwords do not match';
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async (ev) => {
+    ev.preventDefault();
+    setSubmitError('');
+    if (!validate()) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/auth/customer/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: form.email.trim().toLowerCase(),
+          password: form.password,
+          name: form.name.trim(),
+          tenantId: parseInt(form.tenantId, 10),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg = String(data?.error || '');
+        if (res.status === 409 || /already/i.test(msg)) {
+          setErrors((prev) => ({ ...prev, email: 'This email is already registered' }));
+        } else if (res.status === 400) {
+          setSubmitError(msg || 'Please check your inputs and try again.');
+        } else {
+          setSubmitError(msg || `Registration failed (${res.status})`);
+        }
+        return;
+      }
+      // Auto-login. Backend returns { token, user, tenant }. Mirror the SSO
+      // and login flow: setAuthToken puts it in the in-memory holder +
+      // sessionStorage; setUser/setTenant write through to AuthContext.
+      if (data?.token) {
+        setAuthToken(data.token);
+        setToken(data.token);
+      }
+      if (data?.user) setUser(data.user);
+      if (data?.tenant) setTenant(data.tenant);
+      invalidatePermissionCache();
+      // /portal is the closest read-only landing for a customer — it's the
+      // public Knowledge Base + support ticket page. The dashboard isn't a
+      // good landing because CUSTOMER userType is blocked from most staff
+      // endpoints; landing on /dashboard would render an empty shell.
+      navigate('/portal');
+    } catch {
+      setSubmitError('Server error. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '2rem 1rem',
+      }}
+    >
+      <div
+        className="glass"
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          padding: '2rem',
+          borderRadius: 12,
+          border: '1px solid var(--border-color)',
+        }}
+      >
+        <h1 style={{ marginBottom: '0.25rem', fontSize: '1.5rem' }}>Create your account</h1>
+        <p
+          style={{
+            color: 'var(--text-secondary)',
+            marginBottom: '1.5rem',
+            fontSize: '0.875rem',
+          }}
+        >
+          Self-service customer registration. Staff members must be invited by an
+          administrator.
+        </p>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <Field label="Email" htmlFor="cr-email" error={errors.email}>
+            <input
+              id="cr-email"
+              type="email"
+              className="input-field"
+              autoComplete="email"
+              value={form.email}
+              onChange={update('email')}
+              disabled={isLoading}
+              required
+            />
+          </Field>
+
+          <Field label="Full name" htmlFor="cr-name" error={errors.name}>
+            <input
+              id="cr-name"
+              type="text"
+              className="input-field"
+              autoComplete="name"
+              value={form.name}
+              onChange={update('name')}
+              disabled={isLoading}
+              required
+            />
+          </Field>
+
+          <Field label="Organization" htmlFor="cr-tenant" error={errors.tenantId}>
+            <select
+              id="cr-tenant"
+              className="input-field"
+              value={form.tenantId}
+              onChange={update('tenantId')}
+              disabled={isLoading}
+              required
+            >
+              <option value="">Select an organization…</option>
+              {KNOWN_TENANTS.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field
+            label="Password"
+            htmlFor="cr-password"
+            error={errors.password}
+            help="At least 8 characters, including a letter and a number."
+          >
+            <input
+              id="cr-password"
+              type="password"
+              className="input-field"
+              autoComplete="new-password"
+              value={form.password}
+              onChange={update('password')}
+              disabled={isLoading}
+              required
+            />
+            {form.password && (
+              <div
+                style={{
+                  marginTop: '0.4rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                }}
+              >
+                <div
+                  style={{
+                    flex: 1,
+                    height: 4,
+                    background: 'var(--border-color)',
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${(strength / 5) * 100}%`,
+                      height: '100%',
+                      background: strengthColor,
+                      transition: 'width 0.15s, background 0.15s',
+                    }}
+                  />
+                </div>
+                <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
+                  {strengthLabel}
+                </span>
+              </div>
+            )}
+          </Field>
+
+          <Field
+            label="Confirm password"
+            htmlFor="cr-confirm"
+            error={errors.confirmPassword}
+          >
+            <input
+              id="cr-confirm"
+              type="password"
+              className="input-field"
+              autoComplete="new-password"
+              value={form.confirmPassword}
+              onChange={update('confirmPassword')}
+              disabled={isLoading}
+              required
+            />
+          </Field>
+
+          {submitError && (
+            <div
+              role="alert"
+              style={{
+                background: 'rgba(239,68,68,0.1)',
+                color: '#ef4444',
+                padding: '0.6rem 0.75rem',
+                borderRadius: 6,
+                fontSize: '0.875rem',
+                marginBottom: '0.75rem',
+              }}
+            >
+              {submitError}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={isLoading}
+            style={{ width: '100%' }}
+          >
+            {isLoading ? 'Creating account…' : 'Create account'}
+          </button>
+        </form>
+
+        <div
+          style={{
+            marginTop: '1rem',
+            textAlign: 'center',
+            fontSize: '0.875rem',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Already have an account?{' '}
+          <Link
+            to="/login"
+            style={{
+              color: 'var(--primary-color, var(--accent-color))',
+              textDecoration: 'none',
+              fontWeight: 500,
+            }}
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, htmlFor, error, help, children }) {
+  return (
+    <div style={{ marginBottom: '0.85rem' }}>
+      <label
+        htmlFor={htmlFor}
+        style={{
+          display: 'block',
+          fontSize: '0.8rem',
+          color: 'var(--text-secondary)',
+          marginBottom: '0.25rem',
+          fontWeight: 500,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+      {help && !error && (
+        <small
+          style={{
+            display: 'block',
+            marginTop: '0.25rem',
+            color: 'var(--text-secondary)',
+            fontSize: '0.7rem',
+          }}
+        >
+          {help}
+        </small>
+      )}
+      {error && (
+        <small
+          role="alert"
+          style={{
+            display: 'block',
+            marginTop: '0.25rem',
+            color: '#ef4444',
+            fontSize: '0.75rem',
+          }}
+        >
+          {error}
+        </small>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -386,6 +386,12 @@ const Login = () => {
             Sign up
           </Link>
         </div>
+        <div style={{ marginTop: '0.5rem', textAlign: 'center', fontSize: '0.8rem' }}>
+          <span style={{ color: 'var(--text-secondary)' }}>Are you a customer? </span>
+          <Link to="/customer/register" style={{ color: 'var(--primary-color, var(--accent-color))', textDecoration: 'none', fontWeight: '500' }}>
+            Create a customer account
+          </Link>
+        </div>
         </>
         )}
       </div>

--- a/frontend/src/pages/MyPermissions.jsx
+++ b/frontend/src/pages/MyPermissions.jsx
@@ -1,0 +1,236 @@
+import { useContext } from 'react';
+import { AuthContext } from '../App';
+import { usePermissions } from '../hooks/usePermissions';
+import AccessDenied from '../components/AccessDenied';
+
+// Read-only display of the current user's effective permissions, merged across
+// all roles. Useful for: (a) the user verifying what they can do, (b) an
+// admin temporarily switching to the user's seat to debug an access issue.
+//
+// Mounts under /profile/permissions. Gated behind `roles.read` — viewing
+// effective-permission listings is an admin tool (it's also how the same
+// page model is reused for /staff/:userId/permissions to view *other*
+// users' permissions). Non-permitted users see the shared AccessDenied
+// card rather than a working page, matching /settings/roles' gating style.
+export default function MyPermissions() {
+  const { user } = useContext(AuthContext) || {};
+  const {
+    permissions,
+    roles,
+    isOwner,
+    userType,
+    isLoading,
+    error,
+    hasPermission,
+    isReady,
+  } = usePermissions();
+  const canRead = hasPermission('roles', 'read');
+
+  // Wait for the permission fetch to resolve before deciding. Without this,
+  // the page would flash AccessDenied for ~one frame on cold-load for users
+  // who DO have the grant — `hasPermission` returns false until isReady.
+  if (!isReady && isLoading) {
+    return (
+      <div style={{ padding: '2rem', color: 'var(--text-secondary)' }}>
+        Loading…
+      </div>
+    );
+  }
+  if (!canRead && !isOwner) {
+    return <AccessDenied permission={{ module: 'roles', action: 'read' }} />;
+  }
+
+  const grouped = groupByModule(permissions);
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: 960 }}>
+      <h1 style={{ marginBottom: '0.25rem' }}>My permissions</h1>
+      <p
+        style={{
+          color: 'var(--text-secondary)',
+          fontSize: '0.875rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        These are your effective permissions, computed from every role assigned
+        to you. Contact your administrator to request more access.
+      </p>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 200px), 1fr))',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <Card label="Account">{user?.email || '—'}</Card>
+        <Card label="User type">{userType || 'STAFF'}</Card>
+        <Card label="Legacy role">{user?.role || '—'}</Card>
+        {user?.wellnessRole && (
+          <Card label="Wellness role">{user.wellnessRole}</Card>
+        )}
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--text-secondary)' }}>Loading permissions…</p>
+      )}
+      {error && !isLoading && (
+        <div
+          role="alert"
+          style={{
+            background: 'rgba(239,68,68,0.1)',
+            color: '#ef4444',
+            padding: '0.75rem',
+            borderRadius: 8,
+            marginBottom: '1rem',
+          }}
+        >
+          Could not load permissions: {error.message}
+        </div>
+      )}
+
+      {!isLoading && (
+        <>
+          <Section title="Assigned roles">
+            {roles.length === 0 ? (
+              <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+                {isOwner
+                  ? 'OWNER — bypasses the role system'
+                  : 'No RBAC roles assigned.'}
+              </p>
+            ) : (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                {roles.map((r) => (
+                  <span
+                    key={r}
+                    style={{
+                      padding: '0.25rem 0.6rem',
+                      borderRadius: 999,
+                      background: 'var(--subtle-bg-3)',
+                      border: '1px solid var(--border-color)',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                    }}
+                  >
+                    {r}
+                  </span>
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Effective permissions">
+            {isOwner ? (
+              <p style={{ color: '#10b981', fontWeight: 500, margin: 0 }}>
+                ✓ Platform admin — full access to every module
+              </p>
+            ) : grouped.length === 0 ? (
+              <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+                No permissions granted.
+              </p>
+            ) : (
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns:
+                    'repeat(auto-fit, minmax(min(100%, 220px), 1fr))',
+                  gap: '0.75rem',
+                }}
+              >
+                {grouped.map(([module, actions]) => (
+                  <div
+                    key={module}
+                    style={{
+                      padding: '0.75rem',
+                      borderRadius: 8,
+                      border: '1px solid var(--border-color)',
+                      background: 'var(--subtle-bg-2)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        color: 'var(--text-secondary)',
+                        marginBottom: '0.4rem',
+                        letterSpacing: '0.04em',
+                      }}
+                    >
+                      {module}
+                    </div>
+                    <ul
+                      style={{
+                        listStyle: 'none',
+                        padding: 0,
+                        margin: 0,
+                        fontSize: '0.85rem',
+                      }}
+                    >
+                      {actions.map((a) => (
+                        <li key={a} style={{ padding: '0.15rem 0' }}>
+                          ✓ {a}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Card({ label, children }) {
+  return (
+    <div
+      style={{
+        padding: '0.65rem 0.85rem',
+        borderRadius: 8,
+        border: '1px solid var(--border-color)',
+        background: 'var(--subtle-bg-2)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.7rem',
+          textTransform: 'uppercase',
+          color: 'var(--text-secondary)',
+          letterSpacing: '0.04em',
+          marginBottom: '0.2rem',
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontWeight: 500, wordBreak: 'break-word' }}>{children}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function groupByModule(permissions) {
+  const map = new Map();
+  (permissions || []).forEach((p) => {
+    const [module, action] = String(p).split('.');
+    if (!module || !action) return;
+    if (!map.has(module)) map.set(module, []);
+    map.get(module).push(action);
+  });
+  for (const [, arr] of map) arr.sort();
+  return Array.from(map.entries()).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+}

--- a/frontend/src/pages/RolesAdmin.jsx
+++ b/frontend/src/pages/RolesAdmin.jsx
@@ -1,0 +1,1084 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Plus, Shield, Trash2, Users, X, UserMinus, UserPlus } from 'lucide-react';
+import { fetchApi } from '../utils/api';
+import { useNotify } from '../utils/notify';
+import { usePermissions, invalidatePermissionCache } from '../hooks/usePermissions';
+import AccessDenied from '../components/AccessDenied';
+
+// Admin UI for the RBAC role + permission system. Mirrors the 12 endpoints
+// under /api/roles (see backend/routes/roles.js). Tenant scoping is enforced
+// server-side — non-OWNER admins only see their own tenant's roles.
+//
+// Permission catalogue: this list is purely cosmetic (what the matrix UI
+// shows as checkboxes). The server is authoritative — adding a row here
+// without a backend route that enforces the permission is a no-op. Pick
+// modules + actions to match the real route surface.
+const PERMISSION_MODULES = [
+  { module: 'contacts',      actions: ['read', 'write', 'update', 'delete', 'export'] },
+  { module: 'deals',         actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'leads',         actions: ['read', 'write', 'update', 'delete', 'export'] },
+  { module: 'tasks',         actions: ['read', 'write', 'update', 'delete'] },
+  { module: 'tickets',       actions: ['read', 'write', 'update', 'delete'] },
+  { module: 'marketing',     actions: ['read', 'write', 'update', 'delete', 'manage'] },
+  { module: 'reports',       actions: ['read', 'write', 'delete', 'export'] },
+  { module: 'billing',       actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'patients',      actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'appointments',  actions: ['read', 'write', 'update', 'delete', 'export'] },
+  { module: 'prescriptions', actions: ['read', 'write', 'update', 'delete'] },
+  { module: 'visits',        actions: ['read', 'write', 'update', 'delete'] },
+  { module: 'inventory',     actions: ['read', 'write', 'update', 'delete', 'manage'] },
+  { module: 'pos',           actions: ['read', 'write', 'manage'] },
+  { module: 'workflows',     actions: ['read', 'write', 'update', 'delete', 'manage'] },
+  { module: 'integrations',  actions: ['read', 'write', 'update', 'delete', 'manage'] },
+  { module: 'audit',         actions: ['read', 'export'] },
+  { module: 'staff',         actions: ['read', 'write', 'update', 'delete', 'manage'] },
+  { module: 'roles',         actions: ['read', 'manage'] },
+  { module: 'settings',      actions: ['read', 'manage'] },
+];
+
+export default function RolesAdmin() {
+  const {
+    hasPermission,
+    isLoading: permLoading,
+    refresh: refreshPermissions,
+  } = usePermissions();
+  const canRead = hasPermission('roles', 'read');
+  const canManage = hasPermission('roles', 'manage');
+
+  const [roles, setRoles] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [permRole, setPermRole] = useState(null);
+  const [usersRole, setUsersRole] = useState(null);
+
+  const notify = useNotify();
+
+  const loadRoles = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetchApi('/api/roles');
+      setRoles(Array.isArray(res?.roles) ? res.roles : []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!permLoading && canRead) loadRoles();
+  }, [permLoading, canRead, loadRoles]);
+
+  if (permLoading) {
+    return (
+      <div style={{ padding: '2rem', color: 'var(--text-secondary)' }}>
+        Loading…
+      </div>
+    );
+  }
+  if (!canRead) {
+    return <AccessDenied permission={{ module: 'roles', action: 'read' }} />;
+  }
+
+  const refreshAll = async () => {
+    invalidatePermissionCache();
+    await Promise.all([refreshPermissions().catch(() => {}), loadRoles()]);
+  };
+
+  const handleDelete = async (role) => {
+    if (
+      !window.confirm(
+        `Delete role "${role.name}"? Users assigned to this role will lose its permissions.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await fetchApi(`/api/roles/${role.id}`, { method: 'DELETE' });
+      notify.success?.(`Role "${role.name}" deleted`);
+      await refreshAll();
+    } catch {
+      // fetchApi already showed a toast; nothing else needed.
+    }
+  };
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: 1200 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '1rem',
+          marginBottom: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div>
+          <h1 style={{ marginBottom: '0.25rem' }}>Roles &amp; permissions</h1>
+          <p
+            style={{
+              color: 'var(--text-secondary)',
+              fontSize: '0.875rem',
+              margin: 0,
+            }}
+          >
+            Manage RBAC roles and their permission grants for this tenant.
+            System roles cannot be modified.
+          </p>
+        </div>
+        {canManage && (
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="btn-primary"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}
+          >
+            <Plus size={16} /> New role
+          </button>
+        )}
+      </div>
+
+      {error && !isLoading && (
+        <div
+          role="alert"
+          style={{
+            background: 'rgba(239,68,68,0.1)',
+            color: '#ef4444',
+            padding: '0.75rem',
+            borderRadius: 8,
+            marginBottom: '1rem',
+          }}
+        >
+          Could not load roles: {error.message}
+        </div>
+      )}
+
+      <div
+        style={{
+          border: '1px solid var(--border-color)',
+          borderRadius: 12,
+          overflow: 'auto',
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: '0.9rem',
+            minWidth: 760,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                background: 'var(--subtle-bg-3)',
+                textAlign: 'left',
+              }}
+            >
+              <Th>Role</Th>
+              <Th>Key</Th>
+              <Th>User type</Th>
+              <Th>Type</Th>
+              <Th>Users</Th>
+              <Th>Permissions</Th>
+              <Th>Actions</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && (
+              <tr>
+                <Td colSpan={7} center>
+                  Loading roles…
+                </Td>
+              </tr>
+            )}
+            {!isLoading && roles.length === 0 && (
+              <tr>
+                <Td colSpan={7} center>
+                  No roles yet.
+                </Td>
+              </tr>
+            )}
+            {!isLoading &&
+              roles.map((r) => (
+                <tr
+                  key={r.id}
+                  style={{ borderTop: '1px solid var(--border-color)' }}
+                >
+                  <Td>
+                    <strong>{r.name}</strong>
+                    {r.description && (
+                      <div
+                        style={{
+                          fontSize: '0.75rem',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {r.description}
+                      </div>
+                    )}
+                  </Td>
+                  <Td>
+                    <code style={{ fontSize: '0.8rem' }}>{r.key}</code>
+                  </Td>
+                  <Td>{r.userType || 'STAFF'}</Td>
+                  <Td>
+                    {r.isSystem ? (
+                      <Badge color="amber">System</Badge>
+                    ) : (
+                      <Badge color="blue">Custom</Badge>
+                    )}
+                  </Td>
+                  <Td>
+                    <button
+                      type="button"
+                      onClick={() => setUsersRole(r)}
+                      style={linkBtn}
+                      aria-label={`View ${r.userCount ?? 0} users in ${r.name}`}
+                    >
+                      <Users size={14} /> {r.userCount ?? 0}
+                    </button>
+                  </Td>
+                  <Td>
+                    <button
+                      type="button"
+                      onClick={() => setPermRole(r)}
+                      style={linkBtn}
+                      aria-label={`View permissions for ${r.name}`}
+                    >
+                      <Shield size={14} />{' '}
+                      {Array.isArray(r.permissions) ? r.permissions.length : 0}
+                    </button>
+                  </Td>
+                  <Td>
+                    {!r.isSystem && canManage ? (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(r)}
+                        className="btn-secondary"
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '0.3rem',
+                          fontSize: '0.8rem',
+                        }}
+                      >
+                        <Trash2 size={14} /> Delete
+                      </button>
+                    ) : (
+                      <span
+                        style={{
+                          fontSize: '0.75rem',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {r.isSystem ? 'Immutable' : '—'}
+                      </span>
+                    )}
+                  </Td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+
+      {createOpen && (
+        <CreateRoleModal
+          onClose={() => setCreateOpen(false)}
+          onSuccess={async () => {
+            setCreateOpen(false);
+            await loadRoles();
+          }}
+        />
+      )}
+      {permRole && (
+        <PermissionsModal
+          role={permRole}
+          readOnly={!canManage || permRole.isSystem}
+          onClose={() => setPermRole(null)}
+          onSaved={async () => {
+            await refreshAll();
+            setPermRole(null);
+          }}
+        />
+      )}
+      {usersRole && (
+        <UsersModal
+          role={usersRole}
+          canManage={canManage && !usersRole.isSystem}
+          onClose={() => setUsersRole(null)}
+          onChange={() => refreshAll()}
+        />
+      )}
+    </div>
+  );
+}
+
+// ───────────────────────── Create role modal ─────────────────────────
+
+function CreateRoleModal({ onClose, onSuccess }) {
+  const [form, setForm] = useState({
+    name: '',
+    key: '',
+    description: '',
+    userType: 'STAFF',
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [errors, setErrors] = useState({});
+  const notify = useNotify();
+
+  const submit = async (ev) => {
+    ev.preventDefault();
+    setError('');
+    const fieldErrors = {};
+    if (!form.name.trim()) fieldErrors.name = 'Required';
+    if (!form.key.trim()) fieldErrors.key = 'Required';
+    else if (!/^[A-Z][A-Z0-9_]*$/.test(form.key.trim())) {
+      fieldErrors.key = 'Uppercase letters, digits, underscores; must start with a letter';
+    }
+    setErrors(fieldErrors);
+    if (Object.keys(fieldErrors).length) return;
+
+    setIsLoading(true);
+    try {
+      await fetchApi('/api/roles', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: form.name.trim(),
+          key: form.key.trim().toUpperCase(),
+          description: form.description.trim() || undefined,
+          userType: form.userType,
+        }),
+      });
+      notify.success?.(`Role "${form.name.trim()}" created`);
+      onSuccess();
+    } catch (err) {
+      setError(err.message || 'Could not create role');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ModalShell title="Create a new role" onClose={onClose} width={500}>
+      <form onSubmit={submit} noValidate>
+        <Field label="Display name" error={errors.name}>
+          <input
+            type="text"
+            className="input-field"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            placeholder="e.g. Receptionist"
+            disabled={isLoading}
+            required
+          />
+        </Field>
+        <Field label="Key" error={errors.key} help="Unique within this tenant. Uppercase + underscores only.">
+          <input
+            type="text"
+            className="input-field"
+            value={form.key}
+            onChange={(e) => setForm({ ...form, key: e.target.value.toUpperCase() })}
+            placeholder="e.g. RECEPTIONIST"
+            disabled={isLoading}
+            required
+          />
+        </Field>
+        <Field label="Description (optional)">
+          <textarea
+            className="input-field"
+            rows={2}
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            placeholder="What this role is for"
+            disabled={isLoading}
+            style={{ resize: 'vertical', minHeight: 60 }}
+          />
+        </Field>
+        <Field label="User type" help="Which kind of user this role can be assigned to.">
+          <select
+            className="input-field"
+            value={form.userType}
+            onChange={(e) => setForm({ ...form, userType: e.target.value })}
+            disabled={isLoading}
+          >
+            <option value="STAFF">Staff</option>
+            <option value="CUSTOMER">Customer</option>
+          </select>
+        </Field>
+        {error && (
+          <div role="alert" style={errBoxStyle}>{error}</div>
+        )}
+        <ModalActions>
+          <button type="button" onClick={onClose} className="btn-secondary" disabled={isLoading}>
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary" disabled={isLoading}>
+            {isLoading ? 'Creating…' : 'Create role'}
+          </button>
+        </ModalActions>
+      </form>
+    </ModalShell>
+  );
+}
+
+// ──────────────────────── Permissions matrix modal ───────────────────
+
+function PermissionsModal({ role, readOnly, onClose, onSaved }) {
+  // Hydrate from role.permissions (the list endpoint already includes them).
+  // We keep a Set of "module.action" strings for O(1) lookup + toggle.
+  const initial = useMemo(() => {
+    const s = new Set();
+    (role.permissions || []).forEach((p) => {
+      const m = p?.module;
+      const a = p?.action;
+      if (m && a) s.add(`${m}.${a}`);
+    });
+    return s;
+  }, [role]);
+
+  const [selected, setSelected] = useState(initial);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const notify = useNotify();
+
+  const toggle = (module, action) => {
+    if (readOnly) return;
+    const key = `${module}.${action}`;
+    const next = new Set(selected);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    setSelected(next);
+  };
+
+  const toggleModule = (module, actions, allSelected) => {
+    if (readOnly) return;
+    const next = new Set(selected);
+    actions.forEach((a) => {
+      const key = `${module}.${a}`;
+      if (allSelected) next.delete(key);
+      else next.add(key);
+    });
+    setSelected(next);
+  };
+
+  const save = async () => {
+    setError('');
+    setIsLoading(true);
+    try {
+      const body = Array.from(selected).map((s) => {
+        const [module, action] = s.split('.');
+        return { module, action };
+      });
+      await fetchApi(`/api/roles/${role.id}/permissions`, {
+        method: 'PUT',
+        body: JSON.stringify({ permissions: body }),
+      });
+      notify.success?.(`Permissions updated for "${role.name}"`);
+      onSaved();
+    } catch (err) {
+      setError(err.message || 'Could not save permissions');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ModalShell
+      title={`Permissions: ${role.name}`}
+      subtitle={
+        readOnly
+          ? role.isSystem
+            ? 'System role — read-only.'
+            : 'You do not have permission to edit roles.'
+          : `Check the actions this role can perform.`
+      }
+      onClose={onClose}
+      width={760}
+    >
+      <div
+        style={{
+          maxHeight: '60vh',
+          overflowY: 'auto',
+          padding: '0.25rem',
+          marginBottom: '0.75rem',
+        }}
+      >
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns:
+              'repeat(auto-fill, minmax(min(100%, 220px), 1fr))',
+            gap: '0.75rem',
+          }}
+        >
+          {PERMISSION_MODULES.map(({ module, actions }) => {
+            const allSelected = actions.every((a) =>
+              selected.has(`${module}.${a}`),
+            );
+            const anySelected = actions.some((a) =>
+              selected.has(`${module}.${a}`),
+            );
+            return (
+              <div
+                key={module}
+                style={{
+                  padding: '0.75rem',
+                  borderRadius: 8,
+                  border: '1px solid var(--border-color)',
+                  // Selected modules get a slightly more opaque overlay so
+                  // the user can see at a glance which modules carry grants.
+                  // Both vars adapt to light/dark theme automatically.
+                  background: anySelected ? 'var(--subtle-bg-3)' : 'var(--subtle-bg-2)',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    marginBottom: '0.5rem',
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: '0.75rem',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    {module}
+                  </span>
+                  {!readOnly && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        toggleModule(module, actions, allSelected)
+                      }
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        fontSize: '0.7rem',
+                        color: 'var(--primary-color, var(--accent-color))',
+                        padding: '0.1rem 0.3rem',
+                      }}
+                    >
+                      {allSelected ? 'Clear' : 'All'}
+                    </button>
+                  )}
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
+                  {actions.map((a) => {
+                    const key = `${module}.${a}`;
+                    const checked = selected.has(key);
+                    return (
+                      <label
+                        key={a}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '0.4rem',
+                          fontSize: '0.85rem',
+                          cursor: readOnly ? 'not-allowed' : 'pointer',
+                          opacity: readOnly ? 0.7 : 1,
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(module, a)}
+                          disabled={readOnly}
+                          style={{ cursor: readOnly ? 'not-allowed' : 'pointer' }}
+                        />
+                        {a}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {error && (
+        <div role="alert" style={errBoxStyle}>{error}</div>
+      )}
+
+      <ModalActions>
+        <span style={{ flex: 1, fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+          {selected.size} permission{selected.size === 1 ? '' : 's'} selected
+        </span>
+        <button type="button" onClick={onClose} className="btn-secondary" disabled={isLoading}>
+          {readOnly ? 'Close' : 'Cancel'}
+        </button>
+        {!readOnly && (
+          <button type="button" onClick={save} className="btn-primary" disabled={isLoading}>
+            {isLoading ? 'Saving…' : 'Save permissions'}
+          </button>
+        )}
+      </ModalActions>
+    </ModalShell>
+  );
+}
+
+// ──────────────────────── Users-on-role modal ────────────────────────
+
+function UsersModal({ role, canManage, onClose, onChange }) {
+  const [members, setMembers] = useState([]);
+  const [allStaff, setAllStaff] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isStaffLoading, setIsStaffLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [picker, setPicker] = useState('');
+  const [busyUserId, setBusyUserId] = useState(null);
+  const notify = useNotify();
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const res = await fetchApi(`/api/roles/${role.id}/users`);
+      setMembers(Array.isArray(res?.users) ? res.users : []);
+    } catch (err) {
+      setError(err.message || 'Could not load users');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [role.id]);
+
+  const loadStaffList = useCallback(async () => {
+    if (!canManage) return;
+    setIsStaffLoading(true);
+    try {
+      // /api/staff returns the current tenant's users — same scope as roles.
+      // TODO: replace with a dedicated /api/users?available-for-role=N endpoint
+      // once tenants get larger than a single dropdown can handle.
+      const res = await fetchApi('/api/staff');
+      const list = Array.isArray(res) ? res : Array.isArray(res?.staff) ? res.staff : [];
+      setAllStaff(list);
+    } catch {
+      // Non-fatal; the picker just renders empty.
+    } finally {
+      setIsStaffLoading(false);
+    }
+  }, [canManage]);
+
+  useEffect(() => {
+    load();
+    loadStaffList();
+  }, [load, loadStaffList]);
+
+  const assignedIds = useMemo(
+    () => new Set(members.map((m) => m.id)),
+    [members],
+  );
+  const available = useMemo(
+    () => allStaff.filter((u) => !assignedIds.has(u.id)),
+    [allStaff, assignedIds],
+  );
+
+  const assign = async () => {
+    if (!picker) return;
+    setBusyUserId(parseInt(picker, 10));
+    try {
+      await fetchApi(`/api/roles/${role.id}/assign/${picker}`, {
+        method: 'POST',
+      });
+      notify.success?.('Role assigned');
+      setPicker('');
+      await load();
+      onChange?.();
+    } catch {
+      // toast handled by fetchApi
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const unassign = async (userId) => {
+    if (!window.confirm('Remove this role from the user?')) return;
+    setBusyUserId(userId);
+    try {
+      await fetchApi(`/api/roles/${role.id}/assign/${userId}`, {
+        method: 'DELETE',
+      });
+      notify.success?.('Role removed');
+      await load();
+      onChange?.();
+    } catch {
+      // toast handled
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  return (
+    <ModalShell
+      title={`Members of ${role.name}`}
+      subtitle={
+        canManage
+          ? 'Assign or remove users from this role. Changes apply immediately.'
+          : role.isSystem
+            ? 'System role — assignments cannot be changed.'
+            : 'You do not have permission to manage role assignments.'
+      }
+      onClose={onClose}
+      width={620}
+    >
+      {canManage && (
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.5rem',
+            marginBottom: '1rem',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <select
+            className="input-field"
+            value={picker}
+            onChange={(e) => setPicker(e.target.value)}
+            disabled={isStaffLoading || available.length === 0}
+            style={{ flex: 1, minWidth: 220 }}
+          >
+            <option value="">
+              {isStaffLoading
+                ? 'Loading users…'
+                : available.length === 0
+                  ? 'All eligible users are already assigned'
+                  : 'Select a user to add…'}
+            </option>
+            {available.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.name || u.email} {u.email && u.name ? `(${u.email})` : ''}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={assign}
+            disabled={!picker || busyUserId != null}
+            className="btn-primary"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem' }}
+          >
+            <UserPlus size={14} />
+            {busyUserId && picker && busyUserId === parseInt(picker, 10) ? 'Adding…' : 'Add'}
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div role="alert" style={errBoxStyle}>{error}</div>
+      )}
+
+      <div style={{ border: '1px solid var(--border-color)', borderRadius: 8, overflow: 'auto', maxHeight: '50vh' }}>
+        {isLoading && (
+          <div style={{ padding: '1rem', color: 'var(--text-secondary)' }}>Loading members…</div>
+        )}
+        {!isLoading && members.length === 0 && (
+          <div style={{ padding: '1rem', color: 'var(--text-secondary)' }}>
+            No users assigned yet.
+          </div>
+        )}
+        {!isLoading && members.length > 0 && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+            <thead>
+              <tr style={{ background: 'var(--subtle-bg-3)', textAlign: 'left' }}>
+                <Th>Name</Th>
+                <Th>Email</Th>
+                <Th>Type</Th>
+                {canManage && <Th>{''}</Th>}
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((u) => (
+                <tr key={u.id} style={{ borderTop: '1px solid var(--border-color)' }}>
+                  <Td>{u.name || '—'}</Td>
+                  <Td>{u.email}</Td>
+                  <Td>{u.userType || 'STAFF'}</Td>
+                  {canManage && (
+                    <Td>
+                      <button
+                        type="button"
+                        onClick={() => unassign(u.id)}
+                        className="btn-secondary"
+                        disabled={busyUserId === u.id}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '0.3rem',
+                          fontSize: '0.75rem',
+                        }}
+                      >
+                        <UserMinus size={12} />
+                        {busyUserId === u.id ? 'Removing…' : 'Remove'}
+                      </button>
+                    </Td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <ModalActions>
+        <button type="button" onClick={onClose} className="btn-secondary">
+          Close
+        </button>
+      </ModalActions>
+    </ModalShell>
+  );
+}
+
+// ───────────────────────── Shared UI primitives ──────────────────────
+
+function Th({ children }) {
+  return (
+    <th
+      style={{
+        padding: '0.6rem 0.85rem',
+        fontWeight: 600,
+        fontSize: '0.75rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.04em',
+        color: 'var(--text-secondary)',
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, colSpan, center }) {
+  return (
+    <td
+      colSpan={colSpan}
+      style={{
+        padding: '0.6rem 0.85rem',
+        verticalAlign: 'middle',
+        textAlign: center ? 'center' : 'left',
+        color: center ? 'var(--text-secondary)' : 'inherit',
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function Badge({ color = 'blue', children }) {
+  const palette = {
+    blue:  { bg: 'rgba(59,130,246,0.12)',  fg: '#3b82f6', bd: 'rgba(59,130,246,0.3)' },
+    amber: { bg: 'rgba(245,158,11,0.12)',  fg: '#f59e0b', bd: 'rgba(245,158,11,0.3)' },
+    green: { bg: 'rgba(16,185,129,0.12)',  fg: '#10b981', bd: 'rgba(16,185,129,0.3)' },
+  };
+  const c = palette[color] || palette.blue;
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.15rem 0.5rem',
+        borderRadius: 999,
+        fontSize: '0.7rem',
+        fontWeight: 600,
+        background: c.bg,
+        color: c.fg,
+        border: `1px solid ${c.bd}`,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+const linkBtn = {
+  background: 'transparent',
+  border: '1px solid var(--border-color)',
+  padding: '0.25rem 0.55rem',
+  borderRadius: 6,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.3rem',
+  fontSize: '0.8rem',
+  color: 'inherit',
+};
+
+const errBoxStyle = {
+  background: 'rgba(239,68,68,0.1)',
+  color: '#ef4444',
+  padding: '0.6rem 0.75rem',
+  borderRadius: 6,
+  fontSize: '0.85rem',
+  marginBottom: '0.75rem',
+};
+
+function ModalShell({ title, subtitle, onClose, width = 480, children }) {
+  // Lock body scroll while the modal is open.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        backdropFilter: 'blur(2px)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1rem',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="glass"
+        style={{
+          width: '100%',
+          maxWidth: width,
+          maxHeight: '90vh',
+          overflow: 'auto',
+          // --surface-color is the actual theme-aware translucent surface.
+          // The earlier `var(--surface, #fff)` was a bug: --surface doesn't
+          // exist anywhere, so it always fell back to solid white — and
+          // text-primary in dark mode is also white → white-on-white modal.
+          background: 'var(--surface-color)',
+          color: 'var(--text-primary)',
+          borderRadius: 12,
+          border: '1px solid var(--border-color)',
+          padding: '1.25rem',
+          boxShadow: '0 18px 40px rgba(0,0,0,0.45)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: '0.5rem',
+            marginBottom: subtitle ? '0.5rem' : '1rem',
+          }}
+        >
+          <div>
+            <h2 style={{ margin: 0, fontSize: '1.1rem' }}>{title}</h2>
+            {subtitle && (
+              <p
+                style={{
+                  margin: '0.2rem 0 0',
+                  color: 'var(--text-secondary)',
+                  fontSize: '0.8rem',
+                }}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-secondary)',
+              padding: '0.25rem',
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+        {subtitle && <div style={{ marginBottom: '0.75rem' }} />}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ModalActions({ children }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'flex-end',
+        gap: '0.5rem',
+        marginTop: '0.75rem',
+        alignItems: 'center',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, error, help, children }) {
+  return (
+    <div style={{ marginBottom: '0.85rem' }}>
+      <label
+        style={{
+          display: 'block',
+          fontSize: '0.8rem',
+          color: 'var(--text-secondary)',
+          marginBottom: '0.25rem',
+          fontWeight: 500,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+      {help && !error && (
+        <small
+          style={{
+            display: 'block',
+            marginTop: '0.25rem',
+            color: 'var(--text-secondary)',
+            fontSize: '0.7rem',
+          }}
+        >
+          {help}
+        </small>
+      )}
+      {error && (
+        <small
+          role="alert"
+          style={{
+            display: 'block',
+            marginTop: '0.25rem',
+            color: '#ef4444',
+            fontSize: '0.75rem',
+          }}
+        >
+          {error}
+        </small>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -344,8 +344,11 @@ export default function Settings() {
 
       {/* #479/#484: outer two-column grid uses auto-fit + minmax so the
           right column collapses below the second card under ~700px viewports
-          rather than squeezing both columns until labels/buttons clip. */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1.5rem', maxWidth: '1400px' }}>
+          rather than squeezing both columns until labels/buttons clip.
+          alignItems:'start' keeps each column at its natural height so the
+          shorter column's cards don't get spread apart vertically to match
+          the taller column's stretch height. */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1.5rem', maxWidth: '1400px', alignItems: 'start' }}>
 
         {/* Left Column */}
         <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '1.5rem', minWidth: 0 }}>
@@ -648,6 +651,112 @@ export default function Settings() {
           )}
         </div>
 
+        {/* Pipeline Stages Card */}
+        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
+          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Layers size={20} color="var(--accent-color)" /> Pipeline Stages
+          </h3>
+
+          {stagesLoading ? <p>Loading stages...</p> : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1.5rem' }}>
+              {pipelineStages.length === 0 && (
+                <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>No custom stages configured. The pipeline uses default stages.</p>
+              )}
+              {pipelineStages.map((stage, index) => (
+                <div key={stage.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1rem 1.25rem', borderRadius: '8px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                    <div style={{ width: '20px', height: '20px', borderRadius: '6px', backgroundColor: stage.color, flexShrink: 0 }} />
+                    <span style={{ fontWeight: '500' }}>{stage.name}</span>
+                    <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>Position {index + 1}</span>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <button onClick={() => handleMoveStage(index, -1)} disabled={index === 0} style={{ background: 'none', border: 'none', color: index === 0 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === 0 ? 'default' : 'pointer', padding: '0.25rem' }}>
+                      <ArrowUp size={16} />
+                    </button>
+                    <button onClick={() => handleMoveStage(index, 1)} disabled={index === pipelineStages.length - 1} style={{ background: 'none', border: 'none', color: index === pipelineStages.length - 1 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === pipelineStages.length - 1 ? 'default' : 'pointer', padding: '0.25rem' }}>
+                      <ArrowDown size={16} />
+                    </button>
+                    <button onClick={() => handleDeleteStage(stage.id)} style={{ background: 'none', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.25rem' }}>
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* #479: flexWrap so the color picker + Add button drop below the
+              stage-name input on narrow viewports rather than truncating it. */}
+          <form onSubmit={handleAddStage} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+            <input type="text" placeholder="Stage name" required className="input-field" style={{ flex: '1 1 180px', minWidth: 0 }} value={newStage.name} onChange={e => setNewStage({ ...newStage, name: e.target.value })} />
+            <input type="color" value={newStage.color} onChange={e => setNewStage({ ...newStage, color: e.target.value })} style={{ width: '40px', height: '40px', border: '1px solid var(--border-color)', borderRadius: '8px', cursor: 'pointer', padding: '2px', background: 'var(--input-bg)' }} />
+            <button type="submit" className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}>
+              <Plus size={16} /> Add Stage
+            </button>
+          </form>
+        </div>
+        </div>
+
+        {/* Right Column - Roster */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '1.5rem', minWidth: 0 }}>
+        {/* User Roster */}
+        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)', height: 'fit-content' }}>
+          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Shield size={20} color="var(--success-color)" /> Access Control Roster
+          </h3>
+
+          {loading ? <p>Loading team...</p> : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxHeight: '700px', overflowY: 'auto' }}>
+              {users.map(u => (
+                // #479: roster row wraps on narrow viewports so the role
+                // dropdown + delete button drop below the name/email block
+                // instead of squeezing the email into truncation.
+                <div key={u.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1.25rem', borderRadius: '8px', flexWrap: 'wrap', gap: '0.75rem' }}>
+                  <div style={{ minWidth: 0, flex: '1 1 180px' }}>
+                    <h4 style={{ fontWeight: '600', fontSize: '1.1rem', wordBreak: 'break-word' }}>{u.name || 'Unknown User'} <span style={{ fontSize: '0.75rem', padding: '0.2rem 0.6rem', background: u.role === 'ADMIN' ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.2)', color: u.role === 'ADMIN' ? '#ef4444' : '#3b82f6', borderRadius: '12px', marginLeft: '0.5rem' }}>{u.role}</span></h4>
+                    <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '0.25rem', wordBreak: 'break-all' }}>{u.email}</p>
+                  </div>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <select value={u.role} onChange={(e) => handleChangeRole(u.id, e.target.value)} style={{ padding: '0.5rem', borderRadius: '4px', background: 'var(--input-bg)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
+                      <option value="USER">Standard Rep</option>
+                      <option value="MANAGER">Manager</option>
+                      <option value="ADMIN">Admin</option>
+                    </select>
+                    {u.role !== 'ADMIN' ? (
+                      <button onClick={() => handleDelete(u.id)} style={{ background: 'transparent', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.5rem' }}>
+                        <Trash2 size={18} />
+                      </button>
+                    ) : (
+                      <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>—</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Invite User Card */}
+        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
+          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <UserPlus size={20} color="var(--accent-color)" /> Invite Team Member
+          </h3>
+          {/* #484: Invite form uses auto-fit + minmax so fields stack on
+              narrow viewports rather than truncating placeholders/values. */}
+          <form onSubmit={handleCreateUser} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '1rem' }}>
+             <input type="text" placeholder="Full Name" required className="input-field" style={{ minWidth: 0 }} value={newUser.name} onChange={e => setNewUser({...newUser, name: e.target.value})} />
+             <input type="email" placeholder="Email Address" required className="input-field" style={{ minWidth: 0 }} value={newUser.email} onChange={e => setNewUser({...newUser, email: e.target.value})} />
+             <input type="password" placeholder="Temporary Password" required className="input-field" style={{ minWidth: 0 }} value={newUser.password} onChange={e => setNewUser({...newUser, password: e.target.value})} />
+             <select className="input-field" value={newUser.role} onChange={e => setNewUser({...newUser, role: e.target.value})} style={{ background: 'var(--input-bg)', minWidth: 0 }}>
+               <option value="USER">Standard Rep</option>
+               <option value="MANAGER">Sales Manager</option>
+               <option value="ADMIN">System Administrator</option>
+             </select>
+             <button type="submit" className="btn-primary" style={{ gridColumn: '1 / -1' }}>Send Invitation & Create Account</button>
+          </form>
+        </div>
+
         {/* AdsGPT Configuration Card */}
         <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
           <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -813,112 +922,6 @@ export default function Settings() {
               {callifiedMsg}
             </p>
           )}
-        </div>
-
-        {/* Pipeline Stages Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Layers size={20} color="var(--accent-color)" /> Pipeline Stages
-          </h3>
-
-          {stagesLoading ? <p>Loading stages...</p> : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1.5rem' }}>
-              {pipelineStages.length === 0 && (
-                <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>No custom stages configured. The pipeline uses default stages.</p>
-              )}
-              {pipelineStages.map((stage, index) => (
-                <div key={stage.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1rem 1.25rem', borderRadius: '8px' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                    <div style={{ width: '20px', height: '20px', borderRadius: '6px', backgroundColor: stage.color, flexShrink: 0 }} />
-                    <span style={{ fontWeight: '500' }}>{stage.name}</span>
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>Position {index + 1}</span>
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <button onClick={() => handleMoveStage(index, -1)} disabled={index === 0} style={{ background: 'none', border: 'none', color: index === 0 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === 0 ? 'default' : 'pointer', padding: '0.25rem' }}>
-                      <ArrowUp size={16} />
-                    </button>
-                    <button onClick={() => handleMoveStage(index, 1)} disabled={index === pipelineStages.length - 1} style={{ background: 'none', border: 'none', color: index === pipelineStages.length - 1 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === pipelineStages.length - 1 ? 'default' : 'pointer', padding: '0.25rem' }}>
-                      <ArrowDown size={16} />
-                    </button>
-                    <button onClick={() => handleDeleteStage(stage.id)} style={{ background: 'none', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.25rem' }}>
-                      <Trash2 size={16} />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* #479: flexWrap so the color picker + Add button drop below the
-              stage-name input on narrow viewports rather than truncating it. */}
-          <form onSubmit={handleAddStage} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
-            <input type="text" placeholder="Stage name" required className="input-field" style={{ flex: '1 1 180px', minWidth: 0 }} value={newStage.name} onChange={e => setNewStage({ ...newStage, name: e.target.value })} />
-            <input type="color" value={newStage.color} onChange={e => setNewStage({ ...newStage, color: e.target.value })} style={{ width: '40px', height: '40px', border: '1px solid var(--border-color)', borderRadius: '8px', cursor: 'pointer', padding: '2px', background: 'var(--input-bg)' }} />
-            <button type="submit" className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}>
-              <Plus size={16} /> Add Stage
-            </button>
-          </form>
-        </div>
-        </div>
-
-        {/* Right Column - Roster */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '1.5rem', minWidth: 0 }}>
-        {/* User Roster */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)', height: 'fit-content' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Shield size={20} color="var(--success-color)" /> Access Control Roster
-          </h3>
-
-          {loading ? <p>Loading team...</p> : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxHeight: '700px', overflowY: 'auto' }}>
-              {users.map(u => (
-                // #479: roster row wraps on narrow viewports so the role
-                // dropdown + delete button drop below the name/email block
-                // instead of squeezing the email into truncation.
-                <div key={u.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1.25rem', borderRadius: '8px', flexWrap: 'wrap', gap: '0.75rem' }}>
-                  <div style={{ minWidth: 0, flex: '1 1 180px' }}>
-                    <h4 style={{ fontWeight: '600', fontSize: '1.1rem', wordBreak: 'break-word' }}>{u.name || 'Unknown User'} <span style={{ fontSize: '0.75rem', padding: '0.2rem 0.6rem', background: u.role === 'ADMIN' ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.2)', color: u.role === 'ADMIN' ? '#ef4444' : '#3b82f6', borderRadius: '12px', marginLeft: '0.5rem' }}>{u.role}</span></h4>
-                    <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '0.25rem', wordBreak: 'break-all' }}>{u.email}</p>
-                  </div>
-
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                    <select value={u.role} onChange={(e) => handleChangeRole(u.id, e.target.value)} style={{ padding: '0.5rem', borderRadius: '4px', background: 'var(--input-bg)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
-                      <option value="USER">Standard Rep</option>
-                      <option value="MANAGER">Manager</option>
-                      <option value="ADMIN">Admin</option>
-                    </select>
-                    {u.role !== 'ADMIN' ? (
-                      <button onClick={() => handleDelete(u.id)} style={{ background: 'transparent', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.5rem' }}>
-                        <Trash2 size={18} />
-                      </button>
-                    ) : (
-                      <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>—</span>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Invite User Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <UserPlus size={20} color="var(--accent-color)" /> Invite Team Member
-          </h3>
-          {/* #484: Invite form uses auto-fit + minmax so fields stack on
-              narrow viewports rather than truncating placeholders/values. */}
-          <form onSubmit={handleCreateUser} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '1rem' }}>
-             <input type="text" placeholder="Full Name" required className="input-field" style={{ minWidth: 0 }} value={newUser.name} onChange={e => setNewUser({...newUser, name: e.target.value})} />
-             <input type="email" placeholder="Email Address" required className="input-field" style={{ minWidth: 0 }} value={newUser.email} onChange={e => setNewUser({...newUser, email: e.target.value})} />
-             <input type="password" placeholder="Temporary Password" required className="input-field" style={{ minWidth: 0 }} value={newUser.password} onChange={e => setNewUser({...newUser, password: e.target.value})} />
-             <select className="input-field" value={newUser.role} onChange={e => setNewUser({...newUser, role: e.target.value})} style={{ background: 'var(--input-bg)', minWidth: 0 }}>
-               <option value="USER">Standard Rep</option>
-               <option value="MANAGER">Sales Manager</option>
-               <option value="ADMIN">System Administrator</option>
-             </select>
-             <button type="submit" className="btn-primary" style={{ gridColumn: '1 / -1' }}>Send Invitation & Create Account</button>
-          </form>
         </div>
 
         {/* Notification Preferences Card */}

--- a/frontend/src/pages/Staff.jsx
+++ b/frontend/src/pages/Staff.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
-import { UsersRound, Trash2, Shield, Edit3, UserX, UserCheck, Key, MailPlus, X } from 'lucide-react';
+import { UsersRound, Trash2, Shield, ShieldCheck, Edit3, UserX, UserCheck, Key, MailPlus, X } from 'lucide-react';
 import { AuthContext } from '../App';
+import { usePermissions } from '../hooks/usePermissions';
 import { formatDate } from '../utils/date';
 
 const ROLE_CONFIG = {
@@ -25,12 +27,16 @@ function displayRole(member) {
 // that matches the action's intent (edit=neutral, deactivate=amber,
 // reset=blue, invite=teal, delete=red).
 const ACTION_PALETTE = {
-  edit:       { fg: 'var(--text-primary)', bg: 'var(--subtle-bg-3)', bd: 'var(--border-color)' },
-  deactivate: { fg: '#f59e0b', bg: 'rgba(245,158,11,0.1)', bd: 'rgba(245,158,11,0.25)' },
-  reactivate: { fg: '#10b981', bg: 'rgba(16,185,129,0.1)', bd: 'rgba(16,185,129,0.25)' },
-  reset:      { fg: '#3b82f6', bg: 'rgba(59,130,246,0.1)', bd: 'rgba(59,130,246,0.25)' },
-  invite:     { fg: '#0ea5e9', bg: 'rgba(14,165,233,0.1)', bd: 'rgba(14,165,233,0.25)' },
-  delete:     { fg: '#ef4444', bg: 'rgba(239,68,68,0.1)', bd: 'rgba(239,68,68,0.25)' },
+  edit:        { fg: 'var(--text-primary)', bg: 'var(--subtle-bg-3)', bd: 'var(--border-color)' },
+  deactivate:  { fg: '#f59e0b', bg: 'rgba(245,158,11,0.1)', bd: 'rgba(245,158,11,0.25)' },
+  reactivate:  { fg: '#10b981', bg: 'rgba(16,185,129,0.1)', bd: 'rgba(16,185,129,0.25)' },
+  reset:       { fg: '#3b82f6', bg: 'rgba(59,130,246,0.1)', bd: 'rgba(59,130,246,0.25)' },
+  invite:      { fg: '#0ea5e9', bg: 'rgba(14,165,233,0.1)', bd: 'rgba(14,165,233,0.25)' },
+  delete:      { fg: '#ef4444', bg: 'rgba(239,68,68,0.1)', bd: 'rgba(239,68,68,0.25)' },
+  // RBAC per-row "Permissions" button — matches the ADMIN role badge hue at
+  // line 9 above (purple #a855f7) so the action visually signals "admin /
+  // security tooling" without duplicating any other palette entry.
+  permissions: { fg: '#a855f7', bg: 'rgba(168,85,247,0.1)', bd: 'rgba(168,85,247,0.25)' },
 };
 function actionButtonStyle(kind) {
   const p = ACTION_PALETTE[kind] || ACTION_PALETTE.edit;
@@ -73,6 +79,13 @@ export default function Staff() {
   // unless the viewer is an actual ADMIN.
   const { user } = useContext(AuthContext) || {};
   const canManageStaff = user?.role === 'ADMIN';
+  // #618 + RBAC: the Permissions button is gated on the granular roles.read
+  // permission (not the legacy ADMIN role), so a custom non-ADMIN role with
+  // roles.read granted can still view permission sheets. Falls through to
+  // the same AccessDenied card the rest of the RBAC pages use.
+  const { hasPermission } = usePermissions();
+  const canViewPermissions = hasPermission('roles', 'read');
+  const navigate = useNavigate();
   const [staff, setStaff] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState(null);
@@ -400,51 +413,65 @@ export default function Staff() {
                       )}
                     </td>
                     <td style={{ padding: '0.75rem 0.5rem' }} data-testid={`staff-actions-${member.id}`}>
-                      {canManageStaff ? (
+                      {(canManageStaff || canViewPermissions) ? (
                         <div style={{ display: 'flex', gap: '0.3rem', flexWrap: 'wrap' }}>
-                          <button
-                            onClick={() => openEdit(member)}
-                            data-testid={`staff-action-edit-${member.id}`}
-                            title="Edit user"
-                            style={actionButtonStyle('edit')}
-                          >
-                            <Edit3 size={13} /> Edit
-                          </button>
-                          {member.role !== 'ADMIN' && (
-                            <button
-                              onClick={() => toggleActive(member)}
-                              data-testid={`staff-action-deactivate-${member.id}`}
-                              title={member.deactivatedAt ? 'Reactivate user' : 'Deactivate user'}
-                              style={actionButtonStyle(member.deactivatedAt ? 'reactivate' : 'deactivate')}
-                            >
-                              {member.deactivatedAt ? <UserCheck size={13} /> : <UserX size={13} />}
-                              {member.deactivatedAt ? 'Reactivate' : 'Deactivate'}
-                            </button>
+                          {canManageStaff && (
+                            <>
+                              <button
+                                onClick={() => openEdit(member)}
+                                data-testid={`staff-action-edit-${member.id}`}
+                                title="Edit user"
+                                style={actionButtonStyle('edit')}
+                              >
+                                <Edit3 size={13} /> Edit
+                              </button>
+                              {member.role !== 'ADMIN' && (
+                                <button
+                                  onClick={() => toggleActive(member)}
+                                  data-testid={`staff-action-deactivate-${member.id}`}
+                                  title={member.deactivatedAt ? 'Reactivate user' : 'Deactivate user'}
+                                  style={actionButtonStyle(member.deactivatedAt ? 'reactivate' : 'deactivate')}
+                                >
+                                  {member.deactivatedAt ? <UserCheck size={13} /> : <UserX size={13} />}
+                                  {member.deactivatedAt ? 'Reactivate' : 'Deactivate'}
+                                </button>
+                              )}
+                              <button
+                                onClick={() => resetPassword(member)}
+                                data-testid={`staff-action-reset-password-${member.id}`}
+                                title="Send password reset link"
+                                style={actionButtonStyle('reset')}
+                              >
+                                <Key size={13} /> Reset Password
+                              </button>
+                              <button
+                                onClick={() => resendInvite(member)}
+                                data-testid={`staff-action-resend-invite-${member.id}`}
+                                title="Re-send the original invite email"
+                                style={actionButtonStyle('invite')}
+                              >
+                                <MailPlus size={13} /> Resend Invite
+                              </button>
+                              {member.role !== 'ADMIN' && (
+                                <button
+                                  onClick={() => deleteUser(member.id, member.name || member.email)}
+                                  data-testid={`staff-action-delete-${member.id}`}
+                                  title="Delete user"
+                                  style={actionButtonStyle('delete')}
+                                >
+                                  <Trash2 size={13} /> Delete
+                                </button>
+                              )}
+                            </>
                           )}
-                          <button
-                            onClick={() => resetPassword(member)}
-                            data-testid={`staff-action-reset-password-${member.id}`}
-                            title="Send password reset link"
-                            style={actionButtonStyle('reset')}
-                          >
-                            <Key size={13} /> Reset Password
-                          </button>
-                          <button
-                            onClick={() => resendInvite(member)}
-                            data-testid={`staff-action-resend-invite-${member.id}`}
-                            title="Re-send the original invite email"
-                            style={actionButtonStyle('invite')}
-                          >
-                            <MailPlus size={13} /> Resend Invite
-                          </button>
-                          {member.role !== 'ADMIN' && (
+                          {canViewPermissions && (
                             <button
-                              onClick={() => deleteUser(member.id, member.name || member.email)}
-                              data-testid={`staff-action-delete-${member.id}`}
-                              title="Delete user"
-                              style={actionButtonStyle('delete')}
+                              onClick={() => navigate(`/staff/${member.id}/permissions`)}
+                              data-testid={`staff-action-permissions-${member.id}`}
+                              title="View effective permissions for this user"
+                              style={actionButtonStyle('permissions')}
                             >
-                              <Trash2 size={13} /> Delete
+                              <ShieldCheck size={13} /> Permissions
                             </button>
                           )}
                         </div>

--- a/frontend/src/pages/StaffPermissions.jsx
+++ b/frontend/src/pages/StaffPermissions.jsx
@@ -1,0 +1,326 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, ShieldCheck } from 'lucide-react';
+import { fetchApi } from '../utils/api';
+import { usePermissions } from '../hooks/usePermissions';
+import AccessDenied from '../components/AccessDenied';
+
+// Per-target user permission view at /staff/:userId/permissions.
+//
+// Mirrors the visual layout of MyPermissions (account tiles → assigned roles
+// → effective permissions grouped by module) but is driven by a userId URL
+// param + the backend /api/users/:userId/permissions endpoint.
+//
+// Page-level guard: requires roles.read (matches the route's intent — staff
+// directory admins use this to see what a teammate can do). Non-permitted
+// users see the same AccessDenied card the rest of the RBAC pages use.
+export default function StaffPermissions() {
+  const { userId } = useParams();
+  const navigate = useNavigate();
+  const {
+    hasPermission,
+    isLoading: permLoading,
+  } = usePermissions();
+  const canRead = hasPermission('roles', 'read');
+
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // Skip the fetch entirely if the viewer lacks roles.read — backend
+    // would 403 anyway, no point firing a doomed request that pollutes the
+    // toast stream.
+    if (permLoading || !canRead) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    fetchApi(`/api/users/${encodeURIComponent(userId)}/permissions`, {
+      silent: true,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        setData(res);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err);
+        setData(null);
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, canRead, permLoading]);
+
+  if (permLoading) {
+    return (
+      <div style={{ padding: '2rem', color: 'var(--text-secondary)' }}>
+        Loading…
+      </div>
+    );
+  }
+  if (!canRead) {
+    return <AccessDenied permission={{ module: 'roles', action: 'read' }} />;
+  }
+
+  const target = data?.user;
+  const isOwnerTarget = data?.isOwner;
+  const permissions = data?.permissions || [];
+  const roles = data?.roles || [];
+  const grouped = groupByModule(permissions);
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: 960 }}>
+      <button
+        type="button"
+        onClick={() => navigate('/staff')}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.3rem',
+          background: 'transparent',
+          border: 'none',
+          color: 'var(--text-secondary)',
+          cursor: 'pointer',
+          padding: '0.25rem 0',
+          marginBottom: '0.75rem',
+          fontSize: '0.85rem',
+        }}
+      >
+        <ArrowLeft size={14} /> Back to Staff Directory
+      </button>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '1rem',
+          marginBottom: '0.5rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div>
+          <h1 style={{ marginBottom: '0.25rem' }}>
+            {target?.name || target?.email || 'User'} — permissions
+          </h1>
+          <p
+            style={{
+              color: 'var(--text-secondary)',
+              fontSize: '0.875rem',
+              margin: 0,
+            }}
+          >
+            Effective permissions, computed from every role assigned to this
+            user. To change them, edit the user&apos;s role assignments under
+            Roles &amp; permissions.
+          </p>
+        </div>
+        <Link
+          to="/settings/roles"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.35rem',
+            padding: '0.45rem 0.9rem',
+            borderRadius: 8,
+            background: 'var(--subtle-bg-3)',
+            border: '1px solid var(--border-color)',
+            color: 'var(--text-primary)',
+            textDecoration: 'none',
+            fontSize: '0.85rem',
+            fontWeight: 500,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <ShieldCheck size={14} /> Manage roles
+        </Link>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 200px), 1fr))',
+          gap: '0.75rem',
+          marginTop: '1rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <Card label="Account">{target?.email || '—'}</Card>
+        <Card label="User type">{data?.userType || target?.userType || 'STAFF'}</Card>
+        <Card label="Legacy role">{target?.role || '—'}</Card>
+        {target?.wellnessRole && (
+          <Card label="Wellness role">{target.wellnessRole}</Card>
+        )}
+        {target?.deactivatedAt && (
+          <Card label="Status">
+            <span style={{ color: '#ef4444', fontWeight: 600 }}>Inactive</span>
+          </Card>
+        )}
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--text-secondary)' }}>Loading permissions…</p>
+      )}
+
+      {error && !isLoading && (
+        <div
+          role="alert"
+          style={{
+            background: 'rgba(239,68,68,0.1)',
+            color: '#ef4444',
+            padding: '0.75rem',
+            borderRadius: 8,
+            marginBottom: '1rem',
+          }}
+        >
+          Could not load permissions: {error.message || 'Unknown error'}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <>
+          <Section title="Assigned roles">
+            {roles.length === 0 ? (
+              <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+                {isOwnerTarget
+                  ? 'OWNER — bypasses the role system'
+                  : 'No RBAC roles assigned.'}
+              </p>
+            ) : (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                {roles.map((r) => (
+                  <span
+                    key={r}
+                    style={{
+                      padding: '0.25rem 0.6rem',
+                      borderRadius: 999,
+                      background: 'var(--subtle-bg-3)',
+                      border: '1px solid var(--border-color)',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                    }}
+                  >
+                    {r}
+                  </span>
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Effective permissions">
+            {isOwnerTarget ? (
+              <p style={{ color: '#10b981', fontWeight: 500, margin: 0 }}>
+                ✓ Platform admin — full access to every module
+              </p>
+            ) : grouped.length === 0 ? (
+              <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+                No permissions granted.
+              </p>
+            ) : (
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns:
+                    'repeat(auto-fit, minmax(min(100%, 220px), 1fr))',
+                  gap: '0.75rem',
+                }}
+              >
+                {grouped.map(([module, actions]) => (
+                  <div
+                    key={module}
+                    style={{
+                      padding: '0.75rem',
+                      borderRadius: 8,
+                      border: '1px solid var(--border-color)',
+                      background: 'var(--subtle-bg-2)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        color: 'var(--text-secondary)',
+                        marginBottom: '0.4rem',
+                        letterSpacing: '0.04em',
+                      }}
+                    >
+                      {module}
+                    </div>
+                    <ul
+                      style={{
+                        listStyle: 'none',
+                        padding: 0,
+                        margin: 0,
+                        fontSize: '0.85rem',
+                      }}
+                    >
+                      {actions.map((a) => (
+                        <li key={a} style={{ padding: '0.15rem 0' }}>
+                          ✓ {a}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Card({ label, children }) {
+  return (
+    <div
+      style={{
+        padding: '0.65rem 0.85rem',
+        borderRadius: 8,
+        border: '1px solid var(--border-color)',
+        background: 'var(--subtle-bg-2)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.7rem',
+          textTransform: 'uppercase',
+          color: 'var(--text-secondary)',
+          letterSpacing: '0.04em',
+          marginBottom: '0.2rem',
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontWeight: 500, wordBreak: 'break-word' }}>{children}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function groupByModule(permissions) {
+  const map = new Map();
+  (permissions || []).forEach((p) => {
+    const [module, action] = String(p).split('.');
+    if (!module || !action) return;
+    if (!map.has(module)) map.set(module, []);
+    map.get(module).push(action);
+  });
+  for (const [, arr] of map) arr.sort();
+  return Array.from(map.entries()).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+}


### PR DESCRIPTION
[x] Added fine-grained RBAC support with permission-based access control across backend APIs and frontend navigation/routes.
[x] Added new permissions APIs, RBAC seed script, and fixed Prisma tenant-scoping issue causing /api/auth/me/permissions failures for non-owner users.
[x] Added reusable frontend permission utilities including usePermissions, AccessDenied, and permission-aware sidebar routing.
[x] Added complete Roles Management UI for creating/editing roles, assigning permissions, and managing user-role mappings.
[x] Added self and staff permission viewer pages with effective permission breakdowns.
[x] Added public customer self-registration flow with password strength validation and auto-login support.
[x] Updated Staff page actions and sidebar visibility to use granular permission checks instead of legacy role-only checks.
[x] Reorganized Settings page layout for improved section grouping without behavioral changes.