### PR TITLE
feat: add dynamic wellness role catalog with RBAC-integrated access c…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -295,6 +295,7 @@ jobs:
             tests/pos-sale-finalize-api.spec.js \
             tests/travel-quote-lines-api.spec.js \
             tests/travel-idor-cross-tenant-api.spec.js \
+            tests/wellness-role-types-api.spec.js \
             tests/teardown-completeness.spec.js \
             tests/demo-hygiene-api.spec.js
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -463,6 +463,7 @@ jobs:
             tests/pos-sale-finalize-api.spec.js \
             tests/travel-quote-lines-api.spec.js \
             tests/travel-idor-cross-tenant-api.spec.js \
+            tests/wellness-role-types-api.spec.js \
             tests/teardown-completeness.spec.js \
             tests/demo-hygiene-api.spec.js
           echo "::notice::API specs passed"

--- a/backend/lib/csvEntities.js
+++ b/backend/lib/csvEntities.js
@@ -221,8 +221,12 @@ const services = {
     description: "Three-step hydradermabrasion",
     active: "true",
   },
-  readGate: ["doctor", "professional", "telecaller", "admin", "manager"],
+  readGate: ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  // RBAC unlock — any user with services.read passes the read gate.
+  // services.write unlocks template + import.
+  readPermissions: [{ module: "services", action: "read" }],
   writeGate: ["admin", "manager"],
+  writePermissions: [{ module: "services", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     const { q, includeInactive } = req.query;
@@ -316,8 +320,11 @@ const packages = {
     description: "10 sessions over 6 months",
     active: "true",
   },
-  readGate: ["doctor", "professional", "telecaller", "admin", "manager"],
+  readGate: ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  // Memberships are part of the service catalog — same RBAC module.
+  readPermissions: [{ module: "services", action: "read" }],
   writeGate: ["admin", "manager"],
+  writePermissions: [{ module: "services", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     if (req.query.q) where.name = { contains: req.query.q };
@@ -436,8 +443,12 @@ const products = {
     notes: "After meals",
     active: "true",
   },
-  readGate: ["doctor", "admin", "manager"],
+  readGate: ["clinical", "doctor", "admin", "manager"],
+  // Drug catalogue is the prescription typeahead source — clinicians
+  // with prescriptions.read need to browse it.
+  readPermissions: [{ module: "prescriptions", action: "read" }],
   writeGate: ["admin", "manager"],
+  writePermissions: [{ module: "prescriptions", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     if (req.query.q) where.OR = [{ name: { contains: req.query.q } }, { genericName: { contains: req.query.q } }];
@@ -529,8 +540,12 @@ const customers = {
     allergies: "",
     notes: "",
   },
-  readGate: ["doctor", "professional", "telecaller", "admin", "manager"],
-  writeGate: ["doctor", "professional", "admin", "manager"],
+  readGate: ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  // Customer = Patient. patients.read unlocks the directory export;
+  // patients.write unlocks bulk-import.
+  readPermissions: [{ module: "patients", action: "read" }],
+  writeGate: ["clinical", "doctor", "professional", "admin", "manager"],
+  writePermissions: [{ module: "patients", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     if (req.query.q) {
@@ -637,8 +652,22 @@ const bookings = {
     amountCharged: "3500",
     notes: "First visit",
   },
-  readGate: ["doctor", "professional", "telecaller", "admin", "manager"],
-  writeGate: ["doctor", "professional", "admin", "manager"],
+  readGate: ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  // Bookings = Visit rows backing the Calendar. Same wide read set as
+  // phiReadGate so any clinical / scheduling read permission unlocks
+  // the export — matches what the Calendar page itself accepts.
+  readPermissions: [
+    { module: "calendar", action: "read" },
+    { module: "appointments", action: "read" },
+    { module: "visits", action: "read" },
+    { module: "patients", action: "read" },
+  ],
+  writeGate: ["clinical", "doctor", "professional", "admin", "manager"],
+  writePermissions: [
+    { module: "calendar", action: "write" },
+    { module: "appointments", action: "write" },
+    { module: "visits", action: "write" },
+  ],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     if (req.query.status) where.status = req.query.status;
@@ -766,7 +795,9 @@ const invoices = {
     recurFrequency: "",
   },
   readGate: ["admin", "manager"],
+  readPermissions: [{ module: "billing", action: "read" }],
   writeGate: ["admin", "manager"],
+  writePermissions: [{ module: "billing", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     const { status, q } = req.query;

--- a/backend/lib/pageCatalog.js
+++ b/backend/lib/pageCatalog.js
@@ -79,12 +79,13 @@ const PAGE_CATALOG = [
     label: 'Calendar',
     description: 'Day-grid view of appointments + bookings',
     category: 'Clinical',
-    // .read — viewing the day grid is a read action. The slot-click-to-
-    // book action inside the page is gated separately on appointments.write
-    // at the page level + by the POST /api/wellness/visits backend gate.
-    // Sidebar gating policy: lowest action that gives the page meaning,
-    // so a role with only .read sees the page in the nav.
-    requiredPermissions: [{ module: 'appointments', action: 'read' }],
+    // .read on the dedicated `calendar` module — separated from
+    // `appointments` so admins can grant view-only Calendar access
+    // without also exposing the Appointments list, Book Appointment
+    // form, and My Appointments page. Slot-click-to-book and
+    // drag-to-reschedule inside the Calendar are gated on
+    // `calendar.write` at the action level.
+    requiredPermissions: [{ module: 'calendar', action: 'read' }],
   },
   {
     path: '/wellness/appointments',

--- a/backend/lib/permissionCatalog.js
+++ b/backend/lib/permissionCatalog.js
@@ -90,6 +90,16 @@ const PERMISSION_CATALOG = {
 
   patients: ['read', 'write', 'update', 'delete', 'export', 'manage'],
   appointments: ['read', 'write', 'update', 'delete', 'export'],
+  // `calendar` is intentionally separate from `appointments` so admins
+  // can grant view-only access to the Calendar day-grid surface
+  // (`calendar.read`) without also unlocking the Appointments list,
+  // Book Appointment form, and My Appointments page — all gated on
+  // `appointments.read` / `appointments.write`. Calendar mutations
+  // (drag-to-reschedule, slot-click-to-book, right-click-cancel) gate
+  // on `calendar.write`. The backend's PHI gates accept either
+  // permission set for the underlying /api/wellness/visits endpoint so
+  // either grant flow works end-to-end.
+  calendar: ['read', 'write'],
   services: ['read', 'write', 'update', 'delete'],
   prescriptions: ['read', 'write', 'update', 'delete', 'export'],
   consents: ['read', 'write', 'update', 'delete'],
@@ -157,7 +167,7 @@ const PERMISSION_DOMAINS = [
   },
   {
     domain: 'Wellness Clinical',
-    modules: ['patients', 'appointments', 'services', 'prescriptions', 'consents', 'visits'],
+    modules: ['patients', 'appointments', 'calendar', 'services', 'prescriptions', 'consents', 'visits'],
   },
   {
     domain: 'Wellness Inventory',

--- a/backend/lib/wellnessRoleTypes.js
+++ b/backend/lib/wellnessRoleTypes.js
@@ -1,0 +1,113 @@
+/**
+ * Per-tenant wellness role catalog helper.
+ *
+ * Replaces the hard-coded VALID_WELLNESS_ROLES whitelist that used to
+ * live in routes/staff.js. Admins maintain the catalog from Settings →
+ * Wellness Role Types; the Calendar grid + Staff edit form read from
+ * here so a new role like "nurse" surfaces automatically.
+ *
+ * Generic-tenant (non-wellness) installs don't use this — staff.js
+ * skips the catalog check when tenant.vertical !== 'wellness' and falls
+ * back to a fixed legacy whitelist for backward compatibility.
+ */
+
+const prisma = require("./prisma");
+
+// Default role catalog seeded for every wellness tenant. The original
+// hardcoded whitelist was ["doctor","professional","telecaller","helper",
+// "stylist"]; we add "nurse" because that was the example role the
+// product team raised during the Option B kickoff (clinics with a
+// dedicated nursing column).
+const DEFAULT_WELLNESS_ROLES = [
+  { key: "doctor",       label: "Doctor",         canTakeVisits: true,  sortOrder: 10, icon: "Stethoscope" },
+  { key: "professional", label: "Professional",   canTakeVisits: true,  sortOrder: 20, icon: "User" },
+  { key: "nurse",        label: "Nurse",          canTakeVisits: true,  sortOrder: 30, icon: "HeartPulse" },
+  { key: "stylist",      label: "Stylist",        canTakeVisits: true,  sortOrder: 40, icon: "Scissors" },
+  { key: "telecaller",   label: "Telecaller",     canTakeVisits: false, sortOrder: 50, icon: "Phone" },
+  { key: "helper",       label: "Helper",         canTakeVisits: false, sortOrder: 60, icon: "HandHelping" },
+];
+
+// Slug rule: lowercase letters / digits / hyphens, must start with a
+// letter, max 32 chars. Matches the convention used elsewhere for
+// route slugs (booking-page slug, landing-page slug) so admins reading
+// the input help-text recognise the format.
+const ROLE_KEY_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+function ensureRoleKey(value, { required = true } = {}) {
+  if (value == null || value === "") {
+    return required
+      ? { status: 400, error: "key is required", code: "ROLE_KEY_REQUIRED" }
+      : null;
+  }
+  if (typeof value !== "string" || value.length > 32 || !ROLE_KEY_RE.test(value)) {
+    return {
+      status: 400,
+      error: "key must be lowercase letters/digits/hyphens, start with a letter, max 32 chars",
+      code: "INVALID_ROLE_KEY",
+    };
+  }
+  return null;
+}
+
+function ensureRoleLabel(value, { required = true } = {}) {
+  if (value == null || value === "") {
+    return required
+      ? { status: 400, error: "label is required", code: "ROLE_LABEL_REQUIRED" }
+      : null;
+  }
+  if (typeof value !== "string" || value.length > 64) {
+    return { status: 400, error: "label must be a string ≤ 64 chars", code: "INVALID_ROLE_LABEL" };
+  }
+  return null;
+}
+
+async function listForTenant(tenantId, { activeOnly = false } = {}) {
+  const where = { tenantId };
+  if (activeOnly) where.isActive = true;
+  return prisma.wellnessRoleType.findMany({
+    where,
+    orderBy: [{ sortOrder: "asc" }, { label: "asc" }],
+  });
+}
+
+// True when the tenant catalog contains an active row with this key.
+// Returns false on a missing key, an inactive row, or any DB error
+// (caller decides what to do with the false — staff.js returns 400).
+async function isCatalogedKey(tenantId, key) {
+  if (!key) return false;
+  try {
+    const row = await prisma.wellnessRoleType.findFirst({
+      where: { tenantId, key, isActive: true },
+      select: { id: true },
+    });
+    return !!row;
+  } catch (_e) {
+    return false;
+  }
+}
+
+// Upsert the default catalog for a tenant. Used by seed-wellness.js
+// (called for the demo Enhanced Wellness tenant) and by /api/tenants
+// when a new wellness tenant is created in the future.
+async function seedDefaultsForTenant(tenantId) {
+  for (const r of DEFAULT_WELLNESS_ROLES) {
+    const existing = await prisma.wellnessRoleType.findFirst({
+      where: { tenantId, key: r.key },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.wellnessRoleType.create({
+      data: { ...r, tenantId },
+    });
+  }
+}
+
+module.exports = {
+  DEFAULT_WELLNESS_ROLES,
+  ROLE_KEY_RE,
+  ensureRoleKey,
+  ensureRoleLabel,
+  listForTenant,
+  isCatalogedKey,
+  seedDefaultsForTenant,
+};

--- a/backend/middleware/wellnessRole.js
+++ b/backend/middleware/wellnessRole.js
@@ -9,10 +9,26 @@
  * fixes that — use it AFTER verifyToken on wellness routes that need a
  * narrower clinical/operational gate.
  *
- * Allowed list accepts wellnessRole values plus two special tokens:
- *   - "admin"   → owner override; req.user.role === "ADMIN" always passes.
- *   - "manager" → req.user.role === "MANAGER" passes.
+ * Allowed list accepts wellnessRole values plus three special tokens:
+ *   - "admin"    → owner override; req.user.role === "ADMIN" always passes.
+ *   - "manager"  → req.user.role === "MANAGER" passes.
+ *   - "clinical" → ANY wellnessRole present in the tenant's
+ *                  WellnessRoleType catalog with `canTakeVisits = true`
+ *                  passes. Lets admins add a new clinical role (e.g.
+ *                  "nurse", "physiotherapist") in Settings → Wellness
+ *                  Role Types and have it flow through every clinical
+ *                  route automatically with NO code edits.
  * Everything else must literally match req.user.wellnessRole.
+ *
+ * Optional second argument `{ anyOfPermissions: [{module, action}, ...] }`
+ * lets a route ALSO accept RBAC-permission-based access — any user
+ * whose effective permissions include AT LEAST ONE of the listed
+ * grants passes the gate, even without a matching wellnessRole. This
+ * is what makes a brand-new custom role (e.g. "Receptionist") created
+ * in the Roles & Permissions admin UI immediately usable: the admin
+ * grants `appointments.read` to the role and the user gains access to
+ * every route whose `anyOfPermissions` lists that grant — with NO
+ * code changes anywhere.
  *
  * Backwards-compat: tokens minted before the JWT carries `wellnessRole`
  * lack the claim entirely. They will fail any clinical/operational gate
@@ -51,6 +67,12 @@ const prisma = require("../lib/prisma");
 // We keep the granular `code` (WELLNESS_TENANT_REQUIRED /
 // WELLNESS_ROLE_FORBIDDEN) so SDKs / specs can branch on intent.
 const { RBAC_DENIED_MESSAGE } = require("./auth");
+// Whole-module require (NOT destructured) so unit tests can swap out
+// `requirePermissionModule.getUserPermissions` with a deterministic fake
+// without losing the reference — destructuring at require-time would
+// freeze the original function in a const that test re-assignment can't
+// affect.
+const requirePermissionModule = require("./requirePermission");
 
 async function resolveTenantVertical(req) {
   if (req.user?.vertical) return req.user.vertical;
@@ -68,10 +90,36 @@ async function resolveTenantVertical(req) {
   }
 }
 
-function verifyWellnessRole(allowed) {
+// Per-request memoized lookup: is the given wellnessRole key marked as
+// a clinical role (canTakeVisits = true) in the tenant's
+// WellnessRoleType catalog? Returns false on missing key, inactive row,
+// or any DB error — callers degrade to "literal-match only" semantics,
+// preserving the pre-catalog behaviour as the safety net.
+async function isCatalogClinical(req, key) {
+  if (!key || !req.user?.tenantId) return false;
+  if (!req._wellnessRoleCatalog) {
+    try {
+      const rows = await prisma.wellnessRoleType.findMany({
+        where: { tenantId: req.user.tenantId, isActive: true },
+        select: { key: true, canTakeVisits: true },
+      });
+      const map = new Map();
+      for (const r of rows) map.set(r.key, !!r.canTakeVisits);
+      req._wellnessRoleCatalog = map;
+    } catch (_e) {
+      req._wellnessRoleCatalog = new Map();
+    }
+  }
+  return req._wellnessRoleCatalog.get(key) === true;
+}
+
+function verifyWellnessRole(allowed, opts = {}) {
   if (!Array.isArray(allowed) || allowed.length === 0) {
     throw new Error("verifyWellnessRole(allowed): non-empty array required");
   }
+  const anyOfPermissions = Array.isArray(opts.anyOfPermissions)
+    ? opts.anyOfPermissions.filter((p) => p && p.module && p.action)
+    : [];
   return async (req, res, next) => {
     if (!req.user) {
       return res.status(401).json({ error: "Authentication required" });
@@ -94,6 +142,38 @@ function verifyWellnessRole(allowed) {
     if (allowed.includes("manager") && req.user.role === "MANAGER") return next();
     if (req.user.wellnessRole && allowed.includes(req.user.wellnessRole)) {
       return next();
+    }
+    // "clinical" meta-token: passes any wellnessRole the tenant's
+    // WellnessRoleType catalog marks as `canTakeVisits = true`. This
+    // means an admin can add a new clinical role (nurse,
+    // physiotherapist, etc.) from Settings → Wellness Role Types and it
+    // immediately becomes accepted by every clinical-gated route — no
+    // code change required.
+    if (allowed.includes("clinical") && (await isCatalogClinical(req, req.user.wellnessRole))) {
+      return next();
+    }
+    // RBAC-permission fallback: pass if the user's effective
+    // permissions (merged from every UserRole assignment) include AT
+    // LEAST ONE of the route's `anyOfPermissions` grants. Lets an
+    // admin spin up a brand-new custom role like "Receptionist" in
+    // Roles & Permissions, grant `appointments.read`, and have the
+    // assignee immediately use the appointments UI — without needing
+    // to also pick a wellnessRole or edit any code.
+    if (anyOfPermissions.length > 0 && req.user.tenantId && req.user.userId) {
+      try {
+        const userPerms = await requirePermissionModule.getUserPermissions(
+          req.user.tenantId,
+          req.user.userId,
+        );
+        for (const { module, action } of anyOfPermissions) {
+          if (userPerms.has(`${module}.${action}`)) {
+            return next();
+          }
+        }
+      } catch (_e) {
+        // Fail-closed: if the permission lookup throws, fall through
+        // to 403 — never accidentally grant access on a DB hiccup.
+      }
     }
     // `allowed` stays in the envelope to honour the #274 contract
     // (services-api spec pins it; frontend toast mapper keys off the

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -390,6 +390,10 @@ model Tenant {
   // (currently stub-mode pending Q3 cred drop from Travel Stall). Per-
   // tenant scoped + cascade-deletes with the tenant.
   digilockerSessions DigilockerSession[]
+
+  // Per-tenant wellness role catalog (replaces the hard-coded
+  // VALID_WELLNESS_ROLES whitelist; admins can add custom roles).
+  wellnessRoleTypes WellnessRoleType[]
 }
 
 model User {
@@ -2423,24 +2427,24 @@ model CannedResponse {
 // ── NPS / CSAT Surveys ───────────────────────────────────────────
 
 model Survey {
-  id        Int      @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   // `name` is the legacy short-id key used by the NPS cron
   // (wellnessOpsEngine.js); keep it so existing surveys + the
   // auto-NPS flow keep working unchanged.
-  name      String
+  name            String
   // `title` is the human-readable form name used by the multi-question
   // builder. Nullable so legacy NPS rows aren't forced to backfill.
-  title     String?
+  title           String?
   // String-as-enum (matches the codebase convention — see Tenant.vertical,
   // SignatureRequest.documentType, etc.). Allowed values:
   //   Legacy single-question: NPS | CSAT | CUSTOM
   //   New multi-question:     PRODUCT | SERVICE | DOCTOR
   // The wellnessOpsEngine cron continues to write NPS rows; the new
   // builder writes PRODUCT / SERVICE / DOCTOR / CUSTOM rows.
-  type      String   @default("NPS")
+  type            String   @default("NPS")
   // Legacy single-question text — nullable because new multi-question
   // surveys carry their questions in SurveyQuestion rows instead.
-  question  String?
+  question        String?
   // Polymorphic FK; the route validates by `type`:
   //   PRODUCT → relatedEntityId references Product.id
   //   SERVICE → references Service.id
@@ -2451,11 +2455,11 @@ model Survey {
   // Admin who created the survey. Nullable so cron-created NPS rows
   // (which have no user actor) don't need a synthetic user.
   createdById     Int?
-  isActive  Boolean  @default(true)
-  tenantId  Int      @default(1)
-  tenant    Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  isActive        Boolean  @default(true)
+  tenantId        Int      @default(1)
+  tenant          Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   questions SurveyQuestion[]
   answers   SurveyAnswer[]
@@ -2502,7 +2506,7 @@ model SurveyQuestion {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  answers    SurveyAnswer[]
+  answers SurveyAnswer[]
 
   @@index([tenantId, surveyId, order])
 }
@@ -2513,16 +2517,16 @@ model SurveyQuestion {
 // the same Survey if needed (e.g. an NPS-tagged survey that later grows
 // custom questions), and reports consume each independently.
 model SurveyAnswer {
-  id         Int      @id @default(autoincrement())
-  surveyId   Int
-  survey     Survey   @relation(fields: [surveyId], references: [id], onDelete: Cascade)
-  questionId Int
-  question   SurveyQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
-  userId     Int?
+  id           Int            @id @default(autoincrement())
+  surveyId     Int
+  survey       Survey         @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  questionId   Int
+  question     SurveyQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  userId       Int?
   // Free-form text storage — RATE answers stringify the number,
   // YES_NO stringify "True"/"False", SELECT/RADIO stringify the chosen
   // option label. Keeps the schema uniform regardless of fieldType.
-  answer     String?  @db.Text
+  answer       String?        @db.Text
   // Submission grouping key. All SurveyAnswer rows produced by one
   // POST /respond/:token/submit (or POST /:id/submit) share the same
   // submissionId — generated server-side per submit call via crypto
@@ -2538,11 +2542,11 @@ model SurveyAnswer {
   // column existed leave both null. Not declared as Prisma relations
   // because Contact and Patient already cascade on tenant delete and
   // this row's lifetime tracks Survey, not its recipient.
-  contactId  Int?
-  patientId  Int?
-  tenantId   Int      @default(1)
-  tenant     Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  createdAt  DateTime @default(now())
+  contactId    Int?
+  patientId    Int?
+  tenantId     Int            @default(1)
+  tenant       Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  createdAt    DateTime       @default(now())
 
   @@index([tenantId, surveyId])
   @@index([tenantId, questionId])
@@ -3497,6 +3501,34 @@ model Location {
 
   @@index([tenantId, isActive])
   @@index([tenantId, city])
+}
+
+// Per-tenant wellness role catalog. Replaces the hard-coded
+// VALID_WELLNESS_ROLES whitelist in routes/staff.js so admins can add
+// custom roles (e.g. "nurse", "physio") from Settings without a code
+// change. `key` is the slug stored on User.wellnessRole; `label` is
+// the display name shown in dropdowns. `canTakeVisits` flags roles
+// that should appear as columns on the Calendar grid (doctor /
+// professional / nurse — but not telecaller / helper, who don't take
+// patient visits).
+model WellnessRoleType {
+  id            Int     @id @default(autoincrement())
+  key           String // slug: "doctor", "nurse", "physio"
+  label         String // display: "Doctor", "Nurse", "Physiotherapist"
+  icon          String? // optional lucide icon name; null = default Stethoscope
+  color         String? // optional hex/css color for chip; null = theme default
+  canTakeVisits Boolean @default(true)
+  isActive      Boolean @default(true)
+  sortOrder     Int     @default(0)
+
+  tenantId Int
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([key, tenantId])
+  @@index([tenantId, isActive])
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/backend/prisma/seed-wellness.js
+++ b/backend/prisma/seed-wellness.js
@@ -321,6 +321,17 @@ async function main() {
     console.log(`[seed-wellness] backfilled locationId on ${patientsBackfilled.count} patients, ${visitsBackfilled.count} visits`);
   }
 
+  // 1b. Wellness role catalog — per-tenant replacement for the old hard-coded
+  // VALID_WELLNESS_ROLES whitelist. Admins can add custom roles (e.g. "nurse")
+  // from Settings; Staff edit + Calendar grid read from this catalog.
+  try {
+    const { seedDefaultsForTenant } = require("../lib/wellnessRoleTypes");
+    await seedDefaultsForTenant(tenant.id);
+    console.log(`[seed-wellness] wellness role catalog seeded`);
+  } catch (e) {
+    console.warn(`[seed-wellness] role-catalog seed skipped: ${e.message}`);
+  }
+
   // 2. Staff
   const passwordHash = await bcrypt.hash(PASSWORD, 10);
   const userMap = {};

--- a/backend/routes/drugs.js
+++ b/backend/routes/drugs.js
@@ -21,8 +21,21 @@ const { verifyWellnessRole } = require("../middleware/wellnessRole");
 const router = express.Router();
 
 const tenantWhere = (req, extra = {}) => ({ tenantId: req.user.tenantId, ...extra });
-const readGate = verifyWellnessRole(["admin", "manager", "doctor"]);
-const writeGate = verifyWellnessRole(["admin", "manager"]);
+// "clinical" meta-token resolves dynamically against the per-tenant
+// WellnessRoleType catalog (doctor / professional / nurse / stylist /
+// any future custom clinical role with canTakeVisits=true).
+// `anyOfPermissions` adds an RBAC-permission unlock: any custom role
+// granted `prescriptions.read` (the same permission that surfaces the
+// Drug Catalogue page in the sidebar, per the page catalog) hits the
+// route — no code change needed.
+const readGate = verifyWellnessRole(
+  ["admin", "manager", "clinical", "doctor"],
+  { anyOfPermissions: [{ module: "prescriptions", action: "read" }] },
+);
+const writeGate = verifyWellnessRole(
+  ["admin", "manager"],
+  { anyOfPermissions: [{ module: "prescriptions", action: "write" }] },
+);
 
 // ── Drug CRUD + typeahead ─────────────────────────────────────────
 

--- a/backend/routes/pos.js
+++ b/backend/routes/pos.js
@@ -34,25 +34,45 @@ const { verifyWellnessRole } = require("../middleware/wellnessRole");
 
 const router = express.Router();
 
-const tenantWhere = (req, extra = {}) => ({ tenantId: req.user.tenantId, ...extra });
+const tenantWhere = (req, extra = {}) => ({
+  tenantId: req.user.tenantId,
+  ...extra,
+});
 
 // admin/manager can do everything; clinical staff (doctor/professional/
 // telecaller/helper) can ring up sales + manage their own shift but not
 // configure registers / refund.
-const adminGate = verifyWellnessRole(["admin", "manager"]);
-// D17 slice 7 (PRD_POS_NEW_SALE §3.9 + DD-5.7 round-2 RESOLVED 2026-05-25
-// STRICT mode) — void + refund must be ADMIN-only (not manager). Stricter
-// than adminGate above; gives the cashier/manager no escape hatch from the
-// audited destruction of a completed sale + its wallet redemption.
-const strictAdminGate = verifyWellnessRole(["admin"]);
-const cashierGate = verifyWellnessRole([
-  "admin",
-  "manager",
-  "doctor",
-  "professional",
-  "telecaller",
-  "helper",
-]);
+// `anyOfPermissions` lets any RBAC role granted `pos.manage` (admin
+// surfaces — register config, refunds) reach the admin-gated endpoints.
+const adminGate = verifyWellnessRole(["admin", "manager"], {
+  anyOfPermissions: [{ module: "pos", action: "manage" }],
+});
+// "clinical" meta-token covers ALL clinical staff (doctor, professional,
+// nurse, stylist, plus any future custom clinical role with
+// canTakeVisits=true). Telecaller + helper stay as literals because they
+// are operational (canTakeVisits=false) and the cashier surface
+// explicitly includes them — we never want to auto-elevate a new
+// operational role to cashier access just because it appears in the
+// catalog. `anyOfPermissions` opens the cashier surface to any custom
+// role granted `pos.read` or `pos.write` (matches the page catalog's
+// /wellness/pos entry, which requires pos.read).
+const cashierGate = verifyWellnessRole(
+  [
+    "admin",
+    "manager",
+    "clinical",
+    "doctor",
+    "professional",
+    "telecaller",
+    "helper",
+  ],
+  {
+    anyOfPermissions: [
+      { module: "pos", action: "read" },
+      { module: "pos", action: "write" },
+    ],
+  },
+);
 
 // ── Sale-side loyalty auto-credit (PRD Gap §2 item 9) ────────────────
 // Sibling of routes/wellness.js maybeAutoCreditLoyalty(visit, ...). The
@@ -171,7 +191,9 @@ router.get("/registers/:id", cashierGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
     const reg = await prisma.register.findFirst({
       where: tenantWhere(req, { id }),
@@ -189,18 +211,33 @@ router.post("/registers", adminGate, async (req, res) => {
   try {
     const { locationId, name, openingFloat, isActive } = req.body;
     if (!name || typeof name !== "string" || !name.trim()) {
-      return res.status(400).json({ error: "name is required", code: "NAME_REQUIRED" });
+      return res
+        .status(400)
+        .json({ error: "name is required", code: "NAME_REQUIRED" });
     }
     if (!locationId || !Number.isFinite(parseInt(locationId))) {
-      return res.status(400).json({ error: "locationId is required", code: "LOCATION_REQUIRED" });
+      return res
+        .status(400)
+        .json({ error: "locationId is required", code: "LOCATION_REQUIRED" });
     }
     const loc = await prisma.location.findFirst({
       where: tenantWhere(req, { id: parseInt(locationId) }),
     });
-    if (!loc) return res.status(400).json({ error: "locationId does not exist in this tenant", code: "LOCATION_NOT_FOUND" });
+    if (!loc)
+      return res
+        .status(400)
+        .json({
+          error: "locationId does not exist in this tenant",
+          code: "LOCATION_NOT_FOUND",
+        });
     const float = openingFloat !== undefined ? parseFloat(openingFloat) : 0;
     if (!Number.isFinite(float) || float < 0) {
-      return res.status(400).json({ error: "openingFloat must be a non-negative number", code: "INVALID_FLOAT" });
+      return res
+        .status(400)
+        .json({
+          error: "openingFloat must be a non-negative number",
+          code: "INVALID_FLOAT",
+        });
     }
     const reg = await prisma.register.create({
       data: {
@@ -211,10 +248,17 @@ router.post("/registers", adminGate, async (req, res) => {
         tenantId: req.user.tenantId,
       },
     });
-    await writeAudit("Register", "CREATE", reg.id, req.user.userId, req.user.tenantId, {
-      name: reg.name,
-      locationId: reg.locationId,
-    });
+    await writeAudit(
+      "Register",
+      "CREATE",
+      reg.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        name: reg.name,
+        locationId: reg.locationId,
+      },
+    );
     res.status(201).json(reg);
   } catch (e) {
     console.error("[pos] create register error:", e.message);
@@ -226,18 +270,28 @@ router.put("/registers/:id", adminGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
-    const existing = await prisma.register.findFirst({ where: tenantWhere(req, { id }) });
+    const existing = await prisma.register.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!existing) return res.status(404).json({ error: "Register not found" });
 
     const data = {};
     const allowed = ["name", "openingFloat", "isActive", "locationId"];
-    for (const k of allowed) if (req.body[k] !== undefined) data[k] = req.body[k];
+    for (const k of allowed)
+      if (req.body[k] !== undefined) data[k] = req.body[k];
     if (data.openingFloat !== undefined) {
       const f = parseFloat(data.openingFloat);
       if (!Number.isFinite(f) || f < 0) {
-        return res.status(400).json({ error: "openingFloat must be a non-negative number", code: "INVALID_FLOAT" });
+        return res
+          .status(400)
+          .json({
+            error: "openingFloat must be a non-negative number",
+            code: "INVALID_FLOAT",
+          });
       }
       data.openingFloat = f;
     }
@@ -245,19 +299,37 @@ router.put("/registers/:id", adminGate, async (req, res) => {
       const loc = await prisma.location.findFirst({
         where: tenantWhere(req, { id: parseInt(data.locationId) }),
       });
-      if (!loc) return res.status(400).json({ error: "locationId does not exist in this tenant", code: "LOCATION_NOT_FOUND" });
+      if (!loc)
+        return res
+          .status(400)
+          .json({
+            error: "locationId does not exist in this tenant",
+            code: "LOCATION_NOT_FOUND",
+          });
       data.locationId = parseInt(data.locationId);
     }
     if (data.name !== undefined) {
       if (typeof data.name !== "string" || !data.name.trim()) {
-        return res.status(400).json({ error: "name must be a non-empty string", code: "INVALID_NAME" });
+        return res
+          .status(400)
+          .json({
+            error: "name must be a non-empty string",
+            code: "INVALID_NAME",
+          });
       }
       data.name = data.name.trim();
     }
     const updated = await prisma.register.update({ where: { id }, data });
     const changes = diffFields(existing, updated, Object.keys(data));
     if (Object.keys(changes).length > 0) {
-      await writeAudit("Register", "UPDATE", id, req.user.userId, req.user.tenantId, { changedFields: changes });
+      await writeAudit(
+        "Register",
+        "UPDATE",
+        id,
+        req.user.userId,
+        req.user.tenantId,
+        { changedFields: changes },
+      );
     }
     res.json(updated);
   } catch (e) {
@@ -270,9 +342,13 @@ router.delete("/registers/:id", adminGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
-    const existing = await prisma.register.findFirst({ where: tenantWhere(req, { id }) });
+    const existing = await prisma.register.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!existing) return res.status(404).json({ error: "Register not found" });
 
     // Block delete if there's an OPEN shift on this register — operators
@@ -288,9 +364,16 @@ router.delete("/registers/:id", adminGate, async (req, res) => {
       });
     }
     await prisma.register.delete({ where: { id } });
-    await writeAudit("Register", "DELETE", id, req.user.userId, req.user.tenantId, {
-      name: existing.name,
-    });
+    await writeAudit(
+      "Register",
+      "DELETE",
+      id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        name: existing.name,
+      },
+    );
     res.status(204).end();
   } catch (e) {
     console.error("[pos] delete register error:", e.message);
@@ -304,14 +387,18 @@ router.post("/shifts/open", cashierGate, async (req, res) => {
   try {
     const { registerId, openingFloat } = req.body;
     if (!registerId || !Number.isFinite(parseInt(registerId))) {
-      return res.status(400).json({ error: "registerId is required", code: "REGISTER_REQUIRED" });
+      return res
+        .status(400)
+        .json({ error: "registerId is required", code: "REGISTER_REQUIRED" });
     }
     const reg = await prisma.register.findFirst({
       where: tenantWhere(req, { id: parseInt(registerId) }),
     });
     if (!reg) return res.status(404).json({ error: "Register not found" });
     if (!reg.isActive) {
-      return res.status(409).json({ error: "Register is inactive", code: "REGISTER_INACTIVE" });
+      return res
+        .status(409)
+        .json({ error: "Register is inactive", code: "REGISTER_INACTIVE" });
     }
     // 409 if a shift is already open on this register.
     const existing = await prisma.shift.findFirst({
@@ -329,7 +416,12 @@ router.post("/shifts/open", cashierGate, async (req, res) => {
         ? parseFloat(openingFloat)
         : reg.openingFloat;
     if (!Number.isFinite(float) || float < 0) {
-      return res.status(400).json({ error: "openingFloat must be a non-negative number", code: "INVALID_FLOAT" });
+      return res
+        .status(400)
+        .json({
+          error: "openingFloat must be a non-negative number",
+          code: "INVALID_FLOAT",
+        });
     }
     const shift = await prisma.shift.create({
       data: {
@@ -340,10 +432,17 @@ router.post("/shifts/open", cashierGate, async (req, res) => {
         status: "OPEN",
       },
     });
-    await writeAudit("Shift", "OPEN", shift.id, req.user.userId, req.user.tenantId, {
-      registerId: reg.id,
-      openingFloat: float,
-    });
+    await writeAudit(
+      "Shift",
+      "OPEN",
+      shift.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        registerId: reg.id,
+        openingFloat: float,
+      },
+    );
     // PRD Gap §13 item 4 — emit shift.opened so AutomationRules + outbound
     // webhooks can react (e.g. Slack ping the manager when a register opens).
     // Failure here MUST NOT roll back the shift create — fire-and-forget with
@@ -359,9 +458,11 @@ router.post("/shifts/open", cashierGate, async (req, res) => {
           openingFloat: float,
         },
         req.user.tenantId,
-        req.io
+        req.io,
       );
-    } catch (_e) { /* event bus optional */ }
+    } catch (_e) {
+      /* event bus optional */
+    }
     res.status(201).json(shift);
   } catch (e) {
     console.error("[pos] open shift error:", e.message);
@@ -373,27 +474,48 @@ router.post("/shifts/:id/close", cashierGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
-    const shift = await prisma.shift.findFirst({ where: tenantWhere(req, { id }) });
+    const shift = await prisma.shift.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!shift) return res.status(404).json({ error: "Shift not found" });
     if (shift.status !== "OPEN") {
-      return res.status(409).json({ error: "Shift is not open", code: "SHIFT_NOT_OPEN", status: shift.status });
+      return res
+        .status(409)
+        .json({
+          error: "Shift is not open",
+          code: "SHIFT_NOT_OPEN",
+          status: shift.status,
+        });
     }
     // Only the cashier who opened the shift OR an admin can close it.
     if (req.user.role !== "ADMIN" && shift.userId !== req.user.userId) {
       return res.status(403).json({
-        error: "Only the cashier who opened this shift (or an admin) can close it",
+        error:
+          "Only the cashier who opened this shift (or an admin) can close it",
         code: "SHIFT_NOT_OWNER",
       });
     }
     const { closingTotal, notes } = req.body;
     if (closingTotal === undefined || closingTotal === null) {
-      return res.status(400).json({ error: "closingTotal is required", code: "CLOSING_TOTAL_REQUIRED" });
+      return res
+        .status(400)
+        .json({
+          error: "closingTotal is required",
+          code: "CLOSING_TOTAL_REQUIRED",
+        });
     }
     const closing = parseFloat(closingTotal);
     if (!Number.isFinite(closing) || closing < 0) {
-      return res.status(400).json({ error: "closingTotal must be a non-negative number", code: "INVALID_CLOSING_TOTAL" });
+      return res
+        .status(400)
+        .json({
+          error: "closingTotal must be a non-negative number",
+          code: "INVALID_CLOSING_TOTAL",
+        });
     }
     // expectedCash = openingFloat + sum(CASH sales) + sum(DEPOSIT) - sum(WITHDRAWAL).
     // #779: petty-cash ledger now contributes to expected drawer balance.
@@ -412,11 +534,19 @@ router.post("/shifts/:id/close", cashierGate, async (req, res) => {
     });
     const cashTaken = cashSales._sum.paidAmount || 0;
     const deposits = await prisma.pettyCashLedger.aggregate({
-      where: { tenantId: req.user.tenantId, shiftId: shift.id, type: "DEPOSIT" },
+      where: {
+        tenantId: req.user.tenantId,
+        shiftId: shift.id,
+        type: "DEPOSIT",
+      },
       _sum: { amount: true },
     });
     const withdrawals = await prisma.pettyCashLedger.aggregate({
-      where: { tenantId: req.user.tenantId, shiftId: shift.id, type: "WITHDRAWAL" },
+      where: {
+        tenantId: req.user.tenantId,
+        shiftId: shift.id,
+        type: "WITHDRAWAL",
+      },
       _sum: { amount: true },
     });
     const depositsTotal = deposits._sum.amount || 0;
@@ -456,9 +586,11 @@ router.post("/shifts/:id/close", cashierGate, async (req, res) => {
           variance,
         },
         req.user.tenantId,
-        req.io
+        req.io,
       );
-    } catch (_e) { /* event bus optional */ }
+    } catch (_e) {
+      /* event bus optional */
+    }
     res.json(closed);
   } catch (e) {
     console.error("[pos] close shift error:", e.message);
@@ -486,7 +618,8 @@ router.get("/shifts", adminGate, async (req, res) => {
   try {
     const { registerId, from, to, status } = req.query;
     const where = tenantWhere(req);
-    if (registerId && Number.isFinite(parseInt(registerId))) where.registerId = parseInt(registerId);
+    if (registerId && Number.isFinite(parseInt(registerId)))
+      where.registerId = parseInt(registerId);
     if (status) where.status = status;
     if (from || to) {
       where.openedAt = {};
@@ -513,14 +646,25 @@ router.get("/shifts/:id", cashierGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
     const shift = await prisma.shift.findFirst({
       where: tenantWhere(req, { id }),
       include: {
         register: { select: { id: true, name: true } },
         user: { select: { id: true, name: true, email: true } },
-        sales: { select: { id: true, invoiceNumber: true, total: true, paymentMethod: true, status: true, createdAt: true } },
+        sales: {
+          select: {
+            id: true,
+            invoiceNumber: true,
+            total: true,
+            paymentMethod: true,
+            status: true,
+            createdAt: true,
+          },
+        },
       },
     });
     if (!shift) return res.status(404).json({ error: "Shift not found" });
@@ -573,9 +717,13 @@ async function recordPettyCashEntry(req, res, type) {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
-    const shift = await prisma.shift.findFirst({ where: tenantWhere(req, { id }) });
+    const shift = await prisma.shift.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!shift) return res.status(404).json({ error: "Shift not found" });
     if (shift.status !== "OPEN") {
       return res.status(409).json({
@@ -607,12 +755,19 @@ async function recordPettyCashEntry(req, res, type) {
         userId: req.user.userId,
       },
     });
-    await writeAudit("Shift", "CASH_LEDGER", shift.id, req.user.userId, req.user.tenantId, {
-      ledgerId: entry.id,
-      type,
-      amount: amt,
-      reason: entry.reason,
-    });
+    await writeAudit(
+      "Shift",
+      "CASH_LEDGER",
+      shift.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        ledgerId: entry.id,
+        type,
+        amount: amt,
+        reason: entry.reason,
+      },
+    );
     res.status(201).json(entry);
   } catch (e) {
     console.error(`[pos] petty-cash ${type} error:`, e.message);
@@ -621,11 +776,11 @@ async function recordPettyCashEntry(req, res, type) {
 }
 
 router.post("/shifts/:id/deposit", adminGate, (req, res) =>
-  recordPettyCashEntry(req, res, "DEPOSIT")
+  recordPettyCashEntry(req, res, "DEPOSIT"),
 );
 
 router.post("/shifts/:id/withdraw", adminGate, (req, res) =>
-  recordPettyCashEntry(req, res, "WITHDRAWAL")
+  recordPettyCashEntry(req, res, "WITHDRAWAL"),
 );
 
 // GET /api/pos/shifts/:id/petty-cash — list ledger entries for a shift.
@@ -635,9 +790,13 @@ router.get("/shifts/:id/petty-cash", cashierGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
-    const shift = await prisma.shift.findFirst({ where: tenantWhere(req, { id }) });
+    const shift = await prisma.shift.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!shift) return res.status(404).json({ error: "Shift not found" });
     if (
       req.user.role !== "ADMIN" &&
@@ -693,7 +852,12 @@ router.get("/sale-context/:patientId", cashierGate, async (req, res) => {
   try {
     const patientId = parseInt(req.params.patientId, 10);
     if (!Number.isFinite(patientId) || patientId <= 0) {
-      return res.status(400).json({ error: "patientId must be a positive integer", code: "INVALID_PATIENT_ID" });
+      return res
+        .status(400)
+        .json({
+          error: "patientId must be a positive integer",
+          code: "INVALID_PATIENT_ID",
+        });
     }
 
     // Tenant-scoped patient existence check first — cross-tenant probe
@@ -704,7 +868,9 @@ router.get("/sale-context/:patientId", cashierGate, async (req, res) => {
       select: { id: true },
     });
     if (!patient) {
-      return res.status(404).json({ error: "Patient not found", code: "PATIENT_NOT_FOUND" });
+      return res
+        .status(404)
+        .json({ error: "Patient not found", code: "PATIENT_NOT_FOUND" });
     }
 
     const wallet = await prisma.wallet.findFirst({
@@ -737,7 +903,13 @@ router.get("/sale-context/:patientId", cashierGate, async (req, res) => {
 
 // ── Sale create / list / get / refund ────────────────────────────────
 
-const VALID_LINE_TYPES = ["SERVICE", "PRODUCT", "MEMBERSHIP", "GIFTCARD", "PACKAGE"];
+const VALID_LINE_TYPES = [
+  "SERVICE",
+  "PRODUCT",
+  "MEMBERSHIP",
+  "GIFTCARD",
+  "PACKAGE",
+];
 // #789 — payment methods accepted at POS. CASHBACK / PAYLATER / ONLINE
 // were added 2026-05-18 to match the Zylu reference set + the PointOfSale
 // dropdown options. Treatment differs per method:
@@ -788,7 +960,9 @@ router.post("/sales", cashierGate, async (req, res) => {
 
     // Validate shift
     if (!shiftId || !Number.isFinite(parseInt(shiftId))) {
-      return res.status(400).json({ error: "shiftId is required", code: "SHIFT_REQUIRED" });
+      return res
+        .status(400)
+        .json({ error: "shiftId is required", code: "SHIFT_REQUIRED" });
     }
     const shift = await prisma.shift.findFirst({
       where: tenantWhere(req, { id: parseInt(shiftId) }),
@@ -814,16 +988,31 @@ router.post("/sales", cashierGate, async (req, res) => {
 
     // Validate lineItems
     if (!Array.isArray(lineItems) || lineItems.length === 0) {
-      return res.status(400).json({ error: "lineItems must be a non-empty array", code: "LINE_ITEMS_REQUIRED" });
+      return res
+        .status(400)
+        .json({
+          error: "lineItems must be a non-empty array",
+          code: "LINE_ITEMS_REQUIRED",
+        });
     }
     if (lineItems.length > 200) {
-      return res.status(400).json({ error: "lineItems exceeds 200 rows", code: "LINE_ITEMS_TOO_MANY" });
+      return res
+        .status(400)
+        .json({
+          error: "lineItems exceeds 200 rows",
+          code: "LINE_ITEMS_TOO_MANY",
+        });
     }
     const normalisedLines = [];
     for (let i = 0; i < lineItems.length; i++) {
       const li = lineItems[i];
       if (!li || typeof li !== "object") {
-        return res.status(400).json({ error: `lineItems[${i}] must be an object`, code: "INVALID_LINE_ITEM" });
+        return res
+          .status(400)
+          .json({
+            error: `lineItems[${i}] must be an object`,
+            code: "INVALID_LINE_ITEM",
+          });
       }
       if (!VALID_LINE_TYPES.includes(li.lineType)) {
         return res.status(400).json({
@@ -833,23 +1022,47 @@ router.post("/sales", cashierGate, async (req, res) => {
       }
       const refId = parseInt(li.refId);
       if (!Number.isFinite(refId)) {
-        return res.status(400).json({ error: `lineItems[${i}].refId must be numeric`, code: "INVALID_REF_ID" });
+        return res
+          .status(400)
+          .json({
+            error: `lineItems[${i}].refId must be numeric`,
+            code: "INVALID_REF_ID",
+          });
       }
       // Use ?? not || so quantity=0 isn't silently coerced to 1.
       const quantity = parseInt(li.quantity ?? 1);
       if (!Number.isFinite(quantity) || quantity < 1) {
-        return res.status(400).json({ error: `lineItems[${i}].quantity must be >= 1`, code: "INVALID_QUANTITY" });
+        return res
+          .status(400)
+          .json({
+            error: `lineItems[${i}].quantity must be >= 1`,
+            code: "INVALID_QUANTITY",
+          });
       }
       const unitPrice = parseFloat(li.unitPrice);
       if (!Number.isFinite(unitPrice) || unitPrice < 0) {
-        return res.status(400).json({ error: `lineItems[${i}].unitPrice must be >= 0`, code: "INVALID_UNIT_PRICE" });
+        return res
+          .status(400)
+          .json({
+            error: `lineItems[${i}].unitPrice must be >= 0`,
+            code: "INVALID_UNIT_PRICE",
+          });
       }
       const lineDiscount = parseFloat(li.lineDiscount || 0);
       if (!Number.isFinite(lineDiscount) || lineDiscount < 0) {
-        return res.status(400).json({ error: `lineItems[${i}].lineDiscount must be >= 0`, code: "INVALID_LINE_DISCOUNT" });
+        return res
+          .status(400)
+          .json({
+            error: `lineItems[${i}].lineDiscount must be >= 0`,
+            code: "INVALID_LINE_DISCOUNT",
+          });
       }
       const lineTotal = Math.max(0, quantity * unitPrice - lineDiscount);
-      const name = (li.name && typeof li.name === "string" ? li.name : `${li.lineType} #${refId}`).slice(0, 240);
+      const name = (
+        li.name && typeof li.name === "string"
+          ? li.name
+          : `${li.lineType} #${refId}`
+      ).slice(0, 240);
       normalisedLines.push({
         lineType: li.lineType,
         refId,
@@ -871,15 +1084,26 @@ router.post("/sales", cashierGate, async (req, res) => {
     }
 
     // Compute totals
-    const subtotal = normalisedLines.reduce((acc, l) => acc + l.quantity * l.unitPrice, 0);
-    const lineDiscounts = normalisedLines.reduce((acc, l) => acc + l.lineDiscount, 0);
+    const subtotal = normalisedLines.reduce(
+      (acc, l) => acc + l.quantity * l.unitPrice,
+      0,
+    );
+    const lineDiscounts = normalisedLines.reduce(
+      (acc, l) => acc + l.lineDiscount,
+      0,
+    );
     const orderDiscount = Math.max(0, parseFloat(discountTotal || 0));
     const totalDiscount = lineDiscounts + orderDiscount;
     const tax = Math.max(0, parseFloat(taxTotal || 0));
     const total = Math.max(0, subtotal - totalDiscount + tax);
     const paid = paidAmount !== undefined ? parseFloat(paidAmount) : total;
     if (!Number.isFinite(paid) || paid < 0) {
-      return res.status(400).json({ error: "paidAmount must be >= 0", code: "INVALID_PAID_AMOUNT" });
+      return res
+        .status(400)
+        .json({
+          error: "paidAmount must be >= 0",
+          code: "INVALID_PAID_AMOUNT",
+        });
     }
 
     // PRD Gap §2 item 8 — `sum(payments) == grand_total ±0.01` validation.
@@ -892,13 +1116,21 @@ router.post("/sales", cashierGate, async (req, res) => {
     if (pm === "COMBINED") {
       let breakdown;
       if (typeof paymentBreakdownJson === "string") {
-        try { breakdown = JSON.parse(paymentBreakdownJson); } catch { breakdown = null; }
-      } else if (paymentBreakdownJson && typeof paymentBreakdownJson === "object") {
+        try {
+          breakdown = JSON.parse(paymentBreakdownJson);
+        } catch {
+          breakdown = null;
+        }
+      } else if (
+        paymentBreakdownJson &&
+        typeof paymentBreakdownJson === "object"
+      ) {
         breakdown = paymentBreakdownJson;
       }
       if (!Array.isArray(breakdown) || breakdown.length === 0) {
         return res.status(400).json({
-          error: "paymentBreakdownJson must be a non-empty array when paymentMethod=COMBINED",
+          error:
+            "paymentBreakdownJson must be a non-empty array when paymentMethod=COMBINED",
           code: "BREAKDOWN_REQUIRED",
         });
       }
@@ -933,10 +1165,23 @@ router.post("/sales", cashierGate, async (req, res) => {
     if (patientId !== undefined && patientId !== null && patientId !== "") {
       const pid = parseInt(patientId);
       if (!Number.isFinite(pid)) {
-        return res.status(400).json({ error: "patientId must be numeric", code: "INVALID_PATIENT_ID" });
+        return res
+          .status(400)
+          .json({
+            error: "patientId must be numeric",
+            code: "INVALID_PATIENT_ID",
+          });
       }
-      const p = await prisma.patient.findFirst({ where: tenantWhere(req, { id: pid }) });
-      if (!p) return res.status(400).json({ error: "patientId does not exist in this tenant", code: "PATIENT_NOT_FOUND" });
+      const p = await prisma.patient.findFirst({
+        where: tenantWhere(req, { id: pid }),
+      });
+      if (!p)
+        return res
+          .status(400)
+          .json({
+            error: "patientId does not exist in this tenant",
+            code: "PATIENT_NOT_FOUND",
+          });
       resolvedPatientId = pid;
     }
 
@@ -946,7 +1191,9 @@ router.post("/sales", cashierGate, async (req, res) => {
     // stock and ledger out of sync. SERVICE / MEMBERSHIP / GIFTCARD / PACKAGE
     // lines do not touch Product (they reference different tables via the
     // polymorphic refId).
-    const productLines = normalisedLines.filter((l) => l.lineType === "PRODUCT");
+    const productLines = normalisedLines.filter(
+      (l) => l.lineType === "PRODUCT",
+    );
 
     // Transactional create — invoiceNumber + Sale + SaleLineItem rows +
     // Product.currentStock decrements (PRODUCT lines only).
@@ -994,12 +1241,19 @@ router.post("/sales", cashierGate, async (req, res) => {
       return created;
     });
 
-    await writeAudit("Sale", "CREATE", sale.id, req.user.userId, req.user.tenantId, {
-      invoiceNumber: sale.invoiceNumber,
-      total: sale.total,
-      paymentMethod: sale.paymentMethod,
-      lineCount: sale.lineItems.length,
-    });
+    await writeAudit(
+      "Sale",
+      "CREATE",
+      sale.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        invoiceNumber: sale.invoiceNumber,
+        total: sale.total,
+        paymentMethod: sale.paymentMethod,
+        lineCount: sale.lineItems.length,
+      },
+    );
 
     // PRD Gap §2 item 9 — auto-credit loyalty on Sale completion. Same
     // earn-rule shape as the visit-side hook; runs post-transaction so a
@@ -1026,9 +1280,11 @@ router.post("/sales", cashierGate, async (req, res) => {
           registerId: sale.registerId,
         },
         req.user.tenantId,
-        req.io
+        req.io,
       );
-    } catch (_e) { /* event bus optional */ }
+    } catch (_e) {
+      /* event bus optional */
+    }
 
     res.status(201).json(sale);
   } catch (e) {
@@ -1041,8 +1297,10 @@ router.get("/sales", cashierGate, async (req, res) => {
   try {
     const { shiftId, from, to, patientId, status } = req.query;
     const where = tenantWhere(req);
-    if (shiftId && Number.isFinite(parseInt(shiftId))) where.shiftId = parseInt(shiftId);
-    if (patientId && Number.isFinite(parseInt(patientId))) where.patientId = parseInt(patientId);
+    if (shiftId && Number.isFinite(parseInt(shiftId)))
+      where.shiftId = parseInt(shiftId);
+    if (patientId && Number.isFinite(parseInt(patientId)))
+      where.patientId = parseInt(patientId);
     if (status) where.status = status;
     if (from || to) {
       where.createdAt = {};
@@ -1081,7 +1339,9 @@ router.get("/sales/:id", cashierGate, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) {
-      return res.status(400).json({ error: "id must be numeric", code: "INVALID_ID" });
+      return res
+        .status(400)
+        .json({ error: "id must be numeric", code: "INVALID_ID" });
     }
     const sale = await prisma.sale.findFirst({
       where: tenantWhere(req, { id }),
@@ -1196,7 +1456,9 @@ const FINALIZE_ITEM_TYPE_TO_LINE_TYPE = {
 router.post("/sales/finalize", cashierGate, async (req, res) => {
   try {
     if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
-      return res.status(400).json({ error: "Body must be an object", code: "INVALID_PAYLOAD" });
+      return res
+        .status(400)
+        .json({ error: "Body must be an object", code: "INVALID_PAYLOAD" });
     }
     const { patientId, items, payments, discountCents, taxCents } = req.body;
 
@@ -1445,7 +1707,9 @@ router.post("/sales/finalize", cashierGate, async (req, res) => {
             });
             remaining -= consumed;
           }
-          const newBalance = +(wallet.balance - walletDebitCents / 100).toFixed(2);
+          const newBalance = +(wallet.balance - walletDebitCents / 100).toFixed(
+            2,
+          );
           const txnRow = await tx.walletTransaction.create({
             data: {
               tenantId: req.user.tenantId,
@@ -1465,7 +1729,11 @@ router.post("/sales/finalize", cashierGate, async (req, res) => {
           });
         }
 
-        const invoiceNumber = await generateInvoiceNumber(tx, req.user.tenantId, now);
+        const invoiceNumber = await generateInvoiceNumber(
+          tx,
+          req.user.tenantId,
+          now,
+        );
         const grandTotalRupees = +(grandTotal / 100).toFixed(2);
         const subtotalRupees = +(itemsTotal / 100).toFixed(2);
         const discountRupees = +(discount / 100).toFixed(2);
@@ -1491,9 +1759,10 @@ router.post("/sales/finalize", cashierGate, async (req, res) => {
             total: grandTotalRupees,
             paidAmount: grandTotalRupees,
             status: "COMPLETED",
-            paymentMethod: normalisedPayments.length === 1
-              ? normalisedPayments[0].method.toUpperCase()
-              : "COMBINED",
+            paymentMethod:
+              normalisedPayments.length === 1
+                ? normalisedPayments[0].method.toUpperCase()
+                : "COMBINED",
             paymentBreakdownJson: JSON.stringify(
               normalisedPayments.map((p) => ({
                 method: p.method.toUpperCase(),
@@ -1768,7 +2037,9 @@ router.post("/sales/:id/void", strictAdminGate, async (req, res) => {
         .json({ error: "reason exceeds 500 chars", code: "INVALID_REASON" });
     }
 
-    const sale = await prisma.sale.findFirst({ where: tenantWhere(req, { id }) });
+    const sale = await prisma.sale.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!sale) {
       return res
         .status(404)
@@ -1798,19 +2069,26 @@ router.post("/sales/:id/void", strictAdminGate, async (req, res) => {
     let walletIdFromAudit = null;
     if (finalizeAudit && finalizeAudit.details) {
       try {
-        const parsed = typeof finalizeAudit.details === "string"
-          ? JSON.parse(finalizeAudit.details)
-          : finalizeAudit.details;
+        const parsed =
+          typeof finalizeAudit.details === "string"
+            ? JSON.parse(finalizeAudit.details)
+            : finalizeAudit.details;
         if (Array.isArray(parsed.walletBatchesDebited)) {
           batchesToReverse = parsed.walletBatchesDebited.filter(
-            (b) => b && Number.isFinite(b.batchId) && Number.isFinite(b.consumedCents) && b.consumedCents > 0,
+            (b) =>
+              b &&
+              Number.isFinite(b.batchId) &&
+              Number.isFinite(b.consumedCents) &&
+              b.consumedCents > 0,
           );
         }
       } catch (_parseErr) {
         // Malformed audit JSON — proceed with empty reversal list (no wallet
         // path to undo). The void itself is still valid; the diagnostic is
         // logged for operators.
-        console.warn(`[pos] void: malformed finalize audit details for sale ${id}`);
+        console.warn(
+          `[pos] void: malformed finalize audit details for sale ${id}`,
+        );
       }
     }
     // Resolve walletId via the patient (Wallet has @unique patientId).
@@ -1964,15 +2242,15 @@ router.post("/sales/:id/refund", strictAdminGate, async (req, res) => {
     }
     const amt = parseInt(amountCents, 10);
     if (!Number.isFinite(amt) || amt <= 0) {
-      return res
-        .status(400)
-        .json({
-          error: "amountCents must be a positive integer",
-          code: "INVALID_AMOUNT",
-        });
+      return res.status(400).json({
+        error: "amountCents must be a positive integer",
+        code: "INVALID_AMOUNT",
+      });
     }
 
-    const sale = await prisma.sale.findFirst({ where: tenantWhere(req, { id }) });
+    const sale = await prisma.sale.findFirst({
+      where: tenantWhere(req, { id }),
+    });
     if (!sale) {
       return res
         .status(404)

--- a/backend/routes/pos.js
+++ b/backend/routes/pos.js
@@ -47,6 +47,11 @@ const tenantWhere = (req, extra = {}) => ({
 const adminGate = verifyWellnessRole(["admin", "manager"], {
   anyOfPermissions: [{ module: "pos", action: "manage" }],
 });
+// DD-5.7 round-2 RESOLVED 2026-05-25: void + refund endpoints are
+// ADMIN-only (manager explicitly denied). See the §3.9 block below.
+const strictAdminGate = verifyWellnessRole(["admin"], {
+  anyOfPermissions: [{ module: "pos", action: "manage" }],
+});
 // "clinical" meta-token covers ALL clinical staff (doctor, professional,
 // nurse, stylist, plus any future custom clinical role with
 // canTakeVisits=true). Telecaller + helper stay as literals because they

--- a/backend/routes/service_categories.js
+++ b/backend/routes/service_categories.js
@@ -16,7 +16,14 @@ const { verifyWellnessRole } = require("../middleware/wellnessRole");
 const router = express.Router();
 
 const tenantWhere = (req, extra = {}) => ({ tenantId: req.user.tenantId, ...extra });
-const adminGate = verifyWellnessRole(["admin", "manager"]);
+// Service-category mutations are operational config. `anyOfPermissions`
+// lets a custom RBAC role with `services.write` (the page catalog's
+// permission for /wellness/service-categories) perform the action even
+// without a matching wellnessRole.
+const adminGate = verifyWellnessRole(
+  ["admin", "manager"],
+  { anyOfPermissions: [{ module: "services", action: "write" }] },
+);
 
 // ── ServiceCategory CRUD ───────────────────────────────────────────
 

--- a/backend/routes/staff.js
+++ b/backend/routes/staff.js
@@ -1154,7 +1154,6 @@ function validateGoalBody(body, { partial = false } = {}) {
   // Legacy `userId` in body would silently be dropped — caller must use
   // targetUserId. The ESLint no-restricted-syntax rule enforces this on
   // future writes; the helper here is the runtime backstop.
-  // eslint-disable-next-line no-restricted-syntax
   const inputUserId =
     body.targetUserId !== undefined ? body.targetUserId : body.userId;
   if (!partial || inputUserId !== undefined) {
@@ -1305,8 +1304,7 @@ router.post("/revenue-goals", verifyRole(["ADMIN"]), async (req, res) => {
     } = req.body;
     // PRD Gap §1.6 follow-up: prefer targetUserId (non-stripped name).
     // eslint-disable-next-line no-restricted-syntax
-    const resolvedUserId =
-      targetUserId !== undefined ? targetUserId : req.body.userId;
+    const resolvedUserId = targetUserId !== undefined ? targetUserId : req.body.userId;
     // Verify user belongs to this tenant.
     const target = await prisma.user.findFirst({
       where: { id: parseInt(resolvedUserId, 10), tenantId: req.user.tenantId },

--- a/backend/routes/staff.js
+++ b/backend/routes/staff.js
@@ -19,21 +19,78 @@ const {
 
 const router = express.Router();
 const prisma = require("../lib/prisma");
+// Wellness-role catalog lookup. Wellness tenants validate wellnessRole
+// against their per-tenant WellnessRoleType catalog (admins can add
+// custom roles like "nurse" from Settings). Generic tenants fall back
+// to the legacy whitelist below — they never use wellnessRole in
+// practice but the historical contract returned 400 on unknown values,
+// which we preserve for back-compat.
+const { isCatalogedKey } = require("../lib/wellnessRoleTypes");
 
 const VALID_ROLES = ["ADMIN", "MANAGER", "USER"];
-// PRD_WELLNESS_RBAC DD-5.1 [RESOLVED 2026-05-24]: extend the wellnessRole enum
-// with 'cashier' for the POS-only sales role. Cashier is a sales role, NOT
-// clinical — phiReadGate in routes/wellness.js:212 deliberately excludes
-// 'cashier' (DD-5.6 invariant). Verify phiReadGate stays cashier-free on
-// every future allowed-list extension.
-const VALID_WELLNESS_ROLES = ["doctor", "professional", "telecaller", "helper", "stylist", "cashier"];
+// Legacy whitelist — used only when the caller's tenant is non-wellness.
+// Wellness tenants consult the WellnessRoleType catalog instead.
+const LEGACY_WELLNESS_ROLES = [
+  "doctor",
+  "professional",
+  "telecaller",
+  "helper",
+  "stylist",
+];
+
+// Resolve the caller's tenant vertical so we know which validator to run.
+// Cached on req.user for the request lifetime (matches the pattern in
+// middleware/wellnessRole.js's resolveTenantVertical).
+async function getCallerVertical(req) {
+  if (req.user?.vertical) return req.user.vertical;
+  if (!req.user?.tenantId) return "generic";
+  try {
+    const t = await prisma.tenant.findUnique({
+      where: { id: req.user.tenantId },
+      select: { vertical: true },
+    });
+    const v = t?.vertical || "generic";
+    req.user.vertical = v;
+    return v;
+  } catch (_e) {
+    return "generic";
+  }
+}
+
+// Returns null when wellnessRole is valid (or absent), or an error
+// envelope when it isn't. Wellness tenants check the per-tenant catalog;
+// generic tenants check the legacy whitelist.
+async function validateWellnessRole(req, value) {
+  if (value === undefined || value === null || value === "") return null;
+  const vertical = await getCallerVertical(req);
+  if (vertical === "wellness") {
+    const ok = await isCatalogedKey(req.user.tenantId, value);
+    if (!ok) {
+      return {
+        status: 400,
+        error:
+          "Unknown wellness role for this tenant. Add it under Settings → Wellness Role Types first.",
+        code: "ROLE_NOT_IN_CATALOG",
+      };
+    }
+    return null;
+  }
+  if (!LEGACY_WELLNESS_ROLES.includes(value)) {
+    return {
+      status: 400,
+      error: `Invalid wellness role. Must be one of: ${LEGACY_WELLNESS_ROLES.join(", ")}`,
+      code: "INVALID_WELLNESS_ROLE",
+    };
+  }
+  return null;
+}
 
 // Module-scoped reset / invite token stores. Mirrors the pattern in
 // routes/auth.js's `resetTokens` Map — in-memory, 1-hour TTL, hex-32 key.
 // In a multi-instance deploy these would move to Redis; the demo box runs
 // a single backend so a Map suffices.
-const adminResetTokens = new Map();   // token -> { userId, expiresAt }
-const inviteTokens = new Map();        // token -> { userId, expiresAt }
+const adminResetTokens = new Map(); // token -> { userId, expiresAt }
+const inviteTokens = new Map(); // token -> { userId, expiresAt }
 
 // SendGrid wrapper — fire-and-forget, never throws. Mirrors the contract in
 // routes/auth.js sendPasswordResetEmail (kept local instead of importing so
@@ -41,9 +98,12 @@ const inviteTokens = new Map();        // token -> { userId, expiresAt }
 // lib/sendgrid.js is a separate cleanup tracked in TODOS).
 async function sendEmail(toEmail, subject, plainText, html) {
   const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || "";
-  const FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || "noreply@crm.globusdemos.com";
+  const FROM_EMAIL =
+    process.env.SENDGRID_FROM_EMAIL || "noreply@crm.globusdemos.com";
   if (!SENDGRID_API_KEY) {
-    console.log(`[staff] SendGrid not configured — would send to ${toEmail}: ${subject}\n${plainText}`);
+    console.log(
+      `[staff] SendGrid not configured — would send to ${toEmail}: ${subject}\n${plainText}`,
+    );
     return;
   }
   try {
@@ -53,7 +113,10 @@ async function sendEmail(toEmail, subject, plainText, html) {
       subject,
       content: [
         { type: "text/plain", value: plainText },
-        { type: "text/html", value: html || `<p>${plainText.replace(/\n/g, "<br>")}</p>` },
+        {
+          type: "text/html",
+          value: html || `<p>${plainText.replace(/\n/g, "<br>")}</p>`,
+        },
       ],
     };
     const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
@@ -146,8 +209,14 @@ router.get("/", async (req, res) => {
       out = users.map((u) => ({
         ...u,
         id: maskUserId(u.id),
-        name: u.name ? (u.name.split(/\s+/)[0][0] + ". " + u.name.split(/\s+/).slice(1).join(" ")) : u.name,
-        email: u.email ? (u.email[0] + "****@" + (u.email.split("@")[1] || "")) : u.email,
+        name: u.name
+          ? u.name.split(/\s+/)[0][0] +
+            ". " +
+            u.name.split(/\s+/).slice(1).join(" ")
+          : u.name,
+        email: u.email
+          ? u.email[0] + "****@" + (u.email.split("@")[1] || "")
+          : u.email,
       }));
     } else {
       out = users;
@@ -161,7 +230,9 @@ router.get("/", async (req, res) => {
           auditDisclosureDetails(req, "staff_list", users, {
             fields: ["id", "name", "email"],
           }),
-        ).catch((e) => console.warn("[staff] audit User PII_DISCLOSED failed:", e.message));
+        ).catch((e) =>
+          console.warn("[staff] audit User PII_DISCLOSED failed:", e.message),
+        );
       }
     }
     res.json(out);
@@ -179,25 +250,38 @@ router.get("/", async (req, res) => {
 // renders the correct landing view on their first login.
 router.post("/", verifyRole(["ADMIN"]), async (req, res) => {
   try {
-    const { name, email, password, role, wellnessRole, rbacRoleId } = req.body || {};
+    const { name, email, password, role, wellnessRole, rbacRoleId } =
+      req.body || {};
 
     // Basic field presence + shape checks. Mirror auth.js/signup so the
     // error envelope is uniform across signup and admin-create paths.
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return res.status(400).json({ error: "Name is required." });
     }
-    if (!email || typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    if (
+      !email ||
+      typeof email !== "string" ||
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+    ) {
       return res.status(400).json({ error: "A valid work email is required." });
     }
     if (!password || typeof password !== "string" || password.length < 6) {
-      return res.status(400).json({ error: "Password must be at least 6 characters." });
+      return res
+        .status(400)
+        .json({ error: "Password must be at least 6 characters." });
     }
     if (!role || !VALID_ROLES.includes(role)) {
-      return res.status(400).json({ error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` });
+      return res
+        .status(400)
+        .json({
+          error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}`,
+        });
     }
-    if (wellnessRole && !VALID_WELLNESS_ROLES.includes(wellnessRole)) {
-      return res.status(400).json({ error: `Invalid wellness role. Must be one of: ${VALID_WELLNESS_ROLES.join(", ")}` });
-    }
+    const wrErr = await validateWellnessRole(req, wellnessRole);
+    if (wrErr)
+      return res
+        .status(wrErr.status)
+        .json({ error: wrErr.error, code: wrErr.code });
 
     // Optional rbacRoleId: pre-validate before we create the user, so a bad
     // role id doesn't leave a half-created user behind. Must be an integer
@@ -213,19 +297,27 @@ router.post("/", verifyRole(["ADMIN"]), async (req, res) => {
         where: { id: roleIdNum, tenantId: req.user.tenantId },
       });
       if (!rbacRole) {
-        return res.status(404).json({ error: "Role not found in this tenant." });
+        return res
+          .status(404)
+          .json({ error: "Role not found in this tenant." });
       }
       if (rbacRole.userType && rbacRole.userType !== "STAFF") {
-        return res.status(400).json({ error: "Cannot assign a CUSTOMER role to a staff member." });
+        return res
+          .status(400)
+          .json({ error: "Cannot assign a CUSTOMER role to a staff member." });
       }
     }
 
     // Email is globally unique (Prisma @unique). Pre-check inside the
     // tenant so the admin gets a meaningful 409 instead of Prisma's raw
     // P2002 unique-constraint error.
-    const existing = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+    const existing = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+    });
     if (existing) {
-      return res.status(409).json({ error: "A user with that email already exists." });
+      return res
+        .status(409)
+        .json({ error: "A user with that email already exists." });
     }
 
     const passwordHash = await bcrypt.hash(password, 10);
@@ -279,19 +371,28 @@ router.post("/", verifyRole(["ADMIN"]), async (req, res) => {
         rbacRoleId: rbacRole ? rbacRole.id : null,
         rbacRoleKey: rbacRole ? rbacRole.key : null,
       },
-    ).catch((e) => console.warn("[staff] audit User CREATE failed:", e.message));
+    ).catch((e) =>
+      console.warn("[staff] audit User CREATE failed:", e.message),
+    );
 
     res.status(201).json({
       ...created,
       // Echo the assignment so the frontend can update its row state
       // without a refetch.
       primaryRole: rbacRole
-        ? { id: rbacRole.id, key: rbacRole.key, name: rbacRole.name, landingPath: rbacRole.landingPath || null }
+        ? {
+            id: rbacRole.id,
+            key: rbacRole.key,
+            name: rbacRole.name,
+            landingPath: rbacRole.landingPath || null,
+          }
         : null,
     });
   } catch (err) {
     if (err && err.code === "P2002") {
-      return res.status(409).json({ error: "A user with that email already exists." });
+      return res
+        .status(409)
+        .json({ error: "A user with that email already exists." });
     }
     console.error("[staff] POST / failed:", err);
     res.status(500).json({ error: "Failed to create staff member." });
@@ -304,7 +405,11 @@ router.put("/:id/role", verifyRole(["ADMIN"]), async (req, res) => {
     const { role } = req.body;
 
     if (!role || !VALID_ROLES.includes(role)) {
-      return res.status(400).json({ error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` });
+      return res
+        .status(400)
+        .json({
+          error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}`,
+        });
     }
 
     const userId = parseInt(req.params.id, 10);
@@ -314,7 +419,9 @@ router.put("/:id/role", verifyRole(["ADMIN"]), async (req, res) => {
       return res.status(400).json({ error: "Cannot change your own role." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
     const user = await prisma.user.update({
@@ -347,10 +454,13 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       return res.status(400).json({ error: "Invalid user id." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
-    const { name, email, role, wellnessRole, commissionProfileId, rbacRoleId } = req.body || {};
+    const { name, email, role, wellnessRole, commissionProfileId, rbacRoleId } =
+      req.body || {};
     const data = {};
     const changed = {};
     // rbacRoleId handled outside the User.update because it lives on the
@@ -370,10 +480,19 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
           where: { id: roleIdNum, tenantId: req.user.tenantId },
         });
         if (!validatedRbacRole) {
-          return res.status(404).json({ error: "Role not found in this tenant." });
+          return res
+            .status(404)
+            .json({ error: "Role not found in this tenant." });
         }
-        if (validatedRbacRole.userType && validatedRbacRole.userType !== "STAFF") {
-          return res.status(400).json({ error: "Cannot assign a CUSTOMER role to a staff member." });
+        if (
+          validatedRbacRole.userType &&
+          validatedRbacRole.userType !== "STAFF"
+        ) {
+          return res
+            .status(400)
+            .json({
+              error: "Cannot assign a CUSTOMER role to a staff member.",
+            });
         }
         nextRbacRoleId = roleIdNum;
       }
@@ -386,7 +505,7 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
     // with `not-email` and the row was silently corrupted.
     if (name !== undefined) {
       const nameErr = ensureStringLength(name, {
-        field: 'name',
+        field: "name",
         min: 1,
         max: 200,
         required: true,
@@ -410,10 +529,18 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
     }
     if (role !== undefined) {
       if (!VALID_ROLES.includes(role)) {
-        return res.status(400).json({ error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` });
+        return res
+          .status(400)
+          .json({
+            error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}`,
+          });
       }
       // Prevent self-demotion (mirror PUT /:id/role guard)
-      if (req.user.userId === userId && role !== "ADMIN" && target.role === "ADMIN") {
+      if (
+        req.user.userId === userId &&
+        role !== "ADMIN" &&
+        target.role === "ADMIN"
+      ) {
         return res.status(400).json({ error: "Cannot change your own role." });
       }
       if (role !== target.role) {
@@ -422,8 +549,12 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       }
     }
     if (wellnessRole !== undefined) {
-      if (wellnessRole !== null && !VALID_WELLNESS_ROLES.includes(wellnessRole)) {
-        return res.status(400).json({ error: `Invalid wellnessRole. Must be one of: ${VALID_WELLNESS_ROLES.join(", ")} or null` });
+      if (wellnessRole !== null) {
+        const wrErr = await validateWellnessRole(req, wellnessRole);
+        if (wrErr)
+          return res
+            .status(wrErr.status)
+            .json({ error: wrErr.error, code: wrErr.code });
       }
       if (wellnessRole !== target.wellnessRole) {
         data.wellnessRole = wellnessRole;
@@ -432,30 +563,42 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
     }
     // PRD Gap §1.5 — assign / clear a commission profile.
     if (commissionProfileId !== undefined) {
-      const next = commissionProfileId == null || commissionProfileId === "" ? null : parseInt(commissionProfileId, 10);
+      const next =
+        commissionProfileId == null || commissionProfileId === ""
+          ? null
+          : parseInt(commissionProfileId, 10);
       if (next !== null && (!Number.isInteger(next) || next <= 0)) {
         return res.status(400).json({ error: "Invalid commissionProfileId." });
       }
       if (next !== null) {
         // Verify the profile belongs to the same tenant.
-        const profile = await prisma.commissionProfile.findFirst({ where: { id: next, tenantId: req.user.tenantId } });
-        if (!profile) return res.status(404).json({ error: "Commission profile not found." });
+        const profile = await prisma.commissionProfile.findFirst({
+          where: { id: next, tenantId: req.user.tenantId },
+        });
+        if (!profile)
+          return res
+            .status(404)
+            .json({ error: "Commission profile not found." });
       }
       if (next !== target.commissionProfileId) {
         data.commissionProfileId = next;
-        changed.commissionProfileId = { from: target.commissionProfileId, to: next };
+        changed.commissionProfileId = {
+          from: target.commissionProfileId,
+          to: next,
+        };
       }
     }
 
     // rbacRoleId is the only field that lives outside the User table, so
     // it's handled separately. Snapshot whether the RBAC role actually
     // changed so we can audit + skip-no-op without an extra UserRole read.
-    const currentRbacRow = nextRbacRoleId !== undefined
-      ? await prisma.userRole.findFirst({
-          where: { userId: target.id },
-          orderBy: { assignedAt: "desc" },
-        })
-      : null;
+    const currentRbacRow =
+      nextRbacRoleId !== undefined
+        ? await prisma.userRole.findFirst({
+            where: { userId: target.id },
+            orderBy: { assignedAt: "desc" },
+          })
+        : null;
     const currentRbacRoleId = currentRbacRow ? currentRbacRow.roleId : null;
     const rbacRoleChanged =
       nextRbacRoleId !== undefined && nextRbacRoleId !== currentRbacRoleId;
@@ -480,22 +623,23 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       // on either half rolls back. Single-role-per-user is application-
       // enforced: deleteMany existing rows then create the new one.
       user = await prisma.$transaction(async (tx) => {
-        const updated = Object.keys(data).length === 0
-          ? target
-          : await tx.user.update({
-              where: { id: target.id },
-              data,
-              select: {
-                id: true,
-                email: true,
-                name: true,
-                role: true,
-                wellnessRole: true,
-                commissionProfileId: true,
-                createdAt: true,
-                deactivatedAt: true,
-              },
-            });
+        const updated =
+          Object.keys(data).length === 0
+            ? target
+            : await tx.user.update({
+                where: { id: target.id },
+                data,
+                select: {
+                  id: true,
+                  email: true,
+                  name: true,
+                  role: true,
+                  wellnessRole: true,
+                  commissionProfileId: true,
+                  createdAt: true,
+                  deactivatedAt: true,
+                },
+              });
 
         if (rbacRoleChanged) {
           await tx.userRole.deleteMany({ where: { userId: target.id } });
@@ -520,11 +664,18 @@ router.put("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       throw err;
     }
 
-    await writeAudit("User", "EDIT", user.id, req.user.userId, req.user.tenantId, {
-      targetUserId: user.id,
-      targetEmail: user.email,
-      changed,
-    });
+    await writeAudit(
+      "User",
+      "EDIT",
+      user.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: user.id,
+        targetEmail: user.email,
+        changed,
+      },
+    );
 
     // Echo the resolved RBAC role on the response so the staff list can
     // update its row state without a refetch.
@@ -567,15 +718,21 @@ router.patch("/:id", verifyRole(["ADMIN"]), async (req, res) => {
     }
 
     if (req.user.userId === userId) {
-      return res.status(400).json({ error: "Cannot deactivate your own account." });
+      return res
+        .status(400)
+        .json({ error: "Cannot deactivate your own account." });
     }
 
     const { active } = req.body || {};
     if (typeof active !== "boolean") {
-      return res.status(400).json({ error: "Body must include { active: boolean }." });
+      return res
+        .status(400)
+        .json({ error: "Body must include { active: boolean }." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
     const user = await prisma.user.update({
@@ -593,10 +750,17 @@ router.patch("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       },
     });
 
-    await writeAudit("User", active ? "REACTIVATE" : "DEACTIVATE", user.id, req.user.userId, req.user.tenantId, {
-      targetUserId: user.id,
-      targetEmail: user.email,
-    });
+    await writeAudit(
+      "User",
+      active ? "REACTIVATE" : "DEACTIVATE",
+      user.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: user.id,
+        targetEmail: user.email,
+      },
+    );
 
     res.json(user);
   } catch (err) {
@@ -619,13 +783,20 @@ router.post("/:id/reset-password", verifyRole(["ADMIN"]), async (req, res) => {
       return res.status(400).json({ error: "Invalid user id." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
     const token = crypto.randomBytes(32).toString("hex");
-    adminResetTokens.set(token, { userId: target.id, expiresAt: Date.now() + 3600000 });
+    adminResetTokens.set(token, {
+      userId: target.id,
+      expiresAt: Date.now() + 3600000,
+    });
 
-    const frontendBase = process.env.FRONTEND_URL || `https://${req.headers.host || "crm.globusdemos.com"}`;
+    const frontendBase =
+      process.env.FRONTEND_URL ||
+      `https://${req.headers.host || "crm.globusdemos.com"}`;
     const resetUrl = `${frontendBase}/reset-password?token=${encodeURIComponent(token)}`;
 
     // Fire-and-forget — never block the admin's UI on SendGrid latency.
@@ -633,16 +804,27 @@ router.post("/:id/reset-password", verifyRole(["ADMIN"]), async (req, res) => {
       target.email,
       "Your Globussoft CRM password has been reset",
       `An admin has triggered a password reset for your account. Click this link (valid 1 hour) to choose a new password:\n\n${resetUrl}\n\nIf you weren't expecting this, contact your administrator.`,
-      `<p>An admin has triggered a password reset for your account.</p><p><a href="${resetUrl}">Choose a new password</a> (valid 1 hour).</p>`
+      `<p>An admin has triggered a password reset for your account.</p><p><a href="${resetUrl}">Choose a new password</a> (valid 1 hour).</p>`,
     ).catch(() => {});
 
-    await writeAudit("User", "PASSWORD_RESET", target.id, req.user.userId, req.user.tenantId, {
-      targetUserId: target.id,
-      targetEmail: target.email,
-      via: "admin-trigger",
-    });
+    await writeAudit(
+      "User",
+      "PASSWORD_RESET",
+      target.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: target.id,
+        targetEmail: target.email,
+        via: "admin-trigger",
+      },
+    );
 
-    res.json({ status: "ok", code: "PASSWORD_RESET_LINK_SENT", tokenIssued: true });
+    res.json({
+      status: "ok",
+      code: "PASSWORD_RESET_LINK_SENT",
+      tokenIssued: true,
+    });
   } catch (_err) {
     res.status(500).json({ error: "Failed to issue password reset." });
   }
@@ -659,26 +841,40 @@ router.post("/:id/resend-invite", verifyRole(["ADMIN"]), async (req, res) => {
       return res.status(400).json({ error: "Invalid user id." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
     const token = crypto.randomBytes(32).toString("hex");
-    inviteTokens.set(token, { userId: target.id, expiresAt: Date.now() + 24 * 3600000 });
+    inviteTokens.set(token, {
+      userId: target.id,
+      expiresAt: Date.now() + 24 * 3600000,
+    });
 
-    const frontendBase = process.env.FRONTEND_URL || `https://${req.headers.host || "crm.globusdemos.com"}`;
+    const frontendBase =
+      process.env.FRONTEND_URL ||
+      `https://${req.headers.host || "crm.globusdemos.com"}`;
     const inviteUrl = `${frontendBase}/reset-password?token=${encodeURIComponent(token)}`;
 
     sendEmail(
       target.email,
       "You're invited to Globussoft CRM",
       `You've been invited to access Globussoft CRM. Click this link to set your password and sign in (valid 24 hours):\n\n${inviteUrl}\n\nIf you weren't expecting this, you can safely ignore this email.`,
-      `<p>You've been invited to access Globussoft CRM.</p><p><a href="${inviteUrl}">Set your password</a> to get started (valid 24 hours).</p>`
+      `<p>You've been invited to access Globussoft CRM.</p><p><a href="${inviteUrl}">Set your password</a> to get started (valid 24 hours).</p>`,
     ).catch(() => {});
 
-    await writeAudit("User", "INVITE_RESEND", target.id, req.user.userId, req.user.tenantId, {
-      targetUserId: target.id,
-      targetEmail: target.email,
-    });
+    await writeAudit(
+      "User",
+      "INVITE_RESEND",
+      target.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: target.id,
+        targetEmail: target.email,
+      },
+    );
 
     res.json({ status: "ok", code: "INVITE_RESENT" });
   } catch (_err) {
@@ -696,14 +892,21 @@ router.delete("/:id", verifyRole(["ADMIN"]), async (req, res) => {
       return res.status(400).json({ error: "Cannot delete your own account." });
     }
 
-    const target = await prisma.user.findFirst({ where: { id: userId, tenantId: req.user.tenantId } });
+    const target = await prisma.user.findFirst({
+      where: { id: userId, tenantId: req.user.tenantId },
+    });
     if (!target) return res.status(404).json({ error: "User not found." });
 
     // #323: refuse to delete the tenant OWNER. The owner is the sole user with
     // userType=OWNER (set during signup); managers/admins must not be able to
     // remove them, regardless of RBAC role.
     if (target.userType === "OWNER") {
-      return res.status(403).json({ error: "Cannot delete the tenant owner.", code: "OWNER_PROTECTED" });
+      return res
+        .status(403)
+        .json({
+          error: "Cannot delete the tenant owner.",
+          code: "OWNER_PROTECTED",
+        });
     }
 
     await prisma.user.delete({
@@ -728,14 +931,23 @@ router.delete("/:id", verifyRole(["ADMIN"]), async (req, res) => {
 // `commissionProfileId`); CRUD here only manages the profile rows.
 // ───────────────────────────────────────────────────────────────────
 
-const VALID_COMMISSION_BASIS = ["PER_SERVICE", "PER_PRODUCT", "REVENUE_PERCENT", "FLAT_PER_INVOICE"];
+const VALID_COMMISSION_BASIS = [
+  "PER_SERVICE",
+  "PER_PRODUCT",
+  "REVENUE_PERCENT",
+  "FLAT_PER_INVOICE",
+];
 
 function validateCommissionBody(body, { partial = false } = {}) {
   const errors = [];
   if (!partial || body.name !== undefined) {
-    if (typeof body.name !== "string" || !body.name.trim()) errors.push("name is required");
+    if (typeof body.name !== "string" || !body.name.trim())
+      errors.push("name is required");
   }
-  if (body.basis !== undefined && !VALID_COMMISSION_BASIS.includes(body.basis)) {
+  if (
+    body.basis !== undefined &&
+    !VALID_COMMISSION_BASIS.includes(body.basis)
+  ) {
     errors.push(`basis must be one of: ${VALID_COMMISSION_BASIS.join(", ")}`);
   }
   // percentage / flatAmount: at least one is required on create. Validate ranges.
@@ -743,13 +955,18 @@ function validateCommissionBody(body, { partial = false } = {}) {
   const flat = body.flatAmount;
   if (pct !== undefined && pct !== null) {
     const n = Number(pct);
-    if (!Number.isFinite(n) || n < 0 || n > 100) errors.push("percentage must be 0..100");
+    if (!Number.isFinite(n) || n < 0 || n > 100)
+      errors.push("percentage must be 0..100");
   }
   if (flat !== undefined && flat !== null) {
     const n = Number(flat);
     if (!Number.isFinite(n) || n < 0) errors.push("flatAmount must be >= 0");
   }
-  if (!partial && (pct == null || pct === "") && (flat == null || flat === "")) {
+  if (
+    !partial &&
+    (pct == null || pct === "") &&
+    (flat == null || flat === "")
+  ) {
     errors.push("either percentage or flatAmount must be set");
   }
   return errors;
@@ -773,80 +990,148 @@ router.get("/commission-profiles", verifyRole(["ADMIN"]), async (req, res) => {
 router.post("/commission-profiles", verifyRole(["ADMIN"]), async (req, res) => {
   try {
     const errors = validateCommissionBody(req.body || {}, { partial: false });
-    if (errors.length) return res.status(400).json({ error: errors.join("; ") });
+    if (errors.length)
+      return res.status(400).json({ error: errors.join("; ") });
 
-    const { name, percentage, flatAmount, basis, appliesToCategory, isActive } = req.body;
+    const { name, percentage, flatAmount, basis, appliesToCategory, isActive } =
+      req.body;
     const row = await prisma.commissionProfile.create({
       data: {
         tenantId: req.user.tenantId,
         name: String(name).trim(),
-        percentage: percentage == null || percentage === "" ? null : String(percentage),
-        flatAmount: flatAmount == null || flatAmount === "" ? null : String(flatAmount),
+        percentage:
+          percentage == null || percentage === "" ? null : String(percentage),
+        flatAmount:
+          flatAmount == null || flatAmount === "" ? null : String(flatAmount),
         basis: basis || "REVENUE_PERCENT",
         appliesToCategory: appliesToCategory || null,
         isActive: isActive === false ? false : true,
       },
     });
-    await writeAudit("CommissionProfile", "CREATE", row.id, req.user.userId, req.user.tenantId, {
-      name: row.name, basis: row.basis,
-    });
+    await writeAudit(
+      "CommissionProfile",
+      "CREATE",
+      row.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        name: row.name,
+        basis: row.basis,
+      },
+    );
     res.status(201).json(row);
   } catch (err) {
-    if (err.code === "P2002") return res.status(409).json({ error: "A commission profile with that name already exists." });
+    if (err.code === "P2002")
+      return res
+        .status(409)
+        .json({ error: "A commission profile with that name already exists." });
     console.error("[staff][commission-profiles][create]", err);
     res.status(500).json({ error: "Failed to create commission profile." });
   }
 });
 
 // PUT /commission-profiles/:id — update (admin only)
-router.put("/commission-profiles/:id", verifyRole(["ADMIN"]), async (req, res) => {
-  try {
-    const id = parseInt(req.params.id, 10);
-    if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: "Invalid id." });
-    const existing = await prisma.commissionProfile.findFirst({ where: { id, tenantId: req.user.tenantId } });
-    if (!existing) return res.status(404).json({ error: "Commission profile not found." });
+router.put(
+  "/commission-profiles/:id",
+  verifyRole(["ADMIN"]),
+  async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (!Number.isInteger(id) || id <= 0)
+        return res.status(400).json({ error: "Invalid id." });
+      const existing = await prisma.commissionProfile.findFirst({
+        where: { id, tenantId: req.user.tenantId },
+      });
+      if (!existing)
+        return res.status(404).json({ error: "Commission profile not found." });
 
-    const errors = validateCommissionBody(req.body || {}, { partial: true });
-    if (errors.length) return res.status(400).json({ error: errors.join("; ") });
+      const errors = validateCommissionBody(req.body || {}, { partial: true });
+      if (errors.length)
+        return res.status(400).json({ error: errors.join("; ") });
 
-    const { name, percentage, flatAmount, basis, appliesToCategory, isActive } = req.body || {};
-    const data = {};
-    if (name !== undefined) data.name = String(name).trim();
-    if (percentage !== undefined) data.percentage = percentage == null || percentage === "" ? null : String(percentage);
-    if (flatAmount !== undefined) data.flatAmount = flatAmount == null || flatAmount === "" ? null : String(flatAmount);
-    if (basis !== undefined) data.basis = basis;
-    if (appliesToCategory !== undefined) data.appliesToCategory = appliesToCategory || null;
-    if (isActive !== undefined) data.isActive = Boolean(isActive);
+      const {
+        name,
+        percentage,
+        flatAmount,
+        basis,
+        appliesToCategory,
+        isActive,
+      } = req.body || {};
+      const data = {};
+      if (name !== undefined) data.name = String(name).trim();
+      if (percentage !== undefined)
+        data.percentage =
+          percentage == null || percentage === "" ? null : String(percentage);
+      if (flatAmount !== undefined)
+        data.flatAmount =
+          flatAmount == null || flatAmount === "" ? null : String(flatAmount);
+      if (basis !== undefined) data.basis = basis;
+      if (appliesToCategory !== undefined)
+        data.appliesToCategory = appliesToCategory || null;
+      if (isActive !== undefined) data.isActive = Boolean(isActive);
 
-    const row = await prisma.commissionProfile.update({ where: { id }, data });
-    await writeAudit("CommissionProfile", "UPDATE", row.id, req.user.userId, req.user.tenantId, { id });
-    res.json(row);
-  } catch (err) {
-    if (err.code === "P2002") return res.status(409).json({ error: "A commission profile with that name already exists." });
-    if (err.code === "P2025") return res.status(404).json({ error: "Commission profile not found." });
-    console.error("[staff][commission-profiles][update]", err);
-    res.status(500).json({ error: "Failed to update commission profile." });
-  }
-});
+      const row = await prisma.commissionProfile.update({
+        where: { id },
+        data,
+      });
+      await writeAudit(
+        "CommissionProfile",
+        "UPDATE",
+        row.id,
+        req.user.userId,
+        req.user.tenantId,
+        { id },
+      );
+      res.json(row);
+    } catch (err) {
+      if (err.code === "P2002")
+        return res
+          .status(409)
+          .json({
+            error: "A commission profile with that name already exists.",
+          });
+      if (err.code === "P2025")
+        return res.status(404).json({ error: "Commission profile not found." });
+      console.error("[staff][commission-profiles][update]", err);
+      res.status(500).json({ error: "Failed to update commission profile." });
+    }
+  },
+);
 
 // DELETE /commission-profiles/:id — delete (admin only). Cascading FK
 // nulls User.commissionProfileId on every assigned user (SetNull).
-router.delete("/commission-profiles/:id", verifyRole(["ADMIN"]), async (req, res) => {
-  try {
-    const id = parseInt(req.params.id, 10);
-    if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: "Invalid id." });
-    const existing = await prisma.commissionProfile.findFirst({ where: { id, tenantId: req.user.tenantId } });
-    if (!existing) return res.status(404).json({ error: "Commission profile not found." });
+router.delete(
+  "/commission-profiles/:id",
+  verifyRole(["ADMIN"]),
+  async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (!Number.isInteger(id) || id <= 0)
+        return res.status(400).json({ error: "Invalid id." });
+      const existing = await prisma.commissionProfile.findFirst({
+        where: { id, tenantId: req.user.tenantId },
+      });
+      if (!existing)
+        return res.status(404).json({ error: "Commission profile not found." });
 
-    await prisma.commissionProfile.delete({ where: { id } });
-    await writeAudit("CommissionProfile", "DELETE", id, req.user.userId, req.user.tenantId, { name: existing.name });
-    res.status(204).end();
-  } catch (err) {
-    if (err.code === "P2025") return res.status(404).json({ error: "Commission profile not found." });
-    console.error("[staff][commission-profiles][delete]", err);
-    res.status(500).json({ error: "Failed to delete commission profile." });
-  }
-});
+      await prisma.commissionProfile.delete({ where: { id } });
+      await writeAudit(
+        "CommissionProfile",
+        "DELETE",
+        id,
+        req.user.userId,
+        req.user.tenantId,
+        { name: existing.name },
+      );
+      res.status(204).end();
+    } catch (err) {
+      if (err.code === "P2025")
+        return res.status(404).json({ error: "Commission profile not found." });
+      console.error("[staff][commission-profiles][delete]", err);
+      res.status(500).json({ error: "Failed to delete commission profile." });
+    }
+  },
+);
 
 // ───────────────────────────────────────────────────────────────────
 // PRD Gap §1.6 — Staff revenue goals
@@ -870,10 +1155,12 @@ function validateGoalBody(body, { partial = false } = {}) {
   // targetUserId. The ESLint no-restricted-syntax rule enforces this on
   // future writes; the helper here is the runtime backstop.
   // eslint-disable-next-line no-restricted-syntax
-  const inputUserId = body.targetUserId !== undefined ? body.targetUserId : body.userId;
+  const inputUserId =
+    body.targetUserId !== undefined ? body.targetUserId : body.userId;
   if (!partial || inputUserId !== undefined) {
     const uid = parseInt(inputUserId, 10);
-    if (!Number.isInteger(uid) || uid <= 0) errors.push("targetUserId is required (positive integer)");
+    if (!Number.isInteger(uid) || uid <= 0)
+      errors.push("targetUserId is required (positive integer)");
   }
   if (body.period !== undefined && !VALID_GOAL_PERIOD.includes(body.period)) {
     errors.push(`period must be one of: ${VALID_GOAL_PERIOD.join(", ")}`);
@@ -894,7 +1181,9 @@ function validateGoalBody(body, { partial = false } = {}) {
     if (isNaN(d.getTime())) errors.push("periodEnd must be a valid date");
   }
   if (!partial && body.periodStart && body.periodEnd) {
-    if (new Date(body.periodStart).getTime() >= new Date(body.periodEnd).getTime()) {
+    if (
+      new Date(body.periodStart).getTime() >= new Date(body.periodEnd).getTime()
+    ) {
       errors.push("periodStart must be before periodEnd");
     }
   }
@@ -903,7 +1192,14 @@ function validateGoalBody(body, { partial = false } = {}) {
 
 // Compute SUM(Sale.total) for a userId in [periodStart, periodEnd]. Returns
 // a Number; 0 on empty/error so the UI can render "₹0 / ₹50,000".
-async function computeAchievedAmount(tenantId, userId, periodStart, periodEnd, scope, _scopeFilter) {
+async function computeAchievedAmount(
+  tenantId,
+  userId,
+  periodStart,
+  periodEnd,
+  scope,
+  _scopeFilter,
+) {
   try {
     const where = {
       tenantId,
@@ -939,34 +1235,49 @@ async function computeAchievedAmount(tenantId, userId, periodStart, periodEnd, s
 // GET /revenue-goals — admin sees all, USER sees only their own goals.
 router.get("/revenue-goals", async (req, res) => {
   try {
-    const isPrivileged = req.user.role === "ADMIN" || req.user.role === "MANAGER";
+    const isPrivileged =
+      req.user.role === "ADMIN" || req.user.role === "MANAGER";
     const where = { tenantId: req.user.tenantId };
     if (!isPrivileged) where.userId = req.user.userId;
     if (req.query.userId) {
       const filterUid = parseInt(req.query.userId, 10);
       if (!isPrivileged && filterUid !== req.user.userId) {
-        return res.status(403).json({ error: "Cannot read other users' revenue goals." });
+        return res
+          .status(403)
+          .json({ error: "Cannot read other users' revenue goals." });
       }
       where.userId = filterUid;
     }
     const rows = await prisma.staffRevenueGoal.findMany({
       where,
       orderBy: [{ periodStart: "desc" }, { id: "desc" }],
-      include: { user: { select: { id: true, name: true, email: true, wellnessRole: true } } },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, wellnessRole: true },
+        },
+      },
     });
 
     // Refresh achievedAmount on read.
     const out = await Promise.all(
       rows.map(async (g) => {
         const achieved = await computeAchievedAmount(
-          req.user.tenantId, g.userId, g.periodStart, g.periodEnd, g.scope, g.scopeFilter
+          req.user.tenantId,
+          g.userId,
+          g.periodStart,
+          g.periodEnd,
+          g.scope,
+          g.scopeFilter,
         );
         // Best-effort write-back; don't fail the read if it errors.
         prisma.staffRevenueGoal
-          .update({ where: { id: g.id }, data: { achievedAmount: String(achieved) } })
+          .update({
+            where: { id: g.id },
+            data: { achievedAmount: String(achieved) },
+          })
           .catch(() => {});
         return { ...g, achievedAmount: achieved };
-      })
+      }),
     );
     res.json(out);
   } catch (err) {
@@ -979,15 +1290,31 @@ router.get("/revenue-goals", async (req, res) => {
 router.post("/revenue-goals", verifyRole(["ADMIN"]), async (req, res) => {
   try {
     const errors = validateGoalBody(req.body || {}, { partial: false });
-    if (errors.length) return res.status(400).json({ error: errors.join("; ") });
+    if (errors.length)
+      return res.status(400).json({ error: errors.join("; ") });
 
-    const { targetUserId, period, periodStart, periodEnd, targetAmount, scope, scopeFilter, notes } = req.body;
+    const {
+      targetUserId,
+      period,
+      periodStart,
+      periodEnd,
+      targetAmount,
+      scope,
+      scopeFilter,
+      notes,
+    } = req.body;
     // PRD Gap §1.6 follow-up: prefer targetUserId (non-stripped name).
     // eslint-disable-next-line no-restricted-syntax
-    const resolvedUserId = targetUserId !== undefined ? targetUserId : req.body.userId;
+    const resolvedUserId =
+      targetUserId !== undefined ? targetUserId : req.body.userId;
     // Verify user belongs to this tenant.
-    const target = await prisma.user.findFirst({ where: { id: parseInt(resolvedUserId, 10), tenantId: req.user.tenantId } });
-    if (!target) return res.status(404).json({ error: "Target user not found in this tenant." });
+    const target = await prisma.user.findFirst({
+      where: { id: parseInt(resolvedUserId, 10), tenantId: req.user.tenantId },
+    });
+    if (!target)
+      return res
+        .status(404)
+        .json({ error: "Target user not found in this tenant." });
 
     const row = await prisma.staffRevenueGoal.create({
       data: {
@@ -1002,12 +1329,26 @@ router.post("/revenue-goals", verifyRole(["ADMIN"]), async (req, res) => {
         notes: notes || null,
       },
     });
-    await writeAudit("StaffRevenueGoal", "CREATE", row.id, req.user.userId, req.user.tenantId, {
-      targetUserId: target.id, period: row.period, target: targetAmount,
-    });
+    await writeAudit(
+      "StaffRevenueGoal",
+      "CREATE",
+      row.id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: target.id,
+        period: row.period,
+        target: targetAmount,
+      },
+    );
     res.status(201).json(row);
   } catch (err) {
-    if (err.code === "P2002") return res.status(409).json({ error: "A goal already exists for this user / period / start." });
+    if (err.code === "P2002")
+      return res
+        .status(409)
+        .json({
+          error: "A goal already exists for this user / period / start.",
+        });
     console.error("[staff][revenue-goals][create]", err);
     res.status(500).json({ error: "Failed to create revenue goal." });
   }
@@ -1017,14 +1358,27 @@ router.post("/revenue-goals", verifyRole(["ADMIN"]), async (req, res) => {
 router.put("/revenue-goals/:id", verifyRole(["ADMIN"]), async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);
-    if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: "Invalid id." });
-    const existing = await prisma.staffRevenueGoal.findFirst({ where: { id, tenantId: req.user.tenantId } });
-    if (!existing) return res.status(404).json({ error: "Revenue goal not found." });
+    if (!Number.isInteger(id) || id <= 0)
+      return res.status(400).json({ error: "Invalid id." });
+    const existing = await prisma.staffRevenueGoal.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing)
+      return res.status(404).json({ error: "Revenue goal not found." });
 
     const errors = validateGoalBody(req.body || {}, { partial: true });
-    if (errors.length) return res.status(400).json({ error: errors.join("; ") });
+    if (errors.length)
+      return res.status(400).json({ error: errors.join("; ") });
 
-    const { period, periodStart, periodEnd, targetAmount, scope, scopeFilter, notes } = req.body || {};
+    const {
+      period,
+      periodStart,
+      periodEnd,
+      targetAmount,
+      scope,
+      scopeFilter,
+      notes,
+    } = req.body || {};
     const data = {};
     if (period !== undefined) data.period = period;
     if (periodStart !== undefined) data.periodStart = new Date(periodStart);
@@ -1035,10 +1389,18 @@ router.put("/revenue-goals/:id", verifyRole(["ADMIN"]), async (req, res) => {
     if (notes !== undefined) data.notes = notes || null;
 
     const row = await prisma.staffRevenueGoal.update({ where: { id }, data });
-    await writeAudit("StaffRevenueGoal", "UPDATE", row.id, req.user.userId, req.user.tenantId, { id });
+    await writeAudit(
+      "StaffRevenueGoal",
+      "UPDATE",
+      row.id,
+      req.user.userId,
+      req.user.tenantId,
+      { id },
+    );
     res.json(row);
   } catch (err) {
-    if (err.code === "P2025") return res.status(404).json({ error: "Revenue goal not found." });
+    if (err.code === "P2025")
+      return res.status(404).json({ error: "Revenue goal not found." });
     console.error("[staff][revenue-goals][update]", err);
     res.status(500).json({ error: "Failed to update revenue goal." });
   }
@@ -1048,17 +1410,30 @@ router.put("/revenue-goals/:id", verifyRole(["ADMIN"]), async (req, res) => {
 router.delete("/revenue-goals/:id", verifyRole(["ADMIN"]), async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);
-    if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: "Invalid id." });
-    const existing = await prisma.staffRevenueGoal.findFirst({ where: { id, tenantId: req.user.tenantId } });
-    if (!existing) return res.status(404).json({ error: "Revenue goal not found." });
+    if (!Number.isInteger(id) || id <= 0)
+      return res.status(400).json({ error: "Invalid id." });
+    const existing = await prisma.staffRevenueGoal.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing)
+      return res.status(404).json({ error: "Revenue goal not found." });
 
     await prisma.staffRevenueGoal.delete({ where: { id } });
-    await writeAudit("StaffRevenueGoal", "DELETE", id, req.user.userId, req.user.tenantId, {
-      targetUserId: existing.userId, period: existing.period,
-    });
+    await writeAudit(
+      "StaffRevenueGoal",
+      "DELETE",
+      id,
+      req.user.userId,
+      req.user.tenantId,
+      {
+        targetUserId: existing.userId,
+        period: existing.period,
+      },
+    );
     res.status(204).end();
   } catch (err) {
-    if (err.code === "P2025") return res.status(404).json({ error: "Revenue goal not found." });
+    if (err.code === "P2025")
+      return res.status(404).json({ error: "Revenue goal not found." });
     console.error("[staff][revenue-goals][delete]", err);
     res.status(500).json({ error: "Failed to delete revenue goal." });
   }
@@ -1099,14 +1474,16 @@ router.get("/commission-data", verifyRole(["ADMIN"]), async (req, res) => {
 router.get("/commission-data/:id", verifyRole(["ADMIN"]), async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);
-    if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: "Invalid id." });
+    if (!Number.isInteger(id) || id <= 0)
+      return res.status(400).json({ error: "Invalid id." });
 
     const record = await prisma.commissionData.findFirst({
       where: { id, tenantId: req.user.tenantId },
       include: { user: { select: { id: true, email: true, name: true } } },
     });
 
-    if (!record) return res.status(404).json({ error: "Commission record not found." });
+    if (!record)
+      return res.status(404).json({ error: "Commission record not found." });
     res.json(record);
   } catch (err) {
     console.error("[staff][commission-data][detail]", err);
@@ -1115,48 +1492,58 @@ router.get("/commission-data/:id", verifyRole(["ADMIN"]), async (req, res) => {
 });
 
 // GET /commission-data/summary/by-employee — aggregate by employee
-router.get("/commission-data/summary/by-employee", verifyRole(["ADMIN"]), async (req, res) => {
-  try {
-    const records = await prisma.commissionData.findMany({
-      where: { tenantId: req.user.tenantId },
-      select: {
-        employeeName: true,
-        serviceRevenue: true,
-        productRevenue: true,
-        packageRevenue: true,
-        membershipRevenue: true,
-        totalSales: true,
-      },
-    });
+router.get(
+  "/commission-data/summary/by-employee",
+  verifyRole(["ADMIN"]),
+  async (req, res) => {
+    try {
+      const records = await prisma.commissionData.findMany({
+        where: { tenantId: req.user.tenantId },
+        select: {
+          employeeName: true,
+          serviceRevenue: true,
+          productRevenue: true,
+          packageRevenue: true,
+          membershipRevenue: true,
+          totalSales: true,
+        },
+      });
 
-    const summary = {};
-    records.forEach((r) => {
-      if (!summary[r.employeeName]) {
-        summary[r.employeeName] = {
-          employeeName: r.employeeName,
-          serviceRevenue: 0,
-          productRevenue: 0,
-          packageRevenue: 0,
-          membershipRevenue: 0,
-          totalSales: 0,
-          recordCount: 0,
-        };
-      }
-      summary[r.employeeName].serviceRevenue += parseFloat(r.serviceRevenue) || 0;
-      summary[r.employeeName].productRevenue += parseFloat(r.productRevenue) || 0;
-      summary[r.employeeName].packageRevenue += parseFloat(r.packageRevenue) || 0;
-      summary[r.employeeName].membershipRevenue += parseFloat(r.membershipRevenue) || 0;
-      summary[r.employeeName].totalSales += parseFloat(r.totalSales) || 0;
-      summary[r.employeeName].recordCount += 1;
-    });
+      const summary = {};
+      records.forEach((r) => {
+        if (!summary[r.employeeName]) {
+          summary[r.employeeName] = {
+            employeeName: r.employeeName,
+            serviceRevenue: 0,
+            productRevenue: 0,
+            packageRevenue: 0,
+            membershipRevenue: 0,
+            totalSales: 0,
+            recordCount: 0,
+          };
+        }
+        summary[r.employeeName].serviceRevenue +=
+          parseFloat(r.serviceRevenue) || 0;
+        summary[r.employeeName].productRevenue +=
+          parseFloat(r.productRevenue) || 0;
+        summary[r.employeeName].packageRevenue +=
+          parseFloat(r.packageRevenue) || 0;
+        summary[r.employeeName].membershipRevenue +=
+          parseFloat(r.membershipRevenue) || 0;
+        summary[r.employeeName].totalSales += parseFloat(r.totalSales) || 0;
+        summary[r.employeeName].recordCount += 1;
+      });
 
-    const rows = Object.values(summary).sort((a, b) => b.totalSales - a.totalSales);
-    res.json(rows);
-  } catch (err) {
-    console.error("[staff][commission-data][summary]", err);
-    res.status(500).json({ error: "Failed to compute commission summary." });
-  }
-});
+      const rows = Object.values(summary).sort(
+        (a, b) => b.totalSales - a.totalSales,
+      );
+      res.json(rows);
+    } catch (err) {
+      console.error("[staff][commission-data][summary]", err);
+      res.status(500).json({ error: "Failed to compute commission summary." });
+    }
+  },
+);
 
 module.exports = router;
 // Test hooks — exported only for backend/test/routes/staff.test.js.

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -168,19 +168,63 @@ const tenantWhere = (req, extra = {}) => ({
 //
 // Tenant.vertical check is inherited from verifyWellnessRole — non-wellness
 // tenants get 403 WELLNESS_TENANT_REQUIRED before the role check runs.
-const phiReadGate = verifyWellnessRole([
-  "doctor",
-  "professional",
-  "telecaller",
-  "admin",
-  "manager",
-]);
-const phiWriteGate = verifyWellnessRole([
-  "doctor",
-  "professional",
-  "admin",
-  "manager",
-]);
+// "clinical" is a meta-token resolved by verifyWellnessRole against the
+// per-tenant WellnessRoleType catalog — ANY wellnessRole with
+// `canTakeVisits = true` (doctor, professional, nurse, stylist, plus any
+// future custom clinical role added in Settings → Wellness Role Types)
+// passes the gate automatically with NO code change. The literal
+// "doctor" / "professional" entries stay alongside it so existing JWTs +
+// the legacy PHI_READ_ROLES contract pinned in wellnessOwnership.test.js
+// continue to work unchanged; the literal match short-circuits the
+// catalog DB lookup for the common case.
+//
+// `anyOfPermissions` opens a SECOND door alongside the wellnessRole
+// match: any user with one of the listed RBAC permissions (granted via
+// Roles & Permissions admin) passes the gate even without a matching
+// wellnessRole. Each entry mirrors the corresponding page in the
+// backend page catalog (lib/pageCatalog.js) — granting the page's
+// listed `requiredPermissions` to a custom role makes that role
+// immediately usable end-to-end (sidebar → page → API).
+const phiReadGate = verifyWellnessRole(
+  ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  {
+    anyOfPermissions: [
+      { module: "patients", action: "read" },
+      { module: "appointments", action: "read" },
+      { module: "calendar", action: "read" },
+      { module: "visits", action: "read" },
+      { module: "prescriptions", action: "read" },
+      { module: "consents", action: "read" },
+    ],
+  },
+);
+const phiWriteGate = verifyWellnessRole(
+  ["clinical", "doctor", "professional", "admin", "manager"],
+  {
+    anyOfPermissions: [
+      { module: "patients", action: "write" },
+      { module: "appointments", action: "write" },
+      { module: "calendar", action: "write" },
+      { module: "visits", action: "write" },
+      { module: "prescriptions", action: "write" },
+      { module: "consents", action: "write" },
+    ],
+  },
+);
+
+// `adminOrPerm(module, action)` is the canonical factory for admin-only
+// wellness routes that ALSO want to accept a specific RBAC permission
+// grant. Replaces every `verifyWellnessRole(["admin", "manager"])`
+// declaration with a per-route permission unlock — so a custom RBAC
+// role granted e.g. `services.write` can create services even without
+// a matching wellnessRole. The literal `["admin", "manager"]` array
+// stays so RBAC ADMIN/MANAGER continue to short-circuit before any
+// permission lookup (no DB hit on the hot path).
+const adminOrPerm = (module, action) =>
+  verifyWellnessRole(
+    ["admin", "manager"],
+    { anyOfPermissions: [{ module, action }] },
+  );
 
 // Plan #PAT-FILTERS / #PAT-TAGS — querystring helpers shared by the
 // patient list + export + bulk-tag endpoints.
@@ -387,7 +431,15 @@ function parseTenantDateInput(input) {
 // hole #326 closed earlier today.
 router.get(
   "/activetreatment",
-  verifyWellnessRole(["doctor", "professional", "manager", "admin"]),
+  verifyWellnessRole(
+    ["clinical", "doctor", "professional", "manager", "admin"],
+    {
+      anyOfPermissions: [
+        { module: "patients", action: "read" },
+        { module: "visits", action: "read" },
+      ],
+    },
+  ),
   getAllTreatmentPlans,
 );
 router.put("/treatment-plans/:id", requireClinicalRole, updateTreatmentPlan);
@@ -3033,7 +3085,10 @@ router.get("/consents", phiReadGate, async (req, res) => {
 // row level; capturedByUserId stamps the staff member who facilitated.
 router.post(
   "/consents",
-  verifyWellnessRole(["doctor", "professional", "admin"]),
+  verifyWellnessRole(
+    ["clinical", "doctor", "professional", "admin"],
+    { anyOfPermissions: [{ module: "consents", action: "write" }] },
+  ),
   async (req, res) => {
     try {
       const {
@@ -3202,7 +3257,10 @@ router.post(
 // #207/#216: consent metadata edits are admin-only (matches existing body
 // check). The verifyWellnessRole gate just produces a clean 403 with the
 // shared WELLNESS_ROLE_FORBIDDEN code before we touch the DB.
-router.put("/consents/:id", verifyWellnessRole(["admin"]), async (req, res) => {
+router.put("/consents/:id", verifyWellnessRole(
+  ["admin"],
+  { anyOfPermissions: [{ module: "consents", action: "write" }] },
+), async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     const existing = await prisma.consentForm.findFirst({
@@ -3668,7 +3726,7 @@ function normalizeSupportedBookingTypesInput(raw) {
   return { value: JSON.stringify(normalized) };
 }
 
-router.post("/services", verifyWellnessRole(["admin", "manager"]), async (req, res) => {
+router.post("/services", adminOrPerm("services", "write"), async (req, res) => {
   try {
     const { name, category, ticketTier, basePrice, durationMin, targetRadiusKm, description, supportedBookingTypes, imageUrls } = req.body;
     if (!name || !String(name).trim()) return res.status(400).json({ error: "name required" });
@@ -3752,7 +3810,7 @@ router.post("/services", verifyWellnessRole(["admin", "manager"]), async (req, r
   }
 });
 
-router.put("/services/:id", verifyWellnessRole(["admin", "manager"]), async (req, res) => {
+router.put("/services/:id", adminOrPerm("services", "write"), async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     const existing = await prisma.service.findFirst({ where: tenantWhere(req, { id }) });
@@ -3825,6 +3883,161 @@ router.put("/services/:id", verifyWellnessRole(["admin", "manager"]), async (req
     const mapped = httpFromPrismaError(e);
     if (mapped) return res.status(mapped.status).json(mapped);
     res.status(500).json({ error: "Failed to update service" });
+  }
+});
+
+// ── Wellness role catalog ──────────────────────────────────────────
+//
+// Per-tenant catalog that replaces the old hard-coded VALID_WELLNESS_ROLES
+// whitelist in routes/staff.js. Admins maintain rows like
+// {key:"nurse", label:"Nurse", canTakeVisits:true} from Settings; the
+// Calendar grid + Staff edit form read this list to discover which
+// wellnessRole values are valid for the tenant.
+//
+// `key` is a slug stored on User.wellnessRole — it's the value the rest
+// of the codebase already compares against. Changing it for an in-use
+// role would orphan every staff member with that wellnessRole, so the
+// PUT handler refuses key-edits on rows in use. DELETE is similarly
+// refused while in use.
+
+const {
+  ensureRoleKey,
+  ensureRoleLabel,
+  listForTenant: listRoleTypes,
+} = require("../lib/wellnessRoleTypes");
+
+router.get("/role-types", async (req, res) => {
+  try {
+    const activeOnly = req.query.activeOnly === "1" || req.query.activeOnly === "true";
+    const rows = await listRoleTypes(req.user.tenantId, { activeOnly });
+    res.json(rows);
+  } catch (e) {
+    console.error("[wellness] list role-types error:", e.message);
+    res.status(500).json({ error: "Failed to list role types" });
+  }
+});
+
+router.post("/role-types", adminOrPerm("settings", "manage"), async (req, res) => {
+  try {
+    const { key, label, icon, color, canTakeVisits, sortOrder } = req.body || {};
+    const keyErr = ensureRoleKey(key);
+    if (keyErr) return res.status(keyErr.status).json(keyErr);
+    const labelErr = ensureRoleLabel(label);
+    if (labelErr) return res.status(labelErr.status).json(labelErr);
+    const dupe = await prisma.wellnessRoleType.findFirst({
+      where: { tenantId: req.user.tenantId, key },
+      select: { id: true },
+    });
+    if (dupe) return res.status(409).json({ error: `Role key "${key}" already exists`, code: "ROLE_KEY_DUPLICATE" });
+    const row = await prisma.wellnessRoleType.create({
+      data: {
+        key,
+        label,
+        icon: icon || null,
+        color: color || null,
+        canTakeVisits: canTakeVisits === undefined ? true : Boolean(canTakeVisits),
+        sortOrder: Number.isFinite(Number(sortOrder)) ? parseInt(sortOrder, 10) : 0,
+        tenantId: req.user.tenantId,
+      },
+    });
+    try {
+      await writeAudit("WellnessRoleType", "CREATE", row.id, req.user.userId, req.user.tenantId, {
+        key: row.key, label: row.label, canTakeVisits: row.canTakeVisits,
+      });
+    } catch (auditErr) { console.warn("[audit]", auditErr.message); }
+    res.status(201).json(row);
+  } catch (e) {
+    console.error("[wellness] create role-type error:", e.message);
+    res.status(500).json({ error: "Failed to create role type" });
+  }
+});
+
+router.put("/role-types/:id", adminOrPerm("settings", "manage"), async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const existing = await prisma.wellnessRoleType.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing) return res.status(404).json({ error: "Role type not found" });
+    const data = {};
+    if (req.body.label !== undefined) {
+      const labelErr = ensureRoleLabel(req.body.label);
+      if (labelErr) return res.status(labelErr.status).json(labelErr);
+      data.label = req.body.label;
+    }
+    if (req.body.key !== undefined && req.body.key !== existing.key) {
+      // Renaming the key would orphan every User with wellnessRole=oldKey.
+      // Refuse if any staff currently uses it; admins can deactivate the
+      // old row + create a new one + reassign staff manually.
+      const inUse = await prisma.user.count({
+        where: { tenantId: req.user.tenantId, wellnessRole: existing.key },
+      });
+      if (inUse > 0) {
+        return res.status(409).json({
+          error: `Cannot rename key while ${inUse} staff member(s) use it. Reassign them first.`,
+          code: "ROLE_KEY_IN_USE",
+        });
+      }
+      const keyErr = ensureRoleKey(req.body.key);
+      if (keyErr) return res.status(keyErr.status).json(keyErr);
+      const dupe = await prisma.wellnessRoleType.findFirst({
+        where: { tenantId: req.user.tenantId, key: req.body.key, NOT: { id } },
+        select: { id: true },
+      });
+      if (dupe) return res.status(409).json({ error: `Role key "${req.body.key}" already exists`, code: "ROLE_KEY_DUPLICATE" });
+      data.key = req.body.key;
+    }
+    if (req.body.icon !== undefined) data.icon = req.body.icon || null;
+    if (req.body.color !== undefined) data.color = req.body.color || null;
+    if (req.body.canTakeVisits !== undefined) data.canTakeVisits = Boolean(req.body.canTakeVisits);
+    if (req.body.isActive !== undefined) data.isActive = Boolean(req.body.isActive);
+    if (req.body.sortOrder !== undefined) {
+      const n = Number(req.body.sortOrder);
+      if (Number.isFinite(n)) data.sortOrder = parseInt(n, 10);
+    }
+    const updated = await prisma.wellnessRoleType.update({ where: { id }, data });
+    try {
+      const changes = diffFields(existing, updated, Object.keys(data));
+      if (Object.keys(changes).length > 0) {
+        await writeAudit("WellnessRoleType", "UPDATE", updated.id, req.user.userId, req.user.tenantId, {
+          changedFields: changes,
+        });
+      }
+    } catch (auditErr) { console.warn("[audit]", auditErr.message); }
+    res.json(updated);
+  } catch (e) {
+    console.error("[wellness] update role-type error:", e.message);
+    res.status(500).json({ error: "Failed to update role type" });
+  }
+});
+
+router.delete("/role-types/:id", adminOrPerm("settings", "manage"), async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const existing = await prisma.wellnessRoleType.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing) return res.status(404).json({ error: "Role type not found" });
+    const inUse = await prisma.user.count({
+      where: { tenantId: req.user.tenantId, wellnessRole: existing.key },
+    });
+    if (inUse > 0) {
+      return res.status(409).json({
+        error: `Cannot delete role while ${inUse} staff member(s) use it. Deactivate instead or reassign staff first.`,
+        code: "ROLE_IN_USE",
+        inUseCount: inUse,
+      });
+    }
+    await prisma.wellnessRoleType.delete({ where: { id } });
+    try {
+      await writeAudit("WellnessRoleType", "DELETE", id, req.user.userId, req.user.tenantId, {
+        key: existing.key, label: existing.label,
+      });
+    } catch (auditErr) { console.warn("[audit]", auditErr.message); }
+    res.json({ ok: true });
+  } catch (e) {
+    console.error("[wellness] delete role-type error:", e.message);
+    res.status(500).json({ error: "Failed to delete role type" });
   }
 });
 
@@ -3990,7 +4203,7 @@ router.get("/membership-plans/:id", async (req, res) => {
 // /services pattern at line 1955).
 router.post(
   "/membership-plans",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("services", "write"),
   async (req, res) => {
     try {
       const { name, description, durationDays, price, currency, entitlements } =
@@ -4088,7 +4301,7 @@ router.post(
 
 router.put(
   "/membership-plans/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("services", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -4187,7 +4400,7 @@ router.put(
 // until expiry. Only stops new sales of this plan.
 router.delete(
   "/membership-plans/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("services", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -4624,7 +4837,7 @@ router.post("/memberships/:id/redeem", phiWriteGate, async (req, res) => {
 // matches how the existing Memberships card describes value to admins.
 router.get(
   "/memberships/dashboard",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("services", "read"),
   async (req, res) => {
     try {
       const now = new Date();
@@ -4699,7 +4912,7 @@ router.get(
 // stamps cancelledAt + cancelReason. Idempotent if already cancelled (200).
 router.post(
   "/memberships/:id/cancel",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("services", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -4833,7 +5046,7 @@ router.get("/recommendations", async (req, res) => {
 // the gate just makes the 403 match the rest of the wellness shape.
 router.put(
   "/recommendations/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);
@@ -4911,7 +5124,7 @@ router.put(
 
 router.post(
   "/recommendations/:id/approve",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);
@@ -5000,7 +5213,7 @@ router.post(
 // missing verifyWellnessRole gate to all four manual run endpoints.
 router.post(
   "/orchestrator/run",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const result = await runForTenant(req.user.tenantId);
@@ -5019,7 +5232,7 @@ router.post(
 // as such; no enforcement). verifyWellnessRole emits WELLNESS_ROLE_FORBIDDEN.
 router.post(
   "/reminders/run",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const { processTenant } = require("../cron/appointmentRemindersEngine");
@@ -5043,7 +5256,7 @@ router.post(
 // caller's tenant, returns { scored, flagged, notified }.
 router.post(
   "/no-show-risk/run",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const {
@@ -5062,7 +5275,7 @@ router.post(
 
 router.post(
   "/ops/run",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const {
@@ -5091,7 +5304,7 @@ router.post(
 // #216: gate to admin/manager — emails staff and creates notifications.
 router.post(
   "/inventory/low-stock/run",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const { runLowStockForTenant } = require("../cron/lowStockEngine");
@@ -5113,7 +5326,7 @@ router.post(
 
 router.post(
   "/recommendations/:id/reject",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "write"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);
@@ -5227,7 +5440,7 @@ router.get("/locations", async (req, res) => {
 // #216: clinic locations are operational config — admin/manager only.
 router.post(
   "/locations",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const {
@@ -5311,7 +5524,7 @@ router.post(
 
 router.put(
   "/locations/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);
@@ -5391,13 +5604,24 @@ router.put(
 
 router.get(
   "/resources",
-  verifyWellnessRole([
-    "doctor",
-    "professional",
-    "telecaller",
-    "admin",
-    "manager",
-  ]),
+  verifyWellnessRole(
+    ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+    {
+      // Resources back the Calendar page (calendar.read), Appointments
+      // list (appointments.read), the Resources admin page (settings.read),
+      // and any clinical surface that needs to check room availability.
+      // Any one of these read grants unlocks the endpoint so admins
+      // don't have to grant an exact-matching permission — just the
+      // permission for the page the user is trying to use.
+      anyOfPermissions: [
+        { module: "calendar", action: "read" },
+        { module: "appointments", action: "read" },
+        { module: "settings", action: "read" },
+        { module: "patients", action: "read" },
+        { module: "visits", action: "read" },
+      ],
+    },
+  ),
   async (req, res) => {
     try {
       const where = tenantWhere(req);
@@ -5421,7 +5645,7 @@ router.get(
 
 router.post(
   "/resources",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const { name, type, locationId, isActive, serviceIds } = req.body;
@@ -5484,7 +5708,7 @@ router.post(
 
 router.put(
   "/resources/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -5543,7 +5767,7 @@ router.put(
 
 router.delete(
   "/resources/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -5573,7 +5797,21 @@ router.delete(
   },
 );
 
-router.get("/holidays", verifyWellnessRole(["doctor", "professional", "telecaller", "admin", "manager"]), async (req, res) => {
+router.get("/holidays", verifyWellnessRole(
+  ["clinical", "doctor", "professional", "telecaller", "admin", "manager"],
+  {
+    // Holidays back the Calendar page + Holidays admin page. Any clinical
+    // or scheduling-related read grant unlocks the endpoint so partial
+    // permission sets don't strand the user on a half-loaded calendar.
+    anyOfPermissions: [
+      { module: "calendar", action: "read" },
+      { module: "appointments", action: "read" },
+      { module: "settings", action: "read" },
+      { module: "patients", action: "read" },
+      { module: "visits", action: "read" },
+    ],
+  },
+), async (req, res) => {
   try {
     const { from, to } = req.query;
     // Two-bucket fetch: (a) date-bounded non-recurring rows, (b) all
@@ -5638,7 +5876,7 @@ router.get("/holidays", verifyWellnessRole(["doctor", "professional", "telecalle
   }
 });
 
-router.post("/holidays", verifyWellnessRole(["admin", "manager"]), async (req, res) => {
+router.post("/holidays", adminOrPerm("settings", "manage"), async (req, res) => {
   try {
     const { date, name, locationId, doctorId, recurringAnnually } = req.body;
     if (!date) return res.status(400).json({ error: "date is required", code: "DATE_REQUIRED" });
@@ -5667,7 +5905,7 @@ router.post("/holidays", verifyWellnessRole(["admin", "manager"]), async (req, r
 
 router.delete(
   "/holidays/:id",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -5699,13 +5937,28 @@ router.delete(
 
 router.get(
   "/working-hours",
-  verifyWellnessRole([
-    "doctor",
-    "professional",
-    "telecaller",
-    "admin",
-    "manager",
-  ]),
+  verifyWellnessRole(
+    [
+      "clinical",
+      "doctor",
+      "professional",
+      "telecaller",
+      "admin",
+      "manager",
+    ],
+    {
+      // Working hours back the Calendar page + admin config page. Same
+      // wide read set as resources/holidays so partial permissions don't
+      // 403 calendar peripherals.
+      anyOfPermissions: [
+        { module: "calendar", action: "read" },
+        { module: "appointments", action: "read" },
+        { module: "settings", action: "read" },
+        { module: "patients", action: "read" },
+        { module: "visits", action: "read" },
+      ],
+    },
+  ),
   async (req, res) => {
     try {
       const where = tenantWhere(req);
@@ -5725,7 +5978,7 @@ router.get(
 
 router.put(
   "/working-hours/:doctorId",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("settings", "manage"),
   async (req, res) => {
     try {
       const doctorId = parseInt(req.params.doctorId, 10);
@@ -6251,7 +6504,7 @@ async function computePerLocation(req) {
 
 router.get(
   "/reports/pnl-by-service",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "read"),
   async (req, res) => {
     try {
       const result = await computePnlByService(req);
@@ -6267,7 +6520,7 @@ router.get(
 
 router.get(
   "/reports/per-professional",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "read"),
   async (req, res) => {
     try {
       const result = await computePerProfessional(req);
@@ -6285,7 +6538,7 @@ router.get(
 
 router.get(
   "/reports/attribution",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "read"),
   async (req, res) => {
     try {
       const result = await computeAttribution(req);
@@ -6301,7 +6554,7 @@ router.get(
 
 router.get(
   "/reports/per-location",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "read"),
   async (req, res) => {
     try {
       const result = await computePerLocation(req);
@@ -6528,7 +6781,7 @@ const fmtMoney = (n) => {
 
 router.get(
   "/reports/pnl-by-service.csv",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePnlByService(req);
@@ -6572,7 +6825,7 @@ router.get(
 
 router.get(
   "/reports/pnl-by-service.pdf",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePnlByService(req);
@@ -6623,7 +6876,7 @@ router.get(
 
 router.get(
   "/reports/pnl-by-service.xlsx",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePnlByService(req);
@@ -6676,7 +6929,7 @@ router.get(
 
 router.get(
   "/reports/per-professional.csv",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerProfessional(req);
@@ -6706,7 +6959,7 @@ router.get(
 
 router.get(
   "/reports/per-professional.pdf",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerProfessional(req);
@@ -6743,7 +6996,7 @@ router.get(
 
 router.get(
   "/reports/per-professional.xlsx",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerProfessional(req);
@@ -6782,7 +7035,7 @@ router.get(
 
 router.get(
   "/reports/per-location.csv",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerLocation(req);
@@ -6826,7 +7079,7 @@ router.get(
 
 router.get(
   "/reports/per-location.pdf",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerLocation(req);
@@ -6877,7 +7130,7 @@ router.get(
 
 router.get(
   "/reports/per-location.xlsx",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computePerLocation(req);
@@ -6930,7 +7183,7 @@ router.get(
 
 router.get(
   "/reports/attribution.csv",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computeAttribution(req);
@@ -6977,7 +7230,7 @@ router.get(
 
 router.get(
   "/reports/attribution.pdf",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computeAttribution(req);
@@ -7031,7 +7284,7 @@ router.get(
 
 router.get(
   "/reports/attribution.xlsx",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "export"),
   async (req, res) => {
     try {
       const result = await computeAttribution(req);
@@ -7091,7 +7344,7 @@ router.get(
 // the full clinic financials. Lock to admin/manager.
 router.get(
   "/dashboard",
-  verifyWellnessRole(["admin", "manager"]),
+  adminOrPerm("reports", "read"),
   async (req, res) => {
     try {
       const tenantId = req.user.tenantId;
@@ -8414,7 +8667,10 @@ router.get("/consents/:id/pdf", async (req, res) => {
 // action; staff initiates it.
 router.post(
   "/consents/:id/archive",
-  verifyWellnessRole(["doctor", "professional", "admin"]),
+  verifyWellnessRole(
+    ["clinical", "doctor", "professional", "admin"],
+    { anyOfPermissions: [{ module: "consents", action: "write" }] },
+  ),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);

--- a/backend/routes/wellnessCsv.js
+++ b/backend/routes/wellnessCsv.js
@@ -92,7 +92,20 @@ function resolveEntity(req, res) {
 
 function gateFor(def, mode) {
   // mode: "read" for template/export, "write" for import.
-  return verifyWellnessRole(mode === "write" ? def.writeGate : def.readGate);
+  // The role array (def.readGate / def.writeGate) controls who passes
+  // by wellnessRole; def.readPermissions / def.writePermissions opens
+  // the SAME endpoint to custom RBAC roles granted the matching
+  // module.action permission — so a Radiologist role with
+  // `calendar.read` can export bookings without needing a clinical
+  // wellnessRole. Falls back to literal-only behaviour when the entity
+  // doesn't declare permissions (back-compat).
+  const allowed = mode === "write" ? def.writeGate : def.readGate;
+  const anyOfPermissions =
+    mode === "write" ? def.writePermissions : def.readPermissions;
+  const opts = Array.isArray(anyOfPermissions) && anyOfPermissions.length > 0
+    ? { anyOfPermissions }
+    : {};
+  return verifyWellnessRole(allowed, opts);
 }
 
 function sendCsv(res, filename, body) {

--- a/backend/scripts/ensureRbacOnBoot.js
+++ b/backend/scripts/ensureRbacOnBoot.js
@@ -93,6 +93,11 @@ const USER_PERMISSIONS = [
 const DOCTOR_PERMISSIONS = [
   'patients.read', 'patients.write', 'patients.update',
   'appointments.read', 'appointments.write', 'appointments.update',
+  // `calendar` is a sibling-permission to `appointments` — separated so
+  // admins can grant view-only Calendar access independently of the
+  // Appointments list / Book Appointment form. Doctors get both since
+  // they live in the Calendar day-grid view.
+  'calendar.read', 'calendar.write',
   'visits.read', 'visits.write', 'visits.update',
   'prescriptions.read', 'prescriptions.write', 'prescriptions.update',
   'consents.read', 'consents.write',
@@ -108,6 +113,9 @@ const DOCTOR_PERMISSIONS = [
 const NURSE_PERMISSIONS = [
   'patients.read', 'patients.update',
   'appointments.read', 'appointments.update',
+  // Nurse views the Calendar day-grid for context but doesn't book or
+  // reschedule (that's Doctor / Receptionist work). Read-only on calendar.
+  'calendar.read',
   'visits.read', 'visits.write', 'visits.update',
   // Nurse manages BOTH catalog (recording new products as they arrive)
   // AND ledger (logging receipts + adjustments on consumption). They're
@@ -122,6 +130,9 @@ const NURSE_PERMISSIONS = [
 const RECEPTIONIST_PERMISSIONS = [
   'patients.read', 'patients.write',
   'appointments.read', 'appointments.write', 'appointments.update', 'appointments.delete',
+  // Receptionist is THE primary calendar user — books slots, reschedules,
+  // cancels via drag-to-reschedule and right-click-cancel.
+  'calendar.read', 'calendar.write',
   'services.read',
   // Receptionist views the product catalog to look up items for POS
   // sales but doesn't edit it; no stock-ledger access.
@@ -140,6 +151,9 @@ const TELECALLER_PERMISSIONS = [
   'leads.read', 'leads.write', 'leads.update',
   'contacts.read', 'contacts.write',
   'appointments.read', 'appointments.write',
+  // Telecaller books appointments from outbound calls — they need
+  // calendar read+write to pick a slot during the call.
+  'calendar.read', 'calendar.write',
   'communications.read', 'communications.write',
   'sms.read', 'sms.write',
   'whatsapp.read', 'whatsapp.write',

--- a/backend/test/lib/pageCatalog.test.js
+++ b/backend/test/lib/pageCatalog.test.js
@@ -91,6 +91,11 @@ describe('canAccessPath', () => {
     'patients.read',
     'appointments.read',
     'appointments.write',
+    // `calendar` is a separate permission module from `appointments` —
+    // doctors get both so the day-grid view + booking flows work
+    // end-to-end. Mirrors DOCTOR_PERMISSIONS in ensureRbacOnBoot.js.
+    'calendar.read',
+    'calendar.write',
     'prescriptions.read',
   ]);
 
@@ -133,6 +138,10 @@ describe('canAccessPath', () => {
       'patients.update',
       'appointments.read',
       'appointments.update',
+      // Nurse views the Calendar day-grid for context; doesn't write to
+      // it (booking / rescheduling is Doctor / Receptionist work).
+      // Mirrors NURSE_PERMISSIONS in ensureRbacOnBoot.js.
+      'calendar.read',
       'visits.read',
       'visits.write',
       'visits.update',
@@ -171,11 +180,13 @@ describe('canAccessPath', () => {
 
 describe('getAccessiblePages', () => {
   it('returns only pages whose required perms the user satisfies', () => {
-    // Doctor-shape perms (includes appointments.write).
+    // Doctor-shape perms (includes appointments.write + calendar.*).
     const perms = new Set([
       'patients.read',
       'appointments.read',
       'appointments.write',
+      'calendar.read',
+      'calendar.write',
       'prescriptions.read',
     ]);
     const pages = getAccessiblePages(perms);
@@ -194,6 +205,7 @@ describe('getAccessiblePages', () => {
     const perms = new Set([
       'patients.read', 'patients.write', 'patients.update',
       'appointments.read', 'appointments.write', 'appointments.update',
+      'calendar.read', 'calendar.write',
       'visits.read', 'visits.write', 'visits.update',
       'prescriptions.read', 'prescriptions.write', 'prescriptions.update',
       'consents.read', 'consents.write',

--- a/backend/test/lib/wellnessRoleTypes.test.js
+++ b/backend/test/lib/wellnessRoleTypes.test.js
@@ -1,0 +1,245 @@
+// Unit tests for backend/lib/wellnessRoleTypes.js
+//
+// Mocking strategy: monkey-patch the prisma singleton (vi.mock doesn't
+// intercept CJS require in this vitest setup — see leadJunkFilter.test.js
+// for the same pattern).
+//
+// Covers:
+//   - ensureRoleKey / ensureRoleLabel pure-input validators
+//   - DEFAULT_WELLNESS_ROLES shape (one entry per legacy whitelist key
+//     plus the new "nurse" addition that motivated Option B)
+//   - listForTenant + isCatalogedKey + seedDefaultsForTenant DB interactions
+
+import { describe, test, expect, vi, beforeAll, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import roleTypes from '../../lib/wellnessRoleTypes.js';
+
+const {
+  DEFAULT_WELLNESS_ROLES,
+  ROLE_KEY_RE,
+  ensureRoleKey,
+  ensureRoleLabel,
+  listForTenant,
+  isCatalogedKey,
+  seedDefaultsForTenant,
+} = roleTypes;
+
+beforeAll(() => {
+  prisma.wellnessRoleType = {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  prisma.wellnessRoleType.findMany.mockReset();
+  prisma.wellnessRoleType.findFirst.mockReset();
+  prisma.wellnessRoleType.create.mockReset();
+});
+
+describe('module shape', () => {
+  test('exports the public surface', () => {
+    expect(Array.isArray(DEFAULT_WELLNESS_ROLES)).toBe(true);
+    expect(ROLE_KEY_RE).toBeInstanceOf(RegExp);
+    expect(typeof ensureRoleKey).toBe('function');
+    expect(typeof ensureRoleLabel).toBe('function');
+    expect(typeof listForTenant).toBe('function');
+    expect(typeof isCatalogedKey).toBe('function');
+    expect(typeof seedDefaultsForTenant).toBe('function');
+  });
+});
+
+describe('DEFAULT_WELLNESS_ROLES', () => {
+  test('includes every key from the legacy hardcoded whitelist', () => {
+    const keys = DEFAULT_WELLNESS_ROLES.map((r) => r.key);
+    for (const legacy of ['doctor', 'professional', 'telecaller', 'helper', 'stylist']) {
+      expect(keys).toContain(legacy);
+    }
+  });
+
+  test('includes "nurse" — the example role that motivated Option B', () => {
+    const keys = DEFAULT_WELLNESS_ROLES.map((r) => r.key);
+    expect(keys).toContain('nurse');
+  });
+
+  test('every default has canTakeVisits as a boolean', () => {
+    for (const r of DEFAULT_WELLNESS_ROLES) {
+      expect(typeof r.canTakeVisits).toBe('boolean');
+    }
+  });
+
+  test('telecaller + helper are NOT practitioners (operational roles)', () => {
+    const find = (k) => DEFAULT_WELLNESS_ROLES.find((r) => r.key === k);
+    expect(find('telecaller').canTakeVisits).toBe(false);
+    expect(find('helper').canTakeVisits).toBe(false);
+  });
+
+  test('doctor + nurse + professional + stylist ARE practitioners', () => {
+    const find = (k) => DEFAULT_WELLNESS_ROLES.find((r) => r.key === k);
+    expect(find('doctor').canTakeVisits).toBe(true);
+    expect(find('nurse').canTakeVisits).toBe(true);
+    expect(find('professional').canTakeVisits).toBe(true);
+    expect(find('stylist').canTakeVisits).toBe(true);
+  });
+});
+
+describe('ensureRoleKey — pure validator', () => {
+  test('returns ROLE_KEY_REQUIRED on empty when required (default)', () => {
+    expect(ensureRoleKey('')).toEqual(expect.objectContaining({ status: 400, code: 'ROLE_KEY_REQUIRED' }));
+    expect(ensureRoleKey(null)).toEqual(expect.objectContaining({ code: 'ROLE_KEY_REQUIRED' }));
+    expect(ensureRoleKey(undefined)).toEqual(expect.objectContaining({ code: 'ROLE_KEY_REQUIRED' }));
+  });
+
+  test('returns null on empty when required=false', () => {
+    expect(ensureRoleKey('', { required: false })).toBeNull();
+    expect(ensureRoleKey(null, { required: false })).toBeNull();
+  });
+
+  test('accepts valid keys', () => {
+    expect(ensureRoleKey('doctor')).toBeNull();
+    expect(ensureRoleKey('nurse')).toBeNull();
+    expect(ensureRoleKey('senior-doctor')).toBeNull();
+    expect(ensureRoleKey('on-call-nurse-2')).toBeNull();
+    expect(ensureRoleKey('a')).toBeNull();
+  });
+
+  test('rejects uppercase letters', () => {
+    expect(ensureRoleKey('Doctor')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+    expect(ensureRoleKey('NURSE')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+  });
+
+  test('rejects spaces and special characters', () => {
+    expect(ensureRoleKey('senior doctor')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+    expect(ensureRoleKey('nurse_2')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+    expect(ensureRoleKey('nurse@home')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+  });
+
+  test('rejects keys starting with a digit or hyphen', () => {
+    expect(ensureRoleKey('2nd-doctor')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+    expect(ensureRoleKey('-doctor')).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+  });
+
+  test('rejects keys longer than 32 chars', () => {
+    const tooLong = 'a' + 'b'.repeat(32);
+    expect(tooLong.length).toBe(33);
+    expect(ensureRoleKey(tooLong)).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+  });
+
+  test('accepts a key at the 32-char boundary', () => {
+    const boundary = 'a' + 'b'.repeat(31);
+    expect(boundary.length).toBe(32);
+    expect(ensureRoleKey(boundary)).toBeNull();
+  });
+
+  test('rejects non-string values', () => {
+    expect(ensureRoleKey(123)).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+    expect(ensureRoleKey({ key: 'doctor' })).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_KEY' }));
+  });
+});
+
+describe('ensureRoleLabel — pure validator', () => {
+  test('returns ROLE_LABEL_REQUIRED on empty when required (default)', () => {
+    expect(ensureRoleLabel('')).toEqual(expect.objectContaining({ code: 'ROLE_LABEL_REQUIRED' }));
+    expect(ensureRoleLabel(null)).toEqual(expect.objectContaining({ code: 'ROLE_LABEL_REQUIRED' }));
+  });
+
+  test('returns null on empty when required=false', () => {
+    expect(ensureRoleLabel('', { required: false })).toBeNull();
+  });
+
+  test('accepts normal labels', () => {
+    expect(ensureRoleLabel('Doctor')).toBeNull();
+    expect(ensureRoleLabel('Nurse')).toBeNull();
+    expect(ensureRoleLabel('Senior Physiotherapist')).toBeNull();
+  });
+
+  test('rejects labels longer than 64 chars', () => {
+    expect(ensureRoleLabel('x'.repeat(65))).toEqual(expect.objectContaining({ code: 'INVALID_ROLE_LABEL' }));
+  });
+
+  test('accepts a 64-char label (boundary)', () => {
+    expect(ensureRoleLabel('x'.repeat(64))).toBeNull();
+  });
+});
+
+describe('listForTenant', () => {
+  test('queries by tenantId only when activeOnly is false', async () => {
+    prisma.wellnessRoleType.findMany.mockResolvedValue([{ id: 1, key: 'doctor' }]);
+    const rows = await listForTenant(7);
+    expect(prisma.wellnessRoleType.findMany).toHaveBeenCalledWith({
+      where: { tenantId: 7 },
+      orderBy: [{ sortOrder: 'asc' }, { label: 'asc' }],
+    });
+    expect(rows).toEqual([{ id: 1, key: 'doctor' }]);
+  });
+
+  test('adds isActive filter when activeOnly is true', async () => {
+    prisma.wellnessRoleType.findMany.mockResolvedValue([]);
+    await listForTenant(7, { activeOnly: true });
+    expect(prisma.wellnessRoleType.findMany).toHaveBeenCalledWith({
+      where: { tenantId: 7, isActive: true },
+      orderBy: [{ sortOrder: 'asc' }, { label: 'asc' }],
+    });
+  });
+});
+
+describe('isCatalogedKey', () => {
+  test('returns false on empty/missing key without hitting the DB', async () => {
+    expect(await isCatalogedKey(7, '')).toBe(false);
+    expect(await isCatalogedKey(7, null)).toBe(false);
+    expect(await isCatalogedKey(7, undefined)).toBe(false);
+    expect(prisma.wellnessRoleType.findFirst).not.toHaveBeenCalled();
+  });
+
+  test('returns true when an active row exists', async () => {
+    prisma.wellnessRoleType.findFirst.mockResolvedValue({ id: 42 });
+    expect(await isCatalogedKey(7, 'nurse')).toBe(true);
+    expect(prisma.wellnessRoleType.findFirst).toHaveBeenCalledWith({
+      where: { tenantId: 7, key: 'nurse', isActive: true },
+      select: { id: true },
+    });
+  });
+
+  test('returns false when no matching row', async () => {
+    prisma.wellnessRoleType.findFirst.mockResolvedValue(null);
+    expect(await isCatalogedKey(7, 'nurse')).toBe(false);
+  });
+
+  test('returns false on DB error (fails closed)', async () => {
+    prisma.wellnessRoleType.findFirst.mockRejectedValue(new Error('boom'));
+    expect(await isCatalogedKey(7, 'nurse')).toBe(false);
+  });
+});
+
+describe('seedDefaultsForTenant', () => {
+  test('creates every default role when none exist', async () => {
+    prisma.wellnessRoleType.findFirst.mockResolvedValue(null);
+    prisma.wellnessRoleType.create.mockResolvedValue({});
+    await seedDefaultsForTenant(7);
+    expect(prisma.wellnessRoleType.create).toHaveBeenCalledTimes(DEFAULT_WELLNESS_ROLES.length);
+    // Spot-check: nurse was passed in with tenantId
+    const calls = prisma.wellnessRoleType.create.mock.calls;
+    const nurseCall = calls.find((c) => c[0].data.key === 'nurse');
+    expect(nurseCall).toBeDefined();
+    expect(nurseCall[0].data.tenantId).toBe(7);
+    expect(nurseCall[0].data.canTakeVisits).toBe(true);
+  });
+
+  test('is idempotent — skips roles that already exist', async () => {
+    // First role exists, the rest don't.
+    prisma.wellnessRoleType.findFirst.mockImplementation((args) => {
+      if (args.where.key === DEFAULT_WELLNESS_ROLES[0].key) return Promise.resolve({ id: 1 });
+      return Promise.resolve(null);
+    });
+    prisma.wellnessRoleType.create.mockResolvedValue({});
+    await seedDefaultsForTenant(7);
+    expect(prisma.wellnessRoleType.create).toHaveBeenCalledTimes(DEFAULT_WELLNESS_ROLES.length - 1);
+  });
+
+  test('does nothing when all roles already exist', async () => {
+    prisma.wellnessRoleType.findFirst.mockResolvedValue({ id: 1 });
+    await seedDefaultsForTenant(7);
+    expect(prisma.wellnessRoleType.create).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/middleware/wellnessRole.test.js
+++ b/backend/test/middleware/wellnessRole.test.js
@@ -8,8 +8,17 @@
 // Note: the middleware is now async (it may DB-look-up tenant.vertical
 // when the JWT lacks the claim). Every call site awaits it. Tests
 // pre-populate `req.user.vertical` so the middleware never hits prisma.
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
 import { verifyWellnessRole } from '../../middleware/wellnessRole.js';
+// The middleware looks up `getUserPermissions` on the requirePermission
+// module object at CALL TIME (not destructured at require-time), so we
+// can swap it with a deterministic fake here. The eslint rule is fine
+// with this pattern — it's the standard "module reference patch" used
+// throughout the test suite.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const requirePermissionModule = require('../../middleware/requirePermission.js');
+const realGetUserPermissions = requirePermissionModule.getUserPermissions;
 
 // All tests use vertical='wellness' by default — only the dedicated
 // "tenant vertical gate" describe block flips it to test the refusal.
@@ -293,5 +302,263 @@ describe('tenant vertical gate (#325)', () => {
     await mw(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+// "clinical" meta-token: dynamically resolves against the per-tenant
+// WellnessRoleType catalog. Lets admins add a brand-new clinical
+// wellnessRole (e.g. "nurse", "physiotherapist") in Settings → Wellness
+// Role Types and have it flow through every clinical-gated route with
+// ZERO code change. The middleware checks `canTakeVisits = true` on the
+// user's wellnessRole in the catalog; if true and "clinical" is in the
+// allowed list, the request passes.
+describe('"clinical" meta-token (catalog-driven dynamic gate)', () => {
+  // The middleware uses prisma.wellnessRoleType.findMany to read the
+  // catalog. Tests inject a `_wellnessRoleCatalog` Map on req.user so the
+  // middleware never hits prisma — this is the same memoization key the
+  // middleware itself populates on the request after one lookup.
+  function withCatalog(user, catalog) {
+    return { ...user, vertical: 'wellness' };
+  }
+  function makeReqWithCatalog({ user, catalog }) {
+    const req = { user: { ...user, vertical: 'wellness' } };
+    // The middleware memoizes the catalog on req._wellnessRoleCatalog
+    // after its first lookup. Pre-populate it so the middleware reads
+    // ours instead of hitting prisma in unit tests.
+    req._wellnessRoleCatalog = catalog;
+    let statusCode = 200;
+    const res = {
+      status: vi.fn(function (c) { statusCode = c; return this; }),
+      json: vi.fn(function (data) { this.body = data; return this; }),
+      get statusCode() { return statusCode; },
+    };
+    const next = vi.fn();
+    return { req, res, next };
+  }
+
+  test('USER with wellnessRole=nurse passes on ["clinical"] when nurse has canTakeVisits=true', async () => {
+    const mw = verifyWellnessRole(['clinical']);
+    const catalog = new Map([
+      ['doctor', true],
+      ['professional', true],
+      ['nurse', true],
+      ['stylist', true],
+      ['telecaller', false],
+      ['helper', false],
+    ]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'nurse', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('USER with wellnessRole=physiotherapist (new custom role) passes on ["clinical"]', async () => {
+    const mw = verifyWellnessRole(['clinical']);
+    const catalog = new Map([
+      ['doctor', true],
+      ['physiotherapist', true], // admin just added this in Settings → Wellness Role Types
+    ]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'physiotherapist', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  test('USER with wellnessRole=helper (canTakeVisits=false) does NOT pass on ["clinical"]', async () => {
+    const mw = verifyWellnessRole(['clinical']);
+    const catalog = new Map([
+      ['doctor', true],
+      ['helper', false],
+    ]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'helper', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('USER with wellnessRole=nurse does NOT pass on ["doctor"] (no "clinical" token in allow-list)', async () => {
+    // Without "clinical" in the allow-list, only literal matches count —
+    // nurse stays denied. Important: admin-only routes ["admin","manager"]
+    // continue to reject every wellnessRole regardless of canTakeVisits.
+    const mw = verifyWellnessRole(['doctor']);
+    const catalog = new Map([['doctor', true], ['nurse', true]]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'nurse', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('USER with wellnessRole=nurse does NOT pass on ["admin","manager"] (admin-only gate stays admin-only)', async () => {
+    const mw = verifyWellnessRole(['admin', 'manager']);
+    const catalog = new Map([['doctor', true], ['nurse', true]]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'nurse', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('USER with wellnessRole=nurse passes on ["clinical","telecaller","admin","manager"] (the new phiReadGate shape)', async () => {
+    const mw = verifyWellnessRole(['clinical', 'telecaller', 'admin', 'manager']);
+    const catalog = new Map([['doctor', true], ['nurse', true], ['telecaller', false]]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'nurse', tenantId: 1 },
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  test('USER with wellnessRole=doctor passes via LITERAL match on ["clinical","doctor",...] before catalog lookup', async () => {
+    // Performance contract: when the literal "doctor" is in the allow-list,
+    // it matches FIRST and short-circuits the catalog DB query. The
+    // catalog is irrelevant in this hot path — verified by passing an
+    // empty catalog and still seeing next() called.
+    const mw = verifyWellnessRole(['clinical', 'doctor', 'professional', 'admin', 'manager']);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', wellnessRole: 'doctor', tenantId: 1 },
+      catalog: new Map(), // empty catalog — proves literal short-circuit
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  test('USER with no wellnessRole does NOT pass on ["clinical"]', async () => {
+    const mw = verifyWellnessRole(['clinical']);
+    const catalog = new Map([['doctor', true]]);
+    const { req, res, next } = makeReqWithCatalog({
+      user: { role: 'USER', tenantId: 1 }, // no wellnessRole
+      catalog,
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // Silences eslint no-unused-vars on the unused helper
+  void withCatalog;
+});
+
+// anyOfPermissions: RBAC-permission fallback. When the route declares
+// a list of {module, action} grants AND the calling user's effective
+// permissions (from the merged UserRole→RolePermission set) include
+// AT LEAST ONE of them, the request passes — even without a matching
+// wellnessRole. Implements the "I created a Receptionist role, granted
+// appointments.read, expect the appointments UI to work" use case.
+describe('anyOfPermissions (RBAC fallback)', () => {
+  // Swap getUserPermissions with a deterministic fake; restore after.
+  beforeEach(() => {
+    requirePermissionModule.getUserPermissions = vi.fn(
+      async () => new Set(),
+    );
+  });
+  afterEach(() => {
+    requirePermissionModule.getUserPermissions = realGetUserPermissions;
+  });
+
+  function makeReq({ user, perms = [] }) {
+    const req = { user: { ...user, vertical: 'wellness' } };
+    let statusCode = 200;
+    const res = {
+      status: vi.fn(function (c) { statusCode = c; return this; }),
+      json: vi.fn(function (data) { this.body = data; return this; }),
+      get statusCode() { return statusCode; },
+    };
+    const next = vi.fn();
+    requirePermissionModule.getUserPermissions = vi.fn(
+      async () => new Set(perms),
+    );
+    return { req, res, next };
+  }
+
+  test('USER with appointments.read passes on ["clinical","doctor",...] + anyOfPermissions [appointments.read]', async () => {
+    const mw = verifyWellnessRole(
+      ['clinical', 'doctor', 'professional', 'telecaller', 'admin', 'manager'],
+      { anyOfPermissions: [{ module: 'appointments', action: 'read' }] },
+    );
+    // User has no wellnessRole and isn't ADMIN/MANAGER — only the RBAC
+    // grant lets them through.
+    const { req, res, next } = makeReq({
+      user: { role: 'USER', userId: 42, tenantId: 1 },
+      perms: ['appointments.read'],
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('USER without the listed permission falls through to 403', async () => {
+    const mw = verifyWellnessRole(
+      ['doctor', 'professional', 'admin', 'manager'],
+      { anyOfPermissions: [{ module: 'patients', action: 'read' }] },
+    );
+    const { req, res, next } = makeReq({
+      user: { role: 'USER', userId: 42, tenantId: 1 },
+      perms: ['unrelated.read'],
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('user with ANY one of multiple listed grants passes', async () => {
+    const mw = verifyWellnessRole(
+      ['doctor', 'admin', 'manager'],
+      {
+        anyOfPermissions: [
+          { module: 'patients', action: 'read' },
+          { module: 'appointments', action: 'read' },
+          { module: 'visits', action: 'read' },
+        ],
+      },
+    );
+    const { req, res, next } = makeReq({
+      user: { role: 'USER', userId: 42, tenantId: 1 },
+      perms: ['visits.read'], // only the 3rd in the list
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  test('omitting anyOfPermissions leaves behaviour identical to before (literal-only)', async () => {
+    // No 2nd argument → no RBAC fallback. USER with no wellnessRole and
+    // appointments.read grant still gets 403 because the gate has no
+    // anyOfPermissions declared.
+    const mw = verifyWellnessRole(['doctor', 'professional', 'admin', 'manager']);
+    const { req, res, next } = makeReq({
+      user: { role: 'USER', userId: 42, tenantId: 1 },
+      perms: ['appointments.read'],
+    });
+    await mw(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('admin/manager literal aliases still short-circuit before RBAC lookup', async () => {
+    // ADMIN passes via the "admin" alias before any DB lookup. Same
+    // for MANAGER. anyOfPermissions is irrelevant to that path.
+    const mw = verifyWellnessRole(
+      ['admin', 'manager'],
+      { anyOfPermissions: [{ module: 'patients', action: 'read' }] },
+    );
+    const { req, res, next } = makeReq({
+      user: { role: 'ADMIN', userId: 42, tenantId: 1 },
+      perms: [], // empty — proves admin alias short-circuits
+    });
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
   });
 });

--- a/backend/test/middleware/wellnessRole.test.js
+++ b/backend/test/middleware/wellnessRole.test.js
@@ -16,7 +16,6 @@ import { verifyWellnessRole } from '../../middleware/wellnessRole.js';
 // can swap it with a deterministic fake here. The eslint rule is fine
 // with this pattern — it's the standard "module reference patch" used
 // throughout the test suite.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const requirePermissionModule = require('../../middleware/requirePermission.js');
 const realGetUserPermissions = requirePermissionModule.getUserPermissions;
 

--- a/e2e/tests/wellness-role-types-api.spec.js
+++ b/e2e/tests/wellness-role-types-api.spec.js
@@ -1,0 +1,476 @@
+// @ts-check
+/**
+ * Wellness role catalog — per-push gate spec.
+ *
+ * Pins the contract for the per-tenant WellnessRoleType catalog (Option B —
+ * replaces the hard-coded VALID_WELLNESS_ROLES whitelist in routes/staff.js
+ * with admin-maintained rows). Admins add custom roles like "nurse" from
+ * Settings → Wellness Role Types; the Calendar grid + Staff edit form
+ * read from this catalog so a new role surfaces without a code change.
+ *
+ * Endpoints covered:
+ *   GET    /api/wellness/role-types           — list, ?activeOnly=1 filter
+ *   POST   /api/wellness/role-types           — admin/manager create, validation
+ *   PUT    /api/wellness/role-types/:id       — toggle isActive, canTakeVisits, rename
+ *   DELETE /api/wellness/role-types/:id       — refuses when staff use the role
+ *
+ * Status-code + error-key contracts pinned here:
+ *   POST
+ *     201 + row                          — admin / manager with valid input
+ *     400 {code: ROLE_KEY_REQUIRED}      — empty key
+ *     400 {code: INVALID_ROLE_KEY}       — uppercase / spaces / special chars
+ *     400 {code: ROLE_LABEL_REQUIRED}    — empty label
+ *     409 {code: ROLE_KEY_DUPLICATE}     — key already in tenant catalog
+ *     403 {code: WELLNESS_ROLE_FORBIDDEN} — caller is doctor / professional / telecaller / helper
+ *     403 {code: WELLNESS_TENANT_REQUIRED} — caller is on a generic tenant
+ *   PUT
+ *     200 + row                          — toggle isActive / canTakeVisits
+ *     404                                — unknown id
+ *     409 {code: ROLE_KEY_IN_USE}        — rename blocked by assigned staff
+ *   DELETE
+ *     200 {ok: true}                     — unused role
+ *     409 {code: ROLE_IN_USE}            — role currently assigned to staff
+ *     404                                — unknown id
+ *
+ * Staff endpoint integration (proves the staff.js whitelist was replaced):
+ *   POST /api/staff body wellnessRole="nurse" → 201 only when "nurse" exists
+ *     in the catalog; otherwise 400 {code: ROLE_NOT_IN_CATALOG}.
+ *
+ * Persona table (seeded by prisma/seed-wellness.js):
+ *   admin@wellness.demo            — RBAC ADMIN (passes admin gate)
+ *   manager@enhancedwellness.in    — RBAC MANAGER (passes manager gate)
+ *   drharsh@enhancedwellness.in    — wellnessRole=doctor (denied)
+ *   stylist1@enhancedwellness.in   — wellnessRole=professional (denied)
+ *   telecaller@enhancedwellness.in — wellnessRole=telecaller (denied)
+ *   helper1@enhancedwellness.in    — wellnessRole=helper (denied)
+ *   admin@globussoft.com           — generic-tenant ADMIN (wrong vertical)
+ *
+ * RUN_TAG: `E2E_ROLE_<ts>` — afterAll cleans up every created row by id.
+ *
+ * stripDangerous reminder: the global middleware deletes
+ * `id, createdAt, updatedAt, tenantId, userId, isAdmin, passwordHash,
+ * portalPasswordHash` from every request body. None of those are referenced
+ * here — role-type POSTs are key/label/canTakeVisits/icon/color-shaped only.
+ */
+const { test, expect } = require('@playwright/test');
+
+// Tests in this file create + read back + mutate catalog rows under the
+// same tenant. With fullyParallel:true + 2 workers, parallel shuffle
+// scrambles ordering and races on the create-then-delete tests. Pin to
+// serial.
+test.describe.configure({ mode: 'serial' });
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:5000';
+const API = `${BASE_URL}/api`;
+const REQUEST_TIMEOUT = 60000;
+const RUN_TAG = `e2erole${Date.now()}`; // lowercase + digits only — fits ROLE_KEY_RE
+
+// ── Fixtures ───────────────────────────────────────────────────────
+const FIXTURES = {
+  admin:      { email: 'admin@wellness.demo',            password: 'password123' },
+  manager:    { email: 'manager@enhancedwellness.in',    password: 'password123' },
+  drharsh:    { email: 'drharsh@enhancedwellness.in',    password: 'password123' },
+  stylist:    { email: 'stylist1@enhancedwellness.in',   password: 'password123' },
+  telecaller: { email: 'telecaller@enhancedwellness.in', password: 'password123' },
+  helper:     { email: 'helper1@enhancedwellness.in',    password: 'password123' },
+  generic:    { email: 'admin@globussoft.com',           password: 'password123' },
+};
+
+const tokenCache = {};
+
+async function login(request, who) {
+  if (tokenCache[who]) return tokenCache[who];
+  const fixture = FIXTURES[who];
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const r = await request.post(`${API}/auth/login`, {
+        data: fixture,
+        headers: { 'Content-Type': 'application/json' },
+        timeout: REQUEST_TIMEOUT,
+      });
+      if (r.ok()) {
+        const data = await r.json();
+        tokenCache[who] = data.token;
+        return data.token;
+      }
+    } catch (_e) {
+      if (attempt === 0) continue;
+    }
+  }
+  return null;
+}
+
+const authHdr = async (request, who = 'admin') => ({
+  Authorization: `Bearer ${await login(request, who)}`,
+  'Content-Type': 'application/json',
+});
+
+async function authGet(request, path, who = 'admin') {
+  return request.get(`${API}${path}`, {
+    headers: await authHdr(request, who),
+    timeout: REQUEST_TIMEOUT,
+  });
+}
+async function authPost(request, path, body, who = 'admin') {
+  return request.post(`${API}${path}`, {
+    headers: await authHdr(request, who),
+    data: body ?? {},
+    timeout: REQUEST_TIMEOUT,
+  });
+}
+async function authPut(request, path, body, who = 'admin') {
+  return request.put(`${API}${path}`, {
+    headers: await authHdr(request, who),
+    data: body ?? {},
+    timeout: REQUEST_TIMEOUT,
+  });
+}
+async function authDelete(request, path, who = 'admin') {
+  return request.delete(`${API}${path}`, {
+    headers: await authHdr(request, who),
+    timeout: REQUEST_TIMEOUT,
+  });
+}
+
+// Track every catalog row + staff member we create so afterAll can clean up.
+const createdRoleIds = [];
+const createdUserEmails = [];
+
+test.afterAll(async ({ request }) => {
+  if (!tokenCache.admin) return;
+  // Delete staff first — DELETE on role 409s while staff is assigned.
+  for (const email of createdUserEmails) {
+    try {
+      const list = await authGet(request, '/staff');
+      if (list.ok()) {
+        const users = await list.json();
+        const found = users.find((u) => u.email === email);
+        if (found) {
+          await authDelete(request, `/staff/${found.id}`).catch(() => {});
+        }
+      }
+    } catch (_e) { /* swallow */ }
+  }
+  for (const id of createdRoleIds) {
+    await authDelete(request, `/wellness/role-types/${id}`).catch(() => {});
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Auth + tenant-vertical gates
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('auth + tenant gates', () => {
+  test('GET without token → 401', async ({ request }) => {
+    const r = await request.get(`${API}/wellness/role-types`, { timeout: REQUEST_TIMEOUT });
+    expect(r.status()).toBe(401);
+  });
+
+  test('POST as generic-tenant admin → 403 WELLNESS_TENANT_REQUIRED', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', {
+      key: `${RUN_TAG}1`, label: 'Test',
+    }, 'generic');
+    expect(r.status()).toBe(403);
+    const body = await r.json();
+    expect(body.code).toBe('WELLNESS_TENANT_REQUIRED');
+  });
+
+  test('POST as doctor → 403 WELLNESS_ROLE_FORBIDDEN', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', {
+      key: `${RUN_TAG}1`, label: 'Test',
+    }, 'drharsh');
+    expect(r.status()).toBe(403);
+    const body = await r.json();
+    expect(body.code).toBe('WELLNESS_ROLE_FORBIDDEN');
+    expect(Array.isArray(body.allowed)).toBe(true);
+  });
+
+  test('POST as telecaller → 403 WELLNESS_ROLE_FORBIDDEN', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', {
+      key: `${RUN_TAG}1`, label: 'Test',
+    }, 'telecaller');
+    expect(r.status()).toBe(403);
+    expect((await r.json()).code).toBe('WELLNESS_ROLE_FORBIDDEN');
+  });
+
+  test('POST as helper → 403 WELLNESS_ROLE_FORBIDDEN', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', {
+      key: `${RUN_TAG}1`, label: 'Test',
+    }, 'helper');
+    expect(r.status()).toBe(403);
+    expect((await r.json()).code).toBe('WELLNESS_ROLE_FORBIDDEN');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// GET — list + ?activeOnly filter
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('GET /wellness/role-types', () => {
+  test('returns the seeded default catalog including "nurse"', async ({ request }) => {
+    const r = await authGet(request, '/wellness/role-types');
+    expect(r.ok()).toBe(true);
+    const rows = await r.json();
+    expect(Array.isArray(rows)).toBe(true);
+    const keys = rows.map((r) => r.key);
+    // Every legacy whitelist entry should be in the seeded catalog.
+    for (const k of ['doctor', 'professional', 'telecaller', 'helper', 'stylist']) {
+      expect(keys).toContain(k);
+    }
+    // "nurse" is the new addition motivating Option B.
+    expect(keys).toContain('nurse');
+  });
+
+  test('canTakeVisits is a boolean on every row', async ({ request }) => {
+    const r = await authGet(request, '/wellness/role-types');
+    const rows = await r.json();
+    for (const row of rows) {
+      expect(typeof row.canTakeVisits).toBe('boolean');
+    }
+  });
+
+  test('telecaller + helper are operational (canTakeVisits=false)', async ({ request }) => {
+    const r = await authGet(request, '/wellness/role-types');
+    const rows = await r.json();
+    const t = rows.find((x) => x.key === 'telecaller');
+    const h = rows.find((x) => x.key === 'helper');
+    expect(t?.canTakeVisits).toBe(false);
+    expect(h?.canTakeVisits).toBe(false);
+  });
+
+  test('doctor + nurse are practitioners (canTakeVisits=true)', async ({ request }) => {
+    const r = await authGet(request, '/wellness/role-types');
+    const rows = await r.json();
+    const d = rows.find((x) => x.key === 'doctor');
+    const n = rows.find((x) => x.key === 'nurse');
+    expect(d?.canTakeVisits).toBe(true);
+    expect(n?.canTakeVisits).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// POST — validation + happy path
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('POST /wellness/role-types — validation', () => {
+  test('empty key → 400 ROLE_KEY_REQUIRED', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', { key: '', label: 'X' });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe('ROLE_KEY_REQUIRED');
+  });
+
+  test('uppercase in key → 400 INVALID_ROLE_KEY', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', { key: 'Nurse', label: 'Nurse' });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe('INVALID_ROLE_KEY');
+  });
+
+  test('space in key → 400 INVALID_ROLE_KEY', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', { key: 'senior nurse', label: 'X' });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe('INVALID_ROLE_KEY');
+  });
+
+  test('underscore in key → 400 INVALID_ROLE_KEY', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', { key: 'senior_nurse', label: 'X' });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe('INVALID_ROLE_KEY');
+  });
+
+  test('empty label → 400 ROLE_LABEL_REQUIRED', async ({ request }) => {
+    const r = await authPost(request, '/wellness/role-types', { key: `${RUN_TAG}empty`, label: '' });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe('ROLE_LABEL_REQUIRED');
+  });
+
+  test('duplicate key → 409 ROLE_KEY_DUPLICATE', async ({ request }) => {
+    // "doctor" is in the seeded catalog already.
+    const r = await authPost(request, '/wellness/role-types', { key: 'doctor', label: 'Another Doctor' });
+    expect(r.status()).toBe(409);
+    expect((await r.json()).code).toBe('ROLE_KEY_DUPLICATE');
+  });
+});
+
+test.describe('POST /wellness/role-types — happy path', () => {
+  test('admin creates a new role with defaults', async ({ request }) => {
+    const key = `${RUN_TAG}admin`;
+    const r = await authPost(request, '/wellness/role-types', { key, label: 'E2E Admin Role' });
+    expect(r.status()).toBe(201);
+    const body = await r.json();
+    createdRoleIds.push(body.id);
+    expect(body.key).toBe(key);
+    expect(body.label).toBe('E2E Admin Role');
+    expect(body.canTakeVisits).toBe(true); // default
+    expect(body.isActive).toBe(true); // default
+  });
+
+  test('manager can create a role too', async ({ request }) => {
+    const key = `${RUN_TAG}mgr`;
+    const r = await authPost(request, '/wellness/role-types', {
+      key, label: 'E2E Manager Role', canTakeVisits: false,
+    }, 'manager');
+    expect(r.status()).toBe(201);
+    const body = await r.json();
+    createdRoleIds.push(body.id);
+    expect(body.canTakeVisits).toBe(false);
+  });
+
+  test('newly-created role appears in GET list', async ({ request }) => {
+    const key = `${RUN_TAG}list`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E List Role' });
+    expect(created.status()).toBe(201);
+    createdRoleIds.push((await created.json()).id);
+
+    const list = await authGet(request, '/wellness/role-types');
+    const rows = await list.json();
+    expect(rows.map((r) => r.key)).toContain(key);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// PUT — toggles + rename guard
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('PUT /wellness/role-types/:id', () => {
+  test('404 on unknown id', async ({ request }) => {
+    const r = await authPut(request, '/wellness/role-types/9999999', { label: 'nope' });
+    expect(r.status()).toBe(404);
+  });
+
+  test('toggles isActive', async ({ request }) => {
+    const key = `${RUN_TAG}toggle`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E Toggle Role' });
+    const id = (await created.json()).id;
+    createdRoleIds.push(id);
+
+    const off = await authPut(request, `/wellness/role-types/${id}`, { isActive: false });
+    expect(off.ok()).toBe(true);
+    expect((await off.json()).isActive).toBe(false);
+
+    const on = await authPut(request, `/wellness/role-types/${id}`, { isActive: true });
+    expect((await on.json()).isActive).toBe(true);
+  });
+
+  test('toggles canTakeVisits', async ({ request }) => {
+    const key = `${RUN_TAG}ctv`;
+    const created = await authPost(request, '/wellness/role-types', {
+      key, label: 'E2E CTV Role', canTakeVisits: true,
+    });
+    const id = (await created.json()).id;
+    createdRoleIds.push(id);
+
+    const off = await authPut(request, `/wellness/role-types/${id}`, { canTakeVisits: false });
+    expect((await off.json()).canTakeVisits).toBe(false);
+  });
+
+  test('?activeOnly=1 excludes deactivated rows', async ({ request }) => {
+    const key = `${RUN_TAG}hidden`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E Hidden Role' });
+    const id = (await created.json()).id;
+    createdRoleIds.push(id);
+
+    await authPut(request, `/wellness/role-types/${id}`, { isActive: false });
+
+    const all = await authGet(request, '/wellness/role-types');
+    const allKeys = (await all.json()).map((r) => r.key);
+    expect(allKeys).toContain(key);
+
+    const active = await authGet(request, '/wellness/role-types?activeOnly=1');
+    const activeKeys = (await active.json()).map((r) => r.key);
+    expect(activeKeys).not.toContain(key);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// DELETE — refuses when in use
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('DELETE /wellness/role-types/:id', () => {
+  test('404 on unknown id', async ({ request }) => {
+    const r = await authDelete(request, '/wellness/role-types/9999999');
+    expect(r.status()).toBe(404);
+  });
+
+  test('unused role can be deleted', async ({ request }) => {
+    const key = `${RUN_TAG}delok`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E Delete Me' });
+    const id = (await created.json()).id;
+
+    const del = await authDelete(request, `/wellness/role-types/${id}`);
+    expect(del.ok()).toBe(true);
+    expect((await del.json()).ok).toBe(true);
+
+    // Verify gone.
+    const list = await authGet(request, '/wellness/role-types');
+    const keys = (await list.json()).map((r) => r.key);
+    expect(keys).not.toContain(key);
+  });
+
+  test('role in use by a staff member → 409 ROLE_IN_USE', async ({ request }) => {
+    const key = `${RUN_TAG}inuse`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E InUse Role' });
+    const roleId = (await created.json()).id;
+    createdRoleIds.push(roleId);
+
+    // Create a staff member with this wellnessRole.
+    const email = `${RUN_TAG}-inuse@e2e.test`;
+    const staff = await authPost(request, '/staff', {
+      name: 'InUse Staff', email, password: 'password123',
+      role: 'USER', wellnessRole: key,
+    });
+    expect(staff.status()).toBe(201);
+    createdUserEmails.push(email);
+
+    const del = await authDelete(request, `/wellness/role-types/${roleId}`);
+    expect(del.status()).toBe(409);
+    const body = await del.json();
+    expect(body.code).toBe('ROLE_IN_USE');
+    expect(typeof body.inUseCount).toBe('number');
+    expect(body.inUseCount).toBeGreaterThan(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Staff.js integration — catalog drives wellnessRole validation
+// ──────────────────────────────────────────────────────────────────────
+
+test.describe('staff.js wellnessRole catalog integration', () => {
+  test('POST /staff with cataloged key → 201', async ({ request }) => {
+    const key = `${RUN_TAG}cat`;
+    const created = await authPost(request, '/wellness/role-types', { key, label: 'E2E Catalog Role' });
+    expect(created.status()).toBe(201);
+    createdRoleIds.push((await created.json()).id);
+
+    const email = `${RUN_TAG}-cat@e2e.test`;
+    const staff = await authPost(request, '/staff', {
+      name: 'Cataloged Staff', email, password: 'password123',
+      role: 'USER', wellnessRole: key,
+    });
+    expect(staff.status()).toBe(201);
+    createdUserEmails.push(email);
+    const body = await staff.json();
+    expect(body.wellnessRole).toBe(key);
+  });
+
+  test('POST /staff with non-cataloged key → 400 ROLE_NOT_IN_CATALOG', async ({ request }) => {
+    const email = `${RUN_TAG}-bad@e2e.test`;
+    const staff = await authPost(request, '/staff', {
+      name: 'Bad Role Staff', email, password: 'password123',
+      role: 'USER', wellnessRole: `${RUN_TAG}does-not-exist`,
+    });
+    expect(staff.status()).toBe(400);
+    expect((await staff.json()).code).toBe('ROLE_NOT_IN_CATALOG');
+  });
+
+  test('POST /staff with built-in "nurse" key → 201 (proves seed defaults work)', async ({ request }) => {
+    const email = `${RUN_TAG}-nurse@e2e.test`;
+    const staff = await authPost(request, '/staff', {
+      name: 'E2E Nurse', email, password: 'password123',
+      role: 'USER', wellnessRole: 'nurse',
+    });
+    expect(staff.status()).toBe(201);
+    createdUserEmails.push(email);
+    const body = await staff.json();
+    expect(body.wellnessRole).toBe('nurse');
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -228,25 +228,20 @@ export const ThemeContext = createContext();
 // fresh login; this helper covers refresh / `/` / GenericOnly bounces where
 // the URL would otherwise resolve to /wellness Owner Dashboard for everyone.
 function wellnessLandingFor(user) {
-  if (!user) return '/wellness';
+  if (!user) return '/home';
   if (user.role === 'ADMIN' || user.role === 'MANAGER') return '/wellness';
   switch (user.wellnessRole) {
     case 'owner':
     case 'manager':
     case 'admin':
       return '/wellness';
-    case 'doctor':
-    case 'professional':
-      return '/wellness/calendar';
-    case 'telecaller':
-      return '/wellness/telecaller';
-    case 'helper':
-    case 'stylist':
-      return '/wellness/calendar';
     default:
-      // No wellnessRole + not ADMIN/MANAGER — regular user (patient).
-      // Send to appointment booking page where they can book with doctors.
-      return '/wellness/book-appointment';
+      // Everyone else (doctor / professional / telecaller / helper /
+      // plain users) lands on the role-aware /home widget dashboard.
+      // /home renders only the widgets and quick-actions the user has
+      // permission for, so it's always the right starting surface even
+      // when the user has zero wellness clinical permissions.
+      return '/home';
   }
 }
 

--- a/frontend/src/__tests__/AuditLog.integrityChip.test.jsx
+++ b/frontend/src/__tests__/AuditLog.integrityChip.test.jsx
@@ -32,7 +32,11 @@ vi.mock('../utils/api', () => ({
 // each render invalidates the callback identity → useEffect re-fires →
 // setVerifying loops). One object, vi.fn() handles, for the whole run.
 const notifyError = vi.fn();
-const notifyObj = { error: notifyError, info: vi.fn(), success: vi.fn(), confirm: vi.fn() };
+// confirm default-resolves true so destructive-action paths (Run backfill)
+// auto-accept; the old test stubbed window.confirm — the page now uses
+// notify.confirm via useNotify, so we mock at the hook level instead.
+const notifyConfirm = vi.fn(() => Promise.resolve(true));
+const notifyObj = { error: notifyError, info: vi.fn(), success: vi.fn(), confirm: notifyConfirm };
 vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
@@ -190,8 +194,8 @@ describe('<AuditLog /> — hash-chain integrity chip (#558)', () => {
       return Promise.resolve({ logs: [], pages: 1, total: 0 });
     });
 
-    // Stub window.confirm so the "Continue?" prompt auto-accepts.
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // notifyConfirm default-resolves true (see top-of-file mock), so the
+    // "Continue?" prompt auto-accepts.
 
     renderAuditLog();
     await waitFor(() => {
@@ -207,8 +211,6 @@ describe('<AuditLog /> — hash-chain integrity chip (#558)', () => {
       expect(screen.getByTestId('integrity-chip-ok')).toBeInTheDocument();
     });
     expect(screen.getByTestId('integrity-chip-ok').textContent).toMatch(/193 rows/);
-
-    confirmSpy.mockRestore();
   });
 
   it('non-admin (USER role): integrity row + Verify button are NOT rendered', async () => {

--- a/frontend/src/__tests__/Leave.test.jsx
+++ b/frontend/src/__tests__/Leave.test.jsx
@@ -64,13 +64,19 @@ vi.mock('../utils/api', () => ({
 const notifyError = vi.fn();
 const notifySuccess = vi.fn();
 const notifyInfo = vi.fn();
+// notifyConfirm / notifyPrompt back the destructive-action paths (cancel /
+// approve / reject). Default to "user clicked OK" + empty prompt; individual
+// tests override the prompt's return value with mockImplementationOnce to
+// inspect the value the route receives.
+const notifyConfirm = vi.fn(() => Promise.resolve(true));
+const notifyPrompt = vi.fn(() => Promise.resolve(''));
 vi.mock('../utils/notify', () => ({
   useNotify: () => ({
     error: notifyError,
     success: notifySuccess,
     info: notifyInfo,
-    confirm: () => Promise.resolve(true),
-    prompt: () => Promise.resolve(''),
+    confirm: (...args) => notifyConfirm(...args),
+    prompt: (...args) => notifyPrompt(...args),
   }),
 }));
 
@@ -181,14 +187,13 @@ beforeEach(() => {
   notifyError.mockReset();
   notifySuccess.mockReset();
   notifyInfo.mockReset();
-  // Native confirm/prompt — page uses window.confirm() for cancel/approve and
-  // window.prompt() for reject notes. Default both to "user clicked OK".
-  vi.stubGlobal('confirm', vi.fn(() => true));
-  vi.stubGlobal('prompt', vi.fn(() => 'looks fine'));
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
+  // notify.confirm/prompt back the cancel/approve/reject paths. Reset to the
+  // defaults; individual tests override notifyPrompt with mockImplementationOnce
+  // when they need to inspect the value passed to the route.
+  notifyConfirm.mockReset();
+  notifyConfirm.mockResolvedValue(true);
+  notifyPrompt.mockReset();
+  notifyPrompt.mockResolvedValue('');
 });
 
 // ── 1. Balance summary cards ───────────────────────────────────────────────
@@ -489,8 +494,8 @@ describe('<Leave /> — manager approve / reject', () => {
 
   it('clicking Reject prompts for notes and POSTs them to /reject', async () => {
     const user = userEvent.setup();
-    // Override the prompt() stub so we can inspect the arg the route gets.
-    vi.stubGlobal('prompt', vi.fn(() => 'Out of balance — reapply next quarter'));
+    // Override notify.prompt so we can inspect the arg the route gets.
+    notifyPrompt.mockResolvedValueOnce('Out of balance — reapply next quarter');
 
     renderLeave({ user: { id: MANAGER_ID, role: 'ADMIN' } });
     await waitFor(() => expect(screen.getByText('All Leave Requests')).toBeInTheDocument());

--- a/frontend/src/components/DealModal.jsx
+++ b/frontend/src/components/DealModal.jsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { X, FileText, UploadCloud, Download, FileSignature, Trash2 } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../utils/api';
 import { formatMoney } from '../utils/money';
+import { useNotify } from '../utils/notify';
 import CPQBuilder from './CPQBuilder';
 
 const API_BASE = "";
 
 export default function DealModal({ deal, onClose }) {
+  const notify = useNotify();
   const [attachments, setAttachments] = useState([]);
   const [uploading, setUploading] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -122,7 +124,7 @@ export default function DealModal({ deal, onClose }) {
 
         if (!response.ok) {
           console.error("Open failed with status:", response.status, response.statusText);
-          alert(`Failed to open PDF: ${response.status} ${response.statusText}`);
+          notify.error(`Failed to open PDF: ${response.status} ${response.statusText}`);
           return;
         }
 
@@ -138,7 +140,7 @@ export default function DealModal({ deal, onClose }) {
 
         if (!response.ok) {
           console.error("Download failed with status:", response.status, response.statusText);
-          alert(`Failed to open PDF: ${response.status} ${response.statusText}`);
+          notify.error(`Failed to open PDF: ${response.status} ${response.statusText}`);
           return;
         }
 
@@ -149,7 +151,7 @@ export default function DealModal({ deal, onClose }) {
       window.open(url, '_blank');
     } catch (err) {
       console.error("Open error:", err);
-      alert(`Error opening PDF: ${err.message}`);
+      notify.error(`Error opening PDF: ${err.message}`);
     }
   };
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -582,7 +582,7 @@ const Sidebar = ({
         const message = err.message?.includes("not yet available")
           ? "Callified integration will be available soon. Please check back later."
           : "Unable to open Callified. Please try again.";
-        alert(message);
+        notify.error(message);
       } finally {
         setCallifiedLoading(false);
       }
@@ -897,377 +897,86 @@ function renderWellnessNav({
   counts = {},
   accessiblePages = [],
 }) {
+  // Sidebar is rendered ENTIRELY from `accessiblePages` — the per-user
+  // intersection of the server's page catalog and their effective RBAC
+  // permissions returned by /api/pages/me. Editing a role's permissions in
+  // RolesAdmin invalidates the cache + dispatches `sidebar:pages-changed`,
+  // so the sidebar updates without a page reload and with zero JSX edits.
+  //
+  // No hardcoded adminOnly / managerOnly / wellnessRoles gating here — the
+  // backend has already filtered the list by permission. The only role-
+  // sensitive UI bits left are:
+  //   • hideForAdminTier — catalog-level UX flag to hide clinical-day-to-
+  //     day surfaces from users who already see the Admin category.
+  //   • AdsGPT / Callified — external integrations, kept visible only for
+  //     admin/manager so doctors / nurses / telecallers don't see them in
+  //     their nav.
+  void hasPermission;
+  void permissionsReady;
   const labelStyle = sectionLabelStyle || sectionLabel;
+
+  // Group accessible pages by category for ordered rendering.
+  const byCategory = {};
+  for (const page of accessiblePages) {
+    if (!page || !page.category || !page.path) continue;
+    if (page.hideForAdminTier && isAdmin) continue;
+    if (!byCategory[page.category]) byCategory[page.category] = [];
+    byCategory[page.category].push(page);
+  }
+
+  const renderPage = (page) => {
+    const Icon = PAGE_ICON_BY_PATH[page.path] || LayoutDashboard;
+    const countKey = PATH_COUNT_KEY[page.path];
+    const matchPaths = PATH_MATCH_ALIASES[page.path] || [];
+    return (
+      <Link
+        key={page.path}
+        to={page.path}
+        icon={Icon}
+        label={page.label}
+        count={countKey ? counts[countKey] : undefined}
+        matchPaths={matchPaths}
+      />
+    );
+  };
+
+  const renderCategory = (category, { showHeader } = { showHeader: true }) => {
+    const items = byCategory[category];
+    if (!items || items.length === 0) return null;
+    return (
+      <Fragment key={category}>
+        {showHeader && <div style={labelStyle}>{category}</div>}
+        {items.map(renderPage)}
+      </Fragment>
+    );
+  };
+
   return (
     <>
-      {/* Daily essentials — Owner Dashboard + Recommendations are management
-          views over org-wide P&L / pending recommendation cards (#207/#216).
-          Clinical staff (doctor/professional/telecaller/helper) should not see
-          them in the nav. AdsGPT and Callified are external tools the whole
-          team uses, so they stay visible for everyone. */}
-      <Link
-        to="/wellness"
-        icon={LayoutDashboard}
-        label="Owner Dashboard"
-        managerOnly
-      />
-      <Link
-        to="/wellness/recommendations"
-        icon={Sparkles}
-        label="Recommendations"
-        managerOnly
-      />
-      <AdsGptLink icon={Sparkles} label="AdsGPT" />
-      <CallifiedLink icon={PhoneCall} label="Callified" />
+      {/* Core + Manager render at the top with no section header — they're
+          the landing-area items. Manager-tier dashboards (Owner Dashboard,
+          Recommendations) only appear when the user has reports.read, so
+          regular users (doctors, nurses, telecallers) won't see them even
+          though they're grouped near the top. */}
+      {renderCategory("Core", { showHeader: false })}
+      {renderCategory("Manager", { showHeader: false })}
 
-      {/* Clinical — Patients, Calendar, Waitlist visible to clinical staff only
-          (doctors, professionals, helpers). Regular users (with no wellnessRole)
-          cannot access these features, so we hide them from the sidebar.
-          Service Catalog is a pricing/duration config — clinical staff read it
-          but only managers edit it, so we hide the nav link for non-management. */}
-      <div style={labelStyle}>Clinical</div>
-      <Link
-        to="/wellness/patients"
-        icon={HeartPulse}
-        label="Patients"
-        wellnessRoles={["doctor", "professional", "helper"]}
-      />
-      <Link
-        to="/wellness/calendar"
-        icon={Calendar}
-        label="Calendar"
-        wellnessRoles={["doctor", "professional", "helper"]}
-      />
-      <Link
-        to="/wellness/waitlist"
-        icon={Clock}
-        label="Waitlist"
-        wellnessRoles={["doctor", "professional", "helper"]}
-      />
-      <Link
-        to="/wellness/services"
-        icon={Stethoscope}
-        label="Service Catalog"
-        managerOnly
-      />
-      {/* Wave 7 Agent A — ServiceCategory hierarchical taxonomy (PRD Gap §10 #1) */}
-      <Link
-        to="/wellness/service-categories"
-        icon={Stethoscope}
-        label="Service Categories"
-        managerOnly
-      />
-      {/* Wave 7 Agent A — Drug catalogue for prescription writing (PRD Gap §10 #2) */}
-      <Link
-        to="/wellness/drugs"
-        icon={Stethoscope}
-        label="Drug Catalogue"
-        managerOnly
-      />
-      {/* Wave 11 Agent EE: Memberships catalog — manager+ only (mirrors Service Catalog) */}
-      <Link
-        to="/wellness/memberships"
-        icon={Crown}
-        label="Memberships"
-        managerOnly
-      />
-      <Link
-        to="/wellness/visits"
-        icon={HeartPulse}
-        label="Visits"
-        managerOnly
-      />
-      {/* Wave 11 Agent GG — Resource availability (rooms / holidays /
-          working hours). Manager+ only. */}
-      <Link
-        to="/wellness/resources"
-        icon={Building2}
-        label="Resources"
-        managerOnly
-      />
-      <Link
-        to="/wellness/holidays"
-        icon={Calendar}
-        label="Holidays"
-        managerOnly
-      />
-      <Link
-        to="/wellness/working-hours"
-        icon={Clock}
-        label="Working Hours"
-        managerOnly
-      />
+      {/* External integrations: admin/manager only. Doctors, nurses,
+          telecallers, etc. don't need AdsGPT (marketing tool) or Callified
+          (call-centre console) in their day-to-day nav — they land on the
+          role-aware /home dashboard instead. */}
+      {isManager && <AdsGptLink icon={Sparkles} label="AdsGPT" />}
+      {isManager && <CallifiedLink icon={PhoneCall} label="Callified" />}
 
-      {/* Wave 2 Agent JJ — Staff Attendance + Leave Management. */}
-      <div style={labelStyle}>Staff</div>
-      <Link to="/wellness/attendance" icon={Clock} label="Attendance" />
-      <Link to="/wellness/leave" icon={Calendar} label="Leave" />
-
-      {/* Lead-to-revenue */}
-      <div style={labelStyle}>Leads & Revenue</div>
-      <Link
-        to="/inbox"
-        icon={InboxIcon}
-        label="Unified Inbox"
-        count={counts.inbox}
-      />
-      {/* Wave 2 Agent KK - WhatsApp 2-way threads (agent inbox). */}
-      <Link
-        to="/wellness/whatsapp"
-        icon={MessageSquare}
-        label="WhatsApp Threads"
-      />
-      {/* Telecaller Queue: visible to wellnessRole=telecaller and to
-          managers/admins for oversight. Plain users (and clinical staff
-          without the telecaller wellnessRole) saw a 403 toast on every
-          load, so the link is hidden for them — matches the server's
-          verifyWellnessRole(["telecaller","admin","manager"]) gate on
-          /api/wellness/telecaller/queue + /telecaller/dispose. */}
-      <Link
-        to="/wellness/telecaller"
-        icon={PhoneCall}
-        label="Telecaller Queue"
-        wellnessRoles={["telecaller"]}
-      />
-      <Link
-        to="/leads"
-        icon={UserPlus}
-        label="All Leads"
-        managerOnly
-        count={counts.leads}
-      />
-      <Link
-        to="/converted-leads"
-        icon={UserPlus}
-        label="Converted Leads"
-        managerOnly
-      />
-      <Link
-        to="/callified-data"
-        icon={PhoneCall}
-        label="Callified Data"
-        managerOnly
-      />
-      <Link to="/tasks" icon={CheckSquare} label="Tasks" count={counts.tasks} />
-      <Link
-        to="/marketplace-leads"
-        icon={ShoppingBag}
-        label="Marketplace Leads"
-        managerOnly
-        matchPaths={["/marketplace"]}
-      />
-      <Link to="/lead-routing" icon={Send} label="Routing Rules" managerOnly />
-
-      {/* Money — clinic-side, in INR for Indian wellness tenants */}
-      <div style={labelStyle}>Finance</div>
-      {/* Wave 2 Agent II: POS / "New Sale" — open shifts, ring up cash-and-
-          carry sales, close shifts. All staff can use it (backend gates
-          to wellnessRole admin/manager/doctor/professional/telecaller/helper). */}
-      <Link to="/wellness/pos" icon={Calculator} label="Point of Sale" />
-      <Link to="/invoices" icon={Receipt} label="Invoices" />
-      <Link to="/estimates" icon={FileSpreadsheet} label="Estimates" />
-      <Link to="/expenses" icon={DollarSign} label="Expenses" />
-      <Link to="/payments" icon={CreditCard} label="Payments" managerOnly />
-      {/* Wave 11 Agent FF: Wallet + Gift Cards + Coupons + Cashback (manager+) */}
-      <Link
-        to="/wellness/wallet"
-        icon={WalletIcon}
-        label="Patient Wallets"
-        managerOnly
-      />
-      <Link
-        to="/wellness/giftcards"
-        icon={Gift}
-        label="Gift Cards"
-        managerOnly
-      />
-      <Link
-        to="/wellness/coupons"
-        icon={TicketPercent}
-        label="Coupons"
-        managerOnly
-      />
-      <Link
-        to="/wellness/cashback-rules"
-        icon={Coins}
-        label="Cashback Rules"
-        managerOnly
-      />
-
-      {/* Marketing — clinic-side comms (ad campaigns live in AdsGPT). All items are
-          managerOnly, so the whole section is hidden for plain users — otherwise the
-          header rendered as an orphan with no children (#107). */}
-      {isManager && (
-        <>
-          <div style={labelStyle}>Marketing</div>
-          <Link
-            to="/marketing"
-            icon={Send}
-            label="SMS / Email Blasts"
-            managerOnly
-          />
-          <Link
-            to="/sequences"
-            icon={Network}
-            label="Drip Sequences"
-            managerOnly
-          />
-          <Link
-            to="/landing-pages"
-            icon={PanelTop}
-            label="Landing Pages"
-            managerOnly
-          />
-        </>
-      )}
-
-      {/* Reports — wellness-tuned, generic CRM reports removed. Same orphan-header
-          fix as Marketing above. */}
-      {isManager && (
-        <>
-          <div style={labelStyle}>Reports</div>
-          <Link
-            to="/wellness/reports"
-            icon={BarChart3}
-            label="P&L + Attribution"
-            managerOnly
-          />
-          <Link
-            to="/wellness/per-location"
-            icon={Building2}
-            label="Per-Location"
-            managerOnly
-          />
-          <Link
-            to="/wellness/loyalty"
-            icon={Award}
-            label="Loyalty + Referrals"
-            managerOnly
-          />
-          <Link
-            to="/surveys"
-            icon={ClipboardList}
-            label="Patient Surveys"
-            managerOnly
-          />
-          <Link
-            to="/knowledge-base"
-            icon={BookOpen}
-            label="Knowledge Base"
-            managerOnly
-          />
-        </>
-      )}
-
-      {/* Admin */}
-      {isAdmin && (
-        <>
-          <div style={labelStyle}>Admin</div>
-          <Link
-            to="/wellness/locations"
-            icon={Building2}
-            label="Locations"
-            adminOnly
-          />
-          {/* Wave 11 Agent HH — Inventory backbone admin entries.
-              Categories + Vendors are config; Receipts/Adjustments are the
-              operational ledger surfaces; Auto-consumption is the rules engine. */}
-          <div style={labelStyle}>Inventory</div>
-          <Link
-            to="/wellness/product-categories"
-            icon={Layers}
-            label="Product Categories"
-            managerOnly
-          />
-          <Link
-            to="/wellness/products"
-            icon={Package}
-            label="Products"
-            managerOnly
-          />
-          <Link
-            to="/wellness/vendors"
-            icon={Truck}
-            label="Vendors"
-            managerOnly
-          />
-          <Link
-            to="/wellness/inventory-receipts"
-            icon={ArrowDownToLine}
-            label="Receipts"
-            managerOnly
-          />
-          <Link
-            to="/wellness/inventory-adjustments"
-            icon={Receipt}
-            label="Adjustments"
-            managerOnly
-          />
-          <Link
-            to="/wellness/auto-consumption-rules"
-            icon={Recycle}
-            label="Auto-consumption"
-            managerOnly
-          />
-          <Link to="/staff" icon={UsersRound} label="Staff" adminOnly />
-          {/* RBAC role + permission admin. Shown to anyone with `roles.read`
-              granted via RBAC (typically ADMIN). The page itself rechecks. */}
-          <Link
-            to="/settings/roles"
-            icon={ShieldCheck}
-            label="Roles"
-            requiredPermission={{ module: "roles", action: "read" }}
-          />
-          {/* PRD Gap §1.5 / §1.6 — wellness admins also manage payroll. */}
-          <Link
-            to="/commission-profiles"
-            icon={Award}
-            label="Commission Profiles"
-            adminOnly
-          />
-          <Link
-            to="/revenue-goals"
-            icon={Target}
-            label="Revenue Goals"
-            adminOnly
-          />
-          <Link to="/channels" icon={Radio} label="Channels" adminOnly />
-          <Link to="/audit-log" icon={ScrollText} label="Audit Log" adminOnly />
-          <Link to="/privacy" icon={Shield} label="Privacy" adminOnly />
-          <Link to="/settings" icon={Settings} label="Settings" adminOnly />
-        </>
-      )}
-
-      {!isAdmin && isManager && (
-        <>
-          <div style={labelStyle}>Settings</div>
-          <Link to="/settings" icon={Settings} label="Settings" />
-        </>
-      )}
-
-      {/* User Appointments — only for regular users, not admin/manager */}
-      {!isAdmin && !isManager && (
-        <>
-          <div style={labelStyle}>Appointments</div>
-          <Link
-            to="/wellness/book-appointment"
-            icon={Calendar}
-            label="Book Appointment"
-          />
-        </>
-      )}
-
-      {/* User Settings — only for regular users, not admin/manager */}
-      {!isAdmin && !isManager && (
-        <>
-          <div style={labelStyle}>User</div>
-          <Link
-            to="/notification-settings"
-            icon={Settings}
-            label="Notification Settings"
-          />
-        </>
-      )}
+      {/* Remaining categories — order driven by WELLNESS_CATEGORY_ORDER so
+          a new catalog entry slots into the right section automatically.
+          WELLNESS_HEADERLESS_CATEGORIES is the set already rendered above
+          (Core / Manager); everything else gets its category name as the
+          section header. Empty categories (user has no accessible pages
+          in them) collapse silently. */}
+      {WELLNESS_CATEGORY_ORDER
+        .filter((cat) => !WELLNESS_HEADERLESS_CATEGORIES.has(cat))
+        .map((cat) => renderCategory(cat, { showHeader: true }))}
     </>
   );
 }

--- a/frontend/src/pages/AuditLog.jsx
+++ b/frontend/src/pages/AuditLog.jsx
@@ -534,11 +534,15 @@ export default function AuditLog() {
   // suspected tampering, surface the row id so ops can investigate.
   const runBackfill = useCallback(async () => {
     if (!isAdmin) return;
-    if (!window.confirm(
-      'Repair audit chain — re-stamp the link/hash on any row that has the wrong anchor. ' +
-      'Row content is never modified. If a row was actually tampered with, the repair will ' +
-      'abort and show the affected row ID. Continue?'
-    )) return;
+    const ok = await notify.confirm({
+      title: 'Repair audit chain',
+      message:
+        'Re-stamp the link/hash on any row that has the wrong anchor. ' +
+        'Row content is never modified. If a row was actually tampered with, the repair will ' +
+        'abort and show the affected row ID. Continue?',
+      confirmText: 'Repair',
+    });
+    if (!ok) return;
     setBackfilling(true);
     try {
       const data = await fetchApi('/api/audit/backfill', { method: 'POST' });

--- a/frontend/src/pages/Channels.jsx
+++ b/frontend/src/pages/Channels.jsx
@@ -702,7 +702,17 @@ function WebhookInfo({ label, url, copied, copyText }) {
 }
 
 function TemplateSection({ kind, templates, onDelete, onCreate, onEdit, onDuplicate, onSend, onBlast, onPreview, statusColors }) {
+  const notify = useNotify();
   const showStatus = kind === 'whatsapp';
+  const handleDelete = async (t) => {
+    const ok = await notify.confirm({
+      title: 'Delete template',
+      message: `Delete template "${t.name}"?`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (ok) onDelete(t.id);
+  };
   return (
     <div className="card" style={{ padding: '1.5rem' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
@@ -742,7 +752,7 @@ function TemplateSection({ kind, templates, onDelete, onCreate, onEdit, onDuplic
                 {onBlast && (
                   <IconBtn title={kind === 'push' ? 'Send to All Subscribers' : 'Send Blast'} onClick={() => onBlast(t)}><Megaphone size={15} /></IconBtn>
                 )}
-                <IconBtn title="Delete" onClick={() => { if (window.confirm(`Delete template "${t.name}"?`)) onDelete(t.id); }} danger><Trash2 size={15} /></IconBtn>
+                <IconBtn title="Delete" onClick={() => handleDelete(t)} danger><Trash2 size={15} /></IconBtn>
               </div>
             </div>
           ))}

--- a/frontend/src/pages/Expenses.jsx
+++ b/frontend/src/pages/Expenses.jsx
@@ -203,7 +203,11 @@ export default function Expenses() {
   };
 
   const rejectExpense = async (id) => {
-    const reason = prompt('Enter rejection reason (optional):');
+    const reason = await notify.prompt({
+      title: 'Reject expense',
+      message: 'Enter rejection reason (optional):',
+      confirmText: 'Reject',
+    });
     if (reason === null) return; // User cancelled
     try {
       const result = await fetchApi(`/api/expenses/${id}/reject`, {

--- a/frontend/src/pages/RolesAdmin.jsx
+++ b/frontend/src/pages/RolesAdmin.jsx
@@ -161,13 +161,13 @@ export default function RolesAdmin() {
   };
 
   const handleDelete = async (role) => {
-    if (
-      !window.confirm(
-        `Delete role "${role.name}"? Users assigned to this role will lose its permissions.`,
-      )
-    ) {
-      return;
-    }
+    const ok = await notify.confirm({
+      title: 'Delete role',
+      message: `Delete role "${role.name}"? Users assigned to this role will lose its permissions.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/roles/${role.id}`, { method: 'DELETE' });
       notify.success?.(`Role "${role.name}" deleted`);
@@ -805,6 +805,45 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
   const [selected, setSelected] = useState(initial);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  // Page catalog so we can show admins which pages each permission
+  // unlocks. Without this, admins look for a "calendar" module in the
+  // picker, don't find it (calendar is gated by appointments.read), and
+  // assume the permission is missing. Showing "Unlocks: Calendar,
+  // Appointments, …" under each module makes the mapping obvious.
+  const [pageCatalog, setPageCatalog] = useState([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetchApi('/api/pages/catalog')
+      .then((res) => {
+        if (cancelled) return;
+        const list = Array.isArray(res?.catalog) ? res.catalog : [];
+        setPageCatalog(list);
+      })
+      .catch(() => {
+        // Non-fatal — the hint is supplementary, the picker still works.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Build a `module → Set<pageLabel>` map by walking each catalog page's
+  // requiredPermissions. A page that requires `appointments.read` shows
+  // up under the "appointments" module hint — across ALL its actions —
+  // because granting that module's read action is what unlocks it.
+  const pagesByModule = useMemo(() => {
+    const map = new Map();
+    for (const page of pageCatalog) {
+      const reqs = Array.isArray(page?.requiredPermissions) ? page.requiredPermissions : [];
+      for (const { module } of reqs) {
+        if (!module) continue;
+        if (!map.has(module)) map.set(module, new Set());
+        map.get(module).add(page.label);
+      }
+    }
+    return map;
+  }, [pageCatalog]);
+
   const notify = useNotify();
 
   const toggle = (module, action) => {
@@ -933,7 +972,7 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
                           display: 'flex',
                           alignItems: 'center',
                           justifyContent: 'space-between',
-                          marginBottom: '0.5rem',
+                          marginBottom: '0.25rem',
                         }}
                       >
                         <span
@@ -965,6 +1004,33 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
                           </button>
                         )}
                       </div>
+                      {(() => {
+                        // Show "Unlocks: <pages>" so admins can map a
+                        // permission to the SPA pages it grants access
+                        // to. Answers the recurring "I can't find the
+                        // 'calendar' permission" confusion — Calendar
+                        // is unlocked by `appointments`, which now
+                        // says so directly under its header.
+                        const pages = pagesByModule.get(module);
+                        if (!pages || pages.size === 0) return null;
+                        const labels = Array.from(pages).sort();
+                        return (
+                          <div
+                            style={{
+                              fontSize: '0.7rem',
+                              color: 'var(--text-secondary)',
+                              marginBottom: '0.5rem',
+                              lineHeight: 1.35,
+                            }}
+                            title={`Pages requiring this permission: ${labels.join(', ')}`}
+                          >
+                            Unlocks:{' '}
+                            <span style={{ color: 'var(--text-primary)', opacity: 0.85 }}>
+                              {labels.join(', ')}
+                            </span>
+                          </div>
+                        );
+                      })()}
                       <div
                         style={{
                           display: 'flex',
@@ -1377,7 +1443,13 @@ function UsersModal({ role, canManage, onClose, onChange }) {
   };
 
   const unassign = async (userId) => {
-    if (!window.confirm('Remove this role from the user?')) return;
+    const ok = await notify.confirm({
+      title: 'Remove role',
+      message: 'Remove this role from the user?',
+      confirmText: 'Remove',
+      destructive: true,
+    });
+    if (!ok) return;
     setBusyUserId(userId);
     try {
       await fetchApi(`/api/roles/${role.id}/assign/${userId}`, {

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,16 +1,43 @@
-import React, { useState, useEffect, useContext, useRef } from 'react';
-import { Link } from 'react-router-dom';
-import { Shield, UserPlus, Trash2, Key, Sun, Moon, Plus, ArrowUp, ArrowDown, Layers, Building2, Image as ImageIcon, Palette, Monitor, Mail, FileSignature, Bell, Eye, EyeOff, Check, X, Loader, PhoneCall, CreditCard, ArrowRight } from 'lucide-react';
-import { fetchApi, getAuthToken } from '../utils/api';
-import { useNotify } from '../utils/notify';
-import { usePermissions } from '../hooks/usePermissions';
-import { ThemeContext, AuthContext } from '../App';
+import React, { useState, useEffect, useContext, useRef } from "react";
+import { Link } from "react-router-dom";
+import {
+  Shield,
+  UserPlus,
+  Trash2,
+  Key,
+  Sun,
+  Moon,
+  Plus,
+  ArrowUp,
+  ArrowDown,
+  Layers,
+  Building2,
+  Image as ImageIcon,
+  Palette,
+  Monitor,
+  Mail,
+  FileSignature,
+  Bell,
+  Eye,
+  EyeOff,
+  Check,
+  X,
+  Loader,
+  PhoneCall,
+  CreditCard,
+  ArrowRight,
+  Stethoscope,
+} from "lucide-react";
+import { fetchApi, getAuthToken } from "../utils/api";
+import { useNotify } from "../utils/notify";
+import { usePermissions } from "../hooks/usePermissions";
+import { ThemeContext, AuthContext } from "../App";
 
 // #391: single source of truth for the default brand color so the color
 // picker swatch, the placeholder hint, and the color actually applied
 // when no brand color is set all match. Mirrors --accent-color in
 // index.css.
-const DEFAULT_BRAND_COLOR = '#3b82f6';
+const DEFAULT_BRAND_COLOR = "#3b82f6";
 
 export default function Settings() {
   const notify = useNotify();
@@ -19,9 +46,14 @@ export default function Settings() {
   const { isOwner } = usePermissions();
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [newUser, setNewUser] = useState({ name: '', email: '', password: '', role: 'USER' });
+  const [newUser, setNewUser] = useState({
+    name: "",
+    email: "",
+    password: "",
+    role: "USER",
+  });
   const [pipelineStages, setPipelineStages] = useState([]);
-  const [newStage, setNewStage] = useState({ name: '', color: '#3b82f6' });
+  const [newStage, setNewStage] = useState({ name: "", color: "#3b82f6" });
   const [stagesLoading, setStagesLoading] = useState(true);
   const [tenant, setTenantState] = useState(ctxTenant || null);
   const [tenantSaving, setTenantSaving] = useState(false);
@@ -30,7 +62,7 @@ export default function Settings() {
   // emails vanished, Sent folder stayed empty, threading broke.
   const [emailRetentionSaving, setEmailRetentionSaving] = useState(false);
   // Branding (logo + brand color) — backed by /api/wellness/branding
-  const [branding, setBranding] = useState({ logoUrl: null, brandColor: '' });
+  const [branding, setBranding] = useState({ logoUrl: null, brandColor: "" });
   const [brandingSaving, setBrandingSaving] = useState(false);
   // Logo upload UX: pick a file → preview it locally → click "Save logo"
   // to actually upload. Previously the upload fired on file-pick which
@@ -40,41 +72,57 @@ export default function Settings() {
   const [logoBroken, setLogoBroken] = useState(false);
   const logoInputRef = useRef(null);
   const [logoUploading, setLogoUploading] = useState(false);
-  const [brandingMsg, setBrandingMsg] = useState('');
+  const [brandingMsg, setBrandingMsg] = useState("");
   // AdsGPT configuration
-  const [adsgptLogin, setAdsgptLogin] = useState('');
+  const [adsgptLogin, setAdsgptLogin] = useState("");
   const [adsgptSaving, setAdsgptSaving] = useState(false);
-  const [adsgptMsg, setAdsgptMsg] = useState('');
+  const [adsgptMsg, setAdsgptMsg] = useState("");
   // Callified integration
-  const [callifiedApiKey, setCallifiedApiKey] = useState('');
+  const [callifiedApiKey, setCallifiedApiKey] = useState("");
   const [callifiedShowKey, setCallifiedShowKey] = useState(false);
   const [callifiedLoading, setCallifiedLoading] = useState(true);
   const [callifiedSaving, setCallifiedSaving] = useState(false);
   const [callifiedConnected, setCallifiedConnected] = useState(false);
-  const [callifiedMsg, setCallifiedMsg] = useState('');
+  const [callifiedMsg, setCallifiedMsg] = useState("");
   const [callifiedUpdatedAt, setCallifiedUpdatedAt] = useState(null);
 
   useEffect(() => {
-    fetchApi('/api/tenants/current')
-      .then((res) => { setTenantState(res); if (setTenant) setTenant(res); })
-      .catch(() => { /* tenant endpoint may not be reachable */ });
+    fetchApi("/api/tenants/current")
+      .then((res) => {
+        setTenantState(res);
+        if (setTenant) setTenant(res);
+      })
+      .catch(() => {
+        /* tenant endpoint may not be reachable */
+      });
     // Branding lives under /api/wellness/branding (works for any tenant — only the
     // sidebar conditionally surfaces it on wellness verticals today).
-    fetchApi('/api/wellness/branding')
-      .then((res) => setBranding({ logoUrl: res.logoUrl || null, brandColor: res.brandColor || '' }))
-      .catch(() => { /* branding endpoint may be unavailable for non-wellness tenants */ });
+    fetchApi("/api/wellness/branding")
+      .then((res) =>
+        setBranding({
+          logoUrl: res.logoUrl || null,
+          brandColor: res.brandColor || "",
+        }),
+      )
+      .catch(() => {
+        /* branding endpoint may be unavailable for non-wellness tenants */
+      });
     // Fetch AdsGPT login configuration
-    fetchApi('/api/integrations/adsgpt/config')
-      .then((res) => setAdsgptLogin(res.adsgptLogin || ''))
-      .catch(() => { /* adsgpt config may not be available */ });
+    fetchApi("/api/integrations/adsgpt/config")
+      .then((res) => setAdsgptLogin(res.adsgptLogin || ""))
+      .catch(() => {
+        /* adsgpt config may not be available */
+      });
     // Fetch Callified integration status
-    fetchApi('/api/integrations')
+    fetchApi("/api/integrations")
       .then((integrations) => {
-        const callifiedIntegration = integrations.find(i => i.provider === 'callified');
+        const callifiedIntegration = integrations.find(
+          (i) => i.provider === "callified",
+        );
         if (callifiedIntegration && callifiedIntegration.isActive) {
           setCallifiedConnected(true);
           setCallifiedUpdatedAt(callifiedIntegration.updatedAt);
-          setCallifiedApiKey('••••••••••••••••');
+          setCallifiedApiKey("••••••••••••••••");
         }
         setCallifiedLoading(false);
       })
@@ -88,48 +136,49 @@ export default function Settings() {
   const handlePickLogo = (e) => {
     const file = e.target.files && e.target.files[0];
     // Reset the input so picking the same file twice fires onChange again.
-    if (e.target) e.target.value = '';
+    if (e.target) e.target.value = "";
     if (!file) return;
     if (file.size > 20 * 1024 * 1024) {
-      setBrandingMsg('Image too large — max 20 MB.');
+      setBrandingMsg("Image too large — max 20 MB.");
       return;
     }
     if (stagedPreviewUrl) URL.revokeObjectURL(stagedPreviewUrl);
     setStagedLogo(file);
     setStagedPreviewUrl(URL.createObjectURL(file));
-    setBrandingMsg('');
+    setBrandingMsg("");
   };
 
   const cancelStagedLogo = () => {
     if (stagedPreviewUrl) URL.revokeObjectURL(stagedPreviewUrl);
     setStagedLogo(null);
     setStagedPreviewUrl(null);
-    setBrandingMsg('');
+    setBrandingMsg("");
   };
 
   const handleSaveLogo = async () => {
     if (!stagedLogo) return;
     setLogoUploading(true);
-    setBrandingMsg('');
+    setBrandingMsg("");
     try {
       const fd = new FormData();
-      fd.append('logo', stagedLogo);
+      fd.append("logo", stagedLogo);
       const token = getAuthToken();
-      const resp = await fetch('/api/wellness/branding/logo', {
-        method: 'POST',
+      const resp = await fetch("/api/wellness/branding/logo", {
+        method: "POST",
         headers: token ? { Authorization: `Bearer ${token}` } : {},
         body: fd,
       });
       const json = await resp.json().catch(() => ({}));
-      if (!resp.ok) throw new Error(json.error || 'Upload failed');
+      if (!resp.ok) throw new Error(json.error || "Upload failed");
       setBranding((b) => ({ ...b, logoUrl: json.logoUrl }));
       setLogoBroken(false);
       // Reflect into sidebar instantly
-      if (setTenant && ctxTenant) setTenant({ ...ctxTenant, logoUrl: json.logoUrl });
-      setBrandingMsg('Logo updated.');
+      if (setTenant && ctxTenant)
+        setTenant({ ...ctxTenant, logoUrl: json.logoUrl });
+      setBrandingMsg("Logo updated.");
       cancelStagedLogo();
     } catch (err) {
-      setBrandingMsg(err.message || 'Logo upload failed');
+      setBrandingMsg(err.message || "Logo upload failed");
     } finally {
       setLogoUploading(false);
     }
@@ -140,26 +189,26 @@ export default function Settings() {
     return () => {
       if (stagedPreviewUrl) URL.revokeObjectURL(stagedPreviewUrl);
     };
-
   }, []);
 
   const handleSaveBrandColor = async () => {
     setBrandingSaving(true);
-    setBrandingMsg('');
+    setBrandingMsg("");
     try {
-      const value = branding.brandColor || '';
+      const value = branding.brandColor || "";
       if (value && !/^#[0-9a-fA-F]{6}$/.test(value)) {
-        throw new Error('Brand color must be a 6-digit hex (e.g. #265855).');
+        throw new Error("Brand color must be a 6-digit hex (e.g. #265855).");
       }
-      const res = await fetchApi('/api/wellness/branding/color', {
-        method: 'PUT',
+      const res = await fetchApi("/api/wellness/branding/color", {
+        method: "PUT",
         body: JSON.stringify({ brandColor: value || null }),
       });
-      setBranding((b) => ({ ...b, brandColor: res.brandColor || '' }));
-      if (setTenant && ctxTenant) setTenant({ ...ctxTenant, brandColor: res.brandColor || null });
-      setBrandingMsg('Brand color saved.');
+      setBranding((b) => ({ ...b, brandColor: res.brandColor || "" }));
+      if (setTenant && ctxTenant)
+        setTenant({ ...ctxTenant, brandColor: res.brandColor || null });
+      setBrandingMsg("Brand color saved.");
     } catch (err) {
-      setBrandingMsg(err.message || 'Failed to save brand color');
+      setBrandingMsg(err.message || "Failed to save brand color");
     } finally {
       setBrandingSaving(false);
     }
@@ -169,14 +218,17 @@ export default function Settings() {
     e.preventDefault();
     setTenantSaving(true);
     try {
-      const updated = await fetchApi('/api/tenants/current', {
-        method: 'PUT',
-        body: JSON.stringify({ name: tenant.name, ownerEmail: tenant.ownerEmail }),
+      const updated = await fetchApi("/api/tenants/current", {
+        method: "PUT",
+        body: JSON.stringify({
+          name: tenant.name,
+          ownerEmail: tenant.ownerEmail,
+        }),
       });
       setTenantState(updated);
       if (setTenant) setTenant(updated);
     } catch (err) {
-      notify.error('Failed to update organization');
+      notify.error("Failed to update organization");
     }
     setTenantSaving(false);
   };
@@ -189,19 +241,21 @@ export default function Settings() {
     setTenantState({ ...tenant, emailRetention: next });
     setEmailRetentionSaving(true);
     try {
-      const updated = await fetchApi('/api/tenants/current', {
-        method: 'PUT',
+      const updated = await fetchApi("/api/tenants/current", {
+        method: "PUT",
         body: JSON.stringify({ emailRetention: next }),
       });
       setTenantState(updated);
       if (setTenant) setTenant(updated);
-      notify.success(next
-        ? 'Sent emails will now be stored (Sent folder + audit trail).'
-        : 'Sent emails will not be stored. Threading will be limited.');
+      notify.success(
+        next
+          ? "Sent emails will now be stored (Sent folder + audit trail)."
+          : "Sent emails will not be stored. Threading will be limited.",
+      );
     } catch (err) {
       // Revert optimistic flip
       setTenantState({ ...tenant, emailRetention: prevValue });
-      notify.error('Failed to update email retention');
+      notify.error("Failed to update email retention");
     } finally {
       setEmailRetentionSaving(false);
     }
@@ -209,21 +263,25 @@ export default function Settings() {
 
   const handleSaveAdsgptLogin = async () => {
     setAdsgptSaving(true);
-    setAdsgptMsg('');
+    setAdsgptMsg("");
     try {
       if (!adsgptLogin.trim()) {
-        throw new Error('Username or email is required');
+        throw new Error("Username or email is required");
       }
-      await fetchApi('/api/integrations/adsgpt/config', {
-        method: 'PUT',
+      await fetchApi("/api/integrations/adsgpt/config", {
+        method: "PUT",
         body: JSON.stringify({ adsgptLogin: adsgptLogin.trim() }),
       });
-      notify.success('AdsGPT login updated');
-      setAdsgptMsg('✓ Saved');
+      notify.success("AdsGPT login updated");
+      setAdsgptMsg("✓ Saved");
       // Notify other components to refetch the config
-      window.dispatchEvent(new CustomEvent('adsgpt:config-updated', { detail: { adsgptLogin: adsgptLogin.trim() } }));
+      window.dispatchEvent(
+        new CustomEvent("adsgpt:config-updated", {
+          detail: { adsgptLogin: adsgptLogin.trim() },
+        }),
+      );
     } catch (err) {
-      const msg = err.message || 'Failed to save AdsGPT login';
+      const msg = err.message || "Failed to save AdsGPT login";
       setAdsgptMsg(msg);
       notify.error(msg);
     } finally {
@@ -234,27 +292,27 @@ export default function Settings() {
   const handleSaveCallifiedKey = async (e) => {
     e.preventDefault();
     if (!callifiedApiKey || callifiedApiKey.length < 10) {
-      setCallifiedMsg('Please enter a valid API key');
+      setCallifiedMsg("Please enter a valid API key");
       return;
     }
-    if (callifiedApiKey === '••••••••••••••••') {
-      setCallifiedMsg('Please enter the actual API key');
+    if (callifiedApiKey === "••••••••••••••••") {
+      setCallifiedMsg("Please enter the actual API key");
       return;
     }
     setCallifiedSaving(true);
-    setCallifiedMsg('');
+    setCallifiedMsg("");
     try {
-      await fetchApi('/api/integrations/connect', {
-        method: 'POST',
-        body: JSON.stringify({ provider: 'callified', token: callifiedApiKey }),
+      await fetchApi("/api/integrations/connect", {
+        method: "POST",
+        body: JSON.stringify({ provider: "callified", token: callifiedApiKey }),
       });
-      notify.success('Callified API key saved successfully');
+      notify.success("Callified API key saved successfully");
       setCallifiedConnected(true);
       setCallifiedUpdatedAt(new Date().toISOString());
-      setCallifiedApiKey('••••••••••••••••');
-      setCallifiedMsg('✓ Connected to Callified');
+      setCallifiedApiKey("••••••••••••••••");
+      setCallifiedMsg("✓ Connected to Callified");
     } catch (err) {
-      const msg = err.message || 'Failed to save API key';
+      const msg = err.message || "Failed to save API key";
       setCallifiedMsg(msg);
       notify.error(msg);
     } finally {
@@ -263,35 +321,47 @@ export default function Settings() {
   };
 
   const handleDisconnectCallified = async () => {
-    if (!window.confirm('Are you sure you want to disconnect Callified?')) return;
+    const ok = await notify.confirm({
+      title: "Disconnect Callified",
+      message: "Are you sure you want to disconnect Callified?",
+      confirmText: "Disconnect",
+      destructive: true,
+    });
+    if (!ok) return;
     setCallifiedSaving(true);
     try {
-      await fetchApi('/api/integrations/disconnect', {
-        method: 'POST',
-        body: JSON.stringify({ provider: 'callified' }),
+      await fetchApi("/api/integrations/disconnect", {
+        method: "POST",
+        body: JSON.stringify({ provider: "callified" }),
       });
-      notify.success('Callified integration disconnected');
+      notify.success("Callified integration disconnected");
       setCallifiedConnected(false);
-      setCallifiedApiKey('');
+      setCallifiedApiKey("");
       setCallifiedUpdatedAt(null);
-      setCallifiedMsg('');
+      setCallifiedMsg("");
     } catch (err) {
-      notify.error('Failed to disconnect Callified');
+      notify.error("Failed to disconnect Callified");
     } finally {
       setCallifiedSaving(false);
     }
   };
 
   const fetchStages = () => {
-    fetchApi('/api/pipeline_stages')
-      .then(res => { setPipelineStages(Array.isArray(res) ? res : []); setStagesLoading(false); })
+    fetchApi("/api/pipeline_stages")
+      .then((res) => {
+        setPipelineStages(Array.isArray(res) ? res : []);
+        setStagesLoading(false);
+      })
       .catch(() => setStagesLoading(false));
   };
 
   useEffect(() => {
-    fetchApi('/api/auth/users')
-      .then(res => { setUsers(res); setLoading(false); })
-      .catch(err => console.error(err));
+    fetchApi("/api/auth/users")
+      .then((res) => {
+        setUsers(res);
+        setLoading(false);
+      })
+      .catch((err) => console.error(err));
     fetchStages();
   }, []);
 
@@ -299,20 +369,24 @@ export default function Settings() {
     e.preventDefault();
     if (!newStage.name.trim()) return;
     try {
-      await fetchApi('/api/pipeline_stages', {
-        method: 'POST',
-        body: JSON.stringify({ name: newStage.name, color: newStage.color, position: pipelineStages.length })
+      await fetchApi("/api/pipeline_stages", {
+        method: "POST",
+        body: JSON.stringify({
+          name: newStage.name,
+          color: newStage.color,
+          position: pipelineStages.length,
+        }),
       });
-      setNewStage({ name: '', color: '#3b82f6' });
+      setNewStage({ name: "", color: "#3b82f6" });
       fetchStages();
     } catch (err) {
-      notify.error('Failed to add stage');
+      notify.error("Failed to add stage");
     }
   };
 
   const handleDeleteStage = async (id) => {
-    if (await notify.confirm('Delete this pipeline stage?')) {
-      await fetchApi(`/api/pipeline_stages/${id}`, { method: 'DELETE' });
+    if (await notify.confirm("Delete this pipeline stage?")) {
+      await fetchApi(`/api/pipeline_stages/${id}`, { method: "DELETE" });
       fetchStages();
     }
   };
@@ -328,16 +402,19 @@ export default function Settings() {
     const newStages = [...pipelineStages];
     const swapIndex = index + direction;
     if (swapIndex < 0 || swapIndex >= newStages.length) return;
-    [newStages[index], newStages[swapIndex]] = [newStages[swapIndex], newStages[index]];
+    [newStages[index], newStages[swapIndex]] = [
+      newStages[swapIndex],
+      newStages[index],
+    ];
     const reordered = newStages.map((s, i) => ({ id: s.id, position: i }));
     // Reflect new positions locally so the optimistic UI matches what we
     // POST (previously items kept their old position values).
     const optimistic = newStages.map((s, i) => ({ ...s, position: i }));
     setPipelineStages(optimistic);
     try {
-      const updated = await fetchApi('/api/pipeline_stages/reorder', {
-        method: 'PUT',
-        body: JSON.stringify({ stages: reordered })
+      const updated = await fetchApi("/api/pipeline_stages/reorder", {
+        method: "PUT",
+        body: JSON.stringify({ stages: reordered }),
       });
       if (Array.isArray(updated)) {
         setPipelineStages(updated);
@@ -345,7 +422,7 @@ export default function Settings() {
         fetchStages();
       }
     } catch (err) {
-      notify.error('Failed to save stage order');
+      notify.error("Failed to save stage order");
       fetchStages();
     }
   };
@@ -353,13 +430,13 @@ export default function Settings() {
   const handleCreateUser = async (e) => {
     e.preventDefault();
     try {
-      await fetchApi('/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify(newUser)
+      await fetchApi("/api/auth/register", {
+        method: "POST",
+        body: JSON.stringify(newUser),
       });
-      const data = await fetchApi('/api/auth/users');
+      const data = await fetchApi("/api/auth/users");
       setUsers(data);
-      setNewUser({ name: '', email: '', password: '', role: 'USER' });
+      setNewUser({ name: "", email: "", password: "", role: "USER" });
     } catch (err) {
       notify.error("Failed to create user.");
     }
@@ -367,33 +444,60 @@ export default function Settings() {
 
   const handleDelete = async (id) => {
     if (await notify.confirm("Delete this user?")) {
-      await fetchApi(`/api/auth/users/${id}`, { method: 'DELETE' });
-      setUsers(users.filter(u => u.id !== id));
+      await fetchApi(`/api/auth/users/${id}`, { method: "DELETE" });
+      setUsers(users.filter((u) => u.id !== id));
     }
   };
 
   const handleChangeRole = async (id, newRole) => {
-    await fetchApi(`/api/auth/users/${id}/role`, { method: 'PUT', body: JSON.stringify({ role: newRole }) });
-    setUsers(users.map(u => u.id === id ? { ...u, role: newRole } : u));
+    await fetchApi(`/api/auth/users/${id}/role`, {
+      method: "PUT",
+      body: JSON.stringify({ role: newRole }),
+    });
+    setUsers(users.map((u) => (u.id === id ? { ...u, role: newRole } : u)));
   };
 
   // #479/#484: clamp horizontal padding so narrow viewports get 1rem of
   // breathing room instead of the desktop 2rem (which eats ~64px of a
   // 425px viewport before any content gets to render).
   return (
-    <div style={{ padding: 'clamp(1rem, 4vw, 2rem)', height: '100%', overflowY: 'auto', animation: 'fadeIn 0.5s ease-out' }}>
-      <header style={{ marginBottom: '2.5rem' }}>
-        <h1 style={{ fontSize: '2rem', fontWeight: 'bold' }}>Organization Settings</h1>
-        <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>Manage team members, roles, and administrative security.</p>
+    <div
+      style={{
+        padding: "clamp(1rem, 4vw, 2rem)",
+        height: "100%",
+        overflowY: "auto",
+        animation: "fadeIn 0.5s ease-out",
+      }}
+    >
+      <header style={{ marginBottom: "2.5rem" }}>
+        <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>
+          Organization Settings
+        </h1>
+        <p style={{ color: "var(--text-secondary)", marginTop: "0.25rem" }}>
+          Manage team members, roles, and administrative security.
+        </p>
         {/* Owner-only quick-link to the subscription catalog editor. Hidden
             for non-owners — the ManagePlans page itself also gates render
             on isOwner so a direct URL hit shows the access-denied panel. */}
         {isOwner && (
           <Link
             to="/manage-plans"
-            style={{ display: 'inline-flex', alignItems: 'center', gap: 8, marginTop: '1rem', padding: '8px 14px', fontSize: '0.85rem', fontWeight: 600, background: 'var(--accent-color)', color: '#fff', borderRadius: 8, textDecoration: 'none' }}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              marginTop: "1rem",
+              padding: "8px 14px",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              background: "var(--accent-color)",
+              color: "#fff",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
           >
-            <CreditCard size={14} /> Manage Subscription Plans <ArrowRight size={13} />
+            <CreditCard size={14} /> Manage Subscription Plans{" "}
+            <ArrowRight size={13} />
           </Link>
         )}
       </header>
@@ -404,29 +508,89 @@ export default function Settings() {
           alignItems:'start' keeps each column at its natural height so the
           shorter column's cards don't get spread apart vertically to match
           the taller column's stretch height. */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1.5rem', maxWidth: '1400px', alignItems: 'start' }}>
-
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns:
+            "repeat(auto-fit, minmax(min(100%, 320px), 1fr))",
+          gap: "1.5rem",
+          maxWidth: "1400px",
+          alignItems: "start",
+        }}
+      >
         {/* Left Column */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '1.5rem', minWidth: 0 }}>
-
-        {/* Organization Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Building2 size={20} color="var(--accent-color)" /> Organization
-          </h3>
-          {tenant ? (
-            // #484: form grid uses auto-fit + minmax(min(100%, 240px)) so on
-            // narrow viewports columns stack instead of squeezing inputs to
-            // truncation width. min(100%, 240px) keeps the form single-column
-            // on phones while staying two-column on tablets/desktop.
-            <form onSubmit={handleSaveTenant} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))', gap: '1rem' }}>
-              <div style={{ minWidth: 0 }}>
-                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Organization Name</label>
-                <input type="text" required className="input-field" value={tenant.name || ''} onChange={e => setTenantState({ ...tenant, name: e.target.value })} />
-              </div>
-              <div style={{ minWidth: 0 }}>
-                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Slug</label>
-                {/* #715 — slug is read-only after organization creation. Render
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            gap: "1.5rem",
+            minWidth: 0,
+          }}
+        >
+          {/* Organization Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Building2 size={20} color="var(--accent-color)" /> Organization
+            </h3>
+            {tenant ? (
+              // #484: form grid uses auto-fit + minmax(min(100%, 240px)) so on
+              // narrow viewports columns stack instead of squeezing inputs to
+              // truncation width. min(100%, 240px) keeps the form single-column
+              // on phones while staying two-column on tablets/desktop.
+              <form
+                onSubmit={handleSaveTenant}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns:
+                    "repeat(auto-fit, minmax(min(100%, 240px), 1fr))",
+                  gap: "1rem",
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <label
+                    style={{
+                      display: "block",
+                      marginBottom: "0.4rem",
+                      fontSize: "0.875rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Organization Name
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    className="input-field"
+                    value={tenant.name || ""}
+                    onChange={(e) =>
+                      setTenantState({ ...tenant, name: e.target.value })
+                    }
+                  />
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <label
+                    style={{
+                      display: "block",
+                      marginBottom: "0.4rem",
+                      fontSize: "0.875rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Slug
+                  </label>
+                  {/* #715 — slug is read-only after organization creation. Render
                     with `readOnly` + muted background + cursor-not-allowed so
                     the input visibly signals the locked state; pre-fix the
                     `disabled` attr alone left users typing into a field
@@ -435,628 +599,1391 @@ export default function Settings() {
                     update bodies). The helper text under the input makes
                     the read-only state explicit without requiring a hover
                     tooltip. */}
-                <input
-                  type="text"
-                  readOnly
-                  className="input-field"
-                  value={tenant.slug || ''}
-                  title="Slug is read-only after organization creation."
-                  aria-readonly="true"
-                  style={{ background: 'var(--card-bg-secondary, rgba(255,255,255,0.05))', cursor: 'not-allowed', opacity: 0.75 }}
-                />
-                <p style={{ marginTop: '0.4rem', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                  Slug is read-only after organization creation.
-                </p>
-              </div>
-              {/* #441: surface the public booking URL with a one-click copy
+                  <input
+                    type="text"
+                    readOnly
+                    className="input-field"
+                    value={tenant.slug || ""}
+                    title="Slug is read-only after organization creation."
+                    aria-readonly="true"
+                    style={{
+                      background:
+                        "var(--card-bg-secondary, rgba(255,255,255,0.05))",
+                      cursor: "not-allowed",
+                      opacity: 0.75,
+                    }}
+                  />
+                  <p
+                    style={{
+                      marginTop: "0.4rem",
+                      fontSize: "0.75rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Slug is read-only after organization creation.
+                  </p>
+                </div>
+                {/* #441: surface the public booking URL with a one-click copy
                   button. Pre-fix the owner had to view-source / DOM-inspect
                   to retrieve the URL — friction at the "send me your booking
                   link" moment. The URL is built from window.location.origin
                   + slug; SSR doesn't apply (Settings is auth-required, never
                   rendered server-side). */}
-              {tenant.slug && (
-                // #484: gridColumn:'1 / -1' (full row) replaces 'span 2' so
-                // the cell still spans every column whether the auto-fit grid
-                // resolved to 1, 2, or more columns. flexWrap on the inner
-                // row lets the Copy URL button drop below the input on
-                // narrow viewports instead of squeezing the URL input.
-                <div style={{ gridColumn: '1 / -1', minWidth: 0 }}>
-                  <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Public Booking URL</label>
-                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                    <input
-                      type="text"
-                      readOnly
-                      className="input-field"
-                      value={`${window.location.origin}/book/${tenant.slug}`}
-                      style={{ flex: '1 1 200px', minWidth: 0 }}
-                      onFocus={(e) => e.target.select()}
-                    />
-                    <button
-                      type="button"
-                      className="btn-secondary"
-                      onClick={() => {
-                        const url = `${window.location.origin}/book/${tenant.slug}`;
-                        navigator.clipboard?.writeText(url).then(
-                          () => notify.success('Public booking URL copied to clipboard'),
-                          () => notify.error('Could not copy — please select and copy manually')
-                        );
+                {tenant.slug && (
+                  // #484: gridColumn:'1 / -1' (full row) replaces 'span 2' so
+                  // the cell still spans every column whether the auto-fit grid
+                  // resolved to 1, 2, or more columns. flexWrap on the inner
+                  // row lets the Copy URL button drop below the input on
+                  // narrow viewports instead of squeezing the URL input.
+                  <div style={{ gridColumn: "1 / -1", minWidth: 0 }}>
+                    <label
+                      style={{
+                        display: "block",
+                        marginBottom: "0.4rem",
+                        fontSize: "0.875rem",
+                        color: "var(--text-secondary)",
                       }}
-                      style={{ padding: '0.5rem 1rem', whiteSpace: 'nowrap' }}
                     >
-                      Copy URL
-                    </button>
+                      Public Booking URL
+                    </label>
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: "0.5rem",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <input
+                        type="text"
+                        readOnly
+                        className="input-field"
+                        value={`${window.location.origin}/book/${tenant.slug}`}
+                        style={{ flex: "1 1 200px", minWidth: 0 }}
+                        onFocus={(e) => e.target.select()}
+                      />
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={() => {
+                          const url = `${window.location.origin}/book/${tenant.slug}`;
+                          navigator.clipboard?.writeText(url).then(
+                            () =>
+                              notify.success(
+                                "Public booking URL copied to clipboard",
+                              ),
+                            () =>
+                              notify.error(
+                                "Could not copy — please select and copy manually",
+                              ),
+                          );
+                        }}
+                        style={{ padding: "0.5rem 1rem", whiteSpace: "nowrap" }}
+                      >
+                        Copy URL
+                      </button>
+                    </div>
+                    <p
+                      style={{
+                        marginTop: "0.4rem",
+                        fontSize: "0.75rem",
+                        color: "var(--text-secondary)",
+                      }}
+                    >
+                      Share this with{" "}
+                      {tenant.vertical === "wellness"
+                        ? "patients"
+                        : "customers"}{" "}
+                      to let them self-book without logging in.
+                    </p>
                   </div>
-                  <p style={{ marginTop: '0.4rem', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                    Share this with {tenant.vertical === 'wellness' ? 'patients' : 'customers'} to let them self-book without logging in.
-                  </p>
+                )}
+                <div style={{ minWidth: 0 }}>
+                  <label
+                    style={{
+                      display: "block",
+                      marginBottom: "0.4rem",
+                      fontSize: "0.875rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Owner Email
+                  </label>
+                  <input
+                    type="email"
+                    className="input-field"
+                    value={tenant.ownerEmail || ""}
+                    onChange={(e) =>
+                      setTenantState({ ...tenant, ownerEmail: e.target.value })
+                    }
+                  />
                 </div>
-              )}
-              <div style={{ minWidth: 0 }}>
-                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Owner Email</label>
-                <input type="email" className="input-field" value={tenant.ownerEmail || ''} onChange={e => setTenantState({ ...tenant, ownerEmail: e.target.value })} />
-              </div>
-              <div style={{ minWidth: 0 }}>
-                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Plan</label>
-                <input type="text" disabled className="input-field" value={tenant.plan || 'starter'} />
-              </div>
-              <button type="submit" className="btn-primary" disabled={tenantSaving} style={{ gridColumn: '1 / -1' }}>
-                {tenantSaving ? 'Saving...' : 'Save Organization Details'}
-              </button>
-            </form>
-          ) : (
-            <p style={{ color: 'var(--text-secondary)' }}>Loading organization details…</p>
-          )}
-        </div>
+                <div style={{ minWidth: 0 }}>
+                  <label
+                    style={{
+                      display: "block",
+                      marginBottom: "0.4rem",
+                      fontSize: "0.875rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Plan
+                  </label>
+                  <input
+                    type="text"
+                    disabled
+                    className="input-field"
+                    value={tenant.plan || "starter"}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className="btn-primary"
+                  disabled={tenantSaving}
+                  style={{ gridColumn: "1 / -1" }}
+                >
+                  {tenantSaving ? "Saving..." : "Save Organization Details"}
+                </button>
+              </form>
+            ) : (
+              <p style={{ color: "var(--text-secondary)" }}>
+                Loading organization details…
+              </p>
+            )}
+          </div>
 
-        {/* Appearance Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Sun size={20} color="var(--warning-color)" /> Appearance
-          </h3>
-          <div style={{ minWidth: 0 }}>
-            <p id="appearance-theme-label" style={{ fontWeight: '500', fontSize: '1rem', marginBottom: '1rem' }}>Theme</p>
-            <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1rem' }}>
-              Choose how the interface should appear.
-            </p>
-            {/* #874 — role="radiogroup" + aria-labelledby gives screen readers
+          {/* Appearance Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Sun size={20} color="var(--warning-color)" /> Appearance
+            </h3>
+            <div style={{ minWidth: 0 }}>
+              <p
+                id="appearance-theme-label"
+                style={{
+                  fontWeight: "500",
+                  fontSize: "1rem",
+                  marginBottom: "1rem",
+                }}
+              >
+                Theme
+              </p>
+              <p
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: "0.875rem",
+                  marginBottom: "1rem",
+                }}
+              >
+                Choose how the interface should appear.
+              </p>
+              {/* #874 — role="radiogroup" + aria-labelledby gives screen readers
                 proper group semantics on the three theme options. Native
                 same-name radio inputs already handle arrow-key navigation
                 between options (one Tab stop into the group; arrows cycle). */}
-            <div
-              role="radiogroup"
-              aria-labelledby="appearance-theme-label"
-              style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
-            >
-              {[
-                { value: 'light', label: 'Light mode', icon: Sun },
-                { value: 'dark', label: 'Dark mode', icon: Moon },
-                { value: 'system', label: 'Based on system preference', icon: Monitor },
-              ].map(({ value, label, icon: IconComponent }) => (
-                <label
-                  key={value}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.75rem',
-                    padding: '0.75rem 1rem',
-                    borderRadius: '8px',
-                    border: `2px solid ${theme === value ? 'var(--accent-color)' : 'var(--border-color)'}`,
-                    background:
-                      theme === value
-                        ? 'rgba(59, 130, 246, 0.1)'
-                        : 'rgba(59, 130, 246, 0.02)',
-                    cursor: 'pointer',
-                    transition: 'all 0.2s ease',
-                  }}
-                  className="theme-option"
-                  data-selected={theme === value}
-                  onMouseEnter={(e) => {
-                    if (theme !== value) {
-                      e.currentTarget.style.borderColor = '#3b82f6';
-                      e.currentTarget.style.background = 'rgba(59, 130, 246, 0.08)';
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (theme !== value) {
-                      e.currentTarget.style.borderColor = 'var(--border-color)';
-                      e.currentTarget.style.background = 'rgba(59, 130, 246, 0.02)';
-                    }
-                  }}
-                >
-                  <input
-                    type="radio"
-                    name="theme"
-                    value={value}
-                    checked={theme === value}
-                    onChange={(e) => {
-                      if (e.target.checked) {
-                        setTheme(value);
-                        // #875 — confirm the preference landed. setTheme writes
-                        // to local state + localStorage synchronously, so by the
-                        // time this fires the choice is persisted.
-                        notify.success(`Theme set to ${label}`);
+              <div
+                role="radiogroup"
+                aria-labelledby="appearance-theme-label"
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.75rem",
+                }}
+              >
+                {[
+                  { value: "light", label: "Light mode", icon: Sun },
+                  { value: "dark", label: "Dark mode", icon: Moon },
+                  {
+                    value: "system",
+                    label: "Based on system preference",
+                    icon: Monitor,
+                  },
+                ].map(({ value, label, icon: IconComponent }) => (
+                  <label
+                    key={value}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.75rem",
+                      padding: "0.75rem 1rem",
+                      borderRadius: "8px",
+                      border: `2px solid ${theme === value ? "var(--accent-color)" : "var(--border-color)"}`,
+                      background:
+                        theme === value
+                          ? "rgba(59, 130, 246, 0.1)"
+                          : "rgba(59, 130, 246, 0.02)",
+                      cursor: "pointer",
+                      transition: "all 0.2s ease",
+                    }}
+                    className="theme-option"
+                    data-selected={theme === value}
+                    onMouseEnter={(e) => {
+                      if (theme !== value) {
+                        e.currentTarget.style.borderColor = "#3b82f6";
+                        e.currentTarget.style.background =
+                          "rgba(59, 130, 246, 0.08)";
                       }
                     }}
-                    style={{ cursor: 'pointer' }}
-                  />
-                  {IconComponent && <IconComponent size={18} />}
-                  <span style={{ fontWeight: theme === value ? '600' : '500' }}>
-                    {label}
-                  </span>
-                </label>
-              ))}
+                    onMouseLeave={(e) => {
+                      if (theme !== value) {
+                        e.currentTarget.style.borderColor =
+                          "var(--border-color)";
+                        e.currentTarget.style.background =
+                          "rgba(59, 130, 246, 0.02)";
+                      }
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      name="theme"
+                      value={value}
+                      checked={theme === value}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setTheme(value);
+                          // #875 — confirm the preference landed. setTheme writes
+                          // to local state + localStorage synchronously, so by the
+                          // time this fires the choice is persisted.
+                          notify.success(`Theme set to ${label}`);
+                        }
+                      }}
+                      style={{ cursor: "pointer" }}
+                    />
+                    {IconComponent && <IconComponent size={18} />}
+                    <span
+                      style={{ fontWeight: theme === value ? "600" : "500" }}
+                    >
+                      {label}
+                    </span>
+                  </label>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Email Messages Card — #611 retention toggle */}
-        {tenant && (
-          <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }} data-testid="email-retention-card">
-            <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Mail size={20} color="var(--accent-color)" /> Email Messages
-            </h3>
-            <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
-              Store sent messages so they appear in the Sent folder, the contact's
-              activity timeline, and so reply threading works. Recommended for
-              any team that needs an audit trail of customer comms.
-            </p>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={tenant.emailRetention !== false}
-                disabled={emailRetentionSaving}
-                onChange={(e) => handleToggleEmailRetention(e.target.checked)}
-                aria-label="Store sent email messages"
-                data-testid="email-retention-toggle"
-                style={{ width: 18, height: 18, cursor: 'pointer' }}
-              />
-              <span style={{ fontWeight: 500 }}>
-                Store sent messages
-                {emailRetentionSaving && <span style={{ marginLeft: '0.5rem', color: 'var(--text-secondary)', fontSize: '0.8rem' }}>(saving…)</span>}
-              </span>
-            </label>
-            {tenant.emailRetention === false && (
-              <p style={{ marginTop: '0.75rem', padding: '0.6rem 0.85rem', background: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.3)', borderRadius: 8, color: '#d97706', fontSize: '0.8rem' }}>
-                Retention is OFF. Sent emails won't appear in the Sent folder, the
-                contact timeline body will be blank, and reply threading will not
-                link replies to their parent.
+          {/* Email Messages Card — #611 retention toggle */}
+          {tenant && (
+            <div
+              className="card"
+              style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+              data-testid="email-retention-card"
+            >
+              <h3
+                style={{
+                  fontSize: "1.25rem",
+                  fontWeight: "600",
+                  marginBottom: "1rem",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                }}
+              >
+                <Mail size={20} color="var(--accent-color)" /> Email Messages
+              </h3>
+              <p
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: "0.875rem",
+                  marginBottom: "1.25rem",
+                }}
+              >
+                Store sent messages so they appear in the Sent folder, the
+                contact's activity timeline, and so reply threading works.
+                Recommended for any team that needs an audit trail of customer
+                comms.
               </p>
-            )}
-          </div>
-        )}
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.75rem",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={tenant.emailRetention !== false}
+                  disabled={emailRetentionSaving}
+                  onChange={(e) => handleToggleEmailRetention(e.target.checked)}
+                  aria-label="Store sent email messages"
+                  data-testid="email-retention-toggle"
+                  style={{ width: 18, height: 18, cursor: "pointer" }}
+                />
+                <span style={{ fontWeight: 500 }}>
+                  Store sent messages
+                  {emailRetentionSaving && (
+                    <span
+                      style={{
+                        marginLeft: "0.5rem",
+                        color: "var(--text-secondary)",
+                        fontSize: "0.8rem",
+                      }}
+                    >
+                      (saving…)
+                    </span>
+                  )}
+                </span>
+              </label>
+              {tenant.emailRetention === false && (
+                <p
+                  style={{
+                    marginTop: "0.75rem",
+                    padding: "0.6rem 0.85rem",
+                    background: "rgba(245,158,11,0.1)",
+                    border: "1px solid rgba(245,158,11,0.3)",
+                    borderRadius: 8,
+                    color: "#d97706",
+                    fontSize: "0.8rem",
+                  }}
+                >
+                  Retention is OFF. Sent emails won't appear in the Sent folder,
+                  the contact timeline body will be blank, and reply threading
+                  will not link replies to their parent.
+                </p>
+              )}
+            </div>
+          )}
 
-        {/* Consent Templates — wellness only (#612) */}
-        {tenant && tenant.vertical === 'wellness' && (
-          <ConsentTemplatesCard notify={notify} />
-        )}
+          {/* Consent Templates — wellness only (#612) */}
+          {tenant && tenant.vertical === "wellness" && (
+            <ConsentTemplatesCard notify={notify} />
+          )}
 
-        {/* Branding Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Palette size={20} color="var(--accent-color)" /> Branding
-          </h3>
-          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
-            Upload your clinic logo and pick a brand color. These appear in the sidebar and on branded PDFs.
-          </p>
+          {/* Wellness Role Types — wellness only (Option B) */}
+          {tenant && tenant.vertical === "wellness" && (
+            <WellnessRoleTypesCard notify={notify} />
+          )}
 
-          {/* #479: Branding two-column (Logo | Brand color) collapses to
+          {/* Branding Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Palette size={20} color="var(--accent-color)" /> Branding
+            </h3>
+            <p
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "0.875rem",
+                marginBottom: "1.25rem",
+              }}
+            >
+              Upload your clinic logo and pick a brand color. These appear in
+              the sidebar and on branded PDFs.
+            </p>
+
+            {/* #479: Branding two-column (Logo | Brand color) collapses to
               single-column under ~360px-each via auto-fit + minmax, fixing
               the "B colo..." label clip + "Save c..." button-text clip on
               ~425px viewports. */}
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))', gap: '2rem', alignItems: 'start' }}>
-            {/* Logo */}
-            <div style={{ minWidth: 0 }}>
-              <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.875rem', color: 'var(--text-secondary)', fontWeight: 500 }}>
-                <ImageIcon size={14} style={{ verticalAlign: 'middle', marginRight: '0.35rem' }} /> Logo
-              </label>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
-                {/* Preview tile — staged file wins over saved logo so the
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns:
+                  "repeat(auto-fit, minmax(min(100%, 240px), 1fr))",
+                gap: "2rem",
+                alignItems: "start",
+              }}
+            >
+              {/* Logo */}
+              <div style={{ minWidth: 0 }}>
+                <label
+                  style={{
+                    display: "block",
+                    marginBottom: "0.5rem",
+                    fontSize: "0.875rem",
+                    color: "var(--text-secondary)",
+                    fontWeight: 500,
+                  }}
+                >
+                  <ImageIcon
+                    size={14}
+                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
+                  />{" "}
+                  Logo
+                </label>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "1rem",
+                    marginBottom: "0.75rem",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  {/* Preview tile — staged file wins over saved logo so the
                     user can see what they're about to commit. Broken
                     logoUrl falls back to a dashed placeholder instead of
                     leaving the classic broken-image icon in place. */}
-                {stagedPreviewUrl ? (
-                  <div style={{ position: 'relative' }}>
+                  {stagedPreviewUrl ? (
+                    <div style={{ position: "relative" }}>
+                      <img
+                        src={stagedPreviewUrl}
+                        alt="New logo preview"
+                        style={{
+                          width: 80,
+                          height: 80,
+                          borderRadius: 8,
+                          objectFit: "cover",
+                          border: "2px solid var(--accent-color)",
+                        }}
+                      />
+                      <span
+                        style={{
+                          position: "absolute",
+                          bottom: -8,
+                          left: "50%",
+                          transform: "translateX(-50%)",
+                          background: "var(--accent-color)",
+                          color: "#fff",
+                          fontSize: "0.65rem",
+                          padding: "0.1rem 0.45rem",
+                          borderRadius: 999,
+                          whiteSpace: "nowrap",
+                          fontWeight: 600,
+                        }}
+                      >
+                        Pending
+                      </span>
+                    </div>
+                  ) : branding.logoUrl && !logoBroken ? (
                     <img
-                      src={stagedPreviewUrl}
-                      alt="New logo preview"
-                      style={{ width: 80, height: 80, borderRadius: 8, objectFit: 'cover', border: '2px solid var(--accent-color)' }}
+                      src={branding.logoUrl}
+                      alt="Current logo"
+                      onError={() => setLogoBroken(true)}
+                      style={{
+                        width: 80,
+                        height: 80,
+                        borderRadius: 8,
+                        objectFit: "cover",
+                        border: "1px solid var(--border-color)",
+                      }}
                     />
-                    <span style={{ position: 'absolute', bottom: -8, left: '50%', transform: 'translateX(-50%)', background: 'var(--accent-color)', color: '#fff', fontSize: '0.65rem', padding: '0.1rem 0.45rem', borderRadius: 999, whiteSpace: 'nowrap', fontWeight: 600 }}>
-                      Pending
-                    </span>
-                  </div>
-                ) : branding.logoUrl && !logoBroken ? (
-                  <img
-                    src={branding.logoUrl}
-                    alt="Current logo"
-                    onError={() => setLogoBroken(true)}
-                    style={{ width: 80, height: 80, borderRadius: 8, objectFit: 'cover', border: '1px solid var(--border-color)' }}
+                  ) : (
+                    <div
+                      style={{
+                        width: 80,
+                        height: 80,
+                        borderRadius: 8,
+                        border: "1px dashed var(--border-color)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "var(--text-secondary)",
+                        fontSize: "0.7rem",
+                        textAlign: "center",
+                        flexDirection: "column",
+                        gap: "0.2rem",
+                      }}
+                    >
+                      <ImageIcon size={22} />
+                      <span>{logoBroken ? "Image broken" : "No logo"}</span>
+                    </div>
+                  )}
+
+                  {/* Hidden native input; visible buttons trigger it. */}
+                  <input
+                    ref={logoInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+                    onChange={handlePickLogo}
+                    style={{ display: "none" }}
                   />
-                ) : (
-                  <div style={{ width: 80, height: 80, borderRadius: 8, border: '1px dashed var(--border-color)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-secondary)', fontSize: '0.7rem', textAlign: 'center', flexDirection: 'column', gap: '0.2rem' }}>
-                    <ImageIcon size={22} />
-                    <span>{logoBroken ? 'Image broken' : 'No logo'}</span>
-                  </div>
-                )}
 
-                {/* Hidden native input; visible buttons trigger it. */}
-                <input
-                  ref={logoInputRef}
-                  type="file"
-                  accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
-                  onChange={handlePickLogo}
-                  style={{ display: 'none' }}
-                />
-
-                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                  {stagedLogo ? (
-                    <>
+                  <div
+                    style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}
+                  >
+                    {stagedLogo ? (
+                      <>
+                        <button
+                          type="button"
+                          className="btn-primary"
+                          onClick={handleSaveLogo}
+                          disabled={logoUploading}
+                          style={{ whiteSpace: "nowrap" }}
+                        >
+                          {logoUploading ? "Uploading…" : "Save logo"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => logoInputRef.current?.click()}
+                          disabled={logoUploading}
+                          style={{
+                            padding: "0.5rem 0.9rem",
+                            background: "transparent",
+                            border: "1px solid var(--border-color)",
+                            borderRadius: 6,
+                            color: "var(--text-primary)",
+                            cursor: "pointer",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Pick another
+                        </button>
+                        <button
+                          type="button"
+                          onClick={cancelStagedLogo}
+                          disabled={logoUploading}
+                          style={{
+                            padding: "0.5rem 0.9rem",
+                            background: "transparent",
+                            border: "1px solid var(--border-color)",
+                            borderRadius: 6,
+                            color: "var(--danger-color, #ef4444)",
+                            cursor: "pointer",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
                       <button
                         type="button"
                         className="btn-primary"
-                        onClick={handleSaveLogo}
-                        disabled={logoUploading}
-                        style={{ whiteSpace: 'nowrap' }}
-                      >
-                        {logoUploading ? 'Uploading…' : 'Save logo'}
-                      </button>
-                      <button
-                        type="button"
                         onClick={() => logoInputRef.current?.click()}
                         disabled={logoUploading}
-                        style={{ padding: '0.5rem 0.9rem', background: 'transparent', border: '1px solid var(--border-color)', borderRadius: 6, color: 'var(--text-primary)', cursor: 'pointer', whiteSpace: 'nowrap' }}
+                        style={{ whiteSpace: "nowrap" }}
                       >
-                        Pick another
+                        {branding.logoUrl && !logoBroken
+                          ? "Replace logo"
+                          : "Upload logo"}
                       </button>
-                      <button
-                        type="button"
-                        onClick={cancelStagedLogo}
-                        disabled={logoUploading}
-                        style={{ padding: '0.5rem 0.9rem', background: 'transparent', border: '1px solid var(--border-color)', borderRadius: 6, color: 'var(--danger-color, #ef4444)', cursor: 'pointer', whiteSpace: 'nowrap' }}
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      type="button"
-                      className="btn-primary"
-                      onClick={() => logoInputRef.current?.click()}
-                      disabled={logoUploading}
-                      style={{ whiteSpace: 'nowrap' }}
-                    >
-                      {branding.logoUrl && !logoBroken ? 'Replace logo' : 'Upload logo'}
-                    </button>
-                  )}
+                    )}
+                  </div>
                 </div>
+                <p
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  PNG, JPG, GIF, WEBP or SVG. Max 20 MB. Square works best.
+                </p>
               </div>
-              <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>
-                PNG, JPG, GIF, WEBP or SVG. Max 20 MB. Square works best.
-              </p>
-            </div>
 
-            {/* Brand color */}
-            <div style={{ minWidth: 0 }}>
-              <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.875rem', color: 'var(--text-secondary)', fontWeight: 500 }}>
-                <Palette size={14} style={{ verticalAlign: 'middle', marginRight: '0.35rem' }} /> Brand color
-              </label>
-              {/* #479: flexWrap + whiteSpace:nowrap on the Save button so the
+              {/* Brand color */}
+              <div style={{ minWidth: 0 }}>
+                <label
+                  style={{
+                    display: "block",
+                    marginBottom: "0.5rem",
+                    fontSize: "0.875rem",
+                    color: "var(--text-secondary)",
+                    fontWeight: 500,
+                  }}
+                >
+                  <Palette
+                    size={14}
+                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
+                  />{" "}
+                  Brand color
+                </label>
+                {/* #479: flexWrap + whiteSpace:nowrap on the Save button so the
                   button stays as one piece ("Save c..." → "Save color") even
                   when wrapped to its own line. min-width:0 on the hex input
                   lets it shrink instead of pushing the button off-screen. */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
-                <input
-                  type="color"
-                  value={/^#[0-9a-fA-F]{6}$/.test(branding.brandColor || '') ? branding.brandColor : DEFAULT_BRAND_COLOR}
-                  onChange={(e) => setBranding({ ...branding, brandColor: e.target.value })}
-                  style={{ width: 48, height: 40, border: '1px solid var(--border-color)', borderRadius: 8, cursor: 'pointer', padding: 2, background: 'var(--input-bg)' }}
-                />
-                <input
-                  type="text"
-                  className="input-field"
-                  placeholder={DEFAULT_BRAND_COLOR}
-                  value={branding.brandColor || ''}
-                  onChange={(e) => setBranding({ ...branding, brandColor: e.target.value })}
-                  style={{ flex: '1 1 120px', minWidth: 0 }}
-                />
-                <button
-                  type="button"
-                  className="btn-primary"
-                  disabled={brandingSaving}
-                  onClick={handleSaveBrandColor}
-                  style={{ whiteSpace: 'nowrap' }}
-                >
-                  {brandingSaving ? 'Saving...' : 'Save color'}
-                </button>
-              </div>
-              <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>
-                6-digit hex. Leave blank to fall back to the default theme accent.
-              </p>
-            </div>
-          </div>
-
-          {brandingMsg && (
-            <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--accent-color)' }}>{brandingMsg}</p>
-          )}
-        </div>
-
-        {/* Pipeline Stages Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Layers size={20} color="var(--accent-color)" /> Pipeline Stages
-          </h3>
-
-          {stagesLoading ? <p>Loading stages...</p> : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1.5rem' }}>
-              {pipelineStages.length === 0 && (
-                <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>No custom stages configured. The pipeline uses default stages.</p>
-              )}
-              {pipelineStages.map((stage, index) => (
-                <div key={stage.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1rem 1.25rem', borderRadius: '8px' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                    <div style={{ width: '20px', height: '20px', borderRadius: '6px', backgroundColor: stage.color, flexShrink: 0 }} />
-                    <span style={{ fontWeight: '500' }}>{stage.name}</span>
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>Position {index + 1}</span>
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <button onClick={() => handleMoveStage(index, -1)} disabled={index === 0} style={{ background: 'none', border: 'none', color: index === 0 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === 0 ? 'default' : 'pointer', padding: '0.25rem' }}>
-                      <ArrowUp size={16} />
-                    </button>
-                    <button onClick={() => handleMoveStage(index, 1)} disabled={index === pipelineStages.length - 1} style={{ background: 'none', border: 'none', color: index === pipelineStages.length - 1 ? 'var(--border-color)' : 'var(--text-secondary)', cursor: index === pipelineStages.length - 1 ? 'default' : 'pointer', padding: '0.25rem' }}>
-                      <ArrowDown size={16} />
-                    </button>
-                    <button onClick={() => handleDeleteStage(stage.id)} style={{ background: 'none', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.25rem' }}>
-                      <Trash2 size={16} />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* #479: flexWrap so the color picker + Add button drop below the
-              stage-name input on narrow viewports rather than truncating it. */}
-          <form onSubmit={handleAddStage} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
-            <input type="text" placeholder="Stage name" required className="input-field" style={{ flex: '1 1 180px', minWidth: 0 }} value={newStage.name} onChange={e => setNewStage({ ...newStage, name: e.target.value })} />
-            <input type="color" value={newStage.color} onChange={e => setNewStage({ ...newStage, color: e.target.value })} style={{ width: '40px', height: '40px', border: '1px solid var(--border-color)', borderRadius: '8px', cursor: 'pointer', padding: '2px', background: 'var(--input-bg)' }} />
-            <button type="submit" className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}>
-              <Plus size={16} /> Add Stage
-            </button>
-          </form>
-        </div>
-        </div>
-
-        {/* Right Column - Roster */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '1.5rem', minWidth: 0 }}>
-        {/* User Roster */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)', height: 'fit-content' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Shield size={20} color="var(--success-color)" /> Access Control Roster
-          </h3>
-
-          {loading ? <p>Loading team...</p> : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxHeight: '700px', overflowY: 'auto' }}>
-              {users.map(u => (
-                // #479: roster row wraps on narrow viewports so the role
-                // dropdown + delete button drop below the name/email block
-                // instead of squeezing the email into truncation.
-                <div key={u.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '1.25rem', borderRadius: '8px', flexWrap: 'wrap', gap: '0.75rem' }}>
-                  <div style={{ minWidth: 0, flex: '1 1 180px' }}>
-                    <h4 style={{ fontWeight: '600', fontSize: '1.1rem', wordBreak: 'break-word' }}>{u.name || 'Unknown User'} <span style={{ fontSize: '0.75rem', padding: '0.2rem 0.6rem', background: u.role === 'ADMIN' ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.2)', color: u.role === 'ADMIN' ? '#ef4444' : '#3b82f6', borderRadius: '12px', marginLeft: '0.5rem' }}>{u.role}</span></h4>
-                    <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '0.25rem', wordBreak: 'break-all' }}>{u.email}</p>
-                  </div>
-
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                    <select value={u.role} onChange={(e) => handleChangeRole(u.id, e.target.value)} style={{ padding: '0.5rem', borderRadius: '4px', background: 'var(--input-bg)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
-                      <option value="USER">Standard Rep</option>
-                      <option value="MANAGER">Manager</option>
-                      <option value="ADMIN">Admin</option>
-                    </select>
-                    {u.role !== 'ADMIN' ? (
-                      <button onClick={() => handleDelete(u.id)} style={{ background: 'transparent', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.5rem' }}>
-                        <Trash2 size={18} />
-                      </button>
-                    ) : (
-                      <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>—</span>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Invite User Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <UserPlus size={20} color="var(--accent-color)" /> Invite Team Member
-          </h3>
-          {/* #484: Invite form uses auto-fit + minmax so fields stack on
-              narrow viewports rather than truncating placeholders/values. */}
-          <form onSubmit={handleCreateUser} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '1rem' }}>
-             <input type="text" placeholder="Full Name" required className="input-field" style={{ minWidth: 0 }} value={newUser.name} onChange={e => setNewUser({...newUser, name: e.target.value})} />
-             <input type="email" placeholder="Email Address" required className="input-field" style={{ minWidth: 0 }} value={newUser.email} onChange={e => setNewUser({...newUser, email: e.target.value})} />
-             <input type="password" placeholder="Temporary Password" required className="input-field" style={{ minWidth: 0 }} value={newUser.password} onChange={e => setNewUser({...newUser, password: e.target.value})} />
-             <select className="input-field" value={newUser.role} onChange={e => setNewUser({...newUser, role: e.target.value})} style={{ background: 'var(--input-bg)', minWidth: 0 }}>
-               <option value="USER">Standard Rep</option>
-               <option value="MANAGER">Sales Manager</option>
-               <option value="ADMIN">System Administrator</option>
-             </select>
-             <button type="submit" className="btn-primary" style={{ gridColumn: '1 / -1' }}>Send Invitation & Create Account</button>
-          </form>
-        </div>
-
-        {/* AdsGPT Configuration Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Key size={20} color="var(--accent-color)" /> AdsGPT Login
-          </h3>
-          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
-            Enter your AdsGPT aMember username or email. Users will be auto-logged in via SSO when accessing AdsGPT.
-          </p>
-          <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1rem' }}>
-            <input
-              type="text"
-              className="input-field"
-              placeholder="Username or email (e.g. enhanceranchi or user@email.com)"
-              value={adsgptLogin}
-              onChange={(e) => setAdsgptLogin(e.target.value)}
-              disabled={adsgptSaving}
-              style={{ flex: 1, minWidth: 0 }}
-            />
-            <button
-              type="button"
-              className="btn-primary"
-              disabled={adsgptSaving || !adsgptLogin.trim()}
-              onClick={handleSaveAdsgptLogin}
-              style={{ whiteSpace: 'nowrap' }}
-            >
-              {adsgptSaving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-          {adsgptMsg && (
-            <p style={{ fontSize: '0.85rem', color: adsgptMsg.includes('✓') ? 'var(--accent-color)' : 'var(--danger-color)' }}>
-              {adsgptMsg}
-            </p>
-          )}
-        </div>
-
-        {/* Callified Integration Card */}
-        <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-          <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <PhoneCall size={20} color="var(--accent-color)" /> Callified Integration
-          </h3>
-
-          {/* Status Card */}
-          {!callifiedLoading && (
-            <div style={{
-              padding: '1rem',
-              marginBottom: '1.25rem',
-              borderRadius: '8px',
-              background: callifiedConnected ? 'rgba(16, 185, 129, 0.1)' : 'rgba(239, 68, 68, 0.1)',
-              border: `1px solid ${callifiedConnected ? '#10b981' : '#ef4444'}`,
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.75rem'
-            }}>
-              {callifiedConnected ? (
-                <>
-                  <Check size={20} color="#10b981" />
-                  <div style={{ flex: 1 }}>
-                    <p style={{ fontWeight: '500', color: '#10b981', margin: 0 }}>✓ Connected to Callified</p>
-                    {callifiedUpdatedAt && (
-                      <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem', margin: '0.25rem 0 0 0' }}>
-                        Connected since: {new Date(callifiedUpdatedAt).toLocaleDateString()}
-                      </p>
-                    )}
-                  </div>
-                </>
-              ) : (
-                <>
-                  <X size={20} color="#ef4444" />
-                  <div style={{ flex: 1 }}>
-                    <p style={{ fontWeight: '500', color: '#ef4444', margin: 0 }}>Not Connected</p>
-                    <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem', margin: '0.25rem 0 0 0' }}>
-                      Add your API key to get started
-                    </p>
-                  </div>
-                </>
-              )}
-            </div>
-          )}
-
-          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
-            {callifiedConnected
-              ? 'Your Callified account is connected and ready to use.'
-              : 'Enter your Callified API key to enable voice and WhatsApp integration.'}
-          </p>
-
-          <form onSubmit={handleSaveCallifiedKey} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
-              <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
-                <input
-                  type={callifiedShowKey ? 'text' : 'password'}
-                  className="input-field"
-                  placeholder="callified_live_..."
-                  value={callifiedApiKey}
-                  onChange={(e) => setCallifiedApiKey(e.target.value)}
-                  disabled={callifiedSaving}
-                  style={{ width: '100%', minWidth: 0, paddingRight: '40px' }}
-                />
-                <button
-                  type="button"
-                  onClick={() => setCallifiedShowKey(!callifiedShowKey)}
-                  disabled={callifiedSaving}
+                <div
                   style={{
-                    position: 'absolute',
-                    right: '0.75rem',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    background: 'transparent',
-                    border: 'none',
-                    color: 'var(--text-secondary)',
-                    cursor: 'pointer',
-                    padding: '0.25rem',
-                    display: 'flex',
-                    alignItems: 'center'
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.75rem",
+                    marginBottom: "0.75rem",
+                    flexWrap: "wrap",
                   }}
                 >
-                  {callifiedShowKey ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
+                  <input
+                    type="color"
+                    value={
+                      /^#[0-9a-fA-F]{6}$/.test(branding.brandColor || "")
+                        ? branding.brandColor
+                        : DEFAULT_BRAND_COLOR
+                    }
+                    onChange={(e) =>
+                      setBranding({ ...branding, brandColor: e.target.value })
+                    }
+                    style={{
+                      width: 48,
+                      height: 40,
+                      border: "1px solid var(--border-color)",
+                      borderRadius: 8,
+                      cursor: "pointer",
+                      padding: 2,
+                      background: "var(--input-bg)",
+                    }}
+                  />
+                  <input
+                    type="text"
+                    className="input-field"
+                    placeholder={DEFAULT_BRAND_COLOR}
+                    value={branding.brandColor || ""}
+                    onChange={(e) =>
+                      setBranding({ ...branding, brandColor: e.target.value })
+                    }
+                    style={{ flex: "1 1 120px", minWidth: 0 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    disabled={brandingSaving}
+                    onClick={handleSaveBrandColor}
+                    style={{ whiteSpace: "nowrap" }}
+                  >
+                    {brandingSaving ? "Saving..." : "Save color"}
+                  </button>
+                </div>
+                <p
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  6-digit hex. Leave blank to fall back to the default theme
+                  accent.
+                </p>
               </div>
+            </div>
+
+            {brandingMsg && (
+              <p
+                style={{
+                  marginTop: "1rem",
+                  fontSize: "0.85rem",
+                  color: "var(--accent-color)",
+                }}
+              >
+                {brandingMsg}
+              </p>
+            )}
+          </div>
+
+          {/* Pipeline Stages Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Layers size={20} color="var(--accent-color)" /> Pipeline Stages
+            </h3>
+
+            {stagesLoading ? (
+              <p>Loading stages...</p>
+            ) : (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.75rem",
+                  marginBottom: "1.5rem",
+                }}
+              >
+                {pipelineStages.length === 0 && (
+                  <p
+                    style={{
+                      color: "var(--text-secondary)",
+                      fontSize: "0.875rem",
+                    }}
+                  >
+                    No custom stages configured. The pipeline uses default
+                    stages.
+                  </p>
+                )}
+                {pipelineStages.map((stage, index) => (
+                  <div
+                    key={stage.id}
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      background: "var(--surface-color)",
+                      border: "1px solid var(--border-color)",
+                      padding: "1rem 1.25rem",
+                      borderRadius: "8px",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.75rem",
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: "20px",
+                          height: "20px",
+                          borderRadius: "6px",
+                          backgroundColor: stage.color,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span style={{ fontWeight: "500" }}>{stage.name}</span>
+                      <span
+                        style={{
+                          fontSize: "0.75rem",
+                          color: "var(--text-secondary)",
+                        }}
+                      >
+                        Position {index + 1}
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.5rem",
+                      }}
+                    >
+                      <button
+                        onClick={() => handleMoveStage(index, -1)}
+                        disabled={index === 0}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          color:
+                            index === 0
+                              ? "var(--border-color)"
+                              : "var(--text-secondary)",
+                          cursor: index === 0 ? "default" : "pointer",
+                          padding: "0.25rem",
+                        }}
+                      >
+                        <ArrowUp size={16} />
+                      </button>
+                      <button
+                        onClick={() => handleMoveStage(index, 1)}
+                        disabled={index === pipelineStages.length - 1}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          color:
+                            index === pipelineStages.length - 1
+                              ? "var(--border-color)"
+                              : "var(--text-secondary)",
+                          cursor:
+                            index === pipelineStages.length - 1
+                              ? "default"
+                              : "pointer",
+                          padding: "0.25rem",
+                        }}
+                      >
+                        <ArrowDown size={16} />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteStage(stage.id)}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          color: "var(--danger-color)",
+                          cursor: "pointer",
+                          padding: "0.25rem",
+                        }}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* #479: flexWrap so the color picker + Add button drop below the
+              stage-name input on narrow viewports rather than truncating it. */}
+            <form
+              onSubmit={handleAddStage}
+              style={{
+                display: "flex",
+                gap: "0.75rem",
+                alignItems: "center",
+                flexWrap: "wrap",
+              }}
+            >
+              <input
+                type="text"
+                placeholder="Stage name"
+                required
+                className="input-field"
+                style={{ flex: "1 1 180px", minWidth: 0 }}
+                value={newStage.name}
+                onChange={(e) =>
+                  setNewStage({ ...newStage, name: e.target.value })
+                }
+              />
+              <input
+                type="color"
+                value={newStage.color}
+                onChange={(e) =>
+                  setNewStage({ ...newStage, color: e.target.value })
+                }
+                style={{
+                  width: "40px",
+                  height: "40px",
+                  border: "1px solid var(--border-color)",
+                  borderRadius: "8px",
+                  cursor: "pointer",
+                  padding: "2px",
+                  background: "var(--input-bg)",
+                }}
+              />
               <button
                 type="submit"
                 className="btn-primary"
-                disabled={callifiedSaving || !callifiedApiKey.trim()}
-                style={{ whiteSpace: 'nowrap' }}
-              >
-                {callifiedSaving ? (
-                  <>
-                    <Loader size={16} style={{ animation: 'spin 1s linear infinite' }} /> {callifiedConnected ? 'Updating...' : 'Connecting...'}
-                  </>
-                ) : (
-                  callifiedConnected ? 'Update Key' : 'Connect to Callified'
-                )}
-              </button>
-            </div>
-
-            {callifiedConnected && (
-              <button
-                type="button"
-                onClick={handleDisconnectCallified}
-                disabled={callifiedSaving}
                 style={{
-                  padding: '0.75rem 1rem',
-                  borderRadius: '6px',
-                  background: 'rgba(239, 68, 68, 0.1)',
-                  color: '#ef4444',
-                  border: '1px solid #ef4444',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: '500',
-                  whiteSpace: 'nowrap'
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                  whiteSpace: "nowrap",
                 }}
               >
-                {callifiedSaving ? 'Disconnecting...' : 'Disconnect'}
+                <Plus size={16} /> Add Stage
               </button>
+            </form>
+          </div>
+        </div>
+
+        {/* Right Column - Roster */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            gap: "1.5rem",
+            minWidth: 0,
+          }}
+        >
+          {/* User Roster */}
+          <div
+            className="card"
+            style={{
+              padding: "clamp(1.25rem, 3vw, 2rem)",
+              height: "fit-content",
+            }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Shield size={20} color="var(--success-color)" /> Access Control
+              Roster
+            </h3>
+
+            {loading ? (
+              <p>Loading team...</p>
+            ) : (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "1rem",
+                  maxHeight: "700px",
+                  overflowY: "auto",
+                }}
+              >
+                {users.map((u) => (
+                  // #479: roster row wraps on narrow viewports so the role
+                  // dropdown + delete button drop below the name/email block
+                  // instead of squeezing the email into truncation.
+                  <div
+                    key={u.id}
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      background: "var(--surface-color)",
+                      border: "1px solid var(--border-color)",
+                      padding: "1.25rem",
+                      borderRadius: "8px",
+                      flexWrap: "wrap",
+                      gap: "0.75rem",
+                    }}
+                  >
+                    <div style={{ minWidth: 0, flex: "1 1 180px" }}>
+                      <h4
+                        style={{
+                          fontWeight: "600",
+                          fontSize: "1.1rem",
+                          wordBreak: "break-word",
+                        }}
+                      >
+                        {u.name || "Unknown User"}{" "}
+                        <span
+                          style={{
+                            fontSize: "0.75rem",
+                            padding: "0.2rem 0.6rem",
+                            background:
+                              u.role === "ADMIN"
+                                ? "rgba(239, 68, 68, 0.2)"
+                                : "rgba(59, 130, 246, 0.2)",
+                            color: u.role === "ADMIN" ? "#ef4444" : "#3b82f6",
+                            borderRadius: "12px",
+                            marginLeft: "0.5rem",
+                          }}
+                        >
+                          {u.role}
+                        </span>
+                      </h4>
+                      <p
+                        style={{
+                          color: "var(--text-secondary)",
+                          fontSize: "0.875rem",
+                          marginTop: "0.25rem",
+                          wordBreak: "break-all",
+                        }}
+                      >
+                        {u.email}
+                      </p>
+                    </div>
+
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "1rem",
+                      }}
+                    >
+                      <select
+                        value={u.role}
+                        onChange={(e) => handleChangeRole(u.id, e.target.value)}
+                        style={{
+                          padding: "0.5rem",
+                          borderRadius: "4px",
+                          background: "var(--input-bg)",
+                          color: "var(--text-primary)",
+                          border: "1px solid var(--border-color)",
+                        }}
+                      >
+                        <option value="USER">Standard Rep</option>
+                        <option value="MANAGER">Manager</option>
+                        <option value="ADMIN">Admin</option>
+                      </select>
+                      {u.role !== "ADMIN" ? (
+                        <button
+                          onClick={() => handleDelete(u.id)}
+                          style={{
+                            background: "transparent",
+                            border: "none",
+                            color: "var(--danger-color)",
+                            cursor: "pointer",
+                            padding: "0.5rem",
+                          }}
+                        >
+                          <Trash2 size={18} />
+                        </button>
+                      ) : (
+                        <span
+                          style={{
+                            color: "var(--text-secondary)",
+                            fontSize: "0.875rem",
+                          }}
+                        >
+                          —
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
             )}
-          </form>
+          </div>
 
-          {callifiedMsg && (
-            <p style={{
-              marginTop: '1rem',
-              fontSize: '0.85rem',
-              color: callifiedMsg.includes('✓') || callifiedMsg.includes('Connected') ? 'var(--accent-color)' : 'var(--danger-color)'
-            }}>
-              {callifiedMsg}
+          {/* Invite User Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <UserPlus size={20} color="var(--accent-color)" /> Invite Team
+              Member
+            </h3>
+            {/* #484: Invite form uses auto-fit + minmax so fields stack on
+              narrow viewports rather than truncating placeholders/values. */}
+            <form
+              onSubmit={handleCreateUser}
+              style={{
+                display: "grid",
+                gridTemplateColumns:
+                  "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+                gap: "1rem",
+              }}
+            >
+              <input
+                type="text"
+                placeholder="Full Name"
+                required
+                className="input-field"
+                style={{ minWidth: 0 }}
+                value={newUser.name}
+                onChange={(e) =>
+                  setNewUser({ ...newUser, name: e.target.value })
+                }
+              />
+              <input
+                type="email"
+                placeholder="Email Address"
+                required
+                className="input-field"
+                style={{ minWidth: 0 }}
+                value={newUser.email}
+                onChange={(e) =>
+                  setNewUser({ ...newUser, email: e.target.value })
+                }
+              />
+              <input
+                type="password"
+                placeholder="Temporary Password"
+                required
+                className="input-field"
+                style={{ minWidth: 0 }}
+                value={newUser.password}
+                onChange={(e) =>
+                  setNewUser({ ...newUser, password: e.target.value })
+                }
+              />
+              <select
+                className="input-field"
+                value={newUser.role}
+                onChange={(e) =>
+                  setNewUser({ ...newUser, role: e.target.value })
+                }
+                style={{ background: "var(--input-bg)", minWidth: 0 }}
+              >
+                <option value="USER">Standard Rep</option>
+                <option value="MANAGER">Sales Manager</option>
+                <option value="ADMIN">System Administrator</option>
+              </select>
+              <button
+                type="submit"
+                className="btn-primary"
+                style={{ gridColumn: "1 / -1" }}
+              >
+                Send Invitation & Create Account
+              </button>
+            </form>
+          </div>
+
+          {/* AdsGPT Configuration Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Key size={20} color="var(--accent-color)" /> AdsGPT Login
+            </h3>
+            <p
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "0.875rem",
+                marginBottom: "1.25rem",
+              }}
+            >
+              Enter your AdsGPT aMember username or email. Users will be
+              auto-logged in via SSO when accessing AdsGPT.
             </p>
-          )}
-        </div>
+            <div
+              style={{ display: "flex", gap: "0.75rem", marginBottom: "1rem" }}
+            >
+              <input
+                type="text"
+                className="input-field"
+                placeholder="Username or email (e.g. enhanceranchi or user@email.com)"
+                value={adsgptLogin}
+                onChange={(e) => setAdsgptLogin(e.target.value)}
+                disabled={adsgptSaving}
+                style={{ flex: 1, minWidth: 0 }}
+              />
+              <button
+                type="button"
+                className="btn-primary"
+                disabled={adsgptSaving || !adsgptLogin.trim()}
+                onClick={handleSaveAdsgptLogin}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                {adsgptSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+            {adsgptMsg && (
+              <p
+                style={{
+                  fontSize: "0.85rem",
+                  color: adsgptMsg.includes("✓")
+                    ? "var(--accent-color)"
+                    : "var(--danger-color)",
+                }}
+              >
+                {adsgptMsg}
+              </p>
+            )}
+          </div>
 
-        {/* Notification Preferences Card */}
-        <NotificationPreferencesCard notify={notify} />
-        </div>
+          {/* Callified Integration Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <PhoneCall size={20} color="var(--accent-color)" /> Callified
+              Integration
+            </h3>
 
+            {/* Status Card */}
+            {!callifiedLoading && (
+              <div
+                style={{
+                  padding: "1rem",
+                  marginBottom: "1.25rem",
+                  borderRadius: "8px",
+                  background: callifiedConnected
+                    ? "rgba(16, 185, 129, 0.1)"
+                    : "rgba(239, 68, 68, 0.1)",
+                  border: `1px solid ${callifiedConnected ? "#10b981" : "#ef4444"}`,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.75rem",
+                }}
+              >
+                {callifiedConnected ? (
+                  <>
+                    <Check size={20} color="#10b981" />
+                    <div style={{ flex: 1 }}>
+                      <p
+                        style={{
+                          fontWeight: "500",
+                          color: "#10b981",
+                          margin: 0,
+                        }}
+                      >
+                        ✓ Connected to Callified
+                      </p>
+                      {callifiedUpdatedAt && (
+                        <p
+                          style={{
+                            color: "var(--text-secondary)",
+                            fontSize: "0.75rem",
+                            margin: "0.25rem 0 0 0",
+                          }}
+                        >
+                          Connected since:{" "}
+                          {new Date(callifiedUpdatedAt).toLocaleDateString()}
+                        </p>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <X size={20} color="#ef4444" />
+                    <div style={{ flex: 1 }}>
+                      <p
+                        style={{
+                          fontWeight: "500",
+                          color: "#ef4444",
+                          margin: 0,
+                        }}
+                      >
+                        Not Connected
+                      </p>
+                      <p
+                        style={{
+                          color: "var(--text-secondary)",
+                          fontSize: "0.75rem",
+                          margin: "0.25rem 0 0 0",
+                        }}
+                      >
+                        Add your API key to get started
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+
+            <p
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "0.875rem",
+                marginBottom: "1.25rem",
+              }}
+            >
+              {callifiedConnected
+                ? "Your Callified account is connected and ready to use."
+                : "Enter your Callified API key to enable voice and WhatsApp integration."}
+            </p>
+
+            <form
+              onSubmit={handleSaveCallifiedKey}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  gap: "0.75rem",
+                  alignItems: "center",
+                }}
+              >
+                <div style={{ position: "relative", flex: 1, minWidth: 0 }}>
+                  <input
+                    type={callifiedShowKey ? "text" : "password"}
+                    className="input-field"
+                    placeholder="callified_live_..."
+                    value={callifiedApiKey}
+                    onChange={(e) => setCallifiedApiKey(e.target.value)}
+                    disabled={callifiedSaving}
+                    style={{ width: "100%", minWidth: 0, paddingRight: "40px" }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setCallifiedShowKey(!callifiedShowKey)}
+                    disabled={callifiedSaving}
+                    style={{
+                      position: "absolute",
+                      right: "0.75rem",
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      background: "transparent",
+                      border: "none",
+                      color: "var(--text-secondary)",
+                      cursor: "pointer",
+                      padding: "0.25rem",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    {callifiedShowKey ? (
+                      <EyeOff size={18} />
+                    ) : (
+                      <Eye size={18} />
+                    )}
+                  </button>
+                </div>
+                <button
+                  type="submit"
+                  className="btn-primary"
+                  disabled={callifiedSaving || !callifiedApiKey.trim()}
+                  style={{ whiteSpace: "nowrap" }}
+                >
+                  {callifiedSaving ? (
+                    <>
+                      <Loader
+                        size={16}
+                        style={{ animation: "spin 1s linear infinite" }}
+                      />{" "}
+                      {callifiedConnected ? "Updating..." : "Connecting..."}
+                    </>
+                  ) : callifiedConnected ? (
+                    "Update Key"
+                  ) : (
+                    "Connect to Callified"
+                  )}
+                </button>
+              </div>
+
+              {callifiedConnected && (
+                <button
+                  type="button"
+                  onClick={handleDisconnectCallified}
+                  disabled={callifiedSaving}
+                  style={{
+                    padding: "0.75rem 1rem",
+                    borderRadius: "6px",
+                    background: "rgba(239, 68, 68, 0.1)",
+                    color: "#ef4444",
+                    border: "1px solid #ef4444",
+                    cursor: "pointer",
+                    fontSize: "0.875rem",
+                    fontWeight: "500",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {callifiedSaving ? "Disconnecting..." : "Disconnect"}
+                </button>
+              )}
+            </form>
+
+            {callifiedMsg && (
+              <p
+                style={{
+                  marginTop: "1rem",
+                  fontSize: "0.85rem",
+                  color:
+                    callifiedMsg.includes("✓") ||
+                    callifiedMsg.includes("Connected")
+                      ? "var(--accent-color)"
+                      : "var(--danger-color)",
+                }}
+              >
+                {callifiedMsg}
+              </p>
+            )}
+          </div>
+
+          {/* Notification Preferences Card */}
+          <NotificationPreferencesCard notify={notify} />
+        </div>
       </div>
     </div>
   );
@@ -1071,29 +1998,38 @@ function ConsentTemplatesCard({ notify }) {
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
-  const [newTemplate, setNewTemplate] = useState({ key: '', label: '', body: '' });
+  const [newTemplate, setNewTemplate] = useState({
+    key: "",
+    label: "",
+    body: "",
+  });
 
   const load = () => {
-    fetchApi('/api/wellness/consent-templates')
-      .then((res) => { setTemplates(Array.isArray(res) ? res : []); setLoading(false); })
+    fetchApi("/api/wellness/consent-templates")
+      .then((res) => {
+        setTemplates(Array.isArray(res) ? res : []);
+        setLoading(false);
+      })
       .catch(() => setLoading(false));
   };
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
   const create = async (e) => {
     e.preventDefault();
     if (!newTemplate.key.trim() || !newTemplate.label.trim()) return;
     setCreating(true);
     try {
-      await fetchApi('/api/wellness/consent-templates', {
-        method: 'POST',
+      await fetchApi("/api/wellness/consent-templates", {
+        method: "POST",
         body: JSON.stringify(newTemplate),
       });
-      setNewTemplate({ key: '', label: '', body: '' });
+      setNewTemplate({ key: "", label: "", body: "" });
       load();
-      notify.success('Consent template created');
+      notify.success("Consent template created");
     } catch (err) {
-      notify.error(err?.message || 'Failed to create template');
+      notify.error(err?.message || "Failed to create template");
     } finally {
       setCreating(false);
     }
@@ -1102,65 +2038,481 @@ function ConsentTemplatesCard({ notify }) {
   const toggleActive = async (t) => {
     try {
       await fetchApi(`/api/wellness/consent-templates/${t.id}`, {
-        method: 'PUT',
+        method: "PUT",
         body: JSON.stringify({ isActive: !t.isActive }),
       });
       load();
     } catch {
-      notify.error('Failed to update template');
+      notify.error("Failed to update template");
     }
   };
 
   const remove = async (t) => {
-    if (!await notify.confirm({
-      title: 'Delete consent template?',
-      message: `"${t.label}" will be removed from the dropdown. Already-signed forms keep their original template name.`,
-      confirmText: 'Delete',
-      destructive: true,
-    })) return;
+    if (
+      !(await notify.confirm({
+        title: "Delete consent template?",
+        message: `"${t.label}" will be removed from the dropdown. Already-signed forms keep their original template name.`,
+        confirmText: "Delete",
+        destructive: true,
+      }))
+    )
+      return;
     try {
-      await fetchApi(`/api/wellness/consent-templates/${t.id}`, { method: 'DELETE' });
+      await fetchApi(`/api/wellness/consent-templates/${t.id}`, {
+        method: "DELETE",
+      });
       load();
     } catch {
-      notify.error('Failed to delete template');
+      notify.error("Failed to delete template");
     }
   };
 
   return (
-    <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }} data-testid="consent-templates-card">
-      <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <FileSignature size={20} color="var(--accent-color)" /> Consent Templates
+    <div
+      className="card"
+      style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+      data-testid="consent-templates-card"
+    >
+      <h3
+        style={{
+          fontSize: "1.25rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <FileSignature size={20} color="var(--accent-color)" /> Consent
+        Templates
       </h3>
-      <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
+      <p
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: "0.875rem",
+          marginBottom: "1.25rem",
+        }}
+      >
         Manage the consent forms shown when capturing patient signatures. Add
         procedure-specific or paediatric variants. Templates are tenant-scoped.
       </p>
-      {loading ? <p>Loading…</p> : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '1.5rem' }}>
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            marginBottom: "1.5rem",
+          }}
+        >
           {templates.length === 0 && (
-            <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>No templates yet.</p>
+            <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem" }}>
+              No templates yet.
+            </p>
           )}
           {templates.map((t) => (
-            <div key={t.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.75rem', padding: '0.75rem 1rem', background: 'var(--surface-color)', border: '1px solid var(--border-color)', borderRadius: 8, opacity: t.isActive ? 1 : 0.55 }}>
+            <div
+              key={t.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: "0.75rem",
+                padding: "0.75rem 1rem",
+                background: "var(--surface-color)",
+                border: "1px solid var(--border-color)",
+                borderRadius: 8,
+                opacity: t.isActive ? 1 : 0.55,
+              }}
+            >
               <div style={{ minWidth: 0, flex: 1 }}>
-                <div style={{ fontWeight: 500 }}>{t.label} {t.isSeed && <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', marginLeft: '0.5rem' }}>(starter)</span>}</div>
-                <div style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>key: {t.key}</div>
+                <div style={{ fontWeight: 500 }}>
+                  {t.label}{" "}
+                  {t.isSeed && (
+                    <span
+                      style={{
+                        fontSize: "0.7rem",
+                        color: "var(--text-secondary)",
+                        marginLeft: "0.5rem",
+                      }}
+                    >
+                      (starter)
+                    </span>
+                  )}
+                </div>
+                <div
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  key: {t.key}
+                </div>
               </div>
-              <button type="button" onClick={() => toggleActive(t)} style={{ background: 'transparent', border: '1px solid var(--border-color)', color: 'var(--text-secondary)', padding: '0.3rem 0.65rem', borderRadius: 6, cursor: 'pointer', fontSize: '0.75rem' }}>
-                {t.isActive ? 'Disable' : 'Enable'}
+              <button
+                type="button"
+                onClick={() => toggleActive(t)}
+                style={{
+                  background: "transparent",
+                  border: "1px solid var(--border-color)",
+                  color: "var(--text-secondary)",
+                  padding: "0.3rem 0.65rem",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: "0.75rem",
+                }}
+              >
+                {t.isActive ? "Disable" : "Enable"}
               </button>
-              <button type="button" onClick={() => remove(t)} aria-label={`Delete template ${t.label}`} style={{ background: 'transparent', border: 'none', color: 'var(--danger-color)', cursor: 'pointer', padding: '0.25rem' }}>
+              <button
+                type="button"
+                onClick={() => remove(t)}
+                aria-label={`Delete template ${t.label}`}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "var(--danger-color)",
+                  cursor: "pointer",
+                  padding: "0.25rem",
+                }}
+              >
                 <Trash2 size={16} />
               </button>
             </div>
           ))}
         </div>
       )}
-      <form onSubmit={create} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
-        <input type="text" placeholder="Key (e.g. paediatric)" required className="input-field" value={newTemplate.key} onChange={(e) => setNewTemplate({ ...newTemplate, key: e.target.value })} />
-        <input type="text" placeholder="Label (e.g. Paediatric Consent)" required className="input-field" value={newTemplate.label} onChange={(e) => setNewTemplate({ ...newTemplate, label: e.target.value })} />
-        <button type="submit" className="btn-primary" disabled={creating} style={{ gridColumn: '1 / -1', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}>
-          <Plus size={16} /> {creating ? 'Adding…' : 'Add Template'}
+      <form
+        onSubmit={create}
+        style={{
+          display: "grid",
+          gridTemplateColumns:
+            "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+          gap: "0.75rem",
+        }}
+      >
+        <input
+          type="text"
+          placeholder="Key (e.g. paediatric)"
+          required
+          className="input-field"
+          value={newTemplate.key}
+          onChange={(e) =>
+            setNewTemplate({ ...newTemplate, key: e.target.value })
+          }
+        />
+        <input
+          type="text"
+          placeholder="Label (e.g. Paediatric Consent)"
+          required
+          className="input-field"
+          value={newTemplate.label}
+          onChange={(e) =>
+            setNewTemplate({ ...newTemplate, label: e.target.value })
+          }
+        />
+        <button
+          type="submit"
+          className="btn-primary"
+          disabled={creating}
+          style={{
+            gridColumn: "1 / -1",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <Plus size={16} /> {creating ? "Adding…" : "Add Template"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+// Option B: per-tenant wellness role catalog. Admins add roles like
+// "nurse" or "physiotherapist" here; the Calendar grid + Staff edit form
+// read from this catalog so a new role surfaces immediately without a
+// code change. canTakeVisits controls whether the role appears as a
+// column on the Calendar (doctors/nurses yes, telecallers/helpers no).
+function WellnessRoleTypesCard({ notify }) {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [newRow, setNewRow] = useState({
+    key: "",
+    label: "",
+    canTakeVisits: true,
+  });
+
+  const load = () => {
+    fetchApi("/api/wellness/role-types")
+      .then((res) => {
+        setRows(Array.isArray(res) ? res : []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  };
+  useEffect(() => {
+    load();
+  }, []);
+
+  const create = async (e) => {
+    e.preventDefault();
+    const key = newRow.key.trim();
+    const label = newRow.label.trim();
+    if (!key || !label) return;
+    setCreating(true);
+    try {
+      await fetchApi("/api/wellness/role-types", {
+        method: "POST",
+        body: JSON.stringify({
+          key,
+          label,
+          canTakeVisits: newRow.canTakeVisits,
+        }),
+      });
+      setNewRow({ key: "", label: "", canTakeVisits: true });
+      load();
+      notify.success(`Role "${label}" added`);
+    } catch (err) {
+      notify.error(err?.message || "Failed to add role");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const toggleActive = async (r) => {
+    try {
+      await fetchApi(`/api/wellness/role-types/${r.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ isActive: !r.isActive }),
+      });
+      load();
+    } catch {
+      notify.error("Failed to update role");
+    }
+  };
+
+  const toggleCanTakeVisits = async (r) => {
+    try {
+      await fetchApi(`/api/wellness/role-types/${r.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ canTakeVisits: !r.canTakeVisits }),
+      });
+      load();
+    } catch {
+      notify.error("Failed to update role");
+    }
+  };
+
+  const remove = async (r) => {
+    if (
+      !(await notify.confirm({
+        title: "Delete role?",
+        message: `"${r.label}" will be removed from the catalog. Staff currently assigned to this role will block the delete.`,
+        confirmText: "Delete",
+        destructive: true,
+      }))
+    )
+      return;
+    try {
+      await fetchApi(`/api/wellness/role-types/${r.id}`, { method: "DELETE" });
+      load();
+    } catch (err) {
+      // Backend returns 409 ROLE_IN_USE with an "in use by N staff" message
+      // when applicable — surface that directly so the admin knows what to
+      // do next (reassign or deactivate instead).
+      notify.error(err?.message || "Failed to delete role");
+    }
+  };
+
+  return (
+    <div
+      className="card"
+      style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+      data-testid="wellness-role-types-card"
+    >
+      <h3
+        style={{
+          fontSize: "1.25rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <Stethoscope size={20} color="var(--accent-color)" /> Wellness Role
+        Types
+      </h3>
+      <p
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: "0.875rem",
+          marginBottom: "1.25rem",
+        }}
+      >
+        Define the staff roles available in your clinic (doctor, nurse,
+        telecaller, etc.). Roles with <strong>Takes visits</strong> appear as
+        columns on the Calendar grid.
+      </p>
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          {rows.length === 0 && (
+            <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem" }}>
+              No roles yet.
+            </p>
+          )}
+          {rows.map((r) => (
+            <div
+              key={r.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: "0.75rem",
+                padding: "0.75rem 1rem",
+                background: "var(--surface-color)",
+                border: "1px solid var(--border-color)",
+                borderRadius: 8,
+                opacity: r.isActive ? 1 : 0.55,
+              }}
+            >
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontWeight: 500 }}>{r.label}</div>
+                <div
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  key: {r.key}
+                  {r.canTakeVisits
+                    ? " · takes visits"
+                    : " · operational (no calendar column)"}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => toggleCanTakeVisits(r)}
+                style={{
+                  background: "transparent",
+                  border: "1px solid var(--border-color)",
+                  color: "var(--text-secondary)",
+                  padding: "0.3rem 0.65rem",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: "0.75rem",
+                }}
+              >
+                {r.canTakeVisits ? "Hide from calendar" : "Show on calendar"}
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleActive(r)}
+                style={{
+                  background: "transparent",
+                  border: "1px solid var(--border-color)",
+                  color: "var(--text-secondary)",
+                  padding: "0.3rem 0.65rem",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: "0.75rem",
+                }}
+              >
+                {r.isActive ? "Deactivate" : "Activate"}
+              </button>
+              <button
+                type="button"
+                onClick={() => remove(r)}
+                aria-label={`Delete role ${r.label}`}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "var(--danger-color)",
+                  cursor: "pointer",
+                  padding: "0.25rem",
+                }}
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <form
+        onSubmit={create}
+        style={{
+          display: "grid",
+          gridTemplateColumns:
+            "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+          gap: "0.75rem",
+          alignItems: "center",
+        }}
+      >
+        <input
+          type="text"
+          placeholder="Key (e.g. nurse)"
+          required
+          pattern="^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+          title="Lowercase letters, digits, hyphens. Must start with a letter."
+          className="input-field"
+          value={newRow.key}
+          onChange={(e) => setNewRow({ ...newRow, key: e.target.value })}
+        />
+        <input
+          type="text"
+          placeholder="Label (e.g. Nurse)"
+          required
+          className="input-field"
+          value={newRow.label}
+          onChange={(e) => setNewRow({ ...newRow, label: e.target.value })}
+        />
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            fontSize: "0.85rem",
+            color: "var(--text-primary)",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={newRow.canTakeVisits}
+            onChange={(e) =>
+              setNewRow({ ...newRow, canTakeVisits: e.target.checked })
+            }
+          />
+          Takes visits
+        </label>
+        <button
+          type="submit"
+          className="btn-primary"
+          disabled={creating}
+          style={{
+            gridColumn: "1 / -1",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <Plus size={16} /> {creating ? "Adding…" : "Add Role"}
         </button>
       </form>
     </div>
@@ -1175,42 +2527,55 @@ function NotificationPreferencesCard({ notify }) {
 
   // Category and channel options
   const categoryOptions = [
-    { key: 'deal', label: 'Deals & Opportunities' },
-    { key: 'task', label: 'Tasks' },
-    { key: 'ticket', label: 'Support Tickets' },
-    { key: 'lead', label: 'Leads' },
-    { key: 'approval', label: 'Approvals' },
-    { key: 'leave', label: 'Leave Requests' },
-    { key: 'expense', label: 'Expense Reports' },
+    { key: "deal", label: "Deals & Opportunities" },
+    { key: "task", label: "Tasks" },
+    { key: "ticket", label: "Support Tickets" },
+    { key: "lead", label: "Leads" },
+    { key: "approval", label: "Approvals" },
+    { key: "leave", label: "Leave Requests" },
+    { key: "expense", label: "Expense Reports" },
   ];
 
   const channelOptions = [
-    { key: 'db', label: 'In-App Bell' },
-    { key: 'socket', label: 'Real-Time Updates' },
-    { key: 'push', label: 'Browser Push' },
-    { key: 'email', label: 'Email' },
+    { key: "db", label: "In-App Bell" },
+    { key: "socket", label: "Real-Time Updates" },
+    { key: "push", label: "Browser Push" },
+    { key: "email", label: "Email" },
   ];
 
   // Timezone list
   const timezones = [
-    'UTC', 'Asia/Kolkata', 'Asia/Dubai', 'Asia/Bangkok', 'Asia/Singapore', 'Asia/Hong_Kong',
-    'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
-    'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Australia/Sydney'
+    "UTC",
+    "Asia/Kolkata",
+    "Asia/Dubai",
+    "Asia/Bangkok",
+    "Asia/Singapore",
+    "Asia/Hong_Kong",
+    "America/New_York",
+    "America/Chicago",
+    "America/Denver",
+    "America/Los_Angeles",
+    "Europe/London",
+    "Europe/Paris",
+    "Europe/Berlin",
+    "Australia/Sydney",
   ];
 
   const load = async () => {
     try {
-      const data = await fetchApi('/api/notifications/preferences');
+      const data = await fetchApi("/api/notifications/preferences");
       setPrefs(data);
     } catch (err) {
-      console.error('Failed to load preferences:', err);
-      notify.error('Failed to load notification preferences');
+      console.error("Failed to load preferences:", err);
+      notify.error("Failed to load notification preferences");
     } finally {
       setLoading(false);
     }
   };
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
   const handleCategoryToggle = (category) => {
     setPrefs({
@@ -1235,33 +2600,41 @@ function NotificationPreferencesCard({ notify }) {
   const handleSave = async () => {
     setSaving(true);
     try {
-      await fetchApi('/api/notifications/preferences', {
-        method: 'PUT',
+      await fetchApi("/api/notifications/preferences", {
+        method: "PUT",
         body: JSON.stringify(prefs),
       });
-      notify.success('Notification preferences saved');
+      notify.success("Notification preferences saved");
     } catch (err) {
-      notify.error('Failed to save notification preferences');
+      notify.error("Failed to save notification preferences");
     } finally {
       setSaving(false);
     }
   };
 
   const handleReset = async () => {
-    if (!await notify.confirm('Reset notification preferences to defaults?')) return;
+    if (!(await notify.confirm("Reset notification preferences to defaults?")))
+      return;
     setSaving(true);
     try {
-      await fetchApi('/api/notifications/preferences/reset', { method: 'POST' });
+      await fetchApi("/api/notifications/preferences/reset", {
+        method: "POST",
+      });
       load();
-      notify.success('Preferences reset to defaults');
+      notify.success("Preferences reset to defaults");
     } catch (err) {
-      notify.error('Failed to reset preferences');
+      notify.error("Failed to reset preferences");
     } finally {
       setSaving(false);
     }
   };
 
-  if (loading) return <div className="card" style={{ padding: '1.5rem' }}>Loading preferences…</div>;
+  if (loading)
+    return (
+      <div className="card" style={{ padding: "1.5rem" }}>
+        Loading preferences…
+      </div>
+    );
   // Defensive: existing Settings tests mock fetchApi to return `{}` or
   // `[]` for unrecognised URLs (most existing settings cards don't read
   // categoryToggles/channels). Without this guard, the render below
@@ -1272,102 +2645,256 @@ function NotificationPreferencesCard({ notify }) {
   if (!prefs || !prefs.categoryToggles || !prefs.channels) return null;
 
   return (
-    <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
-      <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+    <div className="card" style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}>
+      <h3
+        style={{
+          fontSize: "1.25rem",
+          fontWeight: "600",
+          marginBottom: "1.5rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
         <Bell size={20} color="var(--accent-color)" /> Notification Preferences
       </h3>
 
-      <div style={{ marginBottom: '2rem' }}>
-        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Notification Categories</h4>
-        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Choose which types of notifications you want to receive.</p>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
-          {categoryOptions.map(cat => (
-            <label key={cat.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+      <div style={{ marginBottom: "2rem" }}>
+        <h4
+          style={{
+            fontSize: "0.95rem",
+            fontWeight: "600",
+            marginBottom: "1rem",
+            color: "var(--text-primary)",
+          }}
+        >
+          Notification Categories
+        </h4>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "0.85rem",
+            marginBottom: "1rem",
+          }}
+        >
+          Choose which types of notifications you want to receive.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+            gap: "0.75rem",
+          }}
+        >
+          {categoryOptions.map((cat) => (
+            <label
+              key={cat.key}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                cursor: "pointer",
+                padding: "0.5rem",
+                borderRadius: 6,
+                background: "var(--surface-color)",
+                border: "1px solid var(--border-color)",
+              }}
+            >
               <input
                 type="checkbox"
                 checked={prefs.categoryToggles[cat.key] !== false}
                 onChange={() => handleCategoryToggle(cat.key)}
-                style={{ cursor: 'pointer' }}
+                style={{ cursor: "pointer" }}
               />
-              <span style={{ fontSize: '0.9rem' }}>{cat.label}</span>
+              <span style={{ fontSize: "0.9rem" }}>{cat.label}</span>
             </label>
           ))}
         </div>
       </div>
 
-      <div style={{ marginBottom: '2rem' }}>
-        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Delivery Channels</h4>
-        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Select how you want to receive notifications.</p>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))', gap: '0.75rem' }}>
-          {channelOptions.map(ch => (
-            <label key={ch.key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', padding: '0.5rem', borderRadius: 6, background: 'var(--surface-color)', border: '1px solid var(--border-color)' }}>
+      <div style={{ marginBottom: "2rem" }}>
+        <h4
+          style={{
+            fontSize: "0.95rem",
+            fontWeight: "600",
+            marginBottom: "1rem",
+            color: "var(--text-primary)",
+          }}
+        >
+          Delivery Channels
+        </h4>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "0.85rem",
+            marginBottom: "1rem",
+          }}
+        >
+          Select how you want to receive notifications.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+            gap: "0.75rem",
+          }}
+        >
+          {channelOptions.map((ch) => (
+            <label
+              key={ch.key}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                cursor: "pointer",
+                padding: "0.5rem",
+                borderRadius: 6,
+                background: "var(--surface-color)",
+                border: "1px solid var(--border-color)",
+              }}
+            >
               <input
                 type="checkbox"
                 checked={prefs.channels[ch.key] !== false}
                 onChange={() => handleChannelToggle(ch.key)}
-                style={{ cursor: 'pointer' }}
+                style={{ cursor: "pointer" }}
               />
-              <span style={{ fontSize: '0.9rem' }}>{ch.label}</span>
+              <span style={{ fontSize: "0.9rem" }}>{ch.label}</span>
             </label>
           ))}
         </div>
       </div>
 
-      <div style={{ marginBottom: '2rem' }}>
-        <h4 style={{ fontSize: '0.95rem', fontWeight: '600', marginBottom: '1rem', color: 'var(--text-primary)' }}>Quiet Hours</h4>
-        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>Suppress notifications during these times in your timezone.</p>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 150px), 1fr))', gap: '1rem' }}>
+      <div style={{ marginBottom: "2rem" }}>
+        <h4
+          style={{
+            fontSize: "0.95rem",
+            fontWeight: "600",
+            marginBottom: "1rem",
+            color: "var(--text-primary)",
+          }}
+        >
+          Quiet Hours
+        </h4>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "0.85rem",
+            marginBottom: "1rem",
+          }}
+        >
+          Suppress notifications during these times in your timezone.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(min(100%, 150px), 1fr))",
+            gap: "1rem",
+          }}
+        >
           <div style={{ minWidth: 0 }}>
-            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Timezone</label>
+            <label
+              style={{
+                display: "block",
+                marginBottom: "0.4rem",
+                fontSize: "0.875rem",
+                color: "var(--text-secondary)",
+              }}
+            >
+              Timezone
+            </label>
             <select
               className="input-field"
-              value={prefs.timezone || ''}
-              onChange={(e) => setPrefs({ ...prefs, timezone: e.target.value || null })}
-              style={{ background: 'var(--input-bg)', minWidth: 0 }}
+              value={prefs.timezone || ""}
+              onChange={(e) =>
+                setPrefs({ ...prefs, timezone: e.target.value || null })
+              }
+              style={{ background: "var(--input-bg)", minWidth: 0 }}
             >
               <option value="">—</option>
-              {timezones.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+              {timezones.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tz}
+                </option>
+              ))}
             </select>
           </div>
           <div style={{ minWidth: 0 }}>
-            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Start Time (HH:MM)</label>
+            <label
+              style={{
+                display: "block",
+                marginBottom: "0.4rem",
+                fontSize: "0.875rem",
+                color: "var(--text-secondary)",
+              }}
+            >
+              Start Time (HH:MM)
+            </label>
             <input
               type="time"
               className="input-field"
-              value={prefs.quietHoursStart || ''}
-              onChange={(e) => setPrefs({ ...prefs, quietHoursStart: e.target.value || null })}
+              value={prefs.quietHoursStart || ""}
+              onChange={(e) =>
+                setPrefs({ ...prefs, quietHoursStart: e.target.value || null })
+              }
               style={{ minWidth: 0 }}
             />
           </div>
           <div style={{ minWidth: 0 }}>
-            <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>End Time (HH:MM)</label>
+            <label
+              style={{
+                display: "block",
+                marginBottom: "0.4rem",
+                fontSize: "0.875rem",
+                color: "var(--text-secondary)",
+              }}
+            >
+              End Time (HH:MM)
+            </label>
             <input
               type="time"
               className="input-field"
-              value={prefs.quietHoursEnd || ''}
-              onChange={(e) => setPrefs({ ...prefs, quietHoursEnd: e.target.value || null })}
+              value={prefs.quietHoursEnd || ""}
+              onChange={(e) =>
+                setPrefs({ ...prefs, quietHoursEnd: e.target.value || null })
+              }
               style={{ minWidth: 0 }}
             />
           </div>
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+      <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
         <button
           type="button"
           className="btn-primary"
           onClick={handleSave}
           disabled={saving}
-          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+            whiteSpace: "nowrap",
+          }}
         >
-          {saving ? 'Saving…' : 'Save Preferences'}
+          {saving ? "Saving…" : "Save Preferences"}
         </button>
         <button
           type="button"
           className="btn-secondary"
           onClick={handleReset}
           disabled={saving}
-          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', whiteSpace: 'nowrap' }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+            whiteSpace: "nowrap",
+          }}
         >
           Reset to Defaults
         </button>

--- a/frontend/src/pages/Staff.jsx
+++ b/frontend/src/pages/Staff.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
-import { UsersRound, Trash2, Shield, ShieldCheck, Edit3, UserX, UserCheck, Key, MailPlus, X, UserPlus } from 'lucide-react';
+import { UsersRound, Trash2, Shield, ShieldCheck, Edit3, UserX, UserCheck, Key, MailPlus, X, UserPlus, Search, Filter as FilterIcon } from 'lucide-react';
 import { AuthContext } from '../App';
 import { usePermissions } from '../hooks/usePermissions';
 import { formatDate } from '../utils/date';
@@ -77,8 +77,9 @@ export default function Staff() {
   // so the click would 403, but the UI shouldn't dangle the button at
   // all. Hide both the Delete control and the inline RBAC role select
   // unless the viewer is an actual ADMIN.
-  const { user } = useContext(AuthContext) || {};
+  const { user, tenant } = useContext(AuthContext) || {};
   const canManageStaff = user?.role === 'ADMIN';
+  const isWellness = tenant?.vertical === 'wellness';
   // #618 + RBAC: the Permissions button is gated on the granular roles.read
   // permission (not the legacy ADMIN role), so a custom non-ADMIN role with
   // roles.read granted can still view permission sheets. Falls through to
@@ -89,6 +90,17 @@ export default function Staff() {
   const [staff, setStaff] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState(null);
+  // Free-text search across name + email. Trimmed + lower-cased at match time.
+  const [searchQuery, setSearchQuery] = useState('');
+  // 'all' | 'active' | 'inactive'. Deactivated staff are visible by default in
+  // the table (with the Inactive badge), so the default here stays 'all'.
+  const [statusFilter, setStatusFilter] = useState('all');
+  // Wellness vertical only. '' = no filter; otherwise filters by wellnessRole key.
+  const [wellnessRoleFilter, setWellnessRoleFilter] = useState('');
+  // Filter dropdown open state + click-outside ref so the panel closes when
+  // the user clicks elsewhere on the page.
+  const [filterOpen, setFilterOpen] = useState(false);
+  const filterPanelRef = useRef(null);
   // #618 — edit-modal state. null when closed; { id, name, email, role,
   // wellnessRole } when an admin clicked Edit on a row.
   const [editing, setEditing] = useState(null);
@@ -106,13 +118,25 @@ export default function Staff() {
   // any custom role (Doctor / Nurse / Receptionist / Telecaller / …)
   // without going through a separate Roles & Permissions step.
   const [availableRoles, setAvailableRoles] = useState([]);
+  // Per-tenant wellness role catalog (doctor / professional / nurse / …
+  // plus any custom rows the admin added via Settings → Wellness Role
+  // Types). Populates the "Wellness role" dropdown in both modals so
+  // POST /api/staff doesn't reject a hardcoded value that isn't in the
+  // tenant's catalog (the cause of the "Unknown wellness role for this
+  // tenant" toast on freshly-signed-up wellness tenants).
+  const [wellnessRoleTypes, setWellnessRoleTypes] = useState([]);
   // Staff availability tracking
   const [availDate, setAvailDate] = useState(new Date());
   const [availability, setAvailability] = useState([]);
   const [availLoading, setAvailLoading] = useState(false);
   const [showAvailability, setShowAvailability] = useState(false);
 
-  useEffect(() => { loadStaff(); loadCommissionProfiles(); loadAvailableRoles(); }, []);
+  useEffect(() => {
+    loadStaff();
+    loadCommissionProfiles();
+    loadAvailableRoles();
+    if (isWellness) loadWellnessRoleTypes();
+  }, [isWellness]);
 
   // Load availability when date changes or showAvailability is toggled
   useEffect(() => {
@@ -120,6 +144,18 @@ export default function Staff() {
       loadAvailability();
     }
   }, [availDate, showAvailability]);
+
+  // Close the filter dropdown when the user clicks anywhere outside it.
+  useEffect(() => {
+    if (!filterOpen) return undefined;
+    const onDocClick = (e) => {
+      if (filterPanelRef.current && !filterPanelRef.current.contains(e.target)) {
+        setFilterOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [filterOpen]);
 
   const loadCommissionProfiles = async () => {
     if (!canManageStaff) return;
@@ -156,6 +192,23 @@ export default function Staff() {
     } catch {
       // Non-fatal — the dropdown just hides if the catalog can't be loaded.
       setAvailableRoles([]);
+    }
+  };
+
+  // Wellness-vertical only. The backend GET endpoint auto-seeds the
+  // default catalog (doctor / professional / nurse / stylist / telecaller
+  // / helper) the first time a wellness tenant hits it with an empty
+  // table, so a freshly-signed-up tenant gets sensible defaults without
+  // any admin setup.
+  const loadWellnessRoleTypes = async () => {
+    try {
+      const data = await fetchApi('/api/wellness/role-types?activeOnly=1');
+      setWellnessRoleTypes(Array.isArray(data) ? data : []);
+    } catch {
+      // Non-fatal — the dropdown collapses to "— None —" if the catalog
+      // can't be loaded, and the admin can still pick a non-wellness
+      // role for the user.
+      setWellnessRoleTypes([]);
     }
   };
 
@@ -384,7 +437,34 @@ export default function Staff() {
   const managerCount = staff.filter(s => s.role === 'MANAGER').length;
   const userCount = staff.filter(s => s.role === 'USER').length;
 
-  const filteredStaff = filter ? staff.filter(s => s.role === filter) : staff;
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredStaff = staff.filter((s) => {
+    if (filter && s.role !== filter) return false;
+    if (statusFilter === 'active' && s.deactivatedAt) return false;
+    if (statusFilter === 'inactive' && !s.deactivatedAt) return false;
+    if (wellnessRoleFilter && s.wellnessRole !== wellnessRoleFilter) return false;
+    if (normalizedQuery) {
+      const name = (s.name || '').toLowerCase();
+      const email = (s.email || '').toLowerCase();
+      if (!name.includes(normalizedQuery) && !email.includes(normalizedQuery)) return false;
+    }
+    return true;
+  });
+  // Counts ONLY the filters that live inside the dropdown panel — drives the
+  // numeric badge on the Filter button. Search lives outside the dropdown and
+  // role-pill filter lives in the stats bar above, so they're surfaced visibly
+  // elsewhere already.
+  const activeFilterCount = (
+    (statusFilter !== 'all' ? 1 : 0)
+    + (wellnessRoleFilter ? 1 : 0)
+  );
+  const hasActiveFilters = Boolean(filter) || activeFilterCount > 0 || Boolean(normalizedQuery);
+  const clearFilters = () => {
+    setSearchQuery('');
+    setFilter(null);
+    setStatusFilter('all');
+    setWellnessRoleFilter('');
+  };
 
   return (
     <div style={{ padding: '2rem', height: '100%', overflowY: 'auto', animation: 'fadeIn 0.5s ease-out' }}>
@@ -594,9 +674,165 @@ export default function Staff() {
 
       {/* Staff Table */}
       <div className="card" style={{ padding: '2rem', overflow: 'auto' }}>
-        <h3 style={{ fontSize: '1.15rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <UsersRound size={20} color="var(--accent-color)" /> Team Members
-        </h3>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', marginBottom: '1.25rem', flexWrap: 'wrap' }}>
+          <h3 style={{ fontSize: '1.15rem', fontWeight: '600', margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <UsersRound size={20} color="var(--accent-color)" /> Team Members
+          </h3>
+          {staff.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+              {/* Inline search — name + email, case-insensitive substring match. */}
+              <div style={{ position: 'relative', width: 260 }}>
+                <Search
+                  size={14}
+                  style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-secondary)', pointerEvents: 'none' }}
+                />
+                <input
+                  type="search"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search by name or email…"
+                  aria-label="Search staff by name or email"
+                  data-testid="staff-search-input"
+                  className="input-field"
+                  style={{ width: '100%', padding: '0.45rem 0.6rem 0.45rem 2rem', fontSize: '0.85rem' }}
+                />
+              </div>
+              <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                Showing {filteredStaff.length} of {staff.length}
+              </span>
+              {/* Filter button + popover. Click toggles; click-outside closes.
+                  Badge surfaces the count of active in-panel filters so the
+                  user can see at a glance that the dropdown is narrowing the
+                  table beyond the inline search. */}
+              <div ref={filterPanelRef} style={{ position: 'relative' }}>
+                <button
+                  type="button"
+                  onClick={() => setFilterOpen((v) => !v)}
+                  aria-haspopup="true"
+                  aria-expanded={filterOpen}
+                  data-testid="staff-filter-button"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: '0.4rem',
+                    padding: '0.45rem 0.85rem', borderRadius: '6px',
+                    background: filterOpen || activeFilterCount > 0
+                      ? 'rgba(38,88,85,0.12)'
+                      : 'var(--subtle-bg-3)',
+                    color: activeFilterCount > 0
+                      ? 'var(--primary-color, var(--accent-color))'
+                      : 'var(--text-primary)',
+                    border: `1px solid ${activeFilterCount > 0
+                      ? 'var(--primary-color, var(--accent-color))'
+                      : 'var(--border-color)'}`,
+                    cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500,
+                  }}
+                >
+                  <FilterIcon size={14} /> Filter
+                  {activeFilterCount > 0 && (
+                    <span
+                      data-testid="staff-filter-badge"
+                      style={{
+                        background: 'var(--primary-color, var(--accent-color))',
+                        color: '#fff', borderRadius: '999px',
+                        padding: '0 0.4rem', fontSize: '0.7rem',
+                        fontWeight: 700, lineHeight: '1.25rem',
+                        minWidth: '1.25rem', textAlign: 'center',
+                      }}
+                    >
+                      {activeFilterCount}
+                    </span>
+                  )}
+                </button>
+                {filterOpen && (
+                  <div
+                    data-testid="staff-filter-panel"
+                    style={{
+                      position: 'absolute', top: 'calc(100% + 0.4rem)', right: 0,
+                      width: 300, zIndex: 50,
+                      // Solid page background + subtle blur so the panel doesn't
+                      // bleed table content through. --bg-color is the only
+                      // fully-opaque token in the theme; --subtle-bg-* are all
+                      // semi-transparent and were causing the readability bug.
+                      background: 'var(--bg-color)',
+                      backdropFilter: 'blur(8px)',
+                      WebkitBackdropFilter: 'blur(8px)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '8px',
+                      boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+                      padding: '1rem',
+                      display: 'flex', flexDirection: 'column', gap: '0.85rem',
+                    }}
+                  >
+                    <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', fontWeight: 600 }}>
+                      Status
+                      <select
+                        value={statusFilter}
+                        onChange={(e) => setStatusFilter(e.target.value)}
+                        aria-label="Filter by status"
+                        data-testid="staff-status-filter"
+                        className="input-field"
+                        style={{ width: '100%', padding: '0.4rem 0.6rem', fontSize: '0.85rem', marginTop: '0.3rem' }}
+                      >
+                        <option value="all">All statuses</option>
+                        <option value="active">Active only</option>
+                        <option value="inactive">Inactive only</option>
+                      </select>
+                    </label>
+                    {isWellness && wellnessRoleTypes.length > 0 && (
+                      <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', fontWeight: 600 }}>
+                        Wellness role
+                        <select
+                          value={wellnessRoleFilter}
+                          onChange={(e) => setWellnessRoleFilter(e.target.value)}
+                          aria-label="Filter by wellness role"
+                          data-testid="staff-wellness-role-filter"
+                          className="input-field"
+                          style={{ width: '100%', padding: '0.4rem 0.6rem', fontSize: '0.85rem', marginTop: '0.3rem' }}
+                        >
+                          <option value="">All wellness roles</option>
+                          {wellnessRoleTypes.map((r) => (
+                            <option key={r.id} value={r.key}>{r.label}</option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', borderTop: '1px solid var(--border-color)', paddingTop: '0.75rem' }}>
+                      <button
+                        type="button"
+                        onClick={clearFilters}
+                        disabled={!hasActiveFilters}
+                        data-testid="staff-clear-filters"
+                        style={{
+                          display: 'inline-flex', alignItems: 'center', gap: '0.3rem',
+                          padding: '0.35rem 0.7rem', borderRadius: '6px',
+                          background: 'transparent', color: 'var(--text-secondary)',
+                          border: '1px solid var(--border-color)',
+                          cursor: hasActiveFilters ? 'pointer' : 'not-allowed',
+                          opacity: hasActiveFilters ? 1 : 0.5,
+                          fontSize: '0.8rem',
+                        }}
+                      >
+                        <X size={12} /> Clear all
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setFilterOpen(false)}
+                        style={{
+                          padding: '0.35rem 0.8rem', borderRadius: '6px',
+                          background: 'var(--primary-color, var(--accent-color))',
+                          color: '#fff',
+                          border: '1px solid var(--primary-color, var(--accent-color))',
+                          cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600,
+                        }}
+                      >
+                        Done
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
 
         {loading ? (
           <p style={{ color: 'var(--text-secondary)', textAlign: 'center', padding: '2rem' }}>Loading...</p>
@@ -606,7 +842,7 @@ export default function Staff() {
           </p>
         ) : filteredStaff.length === 0 ? (
           <p style={{ color: 'var(--text-secondary)', textAlign: 'center', padding: '2rem' }}>
-            No staff members with that role.
+            No staff members match the current search or filters.
           </p>
         ) : (
           <div style={{ overflowX: 'auto' }}>
@@ -883,11 +1119,9 @@ export default function Staff() {
                   style={{ width: '100%', marginTop: '0.25rem' }}
                 >
                   <option value="">— None —</option>
-                  <option value="doctor">Doctor</option>
-                  <option value="professional">Professional</option>
-                  <option value="telecaller">Telecaller</option>
-                  <option value="helper">Helper</option>
-                  <option value="stylist">Stylist</option>
+                  {wellnessRoleTypes.map((r) => (
+                    <option key={r.id} value={r.key}>{r.label}</option>
+                  ))}
                 </select>
               </label>
             </div>
@@ -1006,11 +1240,21 @@ export default function Staff() {
                   style={{ width: '100%', marginTop: '0.25rem' }}
                 >
                   <option value="">— None —</option>
-                  <option value="doctor">Doctor</option>
-                  <option value="professional">Professional</option>
-                  <option value="telecaller">Telecaller</option>
-                  <option value="helper">Helper</option>
-                  <option value="stylist">Stylist</option>
+                  {/* If the staff member currently holds a wellnessRole
+                      that's NOT in the active catalog (deactivated /
+                      deleted by an admin after assignment), surface it
+                      as a disabled placeholder option so the dropdown
+                      still reflects the saved value instead of silently
+                      showing "— None —". */}
+                  {editing.wellnessRole &&
+                   !wellnessRoleTypes.some((r) => r.key === editing.wellnessRole) && (
+                    <option value={editing.wellnessRole} disabled>
+                      {editing.wellnessRole} (no longer in catalog)
+                    </option>
+                  )}
+                  {wellnessRoleTypes.map((r) => (
+                    <option key={r.id} value={r.key}>{r.label}</option>
+                  ))}
                 </select>
               </label>
               {/* PRD Gap §1.5 — assign a commission profile. Empty = no profile. */}

--- a/frontend/src/pages/wellness/AutoConsumptionRules.jsx
+++ b/frontend/src/pages/wellness/AutoConsumptionRules.jsx
@@ -75,7 +75,14 @@ export default function AutoConsumptionRules() {
   };
 
   const remove = async (r) => {
-    if (!window.confirm('Delete this auto-consumption rule? Future visits will no longer auto-decrement stock for this service+product.')) return;
+    const ok = await notify.confirm({
+      title: 'Delete auto-consumption rule',
+      message:
+        'Delete this auto-consumption rule? Future visits will no longer auto-decrement stock for this service+product.',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/auto-consumption-rules/${r.id}`, { method: 'DELETE' });
       notify.success('Rule deleted.');

--- a/frontend/src/pages/wellness/Calendar.jsx
+++ b/frontend/src/pages/wellness/Calendar.jsx
@@ -31,13 +31,32 @@ const STATUS_BORDER = {
   'no-show': '#ef4444', cancelled: '#64748b',
 };
 
-// #262: practitioners who can be assigned to visits include both doctors
-// and professionals (salon stylists, aestheticians, slimming therapists,
-// Ayurveda practitioners — see PRD §1). Pre-fix the calendar filter only
-// kept wellnessRole === 'doctor', so 12 professionals had no column even
-// though they had visits booked, and the receptionist couldn't see their
-// availability from the grid.
-const PRACTITIONER_ROLES = new Set(['doctor', 'professional']);
+// #262 / Option B: practitioner roles are now sourced from the per-tenant
+// WellnessRoleType catalog (admins maintain the list from Settings →
+// Wellness Role Types). The hard-coded fallback below is used when the
+// catalog hasn't been fetched yet (or the API errors out) — it matches
+// the original whitelist so behaviour is unchanged in the degenerate case.
+// The catalog gives roles a canTakeVisits flag + label; the role dropdown
+// reads from the live list.
+const FALLBACK_PRACTITIONER_KEYS = new Set(['doctor', 'professional']);
+const ALL_ROLES_KEY = '__all__';
+
+// Bridge between the two parallel role systems in this codebase:
+//   1. User.wellnessRole         — lowercase string, edited from Staff page
+//   2. UserRole → Role.key       — uppercase RBAC role assigned from
+//                                  Settings → Roles & Permissions (returned
+//                                  by /api/staff as `primaryRole.key`).
+// A user is treated as belonging to a wellness role if EITHER is set;
+// wellnessRole wins when both are present so explicit assignments aren't
+// overridden by a coincidentally-named RBAC role. The lowercase
+// normalisation lets RBAC "NURSE" match catalog "nurse" without forcing
+// admins to maintain both lists separately.
+function effectiveWellnessRole(u) {
+  if (u?.wellnessRole) return u.wellnessRole;
+  const rbacKey = u?.primaryRole?.key;
+  if (rbacKey && typeof rbacKey === 'string') return rbacKey.toLowerCase();
+  return null;
+}
 
 // Wave 7D — PRD Gap §11 item 4 — booking-type meta. Mirrors
 // PublicBooking.jsx so the calendar's per-event badge + legend uses the
@@ -106,6 +125,15 @@ export default function CalendarGrid() {
   // Wave 11 Agent GG: resource list (for the New Visit modal) + same-day holidays banner.
   const [resources, setResources] = useState([]);
   const [holidays, setHolidays] = useState([]);
+  // Option B: per-tenant role catalog. Drives the role-filter dropdown
+  // + the practitioner column set. Empty array until the first fetch
+  // resolves — see fallback logic in `practitionerKeys` below.
+  const [roleTypes, setRoleTypes] = useState([]);
+  // Selected role from the dropdown. ALL_ROLES_KEY shows every staff
+  // member whose role has canTakeVisits=true. A specific key narrows to
+  // that role only — useful when a clinic wants to see just nurses or
+  // just stylists.
+  const [selectedRoleKey, setSelectedRoleKey] = useState(ALL_ROLES_KEY);
   const [loading, setLoading] = useState(true);
   const [showAll, setShowAll] = useState(true);
   // #270: empty-slot click opens a "New visit" modal seeded with the chosen
@@ -138,7 +166,7 @@ export default function CalendarGrid() {
       // calendar appeared empty even though the dashboard showed the correct counts.
       const fromQ = `${dStr}T00:00:00+05:30`;
       const toQ = `${dStr}T23:59:59+05:30`;
-      const [staff, vs, svc, pts, wl, rs, hs] = await Promise.all([
+      const [staff, vs, svc, pts, wl, rs, hs, rts] = await Promise.all([
         fetchApi('/api/staff').catch(() => []),
         fetchApi(`/api/wellness/visits?from=${encodeURIComponent(fromQ)}&to=${encodeURIComponent(toQ)}&limit=500`),
         fetchApi('/api/wellness/services').catch(() => []),
@@ -149,6 +177,10 @@ export default function CalendarGrid() {
         fetchApi('/api/wellness/waitlist?status=waiting').catch(() => []),
         fetchApi('/api/wellness/resources?activeOnly=1').catch(() => []),
         fetchApi(`/api/wellness/holidays?from=${dStr}&to=${dStr}`).catch(() => []),
+        // Option B: per-tenant role catalog (admins maintain from Settings).
+        // activeOnly=1 so deactivated roles don't pollute the dropdown but
+        // staff with a now-inactive wellnessRole still render in their column.
+        fetchApi('/api/wellness/role-types?activeOnly=1').catch(() => []),
       ]);
       setAllStaff(Array.isArray(staff) ? staff : []);
       setVisits(Array.isArray(vs) ? vs : []);
@@ -165,7 +197,8 @@ export default function CalendarGrid() {
       setWaitlist(Array.isArray(wl) ? wl : Array.isArray(wl?.items) ? wl.items : []);
       setResources(Array.isArray(rs) ? rs : []);
       setHolidays(Array.isArray(hs) ? hs : []);
-    } catch (_e) { setVisits([]); setAllStaff([]); setWaitlist([]); setResources([]); setHolidays([]); }
+      setRoleTypes(Array.isArray(rts) ? rts : []);
+    } catch (_e) { setVisits([]); setAllStaff([]); setWaitlist([]); setResources([]); setHolidays([]); setRoleTypes([]); }
     setLoading(false);
   };
   useEffect(() => { load(); }, [date]);
@@ -250,18 +283,42 @@ export default function CalendarGrid() {
     }
   };
 
+  // Option B: derive the set of practitioner role keys from the catalog.
+  // A role is "practitioner" when canTakeVisits=true. Until the catalog
+  // fetch resolves, fall back to the original hardcoded set so first-paint
+  // matches pre-Option-B behaviour.
+  const practitionerKeys = useMemo(() => {
+    if (!roleTypes.length) return FALLBACK_PRACTITIONER_KEYS;
+    return new Set(roleTypes.filter((r) => r.canTakeVisits).map((r) => r.key));
+  }, [roleTypes]);
+
+  // Role dropdown options: each catalog role that's a practitioner +
+  // "All staff" sentinel. Empty when the catalog is empty (we just hide
+  // the dropdown in that case).
+  const practitionerRoleOptions = useMemo(() => {
+    if (!roleTypes.length) return [];
+    return roleTypes
+      .filter((r) => r.canTakeVisits)
+      .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0) || a.label.localeCompare(b.label));
+  }, [roleTypes]);
+
   // #262: build the practitioner list. Default view = practitioners with at
   // least one visit on this day (so the grid stays readable on small clinics).
   // Toggle "Show all" to surface every practitioner for booking empty slots.
+  // Option B: also narrow by selectedRoleKey when the dropdown is on a
+  // specific role (ALL_ROLES_KEY = no role filter applied).
   const practitioners = useMemo(() => {
-    const all = allStaff.filter((u) => PRACTITIONER_ROLES.has(u.wellnessRole));
+    let all = allStaff.filter((u) => practitionerKeys.has(effectiveWellnessRole(u)));
+    if (selectedRoleKey !== ALL_ROLES_KEY) {
+      all = all.filter((u) => effectiveWellnessRole(u) === selectedRoleKey);
+    }
     const doctorIdsToday = new Set(visits.map((v) => v.doctorId).filter(Boolean));
     if (showAll) return all;
     const withVisits = all.filter((u) => doctorIdsToday.has(u.id));
     // Fallback: if no practitioner has visits today, surface everyone so the
     // grid isn't empty and the receptionist can still book.
     return withVisits.length ? withVisits : all;
-  }, [allStaff, visits, showAll]);
+  }, [allStaff, visits, showAll, practitionerKeys, selectedRoleKey]);
 
   // #247: include visits without a doctor assignment in an "Unassigned"
   // column instead of silently dropping them. The dashboard counts ALL
@@ -271,7 +328,9 @@ export default function CalendarGrid() {
     const cols = practitioners.map((d) => ({
       id: d.id,
       name: d.name,
-      role: d.wellnessRole,
+      // Column-header role badge uses the effective role so RBAC-only
+      // staff still display a role label (e.g. "NURSE" → "nurse").
+      role: effectiveWellnessRole(d),
       isUnassigned: false,
     }));
     if (visits.some((v) => !v.doctorId)) {
@@ -309,9 +368,19 @@ export default function CalendarGrid() {
     const next = new Date(date); next.setDate(next.getDate() + days); setDate(next);
   };
 
-  // #262 sub-counts for the header chip
-  const totalPractitionerCount = useMemo(() => allStaff.filter((u) => PRACTITIONER_ROLES.has(u.wellnessRole)).length, [allStaff]);
+  // #262 sub-counts for the header chip. Option B: counts honour the
+  // selected role filter so the chip reads "5 of 5 nurses" when narrowed.
+  const totalPractitionerCount = useMemo(() => {
+    const inScope = allStaff.filter((u) => practitionerKeys.has(effectiveWellnessRole(u)));
+    if (selectedRoleKey === ALL_ROLES_KEY) return inScope.length;
+    return inScope.filter((u) => effectiveWellnessRole(u) === selectedRoleKey).length;
+  }, [allStaff, practitionerKeys, selectedRoleKey]);
   const visiblePractitionerCount = practitioners.length;
+  const selectedRoleLabel = useMemo(() => {
+    if (selectedRoleKey === ALL_ROLES_KEY) return 'practitioners';
+    const r = roleTypes.find((rt) => rt.key === selectedRoleKey);
+    return r?.label?.toLowerCase() || selectedRoleKey;
+  }, [selectedRoleKey, roleTypes]);
 
   return (
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
@@ -325,6 +394,31 @@ export default function CalendarGrid() {
           </p>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          {/* Option B: role-filter dropdown. Reads the per-tenant catalog
+              (Settings → Wellness Role Types). "All staff" is the default
+              and shows every catalog role with canTakeVisits=true. Hidden
+              when the catalog is empty (catalog not seeded, generic tenant,
+              or API error). */}
+          {practitionerRoleOptions.length > 0 && (
+            <select
+              value={selectedRoleKey}
+              onChange={(e) => setSelectedRoleKey(e.target.value)}
+              aria-label="Filter by staff role"
+              className="glass"
+              style={{
+                padding: '0.4rem 0.65rem', fontSize: '0.8rem',
+                borderRadius: 8, cursor: 'pointer',
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: 'transparent',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <option value={ALL_ROLES_KEY}>All staff</option>
+              {practitionerRoleOptions.map((r) => (
+                <option key={r.key} value={r.key}>{r.label}</option>
+              ))}
+            </select>
+          )}
           {totalPractitionerCount > 0 && (
             <button
               type="button"
@@ -337,17 +431,18 @@ export default function CalendarGrid() {
                 background: showAll ? 'rgba(99,102,241,0.15)' : 'transparent',
                 color: 'var(--text-primary)',
               }}
-              title={showAll ? `Showing all ${totalPractitionerCount} practitioners` : `Showing ${visiblePractitionerCount} with visits today (click to show all)`}
+              title={showAll ? `Showing all ${totalPractitionerCount} ${selectedRoleLabel}` : `Showing ${visiblePractitionerCount} with visits today (click to show all)`}
             >
               {/* #307: pre-fix copy was "1 of 16" with no unit, which sat right
                   next to the date chevrons and was widely misread as
                   "day 1 of 16" — i.e. the chevrons advanced practitioners.
-                  Add the explicit "practitioners" noun + a stable label
-                  ("All practitioners (16)") for the showAll mode so the chip
-                  is unambiguously about the column filter, not navigation. */}
+                  Add the explicit noun (practitioners / nurses / stylists)
+                  so the chip is unambiguously about the column filter,
+                  not navigation. The noun comes from the dropdown's
+                  selected label (Option B). */}
               {showAll
-                ? `All practitioners (${totalPractitionerCount})`
-                : `${visiblePractitionerCount} of ${totalPractitionerCount} practitioners`}
+                ? `All ${selectedRoleLabel} (${totalPractitionerCount})`
+                : `${visiblePractitionerCount} of ${totalPractitionerCount} ${selectedRoleLabel}`}
             </button>
           )}
           <button onClick={() => shift(-1)} className="glass" style={navBtn}><ChevronLeft size={16} /></button>

--- a/frontend/src/pages/wellness/CashbackRules.jsx
+++ b/frontend/src/pages/wellness/CashbackRules.jsx
@@ -30,7 +30,13 @@ export default function CashbackRulesPage() {
   useEffect(() => { load(); }, []);
 
   const remove = async (id) => {
-    if (!confirm('Delete this cashback rule? Past wallet credits remain.')) return;
+    const ok = await notify.confirm({
+      title: 'Delete cashback rule',
+      message: 'Delete this cashback rule? Past wallet credits remain.',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/cashback-rules/${id}`, { method: 'DELETE' });
       notify.success('Rule deleted');

--- a/frontend/src/pages/wellness/Coupons.jsx
+++ b/frontend/src/pages/wellness/Coupons.jsx
@@ -33,7 +33,13 @@ export default function CouponsPage() {
   useEffect(() => { load(); }, []);
 
   const remove = async (id) => {
-    if (!confirm('Delete this coupon? This cannot be undone.')) return;
+    const ok = await notify.confirm({
+      title: 'Delete coupon',
+      message: 'Delete this coupon? This cannot be undone.',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/coupons/${id}`, { method: 'DELETE' });
       notify.success('Coupon deleted');

--- a/frontend/src/pages/wellness/Drugs.jsx
+++ b/frontend/src/pages/wellness/Drugs.jsx
@@ -79,7 +79,13 @@ export default function Drugs() {
   };
 
   const remove = async (drug) => {
-    if (!confirm(`Delete "${drug.name}" from the catalogue?`)) return;
+    const ok = await notify.confirm({
+      title: 'Delete drug',
+      message: `Delete "${drug.name}" from the catalogue?`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/drugs/${drug.id}`, { method: 'DELETE' });
       notify.success(`Deleted "${drug.name}"`);

--- a/frontend/src/pages/wellness/Holidays.jsx
+++ b/frontend/src/pages/wellness/Holidays.jsx
@@ -81,7 +81,13 @@ export default function Holidays() {
   };
 
   const remove = async (h) => {
-    if (!window.confirm(`Remove holiday "${h.name}" on ${fmtDate(h.date)}?`)) return;
+    const ok = await notify.confirm({
+      title: 'Remove holiday',
+      message: `Remove holiday "${h.name}" on ${fmtDate(h.date)}?`,
+      confirmText: 'Remove',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/holidays/${h.id}`, { method: 'DELETE' });
       notify.success(`Removed "${h.name}"`);

--- a/frontend/src/pages/wellness/InventoryReceipts.jsx
+++ b/frontend/src/pages/wellness/InventoryReceipts.jsx
@@ -126,16 +126,24 @@ export default function InventoryReceipts() {
   };
 
   const remove = async (r) => {
-    if (!window.confirm(`Delete receipt ${r.receiptNumber}?\n\nThis will subtract ${r.quantity} ${r.product?.name || 'units'} from stock and remove the row permanently.`)) return;
+    const ok = await notify.confirm({
+      title: 'Delete receipt',
+      message: `Delete receipt ${r.receiptNumber}?\n\nThis will subtract ${r.quantity} ${r.product?.name || 'units'} from stock and remove the row permanently.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/inventory/receipts/${r.id}`, { method: 'DELETE', silent: true });
       notify.success(`Deleted ${r.receiptNumber}.`);
       load();
     } catch (err) {
       if (err?.status === 409 && (err.code === 'RECEIPT_CONSUMED' || err.code === 'WOULD_OVERDRAW')) {
-        const fallback = window.confirm(
-          `${err.message}\n\nReverse this receipt instead? That creates a stock-correcting Adjustment of -${r.quantity} ${r.product?.name || ''} and keeps the receipt for audit.`,
-        );
+        const fallback = await notify.confirm({
+          title: 'Reverse receipt instead?',
+          message: `${err.message}\n\nReverse this receipt instead? That creates a stock-correcting Adjustment of -${r.quantity} ${r.product?.name || ''} and keeps the receipt for audit.`,
+          confirmText: 'Reverse',
+        });
         if (fallback) {
           try {
             await fetchApi(`/api/wellness/inventory/receipts/${r.id}/reverse`, { method: 'POST', body: JSON.stringify({}) });

--- a/frontend/src/pages/wellness/Leave.jsx
+++ b/frontend/src/pages/wellness/Leave.jsx
@@ -106,7 +106,12 @@ export default function Leave() {
   };
 
   const onApprove = async (id) => {
-    if (!confirm('Approve this leave request?')) return;
+    const ok = await notify.confirm({
+      title: 'Approve leave',
+      message: 'Approve this leave request?',
+      confirmText: 'Approve',
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/leave/requests/${id}/approve`, { method: 'POST', body: JSON.stringify({}) });
       notify.success('Approved');
@@ -117,7 +122,13 @@ export default function Leave() {
   };
 
   const onReject = async (id) => {
-    const notes = prompt('Reason for rejection?') || '';
+    const input = await notify.prompt({
+      title: 'Reject leave',
+      message: 'Reason for rejection?',
+      confirmText: 'Reject',
+    });
+    if (input === null) return;
+    const notes = input || '';
     try {
       await fetchApi(`/api/leave/requests/${id}/reject`, { method: 'POST', body: JSON.stringify({ notes }) });
       notify.success('Rejected');
@@ -128,7 +139,13 @@ export default function Leave() {
   };
 
   const onCancel = async (id) => {
-    if (!confirm('Cancel this leave request?')) return;
+    const ok = await notify.confirm({
+      title: 'Cancel leave',
+      message: 'Cancel this leave request?',
+      confirmText: 'Cancel leave',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/leave/requests/${id}/cancel`, { method: 'POST', body: JSON.stringify({}) });
       notify.success('Cancelled');

--- a/frontend/src/pages/wellness/PatientDetail.jsx
+++ b/frontend/src/pages/wellness/PatientDetail.jsx
@@ -2692,7 +2692,13 @@ function MembershipsTab({ patient, services }) {
   };
 
   const cancel = async (m) => {
-    if (!confirm(`Cancel "${m.plan?.name || 'membership'}"? Remaining entitlements will be void.`)) return;
+    const ok = await notify.confirm({
+      title: 'Cancel membership',
+      message: `Cancel "${m.plan?.name || 'membership'}"? Remaining entitlements will be void.`,
+      confirmText: 'Cancel membership',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/memberships/${m.id}/cancel`, {
         method: 'POST',

--- a/frontend/src/pages/wellness/ProductCategories.jsx
+++ b/frontend/src/pages/wellness/ProductCategories.jsx
@@ -111,8 +111,13 @@ export default function ProductCategories() {
   };
 
   const handleDelete = async (id) => {
-    if (!confirm("Delete this category? Products will become uncategorized."))
-      return;
+    const ok = await notify.confirm({
+      title: 'Delete category',
+      message: 'Delete this category? Products will become uncategorized.',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
 
     try {
       await fetchApi(`/api/wellness/product-categories/${id}`, {

--- a/frontend/src/pages/wellness/Products.jsx
+++ b/frontend/src/pages/wellness/Products.jsx
@@ -154,7 +154,13 @@ export default function Products() {
   };
 
   const handleDelete = async (id) => {
-    if (!confirm('Delete this product?')) return;
+    const ok = await notify.confirm({
+      title: 'Delete product',
+      message: 'Delete this product?',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
 
     try {
       await fetchApi(`/api/wellness/products/${id}`, { method: 'DELETE' });

--- a/frontend/src/pages/wellness/Resources.jsx
+++ b/frontend/src/pages/wellness/Resources.jsx
@@ -78,7 +78,13 @@ export default function Resources() {
   };
 
   const remove = async (r) => {
-    if (!window.confirm(`Delete resource "${r.name}"? Existing visits will keep their slot but lose the resource pointer.`)) return;
+    const ok = await notify.confirm({
+      title: 'Delete resource',
+      message: `Delete resource "${r.name}"? Existing visits will keep their slot but lose the resource pointer.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/resources/${r.id}`, { method: 'DELETE' });
       notify.success(`Deleted "${r.name}"`);

--- a/frontend/src/pages/wellness/ServiceCategories.jsx
+++ b/frontend/src/pages/wellness/ServiceCategories.jsx
@@ -111,7 +111,13 @@ export default function ServiceCategories() {
   };
 
   const remove = async (cat) => {
-    if (!confirm(`Delete "${cat.name}"? Services in this category will keep working but lose the link.`)) return;
+    const ok = await notify.confirm({
+      title: 'Delete service category',
+      message: `Delete "${cat.name}"? Services in this category will keep working but lose the link.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/service-categories/${cat.id}`, { method: 'DELETE' });
       notify.success(`Deleted "${cat.name}"`);

--- a/frontend/src/pages/wellness/Vendors.jsx
+++ b/frontend/src/pages/wellness/Vendors.jsx
@@ -68,7 +68,13 @@ export default function Vendors() {
 
   const setArchived = async (v, archived) => {
     const verb = archived ? 'Archive' : 'Restore';
-    if (!window.confirm(`${verb} vendor "${v.name}"?`)) return;
+    const ok = await notify.confirm({
+      title: `${verb} vendor`,
+      message: `${verb} vendor "${v.name}"?`,
+      confirmText: verb,
+      destructive: archived,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/vendors/${v.id}`, {
         method: 'PUT',
@@ -80,7 +86,13 @@ export default function Vendors() {
   };
 
   const remove = async (v) => {
-    if (!window.confirm(`Delete vendor "${v.name}"? Vendors with prior receipts will be archived instead.`)) return;
+    const ok = await notify.confirm({
+      title: 'Delete vendor',
+      message: `Delete vendor "${v.name}"? Vendors with prior receipts will be archived instead.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await fetchApi(`/api/wellness/vendors/${v.id}`, { method: 'DELETE' });
       notify.success(`Removed "${v.name}"`);


### PR DESCRIPTION
[x] Added dynamic tenant-scoped Wellness Role Types with Prisma model, CRUD APIs, default seeded roles, and admin management UI.
[x] Integrated wellness roles with RBAC using dynamic clinical role resolution and permission-based route access fallbacks.
[x] Added anyOfPermissions and adminOrPerm() utilities to replace hardcoded admin/manager role checks across wellness modules.
[x] Migrated multiple backend wellness routes to use permission-driven access control and dynamic role validation.
[x] Refactored Sidebar navigation to be fully driven by /api/pages/me, removing legacy hardcoded role visibility logic.
[x] Enhanced Staff page with advanced search, status filtering, dynamic wellness role dropdowns, and catalog-driven role editing.
[x] Updated role-aware landing behavior so non-admin wellness users default to the /home dashboard experience.
[x] Modernized UX by replacing native window.confirm and window.prompt usage with notify.confirm and notify.prompt flows across multiple wellness pages.
[x] Added comprehensive API and unit test coverage for dynamic wellness roles, clinical token handling, and permission fallback logic.