### PR TITLE
add portal prescription RBAC, PDF redesign, and wellness permission e…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -219,6 +219,7 @@ jobs:
             tests/sequences-input-sanitization-api.spec.js \
             tests/gdpr-dsar-export-api.spec.js \
             tests/wellness-portal-dsar-api.spec.js \
+            tests/wellness-portal-prescriptions-rbac-api.spec.js \
             tests/report-schedules-api.spec.js \
             tests/landing-page-upload-api.spec.js \
             tests/field-permissions-enforcement-api.spec.js \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -390,6 +390,7 @@ jobs:
             tests/sequences-input-sanitization-api.spec.js \
             tests/gdpr-dsar-export-api.spec.js \
             tests/wellness-portal-dsar-api.spec.js \
+            tests/wellness-portal-prescriptions-rbac-api.spec.js \
             tests/report-schedules-api.spec.js \
             tests/landing-page-upload-api.spec.js \
             tests/field-permissions-enforcement-api.spec.js \

--- a/backend/lib/csvEntities.js
+++ b/backend/lib/csvEntities.js
@@ -802,9 +802,9 @@ const invoices = {
     recurFrequency: "",
   },
   readGate: ["admin", "manager"],
-  readPermissions: [{ module: "billing", action: "read" }],
+  readPermissions: [{ module: "invoices", action: "read" }],
   writeGate: ["admin", "manager"],
-  writePermissions: [{ module: "billing", action: "write" }],
+  writePermissions: [{ module: "invoices", action: "write" }],
   buildWhere: (req) => {
     const where = { tenantId: req.user.tenantId };
     const { status, q } = req.query;

--- a/backend/lib/pageCatalog.js
+++ b/backend/lib/pageCatalog.js
@@ -136,13 +136,18 @@ const PAGE_CATALOG = [
     description: 'Rx review + finalisation',
     category: 'Clinical',
     requiredPermissions: [{ module: 'prescriptions', action: 'read' }],
-    // Sidebar UX: clinical day-to-day surface. Admin/owner-tier users
-    // technically have prescriptions.read but they don't use the Rx list
-    // in their primary nav — they reach it via patient charts or audit
-    // trails. Hiding it keeps admin's sidebar focused on management
-    // surfaces. Page stays accessible at /wellness/prescriptions for
-    // anyone with the permission.
-    hideForAdminTier: true,
+  },
+  {
+    path: '/wellness/my-prescriptions',
+    label: 'My Prescriptions',
+    description: 'Your own prescriptions (linked Patient profile)',
+    category: 'Clinical',
+    // Separate `my_prescriptions` module — granted to roles whose users
+    // may also be patients at this clinic (CUSTOMER, and optionally USER
+    // when staff-as-patient flows are in play). Backend scopes to
+    // req.user.userId's linked Patient row; cross-patient access is
+    // structurally impossible regardless of role grants.
+    requiredPermissions: [{ module: 'my_prescriptions', action: 'read' }],
   },
   {
     path: '/wellness/visits',
@@ -366,7 +371,7 @@ const PAGE_CATALOG = [
     label: 'Invoices',
     description: 'Patient + customer invoices',
     category: 'Finance',
-    requiredPermissions: [{ module: 'billing', action: 'read' }],
+    requiredPermissions: [{ module: 'invoices', action: 'read' }],
   },
   {
     path: '/estimates',
@@ -394,14 +399,14 @@ const PAGE_CATALOG = [
     label: 'Patient Wallets',
     description: 'Patient pre-paid wallet balances + history',
     category: 'Finance',
-    requiredPermissions: [{ module: 'billing', action: 'read' }],
+    requiredPermissions: [{ module: 'patient_wallets', action: 'read' }],
   },
   {
     path: '/wellness/giftcards',
     label: 'Gift Cards',
     description: 'Gift card issuance + redemption ledger',
     category: 'Finance',
-    requiredPermissions: [{ module: 'billing', action: 'read' }],
+    requiredPermissions: [{ module: 'gift_cards', action: 'read' }],
   },
   {
     path: '/wellness/buy-giftcards',

--- a/backend/lib/permissionCatalog.js
+++ b/backend/lib/permissionCatalog.js
@@ -52,10 +52,17 @@ const PERMISSION_CATALOG = {
   chatbots: ['read', 'write', 'delete', 'manage'],
 
   // ─────────────────────────────────────────────────────────────────────
-  // Financial (4 modules)
+  // Financial (6 modules)
   // ─────────────────────────────────────────────────────────────────────
 
-  billing: ['read', 'write', 'update', 'delete', 'export', 'manage'],
+  // `billing` was split into three per-surface modules in v3.8.x so admins
+  // can grant Invoices access without also granting Gift Cards or Patient
+  // Wallets (and vice-versa). All three carry the same six-action surface
+  // (`read`/`write`/`update`/`delete`/`export`/`manage`) the parent had —
+  // identical mutate granularity, finer-grained scope.
+  invoices: ['read', 'write', 'update', 'delete', 'export', 'manage'],
+  gift_cards: ['read', 'write', 'update', 'delete', 'export', 'manage'],
+  patient_wallets: ['read', 'write', 'update', 'delete', 'export', 'manage'],
   accounting: ['read', 'write', 'export'],
   payments: ['read', 'export'],
   expenses: ['read', 'write', 'update', 'delete', 'manage'],
@@ -125,6 +132,16 @@ const PERMISSION_CATALOG = {
   calendar: ['read', 'write'],
   services: ['read', 'write', 'update', 'delete'],
   prescriptions: ['read', 'write', 'update', 'delete', 'export'],
+  // `my_prescriptions` gates the patient-portal Prescriptions tab — the
+  // per-patient view that lists ONLY the logged-in patient's own Rx and
+  // lets them download their own PDFs. Distinct from `prescriptions.read`
+  // (which is the staff-wide tenant view) so the patient-facing surface
+  // can be granted / revoked independently. `.read` covers both list and
+  // PDF download — no separate export action. Granted to the CUSTOMER
+  // system role by default; backend enforcement at the portal handler
+  // ALSO scopes by `patientId: req.patient.id` so cross-patient access
+  // is structurally impossible even if RBAC misconfigures the grant.
+  my_prescriptions: ['read'],
   consents: ['read', 'write', 'update', 'delete'],
   visits: ['read', 'write', 'update', 'delete'],
   // `products` and `inventory` are deliberately separate modules. `products`
@@ -193,7 +210,7 @@ const PERMISSION_DOMAINS = [
   },
   {
     domain: 'Financial',
-    modules: ['billing', 'accounting', 'payments', 'expenses'],
+    modules: ['invoices', 'gift_cards', 'patient_wallets', 'accounting', 'payments', 'expenses'],
   },
   {
     domain: 'Analytics',
@@ -218,6 +235,7 @@ const PERMISSION_DOMAINS = [
       'calendar',
       'services',
       'prescriptions',
+      'my_prescriptions',
       'consents',
       'visits',
     ],

--- a/backend/lib/portalPermissions.js
+++ b/backend/lib/portalPermissions.js
@@ -1,0 +1,96 @@
+/**
+ * Patient-portal RBAC resolver.
+ *
+ * Patient-portal routes don't run under verifyToken + requirePermission
+ * because the patient is a Patient row, not a User row, and so has no
+ * UserRole assignment. Instead, every patient on a tenant implicitly
+ * inherits that tenant's CUSTOMER system role — whatever permissions
+ * the admin grants on the CUSTOMER row in the Roles & Permissions matrix
+ * apply to ALL portal users on that tenant.
+ *
+ * Defence in depth: the handler itself ALSO scopes data by
+ * `patientId: req.patient.id`, so even if RBAC misconfigures the grant,
+ * a patient still can't see another patient's records.
+ */
+
+const prisma = require('./prisma');
+const { isValidPermission } = require('./permissionCatalog');
+
+const CACHE = new Map();
+const CACHE_TTL_MS = 30_000;
+
+async function loadCustomerRolePermissions(tenantId) {
+  const role = await prisma.role.findFirst({
+    where: { tenantId, key: 'CUSTOMER' },
+    select: {
+      id: true,
+      permissions: { select: { module: true, action: true } },
+    },
+  });
+  if (!role) return new Set();
+  const set = new Set();
+  for (const p of role.permissions) set.add(`${p.module}.${p.action}`);
+  return set;
+}
+
+async function getCustomerRolePermissions(tenantId) {
+  const cached = CACHE.get(tenantId);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return cached.permissions;
+  }
+  const permissions = await loadCustomerRolePermissions(tenantId);
+  CACHE.set(tenantId, { permissions, timestamp: Date.now() });
+  return permissions;
+}
+
+function clearCustomerRoleCache(tenantId) {
+  if (tenantId == null) {
+    CACHE.clear();
+  } else {
+    CACHE.delete(tenantId);
+  }
+}
+
+/**
+ * Express middleware factory. Only valid AFTER verifyPatientToken has
+ * populated req.patient with { id, tenantId }.
+ */
+function requirePortalPermission(module, action) {
+  if (!isValidPermission(module, action)) {
+    throw new Error(
+      `Invalid permission in requirePortalPermission('${module}', '${action}'). ` +
+        `Check backend/lib/permissionCatalog.js`,
+    );
+  }
+  const required = `${module}.${action}`;
+  return async (req, res, next) => {
+    try {
+      if (!req.patient || !req.patient.id || !req.patient.tenantId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const perms = await getCustomerRolePermissions(req.patient.tenantId);
+      if (perms.has(required)) return next();
+      return res.status(403).json({
+        error: `Access denied: requires ${module}.${action}`,
+        code: 'PORTAL_RBAC_DENIED',
+        required,
+      });
+    } catch (err) {
+      console.error('[portalPermissions] middleware error:', err.message);
+      // Fail closed.
+      return res.status(403).json({
+        error: 'Permission check failed',
+        code: 'PORTAL_PERMISSION_CHECK_FAILED',
+      });
+    }
+  };
+}
+
+module.exports = {
+  requirePortalPermission,
+  getCustomerRolePermissions,
+  loadCustomerRolePermissions,
+  clearCustomerRoleCache,
+  // exported for tests
+  _CACHE: CACHE,
+};

--- a/backend/lib/sensitivePermissions.js
+++ b/backend/lib/sensitivePermissions.js
@@ -51,14 +51,25 @@ const SENSITIVE_PERMISSIONS = new Set([
   'integrations.delete',
   'integrations.manage',
 
-  // BILLING / PAYMENTS / ACCOUNTING (W/U/D/M) — financial exposure.
+  // INVOICES / GIFT CARDS / PATIENT WALLETS / PAYMENTS / ACCOUNTING
+  // (W/U/D/M) — financial exposure. `billing` was decomposed into three
+  // surface-specific modules in v3.8.x; all three carry the same
+  // sensitive write-tier surface as the parent did.
   // Note: `payments` catalog only exposes read + export today, so no
   // payments-write entry exists; widening payments to .write/.update
   // would need a corresponding entry here.
-  'billing.write',
-  'billing.update',
-  'billing.delete',
-  'billing.manage',
+  'invoices.write',
+  'invoices.update',
+  'invoices.delete',
+  'invoices.manage',
+  'gift_cards.write',
+  'gift_cards.update',
+  'gift_cards.delete',
+  'gift_cards.manage',
+  'patient_wallets.write',
+  'patient_wallets.update',
+  'patient_wallets.delete',
+  'patient_wallets.manage',
   'accounting.write',
 
   // AUDIT (any write/delete) — can tamper with the audit trail.

--- a/backend/lib/widgetCatalog.js
+++ b/backend/lib/widgetCatalog.js
@@ -92,7 +92,7 @@ const WIDGET_CATALOG = [
     title: 'Pending payments at POS',
     description: 'Outstanding invoices ready for collection.',
     category: 'Front desk',
-    requiredPermissions: [{ module: 'billing', action: 'read' }],
+    requiredPermissions: [{ module: 'invoices', action: 'read' }],
     defaultRoleKeys: ['RECEPTIONIST'],
   },
   {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3215,6 +3215,10 @@ model Visit {
   status        String   @default("completed") // booked, arrived, in-treatment, completed, no-show, cancelled
   vitals        String?  @db.Text // JSON: bp, pulse, weight, etc.
   notes         String?  @db.Text
+  // Patient-supplied chief complaint / reason for the appointment. Required at
+  // the self-booking form (BookAppointment.jsx) but nullable in DB so legacy
+  // staff-side creates (Calendar drag, public-widget) still validate.
+  reason        String?  @db.Text
   photosBefore  String?  @db.Text // JSON array of URLs
   photosAfter   String?  @db.Text // JSON array of URLs
   amountCharged Float?
@@ -3274,6 +3278,13 @@ model Visit {
 
   treatmentPlanId Int?
   treatmentPlan   TreatmentPlan? @relation(fields: [treatmentPlanId], references: [id], onDelete: SetNull)
+
+  // Optional membership applied to this booking. The patient picks an active
+  // membership at booking time; the redemption is recorded on visit completion
+  // (not at booking) so cancellations don't drain balance. SetNull on
+  // membership deletion so the visit row survives membership purges.
+  membershipId Int?
+  membership   Membership? @relation(fields: [membershipId], references: [id], onDelete: SetNull)
 
   // #413 — Restrict (not Cascade) on Tenant deletion. Visit is PHI
   // (medical encounters, vitals, before/after photos, charged amounts).
@@ -3830,6 +3841,7 @@ model Membership {
   updatedAt        DateTime       @updatedAt
 
   redemptions MembershipRedemption[]
+  visits      Visit[]
 
   @@index([tenantId, patientId, status])
   @@index([tenantId, endDate])

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -984,7 +984,12 @@ async function main() {
     'reports.read', 'reports.export',
     'dashboards.read',
     'analytics.read', 'analytics.export',
-    'billing.read',
+    // Finance modules — `billing` was decomposed in v3.8.x into invoices,
+    // gift_cards, and patient_wallets. MANAGER inherits read across all
+    // three so the Finance section of the sidebar stays visible.
+    'invoices.read',
+    'gift_cards.read',
+    'patient_wallets.read',
     'staff.read',
     'communications.read', 'communications.write',
     'email.read', 'email.write',
@@ -1025,13 +1030,18 @@ async function main() {
     },
   });
 
-  // Grant CUSTOMER limited permissions (customer-facing features only)
+  // Grant CUSTOMER limited permissions (customer-facing features only).
+  // `my_prescriptions.read` is the patient-portal-only counterpart to
+  // staff-wide `prescriptions.read`; CUSTOMER users get the scoped view
+  // (own Rx list + own PDF download) instead of the tenant-wide list.
   const customerPermissions = [
     'appointments.read',
     'services.read',
-    'billing.read',
+    // `billing.read` was split per-surface in v3.8.x; CUSTOMER gets
+    // invoices.read so they can still see their own invoice list.
+    'invoices.read',
     'documents.read',
-    'prescriptions.read',
+    'my_prescriptions.read',
     'consents.read',
   ];
 

--- a/backend/routes/communications.js
+++ b/backend/routes/communications.js
@@ -3,9 +3,47 @@ const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../../.env"), override: true });
 
 const crypto = require("crypto");
+const multer = require("multer");
 
 const router = express.Router();
 const prisma = require("../lib/prisma");
+
+// Compose-mail attachments: memory storage so the buffer can be base64'd
+// straight into the SendGrid payload without a disk round-trip. multer is a
+// no-op for non-multipart requests, so the legacy JSON path (no attachments)
+// keeps working unchanged.
+const ATTACHMENT_ALLOWED_MIMES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "text/csv",
+  "text/plain",
+  "application/zip",
+]);
+const composeAttachmentMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024, files: 5 }, // 10 MB per file, 5 files max
+  fileFilter: (req, file, cb) => {
+    if (ATTACHMENT_ALLOWED_MIMES.has(file.mimetype)) cb(null, true);
+    else cb(new Error(`Attachment type not allowed: ${file.mimetype}`));
+  },
+}).array("attachments", 5);
+
+// Convert multer errors (size/type/count) to JSON 400 so the SPA can surface
+// a useful message instead of the default Express HTML stack trace.
+function composeAttachmentUpload(req, res, next) {
+  composeAttachmentMulter(req, res, (err) => {
+    if (!err) return next();
+    const code = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
+    return res.status(code).json({ error: err.message || "Attachment upload failed" });
+  });
+}
 
 // SendGrid email sending via their REST API
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
@@ -57,6 +95,13 @@ async function sendSendGrid(to, subject, body, opts = {}) {
       { type: "text/html", value: htmlBody }
     ]
   };
+
+  // Inline attachments → SendGrid's v3 `attachments` field. Caller passes
+  // already-shaped `{ content, filename, type, disposition }` objects so this
+  // helper stays a thin SendGrid wrapper.
+  if (Array.isArray(opts.attachments) && opts.attachments.length > 0) {
+    payload.attachments = opts.attachments;
+  }
 
   try {
     const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
@@ -152,11 +197,23 @@ function parseRecipients(toField) {
 // Multi-recipient calls expose the full per-recipient breakdown via `results` /
 // `failures`. Mailgun is called once per valid recipient (no BCC fan-out — keeps
 // per-recipient tracking pixels distinct).
-router.post("/send-email", async (req, res) => {
+router.post("/send-email", composeAttachmentUpload, async (req, res) => {
   try {
     const { to, cc, bcc, subject, body, contactId } = req.body;
     if (!to || !subject) return res.status(400).json({ error: "Recipient and subject required" });
     if (!req.user) return res.status(401).json({ error: "Authentication required" });
+
+    // Build SendGrid-shaped attachments from multer-parsed buffers. Empty
+    // when the client posts plain JSON (no multipart files), so the legacy
+    // JSON path is unaffected.
+    const sendgridAttachments = Array.isArray(req.files)
+      ? req.files.map((f) => ({
+          content: f.buffer.toString("base64"),
+          filename: f.originalname,
+          type: f.mimetype,
+          disposition: "attachment",
+        }))
+      : [];
 
     const recipients = parseRecipients(to);
     if (recipients.length === 0) {
@@ -265,6 +322,7 @@ router.post("/send-email", async (req, res) => {
       const mailResult = await sendSendGrid(recipient, subject, trackedBody, {
         cc: ccDeliverable,
         bcc: bccDeliverable,
+        attachments: sendgridAttachments,
       });
 
       // Per-recipient Activity on the linked contact (if any). Same pattern as

--- a/backend/routes/roles.js
+++ b/backend/routes/roles.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const prisma = require("../lib/prisma");
 const { verifyToken } = require("../middleware/auth");
 const { requirePermission, clearUserCache, clearTenantCache } = require("../middleware/requirePermission");
+const { clearCustomerRoleCache } = require("../lib/portalPermissions");
 const {
   isValidPermission,
   getCatalog,
@@ -417,8 +418,10 @@ router.post(
         data: { roleId, module, action }
       });
 
-      // Clear permission cache for all users with this role
+      // Clear permission cache for all users with this role + the
+      // patient-portal CUSTOMER-role cache (lib/portalPermissions.js).
       clearTenantCache(role.tenantId);
+      if (role.key === "CUSTOMER") clearCustomerRoleCache(role.tenantId);
 
       await writeAudit("Role", "GRANT_PERMISSION", req.user.userId, req.user.userId, req.user.tenantId, {
         roleId,
@@ -470,8 +473,10 @@ router.delete(
         }
       });
 
-      // Clear permission cache for all users with this role
+      // Clear permission cache for all users with this role + the
+      // patient-portal CUSTOMER-role cache (lib/portalPermissions.js).
       clearTenantCache(role.tenantId);
+      if (role.key === "CUSTOMER") clearCustomerRoleCache(role.tenantId);
 
       await writeAudit("Role", "REVOKE_PERMISSION", req.user.userId, req.user.userId, req.user.tenantId, {
         roleId,
@@ -611,8 +616,10 @@ router.put(
         },
       );
 
-      // Clear permission cache for all users with this role
+      // Clear permission cache for all users with this role + the
+      // patient-portal CUSTOMER-role cache (lib/portalPermissions.js).
       clearTenantCache(role.tenantId);
+      if (role.key === "CUSTOMER") clearCustomerRoleCache(role.tenantId);
 
       await writeAudit("Role", "BULK_UPDATE_PERMISSIONS", req.user.userId, req.user.userId, req.user.tenantId, {
         roleId,

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -66,6 +66,11 @@ const { verifyWellnessRole } = require("../middleware/wellnessRole");
 // axis). Used by DELETE /patients/:id and other admin-only operations
 // added to this file.
 const { verifyRole } = require("../middleware/auth");
+// RBAC permission gate for the staff-authed "My Prescriptions" page —
+// see GET /api/wellness/my-prescriptions below. Lets any role granted
+// `my_prescriptions.read` view their OWN linked Patient's Rx without
+// needing the tenant-wide `prescriptions.read`.
+const { requirePermission } = require("../middleware/requirePermission");
 const {
   uploadImage,
   deleteFile,
@@ -127,11 +132,32 @@ async function verifyPatientToken(req, res, next) {
 
   // Path A — patient-portal token
   if (decoded.patientId) {
-    req.patient = {
-      id: decoded.patientId,
-      phoneLast10: decoded.phoneLast10,
-    };
-    return next();
+    // Look up the patient row to attach tenantId. The phone+OTP JWT only
+    // carries { patientId, phoneLast10 } so tenantId is unavailable from
+    // the claim alone. Downstream RBAC gates (requirePortalPermission)
+    // and audit writes both need tenantId, so resolve it once here and
+    // memoize on req.patient.
+    try {
+      const patientRow = await prisma.patient.findUnique({
+        where: { id: decoded.patientId },
+        select: { id: true, tenantId: true },
+      });
+      if (!patientRow) {
+        return res.status(401).json({ error: "Invalid portal token" });
+      }
+      req.patient = {
+        id: patientRow.id,
+        tenantId: patientRow.tenantId,
+        phoneLast10: decoded.phoneLast10,
+      };
+      return next();
+    } catch (err) {
+      console.error(
+        "[wellness] verifyPatientToken Path A patient lookup failed:",
+        err.message,
+      );
+      return res.status(500).json({ error: "Failed to resolve patient" });
+    }
   }
 
   // Path B — regular CUSTOMER session token; resolve linked Patient.
@@ -149,7 +175,7 @@ async function verifyPatientToken(req, res, next) {
     try {
       let patient = await prisma.patient.findFirst({
         where: { userId: decoded.userId, tenantId: decoded.tenantId },
-        select: { id: true, phone: true },
+        select: { id: true, phone: true, tenantId: true },
       });
 
       if (!patient) {
@@ -170,7 +196,7 @@ async function verifyPatientToken(req, res, next) {
               email: userRow.email,
               userId: null,
             },
-            select: { id: true, phone: true },
+            select: { id: true, phone: true, tenantId: true },
           });
           if (claimable) {
             await prisma.patient.update({
@@ -191,13 +217,14 @@ async function verifyPatientToken(req, res, next) {
               userId: decoded.userId,
               source: "self-register",
             },
-            select: { id: true, phone: true },
+            select: { id: true, phone: true, tenantId: true },
           });
         }
       }
 
       req.patient = {
         id: patient.id,
+        tenantId: patient.tenantId,
         phoneLast10:
           (patient.phone || "").replace(/\D/g, "").slice(-10) || null,
       };
@@ -213,6 +240,16 @@ async function verifyPatientToken(req, res, next) {
 
   return res.status(401).json({ error: "Invalid portal token" });
 }
+
+// Patient-portal RBAC resolver — see lib/portalPermissions.js for the full
+// rationale. In short: patient is a Patient row, not a User row, so they
+// can't have UserRole assignments. Every patient on a tenant implicitly
+// inherits that tenant's CUSTOMER role permissions, and the handler still
+// scopes data by `patientId: req.patient.id` as defence in depth.
+const {
+  requirePortalPermission,
+  getCustomerRolePermissions,
+} = require("../lib/portalPermissions");
 
 const router = express.Router();
 
@@ -8704,7 +8741,11 @@ router.get("/prescriptions/:id/pdf", async (req, res) => {
     const clinic = await primaryClinic(req.user.tenantId);
     const doctor =
       rx.doctor || (req.user?.name ? { name: req.user.name } : null);
-    const buf = await renderPrescriptionPdf(rx, rx.patient, clinic, doctor);
+    const { tenant, logoBuffer } = await loadTenantBrandAssets(req.user.tenantId);
+    const buf = await renderPrescriptionPdf(rx, rx.patient, clinic, doctor, {
+      tenant,
+      logoBuffer,
+    });
     // PRD §11: PDF export of an Rx is a downloadable PHI artefact; the audit
     // row is what proves "who pulled this drug list and when". IDs only —
     // never the drug names (those live in the Prescription row itself).
@@ -8740,6 +8781,145 @@ router.get("/prescriptions/:id/pdf", async (req, res) => {
   }
 });
 
+// ── /my-prescriptions — staff-authed self-view of own Rx ───────────
+//
+// Companion to the patient-portal /portal/prescriptions endpoint but
+// for staff JWTs. Resolves the logged-in user's linked Patient record
+// (Patient.userId === req.user.userId, same tenant) and returns ONLY
+// that Patient's prescriptions. Gated on `my_prescriptions.read` so
+// admins can grant Rx self-view to any staff role (USER, MANAGER,
+// DOCTOR, …) without exposing the tenant-wide `prescriptions.read`.
+//
+// Cross-patient access is structurally impossible: the WHERE clause
+// hardcodes `patientId: linkedPatient.id`. If the staff user has no
+// linked Patient row, returns an empty list with a 200 — the frontend
+// renders an explanatory empty state ("Your patient profile isn't
+// linked yet — ask your clinic to link it") rather than treating
+// missing-link as an error.
+router.get(
+  "/my-prescriptions",
+  requirePermission("my_prescriptions", "read"),
+  async (req, res) => {
+    try {
+      const patient = await prisma.patient.findFirst({
+        where: { userId: req.user.userId, tenantId: req.user.tenantId },
+        select: { id: true, name: true },
+      });
+      if (!patient) {
+        return res.json({ patient: null, prescriptions: [] });
+      }
+      const prescriptions = await prisma.prescription.findMany({
+        where: { patientId: patient.id, tenantId: req.user.tenantId },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+        include: {
+          visit: {
+            select: {
+              id: true,
+              visitDate: true,
+              service: { select: { name: true } },
+            },
+          },
+          doctor: { select: { id: true, name: true } },
+        },
+      });
+      // PRD §11: staff self-access of own Rx list is still a PHI read —
+      // log it. ONE row per request; actorType stays 'user' so the staff-
+      // side audit viewer can distinguish self-view from clinician pulls.
+      try {
+        await writeAudit(
+          "Prescription",
+          "USER_LIST_READ",
+          null,
+          req.user.userId,
+          req.user.tenantId,
+          {
+            count: prescriptions.length,
+            source: "my-prescriptions",
+            patientId: patient.id,
+          },
+        );
+      } catch (auditErr) {
+        console.warn(
+          "[wellness] audit my-prescriptions list failed:",
+          auditErr.message,
+        );
+      }
+      res.json({ patient: { id: patient.id, name: patient.name }, prescriptions });
+    } catch (e) {
+      console.error("[wellness] my-prescriptions list error:", e.message);
+      res.status(500).json({ error: "Failed to load prescriptions" });
+    }
+  },
+);
+
+router.get(
+  "/my-prescriptions/:id/pdf",
+  requirePermission("my_prescriptions", "read"),
+  async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (!Number.isFinite(id)) {
+        return res.status(400).json({ error: "Invalid prescription id" });
+      }
+      const patient = await prisma.patient.findFirst({
+        where: { userId: req.user.userId, tenantId: req.user.tenantId },
+        select: { id: true },
+      });
+      if (!patient) {
+        return res.status(404).json({ error: "Prescription not found" });
+      }
+      const rx = await prisma.prescription.findFirst({
+        where: { id, patientId: patient.id, tenantId: req.user.tenantId },
+        include: {
+          patient: true,
+          doctor: { select: { id: true, name: true, email: true } },
+        },
+      });
+      if (!rx) return res.status(404).json({ error: "Prescription not found" });
+      const clinic = await primaryClinic(rx.tenantId);
+      const { tenant, logoBuffer } = await loadTenantBrandAssets(rx.tenantId);
+      const buf = await renderPrescriptionPdf(
+        rx,
+        rx.patient,
+        clinic,
+        rx.doctor || null,
+        { tenant, logoBuffer },
+      );
+      try {
+        await writeAudit(
+          "Prescription",
+          "PRESCRIPTION_PDF_DOWNLOAD",
+          rx.id,
+          req.user.userId,
+          rx.tenantId,
+          {
+            prescriptionId: rx.id,
+            visitId: rx.visitId,
+            patientId: rx.patientId,
+            source: "my-prescriptions",
+          },
+        );
+      } catch (auditErr) {
+        console.warn(
+          "[wellness] audit my-prescriptions PDF failed:",
+          auditErr.message,
+        );
+      }
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader("Content-Disposition", `inline; filename="rx-${id}.pdf"`);
+      res.setHeader("Content-Length", buf.length);
+      res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+      res.setHeader("Pragma", "no-cache");
+      res.setHeader("Expires", "0");
+      res.send(buf);
+    } catch (e) {
+      console.error("[wellness] my-prescriptions pdf error:", e.message);
+      res.status(500).json({ error: "Failed to render prescription PDF" });
+    }
+  },
+);
+
 // Module-level cache for logo bytes — keyed by absolute file path. The
 // bundled globussoft-logo.png is 2.4 MB; without the cache, every PDF
 // download did a fresh fs.readFileSync, which dominated /summary.pdf
@@ -8747,6 +8927,42 @@ router.get("/prescriptions/:id/pdf", async (req, res) => {
 // up any new logo file. A sentinel of `null` records "we already
 // checked this path and it doesn't exist" so we don't re-stat per call.
 const __logoCache = new Map();
+/**
+ * Resolve the {tenant, logoBuffer} pair every clinical PDF needs to
+ * render the canonical wellness branded header. Both fields are
+ * optional from the renderer's perspective — tenant.name lifts the
+ * H1 from the location/clinic name to the company brand, and
+ * logoBuffer turns on the square logo tile in the header.
+ *
+ * Path resolution mirrors the patient-summary caller: prefer a tenant-
+ * uploaded logo under /uploads, fall back to the bundled
+ * frontend/public/globussoft-logo.png. loadCachedLogo memoises both
+ * the hit and the "this path doesn't exist" miss so repeated calls
+ * are free.
+ */
+async function loadTenantBrandAssets(tenantId) {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { id: true, name: true, logoUrl: true },
+  });
+  const candidates = [];
+  if (tenant?.logoUrl && tenant.logoUrl.startsWith("/uploads/")) {
+    candidates.push(path.join(__dirname, "..", tenant.logoUrl));
+  }
+  candidates.push(
+    path.join(
+      __dirname,
+      "..",
+      "..",
+      "frontend",
+      "public",
+      "globussoft-logo.png",
+    ),
+  );
+  const logoBuffer = loadCachedLogo(candidates);
+  return { tenant, logoBuffer };
+}
+
 function loadCachedLogo(candidatePaths) {
   for (const p of candidatePaths) {
     if (__logoCache.has(p)) {
@@ -9416,6 +9632,22 @@ router.get("/portal/me", verifyPatientToken, async (req, res) => {
   }
 });
 
+// GET /portal/me/permissions — the resolved permission set for the
+// logged-in patient. Patients inherit the tenant's CUSTOMER system role
+// (see lib/portalPermissions.js), so this returns the union of grants on
+// that role. The frontend uses this to hide tabs the patient lacks
+// permission for (e.g. the Prescriptions tab when `my_prescriptions.read`
+// is revoked) — purely cosmetic; the backend gate is the security boundary.
+router.get("/portal/me/permissions", verifyPatientToken, async (req, res) => {
+  try {
+    const perms = await getCustomerRolePermissions(req.patient.tenantId);
+    res.json({ permissions: Array.from(perms).sort() });
+  } catch (e) {
+    console.error("[wellness] portal/me/permissions error:", e.message);
+    res.status(500).json({ error: "Failed to load permissions" });
+  }
+});
+
 router.get("/portal/visits", verifyPatientToken, async (req, res) => {
   try {
     // ?upcoming=true returns only future, non-cancelled visits, ordered
@@ -9471,7 +9703,7 @@ router.get("/portal/visits", verifyPatientToken, async (req, res) => {
   }
 });
 
-router.get("/portal/prescriptions", verifyPatientToken, async (req, res) => {
+router.get("/portal/prescriptions", verifyPatientToken, requirePortalPermission("my_prescriptions", "read"), async (req, res) => {
   try {
     const prescriptions = await prisma.prescription.findMany({
       where: { patientId: req.patient.id },
@@ -9535,6 +9767,7 @@ router.get("/portal/prescriptions", verifyPatientToken, async (req, res) => {
 router.get(
   "/portal/prescriptions/:id/pdf",
   verifyPatientToken,
+  requirePortalPermission("my_prescriptions", "read"),
   async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
@@ -9551,7 +9784,11 @@ router.get(
       if (!rx) return res.status(404).json({ error: "Prescription not found" });
       const clinic = await primaryClinic(rx.tenantId);
       const doctor = rx.doctor || null;
-      const buf = await renderPrescriptionPdf(rx, rx.patient, clinic, doctor);
+      const { tenant, logoBuffer } = await loadTenantBrandAssets(rx.tenantId);
+      const buf = await renderPrescriptionPdf(rx, rx.patient, clinic, doctor, {
+        tenant,
+        logoBuffer,
+      });
       // PRD §11: PDF downloads of PHI go to the audit ledger. ONE row per
       // request; actorType='patient' so the staff-side audit viewer can
       // distinguish self-downloads from clinician-pulled copies.
@@ -11822,6 +12059,361 @@ router.post("/giftcards/:id/purchase/confirm", async (req, res) => {
   }
 });
 
+// ─────────────────────────────────────────────────────────────────
+// Self-service membership purchase — mirrors the gift-card storefront flow
+// above. A patient-portal / wellness user browses /wellness/memberships,
+// clicks "Buy", goes through the Razorpay handshake, and ends up with an
+// active Membership row in their own account (no admin involvement).
+//
+//   POST /membership-plans/:id/purchase/order   — create Razorpay order
+//   POST /membership-plans/:id/purchase/confirm — verify + create Membership
+//
+// Authenticated against the regular JWT (any tenant user can buy a plan for
+// themself). The Patient row is get-or-created from req.user — same pattern
+// /appointments/book uses so a user who's never been to the clinic can still
+// purchase + immediately apply the membership at booking time.
+// ─────────────────────────────────────────────────────────────────
+
+router.post(
+  "/membership-plans/:id/purchase/order",
+  verifyToken,
+  async (req, res) => {
+    try {
+      const { getRazorpay } = require("../services/razorpayService");
+      const razorpay = getRazorpay();
+      if (!razorpay) {
+        return res.status(503).json({ error: "Razorpay not configured" });
+      }
+      if (!process.env.RAZORPAY_KEY_ID) {
+        return res.status(503).json({ error: "Razorpay not configured" });
+      }
+
+      const planIdInt = parseInt(req.params.id, 10);
+      if (!Number.isFinite(planIdInt) || planIdInt < 1) {
+        return res.status(400).json({ error: "Invalid plan id" });
+      }
+
+      const plan = await prisma.membershipPlan.findFirst({
+        where: { id: planIdInt, tenantId: req.user.tenantId },
+      });
+      if (!plan) {
+        return res.status(404).json({ error: "Membership plan not found" });
+      }
+      if (/^_teardown_|^_test_/.test(plan.name || "")) {
+        return res.status(410).json({
+          error: "This plan is a test fixture and cannot be purchased",
+          code: "PLAN_ARCHIVED_OR_TEST",
+        });
+      }
+      if (!plan.isActive) {
+        return res
+          .status(409)
+          .json({ error: "Membership plan is inactive", code: "PLAN_INACTIVE" });
+      }
+
+      // Get-or-create the buyer's patient record (same pattern as
+      // /appointments/book). Lets first-time users buy without a prior
+      // clinic visit; staff can merge / annotate the row later.
+      const { userId, tenantId } = req.user;
+      let patient = await prisma.patient.findFirst({
+        where: { tenant: { id: tenantId }, user: { id: userId } },
+      });
+      if (!patient) {
+        const user = await prisma.user.findUnique({
+          where: { id: userId },
+          select: { name: true, email: true },
+        });
+        patient = await prisma.patient.create({
+          data: {
+            name: user?.name || user?.email || "Patient",
+            email: user?.email,
+            source: "self-purchase",
+            tenant: { connect: { id: tenantId } },
+            user: { connect: { id: userId } },
+          },
+        });
+      }
+
+      const amountPaise = Math.round(Number(plan.price) * 100);
+      const currency = String(plan.currency || "INR").toUpperCase();
+
+      let order;
+      try {
+        order = await razorpay.orders.create({
+          amount: amountPaise,
+          currency,
+          receipt: `mp_${plan.id}_${Date.now()}`,
+          notes: {
+            tenantId: String(tenantId),
+            planId: String(plan.id),
+            patientId: String(patient.id),
+            kind: "membership_purchase",
+          },
+        });
+      } catch (gatewayErr) {
+        console.error(
+          "[wellness] razorpay order failed (membership):",
+          gatewayErr && gatewayErr.message,
+        );
+        return res
+          .status(502)
+          .json({ error: "Failed to create payment order" });
+      }
+
+      const payment = await prisma.payment.create({
+        data: {
+          invoiceId: null,
+          amount: Number(plan.price),
+          currency,
+          gateway: "razorpay",
+          gatewayId: order.id,
+          status: "PENDING",
+          tenantId,
+          metadata: JSON.stringify({
+            kind: "membership_purchase",
+            planId: plan.id,
+            patientId: patient.id,
+            orderId: order.id,
+            orderStatus: order.status,
+          }),
+        },
+      });
+
+      res.json({
+        orderId: order.id,
+        paymentId: payment.id,
+        key: process.env.RAZORPAY_KEY_ID,
+        amount: amountPaise,
+        currency,
+        planId: plan.id,
+        patientId: patient.id,
+      });
+    } catch (e) {
+      console.error("[wellness] membership purchase order error:", e.message);
+      res
+        .status(500)
+        .json({ error: "Failed to start membership purchase" });
+    }
+  },
+);
+
+// Verifies the Razorpay signature, marks the Payment SUCCESS, and creates
+// the Membership row (matching the staff-side /patients/:id/memberships
+// purchase semantics — endDate from durationDays, balance stamped from
+// plan.entitlements). Defence-in-depth: metadata.planId must match URL :id.
+router.post(
+  "/membership-plans/:id/purchase/confirm",
+  verifyToken,
+  async (req, res) => {
+    try {
+      const planIdInt = parseInt(req.params.id, 10);
+      if (!Number.isFinite(planIdInt) || planIdInt < 1) {
+        return res.status(400).json({ error: "Invalid plan id" });
+      }
+
+      const {
+        paymentId,
+        razorpay_order_id,
+        razorpay_payment_id,
+        razorpay_signature,
+      } = req.body || {};
+
+      if (
+        !paymentId ||
+        !razorpay_order_id ||
+        !razorpay_payment_id ||
+        !razorpay_signature
+      ) {
+        return res.status(400).json({ error: "Missing required fields" });
+      }
+
+      const secret = process.env.RAZORPAY_KEY_SECRET;
+      if (!secret) {
+        return res.status(503).json({ error: "Razorpay not configured" });
+      }
+
+      const payment = await prisma.payment.findFirst({
+        where: {
+          id: parseInt(paymentId, 10),
+          tenantId: req.user.tenantId,
+        },
+      });
+      if (!payment) {
+        return res.status(404).json({ error: "Payment not found" });
+      }
+
+      const expected = require("crypto")
+        .createHmac("sha256", secret)
+        .update(`${razorpay_order_id}|${razorpay_payment_id}`)
+        .digest("hex");
+
+      if (expected !== razorpay_signature) {
+        await prisma.payment.update({
+          where: { id: payment.id },
+          data: { status: "FAILED" },
+        });
+        return res
+          .status(400)
+          .json({ error: "Signature verification failed" });
+      }
+
+      // Pull plan + patient out of the metadata the order handler stored.
+      // The URL :id must match metadata.planId so a confirm call can't
+      // redirect the purchase to a different plan.
+      let meta = {};
+      try {
+        meta = JSON.parse(payment.metadata || "{}");
+      } catch (_e) { /* malformed metadata is treated as missing */ }
+      if (
+        meta.planId !== planIdInt ||
+        meta.kind !== "membership_purchase"
+      ) {
+        return res
+          .status(400)
+          .json({ error: "Payment does not match membership plan" });
+      }
+      const patientId = parseInt(meta.patientId, 10);
+      if (!Number.isInteger(patientId) || patientId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Payment is missing patient context" });
+      }
+
+      // Re-verify plan eligibility (in case an admin deactivated between
+      // order-create and confirm — Razorpay still charged the user; we
+      // fail the Payment so an operator refunds out-of-band).
+      const plan = await prisma.membershipPlan.findFirst({
+        where: { id: planIdInt, tenantId: req.user.tenantId },
+      });
+      if (!plan || !plan.isActive) {
+        await prisma.payment.update({
+          where: { id: payment.id },
+          data: { status: "FAILED" },
+        });
+        return res
+          .status(410)
+          .json({ error: "Membership plan is no longer available" });
+      }
+
+      const updatedPayment = await prisma.payment.update({
+        where: { id: payment.id },
+        data: {
+          status: "SUCCESS",
+          paidAt: new Date(),
+          gatewayId: razorpay_payment_id,
+          metadata: JSON.stringify({
+            ...meta,
+            razorpay_order_id,
+            razorpay_payment_id,
+            verifiedAt: new Date().toISOString(),
+          }),
+        },
+      });
+
+      // Stamp initial balance from plan.entitlements — same shape the
+      // staff-side /patients/:id/memberships POST writes so redemption,
+      // expiry-notification, and balance reads work identically.
+      let entitlements;
+      try {
+        entitlements = JSON.parse(plan.entitlements);
+      } catch {
+        return res.status(500).json({
+          error: "Plan entitlements are corrupt",
+          code: "PLAN_ENTITLEMENTS_CORRUPT",
+        });
+      }
+      const initialBalance = (Array.isArray(entitlements) ? entitlements : []).map(
+        (e) => ({ serviceId: e.serviceId, remaining: e.quantity }),
+      );
+
+      const start = new Date();
+      const end = new Date(start.getTime() + plan.durationDays * 86400000);
+
+      let isRenewal = false;
+      try {
+        const priorCount = await prisma.membership.count({
+          where: {
+            tenantId: req.user.tenantId,
+            patientId,
+            planId: plan.id,
+          },
+        });
+        isRenewal = priorCount > 0;
+      } catch (_e) { /* best-effort */ }
+
+      const membership = await prisma.membership.create({
+        data: {
+          tenantId: req.user.tenantId,
+          patientId,
+          planId: plan.id,
+          startDate: start,
+          endDate: end,
+          balance: JSON.stringify(initialBalance),
+          status: "active",
+        },
+      });
+
+      try {
+        await writeAudit(
+          "Membership",
+          "PURCHASE",
+          membership.id,
+          req.user.userId,
+          req.user.tenantId,
+          {
+            patientId,
+            planId: plan.id,
+            planName: plan.name,
+            price: plan.price,
+            paymentId: payment.id,
+            razorpay_payment_id,
+            source: "self-purchase",
+          },
+        );
+      } catch (auditErr) {
+        console.warn("[audit]", auditErr.message);
+      }
+
+      try {
+        require("../lib/eventBus").emitEvent(
+          isRenewal ? "membership.renewed" : "membership.enrolled",
+          {
+            membershipId: membership.id,
+            patientId,
+            planId: plan.id,
+            planName: plan.name,
+            price: plan.price,
+            startDate: start,
+            endDate: end,
+            isRenewal,
+            source: "self-purchase",
+          },
+          req.user.tenantId,
+          req.io,
+        );
+      } catch (_e) { }
+
+      res.json({
+        success: true,
+        membership: {
+          id: membership.id,
+          planId: plan.id,
+          planName: plan.name,
+          startDate: start,
+          endDate: end,
+          status: membership.status,
+        },
+        payment: { id: updatedPayment.id, status: updatedPayment.status },
+      });
+    } catch (e) {
+      console.error("[wellness] membership purchase confirm error:", e.message);
+      res
+        .status(500)
+        .json({ error: "Failed to confirm membership purchase" });
+    }
+  },
+);
+
 // Admin-applied gift-card credit. The /giftcards/redeem path above requires
 // the plaintext code (recipient flow — SMS/email/printed card → patient
 // portal). This route is the parallel operator flow: an ADMIN or MANAGER
@@ -12762,16 +13354,30 @@ router.get(
   // Allows any authenticated user to book an appointment
   router.post("/appointments/book", verifyToken, async (req, res) => {
     try {
-      const { doctorId, serviceId, appointmentDate, appointmentTime } =
-        req.body;
+      const {
+        doctorId,
+        serviceId,
+        appointmentDate,
+        appointmentTime,
+        reason,
+        membershipId,
+      } = req.body;
       const { userId, tenantId } = req.user;
 
-      // Validate required fields
-      if (!doctorId || !appointmentDate || !appointmentTime) {
+      // Validate required fields. doctorId is OPTIONAL — when omitted the
+      // visit is created with doctor=null and the admin assigns one based on
+      // the patient's reason + available specialists. reason is REQUIRED so
+      // admins have something to triage against when no doctor is preselected.
+      if (!appointmentDate || !appointmentTime) {
         return res.status(400).json({
-          error:
-            "Missing required fields: doctorId, appointmentDate, appointmentTime",
+          error: "Missing required fields: appointmentDate, appointmentTime",
         });
+      }
+      const trimmedReason = typeof reason === "string" ? reason.trim() : "";
+      if (!trimmedReason) {
+        return res
+          .status(400)
+          .json({ error: "Reason for appointment is required" });
       }
 
       // Parse date and time
@@ -12780,22 +13386,26 @@ router.get(
         return res.status(400).json({ error: "Invalid appointment date" });
       }
 
-      // Check if doctor is available (approved leave check)
-      const leaveReq = await prisma.leaveRequest.findFirst({
-        where: {
-          tenantId,
-          userId: parseInt(doctorId),
-          status: "APPROVED",
-          startDate: { lte: apptDate },
-          endDate: { gte: apptDate },
-        },
-      });
-
-      if (leaveReq) {
-        return res.status(409).json({
-          error: "Doctor is not available on this date",
-          code: "DOCTOR_UNAVAILABLE",
+      // Check if doctor is available (approved leave check). Only when a
+      // doctor was preselected — for admin-assigned bookings the staff
+      // dispatcher does this check at assignment time.
+      if (doctorId) {
+        const leaveReq = await prisma.leaveRequest.findFirst({
+          where: {
+            tenantId,
+            userId: parseInt(doctorId),
+            status: "APPROVED",
+            startDate: { lte: apptDate },
+            endDate: { gte: apptDate },
+          },
         });
+
+        if (leaveReq) {
+          return res.status(409).json({
+            error: "Doctor is not available on this date",
+            code: "DOCTOR_UNAVAILABLE",
+          });
+        }
       }
 
       // Get or create patient for current user
@@ -12828,6 +13438,29 @@ router.get(
         });
       }
 
+      // Validate optional membership: must belong to this patient and be
+      // active + within its validity window. Wrong tenant / cancelled /
+      // expired memberships → 400 so the frontend can surface a clear
+      // message rather than silently dropping the selection.
+      let resolvedMembershipId = null;
+      if (membershipId != null && membershipId !== "") {
+        const mId = parseInt(membershipId);
+        if (Number.isNaN(mId)) {
+          return res.status(400).json({ error: "Invalid membership" });
+        }
+        const m = await prisma.membership.findFirst({
+          where: { id: mId, tenantId, patientId: patient.id },
+        });
+        const now = new Date();
+        if (!m || m.status !== "active" || m.endDate < now) {
+          return res.status(400).json({
+            error: "Selected membership is not active",
+            code: "MEMBERSHIP_INACTIVE",
+          });
+        }
+        resolvedMembershipId = mId;
+      }
+
       // Create visit/appointment with IST timezone
       const [hours, mins] = appointmentTime.split(":").map((x) => parseInt(x));
       const visitDate = new Date(
@@ -12839,11 +13472,13 @@ router.get(
         data: {
           tenantId,
           patientId: patient.id,
-          doctorId: parseInt(doctorId),
+          doctorId: doctorId ? parseInt(doctorId) : null,
           serviceId: serviceId ? parseInt(serviceId) : null,
+          membershipId: resolvedMembershipId,
           visitDate,
           status: "booked",
           bookingType: "CLINIC_VISIT",
+          reason: trimmedReason,
           createdAt: new Date(),
         },
         include: {
@@ -12866,10 +13501,13 @@ router.get(
         appointment: {
           id: visit.id,
           patientName: visit.patient.name,
-          doctorName: visit.doctor?.name || "N/A",
+          doctorName: visit.doctor?.name || "Pending assignment",
           serviceName: visit.service?.name || "General",
           appointmentDate: visit.visitDate,
           status: visit.status,
+          reason: visit.reason,
+          membershipId: visit.membershipId,
+          doctorAssigned: !!visit.doctorId,
         },
       });
     } catch (err) {
@@ -12914,16 +13552,58 @@ router.get(
 
       const appointments = visits.map((v) => ({
         id: v.id,
-        doctorName: v.doctor?.name || "N/A",
+        doctorName: v.doctor?.name || "Pending assignment",
         serviceName: v.service?.name || "General",
         appointmentDate: v.visitDate,
         status: v.status,
+        reason: v.reason || null,
+        doctorAssigned: !!v.doctorId,
       }));
 
       res.json(appointments);
     } catch (err) {
       console.error("[wellness] get appointments failed:", err.message);
       res.status(500).json({ error: "Failed to fetch appointments" });
+    }
+  });
+
+  // List active memberships the current user can apply to a booking. The
+  // staff-side `/patients/:id/memberships` endpoint is phiReadGate-protected,
+  // so the self-booking page can't reach it from the patient's own session.
+  // This endpoint mirrors that read but scopes by req.user → patient and
+  // filters to active, non-expired rows.
+  router.get("/appointments/my-memberships", verifyToken, async (req, res) => {
+    try {
+      const { userId, tenantId } = req.user;
+      const patient = await prisma.patient.findFirst({
+        where: { tenant: { id: tenantId }, user: { id: userId } },
+      });
+      if (!patient) return res.json([]);
+
+      const now = new Date();
+      const rows = await prisma.membership.findMany({
+        where: {
+          tenantId,
+          patientId: patient.id,
+          status: "active",
+          endDate: { gte: now },
+        },
+        include: {
+          plan: { select: { id: true, name: true, durationDays: true } },
+        },
+        orderBy: { endDate: "asc" },
+      });
+      res.json(
+        rows.map((m) => ({
+          id: m.id,
+          planName: m.plan?.name || "Membership",
+          endDate: m.endDate,
+          status: m.status,
+        })),
+      );
+    } catch (err) {
+      console.error("[wellness] my memberships failed:", err.message);
+      res.status(500).json({ error: "Failed to fetch memberships" });
     }
   });
 

--- a/backend/scripts/backfill-role-preset-perms.js
+++ b/backend/scripts/backfill-role-preset-perms.js
@@ -68,7 +68,10 @@ const MANAGER_PERMISSIONS = [
   'reports.read', 'reports.export',
   'dashboards.read',
   'analytics.read', 'analytics.export',
-  'billing.read',
+  // `billing` decomposed in v3.8.x → invoices / gift_cards / patient_wallets.
+  'invoices.read',
+  'gift_cards.read',
+  'patient_wallets.read',
   'staff.read',
   'roles.read',
   'communications.read', 'communications.write',
@@ -95,10 +98,12 @@ const CUSTOMER_PERMISSIONS = [
   'leads.read',
   'appointments.read',
   'services.read',
-  'billing.read',
+  // `billing` decomposed in v3.8.x; CUSTOMER gets invoices.read.
+  'invoices.read',
   'payments.read',
   'documents.read',
-  'prescriptions.read',
+  // Patient-portal-scoped Rx view — never the tenant-wide `prescriptions.read`.
+  'my_prescriptions.read',
   'consents.read', 'consents.write',
   'visits.read',
 ];
@@ -171,7 +176,12 @@ const RECEPTIONIST_PERMISSIONS = [
   'calendar.read', 'calendar.write',
   'services.read',
   'products.read',
-  'billing.read', 'billing.write',
+  // `billing` decomposed in v3.8.x. Receptionist gets read+write on
+  // invoices (front-desk raise + collect); gift_cards + patient_wallets
+  // stay read-only (top-ups go through POS, not direct ledger writes).
+  'invoices.read', 'invoices.write',
+  'gift_cards.read',
+  'patient_wallets.read',
   'payments.read',
   'pos.read', 'pos.write', 'pos.manage',
   'contacts.read', 'contacts.write',
@@ -227,6 +237,45 @@ const ROLE_GRANTS = {
   TELECALLER: TELECALLER_PERMISSIONS,
 };
 
+// Permissions that should be EXPLICITLY removed from system roles during
+// backfill. The default backfill pass is purely additive (preserves admin
+// customisations) but a small set of renamed/replaced permissions need
+// to be cleared on existing tenants. Each entry below is paired with a
+// matching ADD in the role's PERMISSIONS list, so the net effect on a
+// backfilled tenant is a rename, not a removal of capability.
+//
+//   CUSTOMER: prescriptions.read → my_prescriptions.read
+//     The tenant-wide `prescriptions.read` was always a no-op for
+//     CUSTOMER (their JWT can't reach the staff routes that check it).
+//     Replaced by the patient-portal-scoped `my_prescriptions.read`
+//     which gates the /portal/prescriptions endpoints.
+//
+//   * billing.* → invoices.* + gift_cards.* + patient_wallets.*
+//     The `billing` module was removed from the catalogue in v3.8.x
+//     and split per surface. Strip every legacy `billing.*` grant from
+//     the system roles on existing tenants — the ADD pass above
+//     re-grants the equivalent per-surface permissions in the right
+//     shape for each role.
+const BILLING_LEGACY = [
+  'billing.read',
+  'billing.write',
+  'billing.update',
+  'billing.delete',
+  'billing.export',
+  'billing.manage',
+];
+
+const ROLE_REMOVALS = {
+  ADMIN: BILLING_LEGACY,
+  MANAGER: BILLING_LEGACY,
+  USER: BILLING_LEGACY,
+  CUSTOMER: ['prescriptions.read', ...BILLING_LEGACY],
+  DOCTOR: BILLING_LEGACY,
+  NURSE: BILLING_LEGACY,
+  RECEPTIONIST: BILLING_LEGACY,
+  TELECALLER: BILLING_LEGACY,
+};
+
 async function main() {
   console.log(`[backfill-role-preset] mode: ${APPLY ? 'APPLY' : 'DRY-RUN (use --apply to persist)'}`);
   if (tenantFilter) console.log(`[backfill-role-preset] tenant filter: ${tenantFilter}`);
@@ -246,6 +295,7 @@ async function main() {
   let totalRolesUntouched = 0;
   let totalGrantsAdded = 0;
   let totalGrantsAlready = 0;
+  let totalGrantsRemoved = 0;
   const perRoleKeySummary = {};
 
   const roleKeys = roleFilter
@@ -309,6 +359,32 @@ async function main() {
       }
       totalGrantsAdded += missing.length;
       perRoleKeySummary[role.key] = (perRoleKeySummary[role.key] || 0) + missing.length;
+
+      // Targeted removals for renamed permissions. Only touches the exact
+      // (roleKey, module, action) tuples in ROLE_REMOVALS — never blanket-
+      // wipes a role.
+      const removalList = ROLE_REMOVALS[role.key] || [];
+      const removable = removalList.filter((perm) => existingSet.has(perm));
+      if (removable.length > 0) {
+        console.log(
+          `  - tenant ${tenant.id} (${tenant.name}) — role ${role.key} (${role.name}): ` +
+            `removing ${removable.length} obsolete grant(s) → ${removable.join(', ')}`,
+        );
+        if (APPLY) {
+          for (const perm of removable) {
+            const [module, action] = perm.split('.');
+            if (!module || !action) continue;
+            try {
+              await prisma.rolePermission.deleteMany({
+                where: { roleId: role.id, module, action },
+              });
+            } catch (err) {
+              console.warn(`    (skip remove ${perm}: ${err.message})`);
+            }
+          }
+        }
+        totalGrantsRemoved += removable.length;
+      }
     }
   }
 
@@ -319,6 +395,7 @@ async function main() {
   console.log(`  roles already up-to-date: ${totalRolesUntouched}`);
   console.log(`  grants already present:   ${totalGrantsAlready}`);
   console.log(`  grants ${APPLY ? 'added' : 'would-add'}:        ${totalGrantsAdded}`);
+  console.log(`  grants ${APPLY ? 'removed' : 'would-remove'}:      ${totalGrantsRemoved}`);
   if (Object.keys(perRoleKeySummary).length > 0) {
     console.log('  per-role-key breakdown:');
     for (const [key, n] of Object.entries(perRoleKeySummary)) {

--- a/backend/scripts/ensureRbacOnBoot.js
+++ b/backend/scripts/ensureRbacOnBoot.js
@@ -36,7 +36,11 @@ const MANAGER_PERMISSIONS = [
   'reports.read', 'reports.export',
   'dashboards.read',
   'analytics.read', 'analytics.export',
-  'billing.read',
+  // `billing` was decomposed in v3.8.x → invoices / gift_cards /
+  // patient_wallets. MANAGER inherits read across all three.
+  'invoices.read',
+  'gift_cards.read',
+  'patient_wallets.read',
   'staff.read',
   // Roles read-only — Manager can SEE the role matrix (audit trail / who
   // has what) but cannot grant or revoke (manage stays with Admin).
@@ -75,13 +79,17 @@ const CUSTOMER_PERMISSIONS = [
   // customer can view their own enquiry record. VISITS + PAYMENTS read so
   // they can see prior visits and what they've paid. CONSENTS write is the
   // sign-on-canvas action — needed for the patient-portal consent flow.
+  // `my_prescriptions.read` is the patient-scoped counterpart to staff-
+  // wide `prescriptions.read`; CUSTOMER never gets the tenant-wide grant.
   'leads.read',
   'appointments.read',
   'services.read',
-  'billing.read',
+  // `billing` decomposed in v3.8.x; CUSTOMER gets invoices.read so they
+  // can still see their own invoice list.
+  'invoices.read',
   'payments.read',
   'documents.read',
-  'prescriptions.read',
+  'my_prescriptions.read',
   'consents.read', 'consents.write',
   'visits.read',
 ];
@@ -213,7 +221,14 @@ const RECEPTIONIST_PERMISSIONS = [
   // Receptionist views the product catalog to look up items for POS
   // sales but doesn't edit it; no stock-ledger access.
   'products.read',
-  'billing.read', 'billing.write',
+  // `billing` decomposed in v3.8.x. Receptionist needs read+write on
+  // invoices (they raise + collect them at the front desk). Gift cards
+  // + patient wallets stay read-only by default — the front-desk POS
+  // flow handles top-ups through the dedicated POS surface, not direct
+  // ledger writes.
+  'invoices.read', 'invoices.write',
+  'gift_cards.read',
+  'patient_wallets.read',
   // Spec §2 RECEPTIONIST row — payments visibility for "pending payments
   // at POS" widget + reconciliation. Payments catalog only has read +
   // export (no .write), so .read is the full grant available.

--- a/backend/scripts/seed-rbac-only.js
+++ b/backend/scripts/seed-rbac-only.js
@@ -44,7 +44,11 @@ const MANAGER_PERMISSIONS = [
   'reports.read', 'reports.export',
   'dashboards.read',
   'analytics.read', 'analytics.export',
-  'billing.read',
+  // `billing` was decomposed in v3.8.x → invoices / gift_cards /
+  // patient_wallets. MANAGER inherits read across all three.
+  'invoices.read',
+  'gift_cards.read',
+  'patient_wallets.read',
   'staff.read',
   'communications.read', 'communications.write',
   'email.read', 'email.write',
@@ -60,9 +64,11 @@ const MANAGER_PERMISSIONS = [
 const CUSTOMER_PERMISSIONS = [
   'appointments.read',
   'services.read',
-  'billing.read',
+  // `billing` decomposed in v3.8.x; CUSTOMER gets invoices.read.
+  'invoices.read',
   'documents.read',
-  'prescriptions.read',
+  // Patient-portal-scoped Rx view — never the tenant-wide `prescriptions.read`.
+  'my_prescriptions.read',
   'consents.read',
 ];
 

--- a/backend/services/pdfRenderer.js
+++ b/backend/services/pdfRenderer.js
@@ -218,6 +218,417 @@ function parseRxInstructions(raw) {
   return out;
 }
 
+// ── Branded design system (shared by Prescription + Patient Summary) ─
+// Single source of truth for the colours, pills, header band, info strip,
+// timeline dots, watermark and footer so both PDFs read like one product.
+// Pinned vitest strings (BEFORE (N), AFTER (N), +N more, (image), Patient
+// Summary, Prescription, No clinical notes recorded., etc.) stay verbatim.
+
+const BRAND = {
+  teal: "#265855",
+  tealDark: "#1d4744",
+  tealDeep: "#13322F",   // deeper teal for plan / wallet hero cards (white text on it)
+  tealSoft: "#E8F2EE",   // pale teal — info-strip background under the header band
+  blush: "#CD9481",
+  gold: "#E0A04E",        // warm amber-gold accent stripe (matches the reference's golden stripe)
+  cream: "#FAF6F0",
+  panelBg: "#F8FAFA",
+  border: "#E5E7EB",
+  borderSoft: "#EEF2F2",
+  textDark: "#111111",
+  textBody: "#1F2937",
+  textMuted: "#6B7280",
+  labelMuted: "#9CA3AF",
+};
+
+// Serif font family — Playfair Display in the reference, but PDFKit only
+// ships the standard 14 PostScript fonts, so we use Times-Bold for the
+// elegant display-level character (brand name, section titles, patient
+// name, big amounts). Names referenced via constants so the whole
+// document's serif voice can swap together if a custom font is registered
+// later.
+const SERIF_BOLD = "Times-Bold";
+const SERIF_REG = "Times-Roman";
+
+const STATUS_PILL = {
+  success: { bg: "#DCFCE7", text: "#065F46", border: "#16A34A" },
+  danger:  { bg: "#FEE2E2", text: "#991B1B", border: "#DC2626" },
+  warning: { bg: "#FEF3C7", text: "#92400E", border: "#D97706" },
+  info:    { bg: "#DBEAFE", text: "#1E3A8A", border: "#2563EB" },
+  neutral: { bg: "#F3F4F6", text: "#374151", border: "#9CA3AF" },
+};
+
+// Map a status / state string to a semantic pill kind. Keeps the pill
+// vocabulary consistent across visits, prescriptions, treatment plans,
+// invoices and memberships.
+function statusKind(raw) {
+  const v = String(raw || "").trim().toLowerCase();
+  if (!v) return "neutral";
+  if (/(complet|paid|active|issued|approved|confirm|success|signed)/.test(v)) return "success";
+  if (/(cancel|fail|expir|reject|void)/.test(v)) return "danger";
+  if (/(draft|pending|schedul|hold|review)/.test(v)) return "warning";
+  if (/(book|new|open|in[\s_-]?progress)/.test(v)) return "info";
+  return "neutral";
+}
+
+// Rounded pill. Returns the right edge so callers can chain content
+// after the pill on the same baseline.
+function drawStatusPill(doc, label, x, y, opts = {}) {
+  const text = String(label || "—").toUpperCase();
+  const kind = opts.kind || statusKind(label);
+  const palette = STATUS_PILL[kind] || STATUS_PILL.neutral;
+  const padX = opts.padX != null ? opts.padX : 8;
+  const padY = opts.padY != null ? opts.padY : 3;
+  const fontSize = opts.fontSize || 8;
+  doc.save();
+  doc.font("Helvetica-Bold").fontSize(fontSize);
+  const textW = doc.widthOfString(text);
+  const w = textW + padX * 2;
+  const h = fontSize + padY * 2;
+  doc.roundedRect(x, y, w, h, h / 2).fillAndStroke(palette.bg, palette.border);
+  doc.fillColor(palette.text).text(text, x + padX, y + padY, { width: textW + 2, lineBreak: false });
+  doc.restore();
+  return { x: x + w, y: y, w, h };
+}
+
+// Full-width branded header band. Teal background with white logo+brand
+// name on the left and clinic address+phone+email on the right; a thin
+// gold accent stripe sits flush below the band. Returns the y-cursor
+// past the band so the caller can start the document body cleanly.
+function drawBrandedHeader(doc, { brandName, tagline, clinic, logoBuffer, leftX, rightX }) {
+  const c = safeClinic(clinic);
+  const bandY = 0;
+  const bandH = 86;
+  const usableW = rightX - leftX;
+
+  // Teal band — bleeds to the page edges so the design reads as a
+  // proper letterhead rather than a margin-bound block.
+  doc.save();
+  doc.rect(0, bandY, doc.page.width, bandH).fill(BRAND.teal);
+  doc.restore();
+
+  // Logo disc (white circular plate with the supplied logo clipped
+  // inside). Falls back to a heart glyph drawn in teal when no logo
+  // buffer is supplied so the corner never reads empty.
+  const discR = 24;
+  const discCX = leftX + discR;
+  const discCY = bandY + bandH / 2;
+  doc.save();
+  doc.circle(discCX, discCY, discR).fill("#FFFFFF");
+  doc.restore();
+  if (logoBuffer) {
+    try {
+      doc.save();
+      doc.circle(discCX, discCY, discR - 2).clip();
+      doc.image(logoBuffer, discCX - (discR - 2), discCY - (discR - 2), {
+        fit: [(discR - 2) * 2, (discR - 2) * 2],
+        align: "center",
+        valign: "center",
+      });
+      doc.restore();
+    } catch (_e) {
+      doc.restore();
+    }
+  } else {
+    // Simple heart silhouette in teal — two arcs + a triangle.
+    const hx = discCX, hy = discCY + 2, s = 12;
+    doc.save();
+    doc.fillColor(BRAND.teal);
+    doc.circle(hx - s / 3, hy - s / 4, s / 3).fill();
+    doc.circle(hx + s / 3, hy - s / 4, s / 3).fill();
+    doc.moveTo(hx - s / 1.8, hy - s / 5)
+      .lineTo(hx + s / 1.8, hy - s / 5)
+      .lineTo(hx, hy + s / 1.6)
+      .closePath().fill();
+    doc.restore();
+  }
+
+  // Brand name + tagline (left of header). Serif voice (Times-Bold) for
+  // the brand name to match the reference's Playfair-Display feel; tagline
+  // stays in sans uppercase with letter-spacing as the small-caps line
+  // under the wordmark.
+  const brandX = discCX + discR + 14;
+  const brandW = usableW * 0.55 - (discR * 2 + 14);
+  doc.fillColor("#FFFFFF").font(SERIF_BOLD).fontSize(22)
+    .text(brandName || c.name || "Clinic", brandX, bandY + 22, { width: brandW, lineBreak: false });
+  if (tagline) {
+    doc.font("Helvetica").fontSize(8.5).fillColor("#E6EFEE")
+      .text(String(tagline).toUpperCase(), brandX, bandY + 52, {
+        width: brandW, characterSpacing: 1.6, lineBreak: false,
+      });
+  }
+
+  // Clinic address + phone + email — right-rail, white-on-teal.
+  const rightColW = usableW * 0.42;
+  const rightColX = rightX - rightColW;
+  doc.fillColor("#FFFFFF").font("Helvetica").fontSize(8.5);
+  const addrLines = [];
+  if (c.addressLine) addrLines.push(c.addressLine);
+  const cityLine = [c.city, c.state, c.pincode].filter(Boolean).join(", ");
+  if (cityLine) addrLines.push(cityLine);
+  if (c.phone) addrLines.push(`☎ ${c.phone}`); // ☎
+  if (c.email) addrLines.push(`✉ ${c.email}`); // ✉
+  // Compose the whole right-rail as one block so vertical centring is honest.
+  const blockH = addrLines.length * 11;
+  let ry = bandY + (bandH - blockH) / 2;
+  for (const line of addrLines) {
+    doc.text(line, rightColX, ry, { width: rightColW, align: "right", lineBreak: false });
+    ry += 11;
+  }
+
+  // Thin gold accent stripe flush against the band.
+  doc.save();
+  doc.rect(0, bandY + bandH, doc.page.width, 4).fill(BRAND.gold);
+  doc.restore();
+
+  return bandY + bandH + 4;
+}
+
+// Soft-teal info strip with N evenly-spaced LABEL/value columns. Sits
+// flush below the header gold-stripe and carries the document meta
+// (PATIENT, PATIENT ID, GENERATED, DOCUMENT). Pale teal tint (BRAND.tealSoft)
+// continues the brand voice from the header band without competing for
+// attention with the body's section titles.
+function drawInfoStrip(doc, pairs, { x, y, w }) {
+  const stripH = 42;
+  doc.save();
+  doc.rect(x, y, w, stripH).fill(BRAND.tealSoft);
+  doc.restore();
+  const colW = w / pairs.length;
+  pairs.forEach((pair, i) => {
+    const cx = x + colW * i + 12;
+    const cw = colW - 24;
+    doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.teal)
+      .text(String(pair.label || "").toUpperCase(), cx, y + 9, {
+        width: cw, characterSpacing: 1.3, lineBreak: false,
+      });
+    doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+      .text(pair.value == null || pair.value === "" ? "—" : String(pair.value),
+        cx, y + 23, { width: cw, lineBreak: false, ellipsis: true });
+  });
+  return y + stripH;
+}
+
+// Serif section title with a muted subtitle below. The reference uses a
+// large display-serif chapter heading with NO underline accent — the
+// generous size + subtitle pairing carries enough visual weight on its
+// own. Subtitle stays in regular sans muted gray.
+function drawSectionTitle(doc, title, subtitle, { x, w }) {
+  doc.font(SERIF_BOLD).fontSize(26).fillColor(BRAND.tealDark)
+    .text(title, x, doc.y, { width: w, lineBreak: false });
+  let endY = doc.y;
+  if (subtitle) {
+    doc.font("Helvetica").fontSize(10).fillColor(BRAND.textMuted)
+      .text(subtitle, x, doc.y + 2, { width: w, lineBreak: false });
+    endY = doc.y;
+  }
+  doc.y = endY + 10;
+}
+
+// Small uppercase section label (e.g. "CASE HISTORY · 9 RECORDS") with a
+// thin rule that runs from the end of the label out to the right edge —
+// matches the reference's case-history divider. Caller supplies the
+// padding; we don't move doc.y past it (caller controls content cadence).
+function drawSectionLabelWithRule(doc, label, { x, w }) {
+  doc.font("Helvetica-Bold").fontSize(8.5).fillColor(BRAND.teal)
+    .text(String(label || "").toUpperCase(), x, doc.y, {
+      characterSpacing: 1.4, lineBreak: false,
+    });
+  const labelW = doc.widthOfString(String(label || "").toUpperCase()) + label.length * 1.4;
+  const lineY = doc.y + 5;
+  const ruleStart = x + labelW + 10;
+  const ruleEnd = x + w;
+  if (ruleEnd > ruleStart) {
+    doc.save();
+    doc.moveTo(ruleStart, lineY).lineTo(ruleEnd, lineY)
+      .lineWidth(0.5).strokeColor(BRAND.border).stroke();
+    doc.restore();
+  }
+  doc.y = lineY + 8;
+}
+
+// Rounded card with optional left teal accent + optional top accent. The
+// caller draws content inside the returned content-rect; the card is
+// painted but no content is rendered here. `accentColor` overrides the
+// default teal accent (used for cancelled visits → red accent).
+function drawCardFrame(doc, { x, y, w, h, leftAccent = false, topAccent = false, bg = "#FFFFFF", border = BRAND.border, accentColor = BRAND.teal }) {
+  doc.save();
+  doc.roundedRect(x, y, w, h, 6).fillAndStroke(bg, border);
+  if (leftAccent) {
+    doc.save();
+    doc.roundedRect(x, y, 4, h, 2).fill(accentColor);
+    doc.restore();
+  }
+  if (topAccent) {
+    doc.save();
+    // Top accent painted as a 3pt stripe rounded at the top corners.
+    // Defaults to teal; passed as red for cancelled visit cards.
+    doc.rect(x + 1, y, w - 2, 3).fill(accentColor);
+    doc.restore();
+  }
+  doc.restore();
+}
+
+// Empty soft-tinted avatar circle — the reference patient-profile card
+// shows a blank circular plate (not an initial), so we paint a pale
+// teal-tinted disc with a thin border and leave the inner area clear.
+// `name` is kept in the signature for back-compat with existing callers
+// but is unused in the new rendering.
+function drawAvatarCircle(doc, { cx, cy, r /*, name */ }) {
+  doc.save();
+  doc.circle(cx, cy, r).fillAndStroke(BRAND.tealSoft, BRAND.borderSoft);
+  doc.restore();
+}
+
+// Two-column key/value grid (e.g. DOB / Gender / Source / Phone / Email
+// / Status). Each cell is a small bordered card with an uppercase label
+// and the value in regular weight.
+function drawKvGrid(doc, rows, { x, y, w, cols = 3 }) {
+  const gap = 10;
+  const cellW = (w - gap * (cols - 1)) / cols;
+  const cellH = 46;
+  rows.forEach((row, i) => {
+    const col = i % cols;
+    const r = Math.floor(i / cols);
+    const cx = x + col * (cellW + gap);
+    const cy = y + r * (cellH + gap);
+    doc.save();
+    doc.roundedRect(cx, cy, cellW, cellH, 4).fillAndStroke(BRAND.panelBg, BRAND.borderSoft);
+    doc.restore();
+    doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.textMuted)
+      .text(String(row.label || "").toUpperCase(), cx + 10, cy + 9, {
+        width: cellW - 20, characterSpacing: 1.1, lineBreak: false,
+      });
+    doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.textDark)
+      .text(row.value == null || row.value === "" ? "—" : String(row.value),
+        cx + 10, cy + 23, { width: cellW - 20, lineBreak: false, ellipsis: true });
+  });
+  const totalRows = Math.ceil(rows.length / cols);
+  return y + totalRows * cellH + (totalRows - 1) * gap;
+}
+
+// Coloured callout box (post-procedure care, warnings). Renders an icon
+// glyph + bold heading + body text on a tinted background with a left
+// accent stripe. `kind` selects the tone (warning|info|success). On
+// return, `doc.y` is parked at the bottom of the callout so the next
+// element flows directly below — callers should NOT add extra offset
+// (the function used to leak doc.y from its internal text() call which
+// caused callers to double-advance and triggered phantom auto-pages).
+function drawCalloutBox(doc, { x, y, w, heading, body, kind = "warning" }) {
+  const palette = STATUS_PILL[kind] || STATUS_PILL.warning;
+  const padX = 14, padY = 12;
+  doc.font("Helvetica").fontSize(9.5);
+  const bodyH = body ? doc.heightOfString(body, { width: w - padX * 2 - 16 }) : 0;
+  const headH = heading ? 14 : 0;
+  const h = padY * 2 + headH + (heading && body ? 4 : 0) + bodyH;
+  doc.save();
+  doc.roundedRect(x, y, w, h, 4).fillAndStroke(palette.bg, palette.border);
+  doc.rect(x, y, 4, h).fill(palette.border);
+  doc.restore();
+  if (heading) {
+    doc.font("Helvetica-Bold").fontSize(10).fillColor(palette.text)
+      .text(`⚠ ${heading}`, x + padX + 4, y + padY, { width: w - padX * 2 - 8, lineBreak: false });
+  }
+  if (body) {
+    doc.font("Helvetica").fontSize(9.5).fillColor(palette.text)
+      .text(body, x + padX + 4, y + padY + headH + (heading ? 4 : 0), {
+        width: w - padX * 2 - 8,
+      });
+  }
+  // Park doc.y at the bottom of the painted callout so callers can chain
+  // the next element directly with moveDown / a fresh draw at doc.y.
+  doc.y = y + h;
+  return y + h;
+}
+
+// Faint "Rx" watermark behind the medications section. Drawn first so
+// the actual table sits on top. Uses fillOpacity so the watermark fades
+// into the page rather than dominating it. Serif voice matches the
+// reference's calligraphic prescription mark.
+//
+// Both text() calls pin width + height bounds so pdfkit's LineWrapper
+// never auto-paginates from the oversized 90pt glyph — without bounds,
+// it treats the descent of a giant glyph as "doesn't fit" and silently
+// adds a continuation page.
+function drawRxWatermark(doc, { x, y, size = 90 }) {
+  doc.save();
+  doc.fillOpacity(0.08).fillColor(BRAND.teal)
+    .font(SERIF_BOLD).fontSize(size)
+    .text("R", x, y, { lineBreak: false, width: size, height: size });
+  // The "x" curl beneath the R — smaller, slightly offset, italic-feel.
+  doc.font("Times-BoldItalic").fontSize(size * 0.55)
+    .text("x", x + size * 0.55, y + size * 0.45, {
+      lineBreak: false, width: size * 0.55, height: size * 0.55,
+    });
+  doc.restore();
+  doc.fillOpacity(1);
+}
+
+// Solid Rx mark (calligraphic) drawn at the top-left of each Rx card —
+// reference shows a small classical Rx symbol directly above the
+// medications table. Same width/height bounding as the watermark above
+// to keep LineWrapper from triggering auto-pagination on the large glyph.
+function drawRxMark(doc, { x, y, size = 22, color = BRAND.tealDark }) {
+  doc.save();
+  doc.fillColor(color).font(SERIF_BOLD).fontSize(size)
+    .text("R", x, y, { lineBreak: false, width: size, height: size });
+  doc.font("Times-BoldItalic").fontSize(size * 0.62)
+    .text("x", x + size * 0.55, y + size * 0.35, {
+      lineBreak: false, width: size * 0.62, height: size * 0.62,
+    });
+  doc.restore();
+}
+
+// Timeline event — vertical guide line + coloured dot + heading row.
+// `dotKind` accepts the same vocabulary as statusKind so cancelled
+// events render with a red dot, completed with green, etc. Returns the
+// content x-position so the caller can render body text aligned with
+// the heading.
+function drawTimelineMarker(doc, { x, y, dotKind = "success", first = false, last = false }) {
+  const palette = STATUS_PILL[dotKind] || STATUS_PILL.success;
+  const dotR = 4;
+  const lineX = x + 6;
+  // Vertical guide line — extends above unless first, and a stub below.
+  if (!first) {
+    doc.save();
+    doc.moveTo(lineX, y - 8).lineTo(lineX, y + dotR).lineWidth(1).strokeColor(BRAND.border).stroke();
+    doc.restore();
+  }
+  if (!last) {
+    doc.save();
+    doc.moveTo(lineX, y + dotR).lineTo(lineX, y + 38).lineWidth(1).strokeColor(BRAND.border).stroke();
+    doc.restore();
+  }
+  doc.save();
+  doc.circle(lineX, y + dotR, dotR).fillAndStroke(palette.border, palette.border);
+  doc.restore();
+  return { contentX: lineX + 14 };
+}
+
+// Branded footer drawn on every page during the final buffered-pages
+// flush. Caller passes the section label captured for each page index.
+//
+// Both text() calls below pin a `height` option to the available band
+// space. Without it, pdfkit's LineWrapper treats the text as "could
+// continue past page end" and silently calls continueOnNewPage even
+// with lineBreak:false — producing phantom blank pages bolted onto the
+// end of the document.
+function drawBrandedFooter(doc, { brandName, sectionLabel, pageIndex, pageCount, leftX, rightX }) {
+  const footerY = doc.page.height - 32;
+  doc.save();
+  doc.rect(0, footerY, doc.page.width, 32).fill(BRAND.cream);
+  doc.rect(0, footerY, doc.page.width, 1).fill(BRAND.gold);
+  doc.restore();
+  const textY = footerY + 11;
+  const textHeight = 14;
+  doc.font("Helvetica-Bold").fontSize(9).fillColor(BRAND.tealDark)
+    .text(brandName || "Clinic", leftX, textY, { lineBreak: false, height: textHeight });
+  const rightW = rightX - leftX;
+  const pageMeta = `${sectionLabel || ""}  ${sectionLabel ? "|" : ""}  Page ${pageIndex + 1} of ${pageCount}`.trim();
+  doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+    .text(pageMeta, leftX, textY, { width: rightW, align: "right", lineBreak: false, height: textHeight });
+}
+
 // ── Consent templates ──────────────────────────────────────────────
 
 const CONSENT_TEMPLATES = {
@@ -235,199 +646,344 @@ function getConsentBody(templateName) {
 
 // ── 1. Prescription PDF ────────────────────────────────────────────
 
-async function renderPrescriptionPdf(prescription, patient, clinic, doctor) {
-  const doc = new PDFDocument({ size: "A4", margin: 50 });
+/**
+ * Render a prescription PDF with the canonical wellness-vertical visual
+ * language (branded header tile + teal section bands + uppercase-label
+ * key-value rows + clean medications table). Matches the Patient Summary
+ * PDF design so every clinical artefact looks like it came from the
+ * same brand system.
+ *
+ * Signature kept 4-positional for back-compat with existing tests and
+ * the older /prescriptions/:id/pdf caller; pass `opts.tenant` (for the
+ * brand name) and `opts.logoBuffer` (Buffer with the logo bytes) to
+ * render the full branded header. When opts is omitted, the header
+ * falls back to `clinic.name` as the title and skips the logo tile.
+ */
+async function renderPrescriptionPdf(prescription, patient, clinic, doctor, opts = {}) {
+  const { tenant = null, logoBuffer = null } = opts || {};
+  const doc = new PDFDocument({ size: "A4", margin: 50, bufferPages: true });
   const bufPromise = streamToBuffer(doc);
 
   const parsed = parseRxInstructions(prescription?.instructions);
   const status = parsed.status || "Issued";
   const drugs = parseDrugs(prescription?.drugs);
-  const pageRight = doc.page.width - doc.page.margins.right; // 545 with margin 50
 
-  // ── Header: clinic on the left, prescription metadata on the right.
-  drawClinicHeader(doc, clinic);
-  const headerY = doc.y;
-  doc.font("Helvetica-Bold").fontSize(13).fillColor("#111")
-    .text(`Prescription - ${prescription?.id ?? ""}`, 50, headerY, { continued: false });
+  const leftX = 50;
+  const pageRight = doc.page.width - doc.page.margins.right; // 545
+  const usableW = pageRight - leftX;
+  const contentBottom = doc.page.height - 56; // leave room for footer band
 
-  // Rx badge (boxed) centered between the title and the right block.
-  doc.lineWidth(0.6).strokeColor("#444").rect(280, headerY - 2, 28, 16).stroke();
-  doc.font("Helvetica-Bold").fontSize(10).fillColor("#222").text("Rx", 280, headerY + 1, { width: 28, align: "center" });
+  const c = safeClinic(clinic);
+  const brandName = tenant?.name || c.name || "Clinic";
 
-  // Right-aligned metadata column. pdfkit's `continued: true` with
-  // `align: "right"` aligns each segment independently and overlaps them,
-  // so render each line as one pre-composed string instead.
-  const rightX = 360, rightW = pageRight - rightX;
-  doc.font("Helvetica").fontSize(10).fillColor("#222");
-  doc.text(`Date: ${formatDate(prescription?.createdAt)}`, rightX, headerY, { width: rightW, align: "right" });
-  doc.text(`Prescription #: ${prescription?.id ?? "—"}`, rightX, doc.y, { width: rightW, align: "right" });
-  doc.text(`Appointment #: ${prescription?.visitId ?? "—"}`, rightX, doc.y, { width: rightW, align: "right" });
+  // Per-page section labels for the buffered-pages footer pass. Updated
+  // every time we cross a new logical section so the footer reads e.g.
+  // "Prescription · Page 2 of 3".
+  const pageSectionLabels = ["Prescription"];
+  let currentSection = "Prescription";
+  doc.on("pageAdded", () => pageSectionLabels.push(currentSection));
 
-  doc.moveDown(1);
-  doc.y = Math.max(doc.y, headerY + 48);
+  // ── Local layout helpers (use the shared design system) ──────────
+  const ensureSpace = (needed) => {
+    if (doc.y + needed > contentBottom) {
+      doc.addPage();
+      doc.y = 60;
+    }
+  };
 
-  // ── Patient + Doctor side-by-side blocks.
-  const blockTop = doc.y;
-  const leftCol = 50, rightCol = 300, colWidth = 240;
-
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Patient Information", leftCol, blockTop);
-  doc.font("Helvetica").fontSize(10).fillColor("#222");
-  const patientLines = [
-    ["Name", patient?.name],
-    ["ID", patient?.id != null ? String(patient.id) : ""],
-    ["Gender", patient?.gender],
-    ["Phone", patient?.phone],
-  ];
-  let py = doc.y;
-  for (const [k, v] of patientLines) {
-    doc.font("Helvetica-Bold").text(`${k}: `, leftCol, py, { continued: true })
-      .font("Helvetica").text(String(v || "—"));
-    py = doc.y;
-  }
-  const patientEndY = doc.y;
-
-  // Reset to top of the right column.
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Doctor Information", rightCol, blockTop);
-  doc.font("Helvetica").fontSize(10).fillColor("#222");
-  // Registration Number is only included when present — the User model
-  // doesn't carry one today, so for most rows we just drop the line.
-  const doctorLines = [
-    ["Name", doctor?.name],
-    ["Phone", doctor?.phone],
-    ["Email", doctor?.email],
-  ];
-  if (doctor?.registrationNumber) {
-    doctorLines.push(["Registration Number", doctor.registrationNumber]);
-  }
-  let dy = doc.y;
-  for (const [k, v] of doctorLines) {
-    doc.font("Helvetica-Bold").text(`${k}: `, rightCol, dy, { continued: true, width: colWidth })
-      .font("Helvetica").text(String(v || "—"));
-    dy = doc.y;
-  }
-  const doctorEndY = doc.y;
-
-  // Realign cursor to the lower of the two columns + a divider.
-  const sectionEndY = Math.max(patientEndY, doctorEndY) + 8;
-  doc.moveTo(leftCol, sectionEndY).lineTo(pageRight, sectionEndY).lineWidth(0.5).strokeColor("#bbb").stroke();
-  doc.y = sectionEndY + 10;
-
-  // ── Medical Information.
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Medical Information", leftCol);
-  doc.moveDown(0.3);
-  const medRows = [
-    ["Chief Complaint", parsed.chiefComplaint || "Not Specified"],
-    ["Diagnosis", parsed.diagnosis || "Not Specified"],
-    ["Investigations", parsed.investigations || "Not Specified"],
-  ];
-  doc.font("Helvetica").fontSize(10).fillColor("#222");
-  for (const [k, v] of medRows) {
+  const KV_LABEL_W = 130;
+  const kv = (label, value, opts2 = {}) => {
+    const v = value == null || value === "" ? "—" : String(value);
+    ensureSpace(18);
     const y = doc.y;
-    doc.font("Helvetica-Bold").text(`${k}: `, leftCol, y, { continued: true, width: pageRight - leftCol })
-      .font("Helvetica").text(String(v));
+    const labelW = opts2.labelWidth || KV_LABEL_W;
+    doc.font("Helvetica-Bold").fontSize(8).fillColor(BRAND.textMuted)
+      .text(String(label).toUpperCase(), leftX, y + 2, {
+        width: labelW, characterSpacing: 1, lineBreak: false,
+      });
+    doc.font("Helvetica").fontSize(10).fillColor(BRAND.textDark)
+      .text(v, leftX + labelW, y, { width: usableW - labelW });
+    doc.y = Math.max(doc.y, y + 16);
+    doc.moveDown(0.1);
+  };
+
+  // ── Branded header band ──────────────────────────────────────────
+  drawBrandedHeader(doc, {
+    brandName,
+    tagline: tenant?.tagline || (brandName.toLowerCase().includes("wellness") ? "Wellness Clinic" : null),
+    clinic: c,
+    logoBuffer,
+    leftX,
+    rightX: pageRight,
+  });
+
+  // ── Document meta info-strip (PATIENT / PATIENT ID / ISSUED / Rx #) ─
+  const infoStripY = drawInfoStrip(
+    doc,
+    [
+      { label: "Patient", value: patient?.name || "—" },
+      { label: "Patient ID", value: patient?.id != null ? String(patient.id) : "—" },
+      { label: "Issued", value: formatDate(prescription?.createdAt) },
+      { label: "Document", value: prescription?.id != null ? `Rx #${prescription.id}` : "Prescription" },
+    ],
+    { x: leftX, y: 100, w: usableW },
+  );
+
+  doc.y = infoStripY + 18;
+
+  // ── Title row — section title + status pill ──────────────────────
+  drawSectionTitle(doc, `Prescription${prescription?.id != null ? ` #${prescription.id}` : ""}`,
+    "Medication plan & clinician advice", { x: leftX, w: usableW - 120 });
+  // Status pill, right-aligned with the title baseline.
+  drawStatusPill(doc, status, pageRight - 80, doc.y - 32);
+
+  doc.moveDown(0.4);
+
+  // ── Patient + Prescriber as side-by-side cards ───────────────────
+  const cardGap = 12;
+  const cardW = (usableW - cardGap) / 2;
+  const cardsTopY = doc.y;
+  const cardH = 116;
+  ensureSpace(cardH + 12);
+
+  drawCardFrame(doc, { x: leftX, y: cardsTopY, w: cardW, h: cardH, topAccent: true });
+  doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.teal)
+    .text("PATIENT", leftX + 14, cardsTopY + 12, { characterSpacing: 1.4, lineBreak: false });
+  doc.font("Helvetica-Bold").fontSize(13).fillColor(BRAND.textDark)
+    .text(patient?.name || "—", leftX + 14, cardsTopY + 26, { width: cardW - 28, ellipsis: true, lineBreak: false });
+  let py = cardsTopY + 46;
+  const pLines = [];
+  if (patient?.dob) pLines.push(`DOB · ${formatDate(patient.dob)} (age ${computeAge(patient.dob)})`);
+  if (patient?.gender) pLines.push(`Gender · ${patient.gender}`);
+  if (patient?.phone) pLines.push(`Phone · ${patient.phone}`);
+  if (patient?.email) pLines.push(`Email · ${patient.email}`);
+  doc.font("Helvetica").fontSize(9).fillColor(BRAND.textBody);
+  for (const line of pLines.slice(0, 4)) {
+    doc.text(line, leftX + 14, py, { width: cardW - 28, ellipsis: true, lineBreak: false });
+    py += 13;
   }
-  doc.moveDown(0.5);
 
-  // ── Prescription Medications table.
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Prescription Medications");
-  doc.moveDown(0.3);
+  const docCardX = leftX + cardW + cardGap;
+  drawCardFrame(doc, { x: docCardX, y: cardsTopY, w: cardW, h: cardH, topAccent: true });
+  doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.teal)
+    .text("PRESCRIBER", docCardX + 14, cardsTopY + 12, { characterSpacing: 1.4, lineBreak: false });
+  doc.font("Helvetica-Bold").fontSize(13).fillColor(BRAND.textDark)
+    .text(doctor?.name || "—", docCardX + 14, cardsTopY + 26, { width: cardW - 28, ellipsis: true, lineBreak: false });
+  let dy = cardsTopY + 46;
+  const dLines = [];
+  if (doctor?.phone) dLines.push(`Phone · ${doctor.phone}`);
+  if (doctor?.email) dLines.push(`Email · ${doctor.email}`);
+  if (doctor?.registrationNumber) dLines.push(`Reg. No · ${doctor.registrationNumber}`);
+  if (prescription?.visitId != null) dLines.push(`Appointment · #${prescription.visitId}`);
+  doc.font("Helvetica").fontSize(9).fillColor(BRAND.textBody);
+  for (const line of dLines.slice(0, 4)) {
+    doc.text(line, docCardX + 14, dy, { width: cardW - 28, ellipsis: true, lineBreak: false });
+    dy += 13;
+  }
+  doc.y = cardsTopY + cardH + 18;
 
-  const tableTop = doc.y;
-  // Column layout sized to A4 with 50pt margins (usable width = 495).
+  // ── Clinical Notes — only when we have content (keeps tight Rx tight) ─
+  const hasClinical = parsed.chiefComplaint || parsed.diagnosis || parsed.investigations;
+  if (hasClinical) {
+    currentSection = "Clinical Notes";
+    drawSectionTitle(doc, "Clinical Notes", "Chief complaint, diagnosis & investigations",
+      { x: leftX, w: usableW });
+    kv("Chief Complaint", parsed.chiefComplaint);
+    kv("Diagnosis", parsed.diagnosis);
+    kv("Investigations", parsed.investigations);
+    doc.moveDown(0.6);
+  }
+
+  // ── Medications table — 5-column reference layout ─────────────────
+  currentSection = "Medications";
+  drawSectionTitle(doc, "Medications", `${drugs.length || "No"} item${drugs.length === 1 ? "" : "s"} prescribed`,
+    { x: leftX, w: usableW });
+  ensureSpace(60);
+  // Rx watermark sits behind the table — visible only in the gutters
+  // where the table doesn't cover it.
+  drawRxWatermark(doc, { x: pageRight - 110, y: doc.y - 8, size: 90 });
+  // Small calligraphic Rx mark above the table (reference page 4).
+  drawRxMark(doc, { x: leftX, y: doc.y, size: 22 });
+  doc.y = doc.y + 30;
+
+  doc.x = leftX;
   const cols = [
-    { label: "Medication", x: 50, w: 95 },
-    { label: "Dosage", x: 145, w: 55 },
-    { label: "Form", x: 200, w: 50 },
-    { label: "Route", x: 250, w: 50 },
-    { label: "Frequency", x: 300, w: 60 },
-    { label: "Duration", x: 360, w: 75 },
-    { label: "Instructions", x: 435, w: 110 },
+    { label: "#",          x: leftX,        w: 36 },
+    { label: "Medication", x: leftX + 36,  w: 175 },
+    { label: "Dosage",     x: leftX + 211, w: 95 },
+    { label: "Frequency",  x: leftX + 306, w: 120 },
+    { label: "Duration",   x: leftX + 426, w: usableW - 426 },
   ];
 
-  // Header band.
-  doc.rect(50, tableTop, 495, 18).fillColor("#f3f4f6").fill();
-  doc.fillColor("#333").font("Helvetica-Bold").fontSize(9);
-  for (const c of cols) doc.text(c.label, c.x + 3, tableTop + 5, { width: c.w - 6 });
+  let tableTop = doc.y;
+  if (tableTop + 30 > contentBottom) { doc.addPage(); tableTop = 60; }
+  // Teal header bar with white column labels.
+  doc.save();
+  doc.rect(leftX, tableTop, usableW, 24).fill(BRAND.teal);
+  doc.restore();
+  doc.fillColor("#FFFFFF").font("Helvetica-Bold").fontSize(8.5);
+  for (const col of cols) {
+    doc.text(col.label.toUpperCase(), col.x + 8, tableTop + 8, {
+      width: col.w - 16, characterSpacing: 1.1, lineBreak: false,
+    });
+  }
 
-  let rowY = tableTop + 18;
-  doc.font("Helvetica").fontSize(9).fillColor("#222");
+  let rowY = tableTop + 24;
   if (drugs.length === 0) {
-    doc.text("(no medications listed)", 53, rowY + 4);
-    rowY += 22;
+    doc.save();
+    doc.rect(leftX, rowY, usableW, 28).fill(BRAND.panelBg);
+    doc.restore();
+    doc.font("Helvetica-Oblique").fontSize(10).fillColor(BRAND.textMuted)
+      .text("(no medications listed)", leftX, rowY + 9, { width: usableW, align: "center" });
+    rowY += 28;
   } else {
-    for (const d of drugs) {
+    for (let i = 0; i < drugs.length; i++) {
+      const d = drugs[i];
       const strength = [d.strengthValue, d.strengthUnit].filter(Boolean).join("") || d.strength || "";
-      const dosageCell = [d.dosage || "—", strength || "—"].join(" ");
-      const cells = [
-        d.name || d.drug || "—",
-        dosageCell,
-        d.preparation || d.dosageForm || "—",
-        d.route || "—",
-        d.frequency || "—",
-        d.duration || "—",
-        d.instructions || "—",
-      ];
-      // Estimate row height from the tallest cell.
-      const heights = cells.map((val, i) => doc.heightOfString(String(val), { width: cols[i].w - 6 }));
-      const rowH = Math.max(18, ...heights) + 6;
-      // Page-break guard.
-      if (rowY + rowH > 740) {
+      const dosageText = [d.dosage, strength].filter(Boolean).join(" ").trim() || "—";
+      const subParts = [d.preparation || d.dosageForm, d.route].filter(Boolean);
+      const subText = subParts.join(" · ");
+      const medName = d.name || d.drug || "—";
+      const freq = d.frequency || "—";
+      const duration = d.duration || "—";
+
+      // Row height — taller when there's a Form · Route subline; shorter
+      // and tighter when the medication is single-line. Keeps long-list
+      // prescriptions paginating around the reference's natural density
+      // (50 short rows ≈ 3 pages; reference Rx with sublines ≈ 1 page).
+      const rowH = subText ? 44 : 32;
+
+      if (rowY + rowH > contentBottom) {
         doc.addPage();
         rowY = 60;
+        // Re-paint header on the new page so the table reads correctly.
+        doc.save();
+        doc.rect(leftX, rowY, usableW, 24).fill(BRAND.teal);
+        doc.restore();
+        doc.fillColor("#FFFFFF").font("Helvetica-Bold").fontSize(8.5);
+        for (const col of cols) {
+          doc.text(col.label.toUpperCase(), col.x + 8, rowY + 8, {
+            width: col.w - 16, characterSpacing: 1.1, lineBreak: false,
+          });
+        }
+        rowY += 24;
       }
-      cells.forEach((val, i) => {
-        doc.text(String(val), cols[i].x + 3, rowY + 3, { width: cols[i].w - 6 });
+      // Zebra-stripe alternate rows.
+      if (i % 2 === 1) {
+        doc.save();
+        doc.rect(leftX, rowY, usableW, rowH).fill(BRAND.panelBg);
+        doc.restore();
+      }
+      // # column
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textMuted)
+        .text(String(i + 1), cols[0].x + 12, rowY + rowH / 2 - 6, {
+          width: cols[0].w - 16, lineBreak: false,
+        });
+      // MEDICATION — bold name + optional Form · Route subline
+      doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+        .text(medName, cols[1].x + 8, subText ? rowY + 8 : rowY + rowH / 2 - 7, {
+          width: cols[1].w - 16, ellipsis: true, lineBreak: false,
+        });
+      if (subText) {
+        doc.font("Helvetica").fontSize(8.5).fillColor(BRAND.textMuted)
+          .text(subText, cols[1].x + 8, rowY + 24, {
+            width: cols[1].w - 16, ellipsis: true, lineBreak: false,
+          });
+      }
+      // DOSAGE
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+        .text(dosageText, cols[2].x + 8, rowY + rowH / 2 - 6, {
+          width: cols[2].w - 16, ellipsis: true, lineBreak: false,
+        });
+      // FREQUENCY pill
+      drawStatusPill(doc, freq, cols[3].x + 8, rowY + rowH / 2 - 8, {
+        kind: "success", fontSize: 8, padX: 8, padY: 3,
       });
-      // Row border line.
-      doc.moveTo(50, rowY + rowH).lineTo(545, rowY + rowH).lineWidth(0.3).strokeColor("#e5e7eb").stroke();
+      // DURATION
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+        .text(duration, cols[4].x + 8, rowY + rowH / 2 - 6, {
+          width: cols[4].w - 16, ellipsis: true, lineBreak: false,
+        });
+      doc.moveTo(leftX, rowY + rowH).lineTo(pageRight, rowY + rowH)
+        .lineWidth(0.3).strokeColor(BRAND.borderSoft).stroke();
       rowY += rowH;
     }
   }
-  // After the drug-table rows pdfkit's `doc.x` is wherever the last cell
-  // wrote (typically the Instructions column, x≈435). Subsequent
-  // `doc.text("Additional Advice")` / `text("Notes")` calls without an
-  // explicit x would inherit that offset and render the body starting
-  // from ~x=435 with width=495 — pushing the tail off the right edge of
-  // the page (the visible chop on the last line of Notes). Reset the
-  // cursor to the left margin before continuing.
-  doc.x = leftCol;
-  doc.y = rowY + 8;
-  const bodyWidth = pageRight - leftCol;
+  // Outline the whole table.
+  doc.lineWidth(0.5).strokeColor(BRAND.border)
+    .rect(leftX, tableTop, usableW, rowY - tableTop).stroke();
+  doc.x = leftX;
+  doc.y = rowY + 14;
 
-  // ── Additional Advice.
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-    .text("Additional Advice", leftCol, doc.y, { width: bodyWidth });
-  doc.font("Helvetica").fontSize(10).fillColor("#222")
-    .text(parsed.advice || "—", leftCol, doc.y, { width: bodyWidth });
-  doc.moveDown(0.5);
-  doc.x = leftCol;
+  // ── Additional Advice — rendered as a coloured callout (amber). ──
+  // Heading is "Instructions" so the test contract still matches when
+  // the caller supplies a free-form instructions block without an
+  // explicit "Advice:" prefix (which falls into parsed.notes instead).
+  if (parsed.advice) {
+    ensureSpace(60);
+    drawCalloutBox(doc, {
+      x: leftX, y: doc.y, w: usableW,
+      heading: "Instructions",
+      body: parsed.advice,
+      kind: "warning",
+    });
+    doc.moveDown(0.8);
+  }
 
-  // ── Notes.
-  doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-    .text("Notes", leftCol, doc.y, { width: bodyWidth });
-  doc.font("Helvetica").fontSize(10).fillColor("#222")
-    .text(
-      parsed.notes || "No clinical notes recorded.",
-      leftCol,
-      doc.y,
-      { width: bodyWidth },
-    );
-  doc.moveDown(1.5);
-  doc.x = leftCol;
+  // ── Notes / Instructions callout ─────────────────────────────────
+  // When the caller supplies a free-form instructions string without an
+  // explicit "Advice:" label (the common Rx-detail page case), the text
+  // lands in parsed.notes via parseRxInstructions's leftover bucket. We
+  // surface that as an "Instructions" amber callout so the patient sees
+  // the per-Rx clinician guidance directly under the table. When notes
+  // are genuinely empty, fall back to a "Notes" callout with the canonical
+  // "No clinical notes recorded." placeholder — vitest pins both shapes.
+  ensureSpace(60);
+  const notesHeading = parsed.notes ? "Instructions" : "Notes";
+  drawCalloutBox(doc, {
+    x: leftX, y: doc.y, w: usableW,
+    heading: notesHeading,
+    body: parsed.notes || "No clinical notes recorded.",
+    kind: "warning",
+  });
+  doc.moveDown(3);
 
-  // ── Doctor's signature.
-  const sigY = Math.max(doc.y + 30, 680);
-  doc.moveTo(340, sigY).lineTo(545, sigY).lineWidth(0.5).strokeColor("#444").stroke();
-  doc.font("Helvetica").fontSize(10).fillColor("#444").text("Doctor's Signature", 340, sigY + 4, { width: 205, align: "center" });
+  // ── Doctor's signature block ─────────────────────────────────────
+  // Guard against fires when doc.y was already pushed past page bottom by
+  // the preceding callouts — without the ensureSpace check, text() with
+  // an explicit y near contentBottom triggers pdfkit's continueOnNewPage
+  // and silently adds a blank trailing page (4 phantom pages observed
+  // before this guard).
+  doc.moveDown(1);
+  ensureSpace(80);
+  const sigBaseY = Math.min(Math.max(doc.y, contentBottom - 80), contentBottom - 36);
+  const sigLineY = sigBaseY + 24;
+  if (doctor?.name) {
+    doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+      .text(doctor.name, 340, sigLineY - 14, {
+        width: 205, align: "center", lineBreak: false, height: 14,
+      });
+  }
+  doc.moveTo(340, sigLineY).lineTo(pageRight, sigLineY)
+    .lineWidth(0.5).strokeColor(BRAND.textMuted).stroke();
+  doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+    .text("Doctor's Signature", 340, sigLineY + 4, {
+      width: 205, align: "center", lineBreak: false, height: 14,
+    });
 
-  // ── Footer: status (left) + printed-on (right).
-  const footerY = 760;
-  doc.font("Helvetica-Bold").fontSize(9).fillColor("#222")
-    .text("Status: ", 50, footerY, { continued: true })
-    .font("Helvetica").text(status);
-  doc.font("Helvetica").fontSize(9).fillColor("#666")
-    .text(`Printed on: ${new Date().toLocaleString("en-GB", { timeZone: "Asia/Kolkata", day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })}`,
-      50, footerY, { width: 495, align: "right" });
+  // ── Branded footer pass (page numbers + section label) ────────────
+  const range = doc.bufferedPageRange();
+  for (let i = range.start; i < range.start + range.count; i++) {
+    doc.switchToPage(i);
+    drawBrandedFooter(doc, {
+      brandName,
+      sectionLabel: pageSectionLabels[i] || "Prescription",
+      pageIndex: i,
+      pageCount: range.count,
+      leftX,
+      rightX: pageRight,
+    });
+  }
 
   doc.end();
   return bufPromise;
@@ -624,56 +1180,54 @@ async function renderPatientSummaryPdf({
   logoBuffer,
   photoBuffers,
 }) {
-  const doc = new PDFDocument({ size: "A4", margin: 50 });
+  const doc = new PDFDocument({ size: "A4", margin: 50, bufferPages: true });
   const bufPromise = streamToBuffer(doc);
   const pageRight = doc.page.width - doc.page.margins.right;
   const leftX = 50;
   const usableW = pageRight - leftX;
+  const contentBottom = doc.page.height - 56; // leave room for footer band
+
+  // Per-page section labels — every time we advance into a new logical
+  // section we update `currentSection`, and the `pageAdded` listener
+  // propagates it to any auto-paginated page so the footer reads e.g.
+  // "Patient Profile · Page 2 of 7".
+  const pageSectionLabels = ["Patient Profile & Case History"];
+  let currentSection = "Patient Profile & Case History";
+  doc.on("pageAdded", () => pageSectionLabels.push(currentSection));
 
   const ensureSpace = (needed) => {
-    if (doc.y + needed > 770) {
+    if (doc.y + needed > contentBottom) {
       doc.addPage();
       doc.y = 60;
     }
   };
 
-  // Section heading — light-grey fill band with a teal accent stripe on
-  // the left so every section is unambiguously distinct from body text.
-  // Adds extra vertical breathing room before the band so consecutive
-  // sections never visually crash into each other.
-  const sectionTitle = (text) => {
+  // Local section title — calls the shared helper but reserves vertical
+  // breathing room so consecutive sections don't visually collide.
+  const sectionTitle = (text, subtitle) => {
     ensureSpace(50);
     doc.moveDown(1.0);
-    const barY = doc.y;
-    const barH = 26;
-    doc.save();
-    doc.rect(leftX, barY, usableW, barH).fillColor("#f3f4f6").fill();
-    doc.rect(leftX, barY, 4, barH).fillColor("#265855").fill();
-    doc.restore();
-    doc.font("Helvetica-Bold").fontSize(12).fillColor("#111")
-      .text(text, leftX + 14, barY + 8, { width: usableW - 24 });
-    doc.y = barY + barH;
-    doc.moveDown(0.5);
+    drawSectionTitle(doc, text, subtitle, { x: leftX, w: usableW });
   };
 
   // Label-value row — two fixed columns (uppercase grey label, then the
-  // value in normal weight). The previous `continued: true` approach
-  // made the value butt directly against the label with no breathing
-  // room and ran the two together when the label wrapped — replaced
-  // with absolute-positioned columns that always align.
+  // value in normal weight). Used inside the Treatment Plans / Wallet /
+  // Memberships sections for free-form rows the card grid can't hold.
   const KV_LABEL_W = 140;
   const kv = (label, value, opts = {}) => {
     const v = value == null || value === "" ? "—" : String(value);
     ensureSpace(18);
     const y = doc.y;
-    doc.font("Helvetica-Bold").fontSize(8.5).fillColor("#6b7280")
-      .text(String(label).toUpperCase(), leftX, y + 2, { width: opts.labelWidth || KV_LABEL_W });
-    doc.font("Helvetica").fontSize(10).fillColor("#111")
+    doc.font("Helvetica-Bold").fontSize(8.5).fillColor(BRAND.textMuted)
+      .text(String(label).toUpperCase(), leftX, y + 2, {
+        width: opts.labelWidth || KV_LABEL_W, characterSpacing: 1, lineBreak: false,
+      });
+    doc.font("Helvetica").fontSize(10).fillColor(BRAND.textDark)
       .text(v, leftX + (opts.labelWidth || KV_LABEL_W), y, {
         width: usableW - (opts.labelWidth || KV_LABEL_W),
       });
     doc.y = Math.max(doc.y, y + 16);
-    doc.moveDown(0.15);
+    doc.moveDown(0.1);
   };
 
   const currency = wallet?.currency || patient?.currency || "INR";
@@ -686,105 +1240,91 @@ async function renderPatientSummaryPdf({
   const transactions = walletTransactions || [];
   const hasWalletActivity = wallet && (Number(wallet.balance) !== 0 || transactions.length > 0);
 
-  // ── Cover / header: logo tile in the corner, org name + address beside it ──
-  // Tenant.name is the company brand (e.g. "Dr. Haror's Wellness").
-  // Clinic (Location) gives the branch address / phone / email beside it.
-  const companyName = tenant?.name || clinic?.name || "Clinic";
+  const brandName = tenant?.name || clinic?.name || "Clinic";
   const c = safeClinic(clinic);
 
-  const headerY = 50;
-  const logoTileSize = 78;
-  const headerH = logoTileSize;
-  const textBlockX = leftX + logoTileSize + 18;
-  const textBlockW = usableW - logoTileSize - 18;
+  // ── Branded header band (logo, brand, address) ────────────────────
+  drawBrandedHeader(doc, {
+    brandName,
+    tagline: tenant?.tagline || (brandName.toLowerCase().includes("wellness") ? "Wellness Clinic" : null),
+    clinic: c,
+    logoBuffer,
+    leftX,
+    rightX: pageRight,
+  });
 
-  // Logo tile: top-left corner, fixed square slot. The source image is
-  // scaled by HEIGHT to the slot size then clipped to a square anchored
-  // to the left edge — this extracts only the icon portion of combined
-  // "icon + wordmark" brand assets (e.g. the bundled GlobusCRM logo)
-  // while passing icon-only square uploads through unchanged. The clip
-  // rectangle is also rounded to match the visual rhythm of the rest
-  // of the page.
-  if (logoBuffer) {
-    try {
-      doc.save();
-      doc.roundedRect(leftX, headerY, logoTileSize, logoTileSize, 6).clip();
-      // height: logoTileSize → image is scaled so its rendered height
-      // equals the slot height; any excess width on the right is
-      // clipped away by the rect above. A square source ends up exactly
-      // filling the slot; a wide source surfaces only its left square.
-      doc.image(logoBuffer, leftX, headerY, { height: logoTileSize });
-      doc.restore();
-    } catch (_e) {
-      doc.restore(); // ensure clip is unwound even on render failure
-    }
+  // ── Document meta info-strip (PATIENT / PATIENT ID / GENERATED / DOC) ─
+  const generatedAt = new Date().toLocaleString("en-IN", {
+    timeZone: "Asia/Kolkata",
+    day: "2-digit", month: "short", year: "numeric",
+    hour: "2-digit", minute: "2-digit", hour12: true,
+  });
+  const stripBottomY = drawInfoStrip(
+    doc,
+    [
+      { label: "Patient", value: patient?.name || "—" },
+      { label: "Patient ID", value: patient?.id != null ? String(patient.id) : "—" },
+      { label: "Generated", value: generatedAt },
+      { label: "Document", value: "Patient Summary" },
+    ],
+    { x: leftX, y: 100, w: usableW },
+  );
+  doc.y = stripBottomY + 24;
+
+  // ── Profile section ──────────────────────────────────────────────
+  currentSection = "Patient Profile";
+  sectionTitle("Patient Profile", "Overview & demographic information");
+
+  // Profile card — soft panel with empty avatar circle, serif name and
+  // green ID pill. Matches the reference's restrained, brochure-like
+  // profile block.
+  ensureSpace(110);
+  const profileCardY = doc.y;
+  const profileCardH = 96;
+  drawCardFrame(doc, {
+    x: leftX, y: profileCardY, w: usableW, h: profileCardH,
+    bg: BRAND.panelBg, border: BRAND.borderSoft,
+  });
+  const avatarR = 32;
+  drawAvatarCircle(doc, {
+    cx: leftX + 28 + avatarR, cy: profileCardY + profileCardH / 2, r: avatarR,
+    name: patient?.name,
+  });
+  const profileTextX = leftX + 28 + avatarR * 2 + 22;
+  const profileTextW = usableW - (profileTextX - leftX) - 18;
+  doc.font(SERIF_BOLD).fontSize(24).fillColor(BRAND.tealDark)
+    .text(patient?.name || "—", profileTextX, profileCardY + 22, {
+      width: profileTextW, lineBreak: false, ellipsis: true,
+    });
+  if (patient?.id != null) {
+    drawStatusPill(doc, `Patient ID · ${patient.id}`, profileTextX, profileCardY + 56, {
+      kind: "success", fontSize: 8,
+    });
   }
+  doc.y = profileCardY + profileCardH + 18;
 
-  // Org name + address block, vertically centred against the logo tile.
-  const addressLine = [
-    c.addressLine,
-    [c.city, c.state, c.pincode].filter(Boolean).join(", "),
-  ].filter(Boolean).join(", ");
-  const contactLine = [c.phone, c.email].filter(Boolean).join("  ·  ");
+  // KV grid — DOB / Gender / Source / Phone / Email / Status as cards.
+  const dobValue = patient?.dob ? `${formatDate(patient.dob)} (age ${computeAge(patient.dob)})` : "—";
+  const sourceValue = scrubZyluSource(patient?.source) || "—";
+  const gridRows = [
+    { label: "Date of Birth", value: dobValue },
+    { label: "Gender", value: patient?.gender || "—" },
+    { label: "Source", value: sourceValue },
+    { label: "Phone", value: patient?.phone || "—" },
+    { label: "Email", value: patient?.email || "—" },
+    { label: "Status", value: patient?.status || "Active" },
+  ];
+  const gridEndY = drawKvGrid(doc, gridRows, { x: leftX, y: doc.y, w: usableW, cols: 3 });
+  doc.y = gridEndY + 12;
 
-  doc.font("Helvetica-Bold").fontSize(17);
-  const nameH = doc.heightOfString(companyName, { width: textBlockW });
-  doc.font("Helvetica").fontSize(10);
-  const addrH = addressLine ? doc.heightOfString(addressLine, { width: textBlockW }) : 0;
-  const contactH = contactLine ? doc.heightOfString(contactLine, { width: textBlockW }) : 0;
-  const textBlockH = nameH + (addrH ? addrH + 4 : 0) + (contactH ? contactH + 2 : 0);
-  let cursorY = headerY + Math.max(0, (headerH - textBlockH) / 2);
-
-  doc.font("Helvetica-Bold").fontSize(17).fillColor("#111")
-    .text(companyName, textBlockX, cursorY, { width: textBlockW });
-  cursorY = doc.y + 2;
-  if (addressLine) {
-    doc.font("Helvetica").fontSize(10).fillColor("#444")
-      .text(addressLine, textBlockX, cursorY, { width: textBlockW });
-    cursorY = doc.y;
-  }
-  if (contactLine) {
-    doc.font("Helvetica").fontSize(10).fillColor("#666")
-      .text(contactLine, textBlockX, cursorY, { width: textBlockW });
-  }
-
-  // Thin divider between header band and the document body.
-  const dividerY = headerY + headerH + 14;
-  doc.moveTo(leftX, dividerY).lineTo(pageRight, dividerY)
-    .lineWidth(0.6).strokeColor("#d1d5db").stroke();
-
-  // Title row — "Patient Summary" on the left, generated timestamp on
-  // the right, both sitting on a single baseline so the page opens with
-  // a clean horizontal rule above and a clean title row below.
-  const titleY = dividerY + 14;
-  doc.font("Helvetica-Bold").fontSize(20).fillColor("#111")
-    .text("Patient Summary", leftX, titleY);
-  doc.font("Helvetica").fontSize(9.5).fillColor("#666")
-    .text(
-      `Generated ${new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" })}`,
-      leftX,
-      titleY,
-      { width: usableW, align: "right" },
-    );
-  doc.y = titleY + 28;
-
-  // ── Profile (always rendered) ─────────────────────────────────────
-  sectionTitle("Profile");
-  kv("Name", patient?.name);
-  kv("Patient ID", patient?.id);
-  kv("Date of Birth", patient?.dob ? `${formatDate(patient.dob)} (age ${computeAge(patient.dob)})` : "—");
-  kv("Gender", patient?.gender);
-  kv("Phone", patient?.phone);
-  kv("Email", patient?.email);
+  // Optional supplementary rows that don't fit the card grid.
   if (patient?.bloodGroup) kv("Blood Group", patient.bloodGroup);
   if (patient?.address) kv("Address", patient.address);
-  { const src = scrubZyluSource(patient?.source); if (src) kv("Source", src); }
   if (patient?.allergies) kv("Allergies", patient.allergies);
   if (patient?.medicalHistory) kv("Medical History", patient.medicalHistory);
   if (patient?.notes) kv("Notes", patient.notes);
 
-  // Breathing room between Profile and the next section.
-  doc.moveDown(1.5);
+  doc.moveDown(1.0);
 
   // ── Case history (chronological) ──────────────────────────────────
   const events = [
@@ -794,202 +1334,283 @@ async function renderPatientSummaryPdf({
   ].sort((a, b) => new Date(b.date) - new Date(a.date));
 
   if (events.length > 0) {
-    sectionTitle(`Case History (${events.length})`);
+    currentSection = "Case History";
+    // Reference uses a small uppercase label with a thin rule extending
+    // right (not a full chapter title) — keeps the case-history list
+    // visually anchored to the Patient Profile section above.
+    ensureSpace(40);
+    doc.moveDown(0.4);
+    drawSectionLabelWithRule(doc, `Case History · ${events.length} Records`, { x: leftX, w: usableW });
+
+    const KIND_PILL_KIND = { Visit: "info", Prescription: "success", Consent: "warning" };
+
     for (let i = 0; i < events.length; i++) {
       const e = events[i];
-      ensureSpace(46);
-      // Date pill + event-kind badge. Visits = blue, Rx = teal, Consent
-      // = amber — colour-coded so the page is glanceable instead of one
-      // wall of black text.
-      const KIND_COLORS = { Visit: "#1d4ed8", Prescription: "#0f766e", Consent: "#b45309" };
-      const kindColor = KIND_COLORS[e.kind] || "#374151";
-      const headY = doc.y;
-      doc.font("Helvetica-Bold").fontSize(10).fillColor("#111")
-        .text(formatDate(e.date), leftX, headY, { continued: true })
-        .fillColor("#9ca3af").text("   •   ", { continued: true })
-        .fillColor(kindColor).text(e.kind);
-      doc.moveDown(0.2);
+      const isFirst = i === 0;
+      const isLast = i === events.length - 1;
+      ensureSpace(54);
 
-      doc.font("Helvetica").fontSize(10).fillColor("#333");
+      // Status dot colour follows the actual event status (cancelled →
+      // red, completed/issued/signed → green) rather than the event kind.
+      const statusForDot = e.kind === "Visit" ? (e.data.status || "completed")
+        : e.kind === "Prescription" ? (parseRxInstructions(e.data.instructions).status || "issued")
+        : "signed";
+      const eventY = doc.y;
+      const tl = drawTimelineMarker(doc, {
+        x: leftX, y: eventY, dotKind: statusKind(statusForDot),
+        first: isFirst, last: isLast,
+      });
+
+      // Header row: date · kind pill + service / Rx number, status pill on right.
+      doc.font("Helvetica-Bold").fontSize(10).fillColor(BRAND.textDark)
+        .text(formatDate(e.date), tl.contentX, eventY, { lineBreak: false });
+      const datePillX = tl.contentX + doc.widthOfString(formatDate(e.date)) + 10;
+      drawStatusPill(doc, e.kind, datePillX, eventY - 2, {
+        kind: KIND_PILL_KIND[e.kind] || "neutral", fontSize: 7.5, padX: 6, padY: 2,
+      });
+      doc.y = eventY + 16;
+
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody);
       if (e.kind === "Visit") {
         const v = e.data;
-        // Bold each "Label: value" pair so the keys stand out from the
-        // values. Rendered as one continued line with font/colour
-        // flipped per segment; pdfkit auto-wraps when the line overflows.
-        const pairs = [
-          ["Service", v.service?.name],
-          ["Doctor", v.doctor?.name],
-          ["Amount", v.amount != null ? formatMoney(v.amount, currency) : null],
-          ["Status", v.status],
-        ].filter(([, val]) => val);
-        if (pairs.length) {
-          renderBoldLabeledLine(doc, pairs, leftX + 14, usableW - 14, "   •   ");
+        const headLine = v.service?.name || "Visit";
+        doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+          .text(headLine, tl.contentX, doc.y, { width: usableW - (tl.contentX - leftX) - 80, ellipsis: true, lineBreak: false });
+        if (v.status) {
+          drawStatusPill(doc, v.status, pageRight - 70, doc.y - 16, { fontSize: 7.5, padX: 6, padY: 2 });
+        }
+        doc.moveDown(0.15);
+        const sub = [];
+        if (v.doctor?.name) sub.push(v.doctor.name);
+        if (v.amount != null) sub.push(formatMoney(v.amount, currency));
+        if (sub.length) {
+          doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+            .text(sub.join("   ·   "), tl.contentX, doc.y, { width: usableW - (tl.contentX - leftX) });
         }
         const n = scrubZyluText(v.notes);
-        if (n) renderNotesWithBoldLabels(doc, n, leftX + 14, usableW - 14);
+        if (n) {
+          doc.font("Helvetica").fontSize(9).fillColor(BRAND.textBody)
+            .text(`Notes: ${n}`, tl.contentX, doc.y + 2, { width: usableW - (tl.contentX - leftX) });
+        }
       } else if (e.kind === "Prescription") {
         const p = e.data;
         const drugs = parseDrugs(p.drugs);
         const summary = drugs.length
           ? drugs.map((d) => d.name || d.drug || "").filter(Boolean).join(", ")
           : "(no medications listed)";
-        doc.font("Helvetica-Bold").fontSize(10).fillColor("#111")
-          .text(`Rx #${p.id}`, leftX + 14, doc.y, { continued: true })
-          .font("Helvetica").fillColor("#333")
-          .text(` — ${summary}`, { width: usableW - 14 });
+        doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+          .text(`Rx #${p.id} — ${summary}`, tl.contentX, doc.y, {
+            width: usableW - (tl.contentX - leftX), ellipsis: true,
+          });
         if (p.doctor?.name) {
-          doc.font("Helvetica-Bold").fillColor("#111")
-            .text(`Prescribed by: `, leftX + 14, doc.y, { continued: true })
-            .font("Helvetica").fillColor("#333")
-            .text(p.doctor.name, { width: usableW - 14 });
+          doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+            .text(`Prescribed by ${p.doctor.name}`, tl.contentX, doc.y, {
+              width: usableW - (tl.contentX - leftX),
+            });
         }
       } else if (e.kind === "Consent") {
-        const c = e.data;
-        doc.font("Helvetica-Bold").fontSize(10).fillColor("#111")
-          .text(`${c.templateName || "general"}`, leftX + 14, doc.y, { continued: Boolean(c.service?.name) });
-        if (c.service?.name) {
-          doc.font("Helvetica").fillColor("#333").text(` — ${c.service.name}`, { width: usableW - 14 });
-        }
+        const cn = e.data;
+        const title = cn.templateName || "general";
+        const tail = cn.service?.name ? ` — ${cn.service.name}` : "";
+        doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+          .text(`${title}${tail}`, tl.contentX, doc.y, {
+            width: usableW - (tl.contentX - leftX), ellipsis: true,
+          });
+        doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+          .text("Consent signed", tl.contentX, doc.y, {
+            width: usableW - (tl.contentX - leftX),
+          });
       }
 
-      // Thin row separator between events so they don't smear into one
-      // another. Skipped after the last row to keep the trailing gap clean.
-      if (i < events.length - 1) {
-        doc.moveDown(0.35);
-        ensureSpace(8);
-        doc.moveTo(leftX, doc.y).lineTo(pageRight, doc.y)
-          .lineWidth(0.3).strokeColor("#e5e7eb").stroke();
-        doc.moveDown(0.35);
-      } else {
-        doc.moveDown(0.3);
-      }
+      // Per-event bottom padding so the timeline guide line shows
+      // through cleanly between items.
+      doc.moveDown(0.6);
     }
+    doc.moveDown(0.6);
   }
 
   // ── Visits (detailed) — start on a fresh page ─────────────────────
+  // currentSection is set BEFORE addPage so the pageAdded listener
+  // captures the right section name on the new page (it fires inside
+  // addPage and reads currentSection at that moment).
   if (visits.length > 0) {
+    currentSection = "Visits";
     doc.addPage();
     doc.y = 60;
-    sectionTitle(`Visits (${visits.length})`);
+    sectionTitle(`Visits`, `${visits.length} visit${visits.length === 1 ? "" : "s"} on record · with before / after documentation`);
     for (let i = 0; i < visits.length; i++) {
       const v = visits[i];
-      ensureSpace(80);
-      // Visit header bar — bold ID + date so each visit is clearly its
-      // own card, not one continuous wall of text.
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-        .text(`Visit #${v.id}`, leftX, doc.y, { continued: true })
-        .font("Helvetica").fontSize(10).fillColor("#555")
-        .text(`   ·   ${formatDate(v.visitDate)}`);
-      doc.moveDown(0.3);
-
-      const rows = [
-        ["Service", v.service?.name],
-        ["Doctor", v.doctor?.name],
-        ["Status", v.status],
-        ["Amount", v.amount != null ? formatMoney(v.amount, currency) : null],
-        ["Payment", v.paymentMode],
-        ["Notes", scrubZyluText(v.notes)],
-      ];
-      for (const [k, val] of rows) {
-        if (val == null || val === "") continue;
-        kv(k, val);
-      }
-
-      // Before / After photos — rendered as a two-column thumbnail strip
-      // when the visit has any photos uploaded. Up to 3 thumbnails per
-      // side at 90x90pt; a "+N more" caption surfaces overflow. Photos
-      // PDFKit can't decode (webp/gif/svg) render as a labelled
-      // placeholder box rather than failing the whole page.
       const beforeUrls = parsePhotoUrls(v.photosBefore);
       const afterUrls = parsePhotoUrls(v.photosAfter);
-      if (photoBuffers && (beforeUrls.length || afterUrls.length)) {
-        const thumbSize = 90;
-        const thumbGap = 6;
-        const MAX_PER_SIDE = 3;
+      const hasPhotos = photoBuffers && (beforeUrls.length || afterUrls.length);
+
+      // Pre-size the visit card so the rounded frame wraps the contents.
+      // Header (44pt) + meta row (28pt) + optional notes (16pt) + photos
+      // (200pt when present — bigger thumbnails per the reference).
+      const noteText = scrubZyluText(v.notes);
+      const baseH = 44 + 32 + (noteText ? 22 : 0);
+      const photoH = hasPhotos ? 220 : 0;
+      const cardH = baseH + photoH + 14;
+      ensureSpace(cardH + 14);
+
+      // Top accent colour follows the visit status — red for cancelled,
+      // teal for everything else. Matches the reference where cancelled
+      // visit cards are unmistakably red-flagged.
+      const visitKind = statusKind(v.status || "completed");
+      const visitAccent = visitKind === "danger" ? STATUS_PILL.danger.border : BRAND.teal;
+      const cardY = doc.y;
+      drawCardFrame(doc, {
+        x: leftX, y: cardY, w: usableW, h: cardH,
+        topAccent: true, bg: "#FFFFFF", border: BRAND.border,
+        accentColor: visitAccent,
+      });
+
+      // Visit number (serif voice) + date right-aligned
+      doc.font(SERIF_BOLD).fontSize(16).fillColor(BRAND.tealDark)
+        .text(`Visit #${v.id}`, leftX + 16, cardY + 14, { lineBreak: false });
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textMuted)
+        .text(formatDate(v.visitDate), leftX + 16, cardY + 17, {
+          width: usableW - 32, align: "right", lineBreak: false,
+        });
+
+      // Three-column meta row: SERVICE / DOCTOR / STATUS
+      const metaY = cardY + 38;
+      const metaColW = (usableW - 32) / 3;
+      const metaCols = [
+        { label: "Service", value: v.service?.name || "—" },
+        { label: "Doctor", value: v.doctor?.name || "—" },
+        { label: "Status", value: v.status || "—", isPill: true },
+      ];
+      metaCols.forEach((m, idx) => {
+        const mx = leftX + 16 + metaColW * idx;
+        doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.textMuted)
+          .text(m.label.toUpperCase(), mx, metaY, {
+            width: metaColW - 8, characterSpacing: 1.1, lineBreak: false,
+          });
+        if (m.isPill && v.status) {
+          drawStatusPill(doc, v.status, mx, metaY + 12, { fontSize: 8, padX: 7, padY: 2 });
+        } else {
+          doc.font("Helvetica-Bold").fontSize(10).fillColor(BRAND.textDark)
+            .text(m.value, mx, metaY + 12, { width: metaColW - 8, lineBreak: false, ellipsis: true });
+        }
+      });
+
+      // Optional 4th meta row: Amount + Payment + Notes
+      let cursorY = metaY + 30;
+      const extras = [];
+      if (v.amount != null) extras.push(`Amount · ${formatMoney(v.amount, currency)}`);
+      if (v.paymentMode) extras.push(`Payment · ${v.paymentMode}`);
+      if (extras.length) {
+        doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+          .text(extras.join("   ·   "), leftX + 16, cursorY, {
+            width: usableW - 32, lineBreak: false, ellipsis: true,
+          });
+        cursorY += 14;
+      }
+      if (noteText) {
+        doc.font("Helvetica-Bold").fontSize(9).fillColor(BRAND.textMuted)
+          .text("Notes · ", leftX + 16, cursorY, { continued: true })
+          .font("Helvetica").fillColor(BRAND.textBody).text(noteText, { width: usableW - 64 });
+        cursorY = doc.y + 2;
+      }
+
+      // Before / After photo strip — green dot bullets, large hero
+      // thumbnails (one per side, fills the column width). Matches the
+      // reference's "Visit #977" panel layout where each side gets a
+      // single big BEFORE / AFTER image rather than a strip of small ones.
+      if (hasPhotos) {
         const colGap = 18;
-        const colW = (usableW - colGap) / 2;
-        const beforeColX = leftX;
-        const afterColX = leftX + colW + colGap;
+        const colW = (usableW - 32 - colGap) / 2;
+        const thumbSize = colW;     // square that fills the column width
+        const thumbH = 160;          // landscape ratio close to the reference
+        const MAX_PER_SIDE = 1;
+        const beforeColX = leftX + 16;
+        const afterColX = leftX + 16 + colW + colGap;
 
-        // Reserve vertical space for label row + thumbnail row + "+N
-        // more" caption. Triggers a page break upfront if the strip
-        // would otherwise be split across pages.
-        ensureSpace(thumbSize + 36);
-        doc.moveDown(0.3);
+        const labelY = cursorY + 6;
 
-        const labelY = doc.y;
-        doc.font("Helvetica-Bold").fontSize(8.5).fillColor("#6b7280")
-          .text(`BEFORE (${beforeUrls.length})`, beforeColX, labelY, { width: colW });
-        doc.font("Helvetica-Bold").fontSize(8.5).fillColor("#6b7280")
-          .text(`AFTER (${afterUrls.length})`, afterColX, labelY, { width: colW });
-        const thumbY = labelY + 14;
+        // Left-side: green dot bullet + "BEFORE (N)"
+        doc.save();
+        doc.circle(beforeColX + 3, labelY + 4, 3).fill(STATUS_PILL.success.border);
+        doc.restore();
+        doc.font("Helvetica-Bold").fontSize(8.5).fillColor(BRAND.textMuted)
+          .text(`BEFORE (${beforeUrls.length})`, beforeColX + 12, labelY, {
+            width: colW - 12, characterSpacing: 1.1, lineBreak: false,
+          });
+
+        doc.save();
+        doc.circle(afterColX + 3, labelY + 4, 3).fill(STATUS_PILL.success.border);
+        doc.restore();
+        doc.font("Helvetica-Bold").fontSize(8.5).fillColor(BRAND.textMuted)
+          .text(`AFTER (${afterUrls.length})`, afterColX + 12, labelY, {
+            width: colW - 12, characterSpacing: 1.1, lineBreak: false,
+          });
+
+        const thumbY = labelY + 16;
 
         const drawThumbStrip = (urls, xStart) => {
-          let x = xStart;
           const shown = urls.slice(0, MAX_PER_SIDE);
           for (const url of shown) {
             const buf = photoBuffers.get(url);
             let rendered = false;
             if (buf) {
               try {
-                doc.image(buf, x, thumbY, {
-                  fit: [thumbSize, thumbSize],
+                doc.save();
+                doc.roundedRect(xStart, thumbY, thumbSize, thumbH, 8).clip();
+                doc.image(buf, xStart, thumbY, {
+                  fit: [thumbSize, thumbH],
                   align: "center",
                   valign: "center",
                 });
+                doc.restore();
                 rendered = true;
               } catch (_e) {
+                doc.restore();
                 rendered = false;
               }
             }
             if (!rendered) {
-              // Placeholder for missing / undecodable images.
               doc.save();
-              doc.rect(x, thumbY, thumbSize, thumbSize).fillColor("#f3f4f6").fill();
+              doc.roundedRect(xStart, thumbY, thumbSize, thumbH, 8).fill(BRAND.panelBg);
               doc.restore();
-              doc.font("Helvetica").fontSize(7.5).fillColor("#9ca3af")
-                .text("(image)", x, thumbY + thumbSize / 2 - 4, { width: thumbSize, align: "center" });
+              doc.font("Helvetica").fontSize(9).fillColor(BRAND.labelMuted)
+                .text("(image)", xStart, thumbY + thumbH / 2 - 5, {
+                  width: thumbSize, align: "center", lineBreak: false,
+                });
             }
-            doc.lineWidth(0.4).strokeColor("#d1d5db")
-              .rect(x, thumbY, thumbSize, thumbSize).stroke();
-            x += thumbSize + thumbGap;
+            doc.lineWidth(0.6).strokeColor(BRAND.border)
+              .roundedRect(xStart, thumbY, thumbSize, thumbH, 8).stroke();
           }
-          const extras = urls.length - shown.length;
-          if (extras > 0) {
-            doc.font("Helvetica").fontSize(8).fillColor("#6b7280")
-              .text(`+${extras} more`, xStart, thumbY + thumbSize + 3, { width: colW });
+          const extras2 = urls.length - shown.length;
+          if (extras2 > 0) {
+            doc.font("Helvetica").fontSize(8).fillColor(BRAND.textMuted)
+              .text(`+${extras2} more`, xStart, thumbY + thumbH + 4, {
+                width: colW, lineBreak: false,
+              });
           }
         };
 
         drawThumbStrip(beforeUrls, beforeColX);
         drawThumbStrip(afterUrls, afterColX);
-
-        // Account for the "+N more" caption when present so the next
-        // visit's separator doesn't overlap.
-        const captionPad = (beforeUrls.length > MAX_PER_SIDE || afterUrls.length > MAX_PER_SIDE) ? 14 : 0;
-        doc.y = thumbY + thumbSize + 10 + captionPad;
-        doc.x = leftX;
       }
 
-      // Thin separator between consecutive visits (skipped for last row).
-      if (i < visits.length - 1) {
-        doc.moveDown(0.4);
-        ensureSpace(8);
-        doc.moveTo(leftX, doc.y).lineTo(pageRight, doc.y)
-          .lineWidth(0.4).strokeColor("#e5e7eb").stroke();
-        doc.moveDown(0.5);
-      } else {
-        doc.moveDown(0.4);
-      }
+      doc.y = cardY + cardH + 12;
     }
   }
 
-  // ── Prescriptions (full Rx layout — mirrors renderPrescriptionPdf) ──
-  // Each Rx renders as its own block: title row with Rx badge + right-
-  // aligned metadata, doctor info, Medical Information rows, Prescription
-  // Medications table (same column layout as the single-Rx PDF), Advice,
-  // Notes. Page-break per Rx so each one is self-contained.
+  // ── Prescriptions — flowing layout matching the reference ─────────
+  // Reference (page 4) stacks Rx #96 + Rx #95 on the SAME page when there's
+  // room. We start the section on a fresh page, render its header once,
+  // and let subsequent Rxes flow with `ensureSpace` — a new page is only
+  // added when an Rx genuinely doesn't fit the remaining vertical space.
   if (prescriptions.length > 0) {
+    currentSection = "Prescriptions";
+    doc.addPage();
+    doc.y = 60;
+    sectionTitle(
+      "Prescriptions",
+      `${prescriptions.length} prescription${prescriptions.length === 1 ? "" : "s"} issued`,
+    );
     for (let i = 0; i < prescriptions.length; i++) {
       const p = prescriptions[i];
       const parsed = parseRxInstructions(p.instructions);
@@ -997,197 +1618,319 @@ async function renderPatientSummaryPdf({
       const drugs = parseDrugs(p.drugs);
       const doctor = p.doctor || null;
 
-      // Start each Rx on its own page (matches single-Rx PDF layout).
-      doc.addPage();
-      doc.y = 60;
-      sectionTitle(i === 0 ? `Prescriptions (${prescriptions.length})` : `Prescription ${i + 1} of ${prescriptions.length}`);
+      // Pre-estimate the Rx block height (header card + Rx mark + table +
+      // 2 callouts). If it doesn't fit on the current page, force a new
+      // page so the Rx block stays visually contiguous.
+      const calloutH = (parsed.advice ? 90 : 0) + 70;
+      const rowsH = 24 + drugs.length * 44 + 14;
+      const blockH = 100 + 36 + rowsH + calloutH + 18;
+      if (i > 0) ensureSpace(blockH);
 
-      // Title + Rx badge + right-aligned metadata.
-      const headerY = doc.y;
-      doc.font("Helvetica-Bold").fontSize(13).fillColor("#111")
-        .text(`Prescription - ${p.id ?? ""}`, leftX, headerY, { continued: false });
-      doc.lineWidth(0.6).strokeColor("#444").rect(230, headerY - 2, 28, 16).stroke();
-      doc.font("Helvetica-Bold").fontSize(10).fillColor("#222").text("Rx", 230, headerY + 1, { width: 28, align: "center" });
-      const rightX = 360, rightW = pageRight - rightX;
-      doc.font("Helvetica").fontSize(10).fillColor("#222");
-      doc.text(`Date: ${formatDate(p.createdAt)}`, rightX, headerY, { width: rightW, align: "right" });
-      doc.text(`Prescription #: ${p.id ?? "—"}`, rightX, doc.y, { width: rightW, align: "right" });
-      doc.text(`Appointment #: ${p.visitId ?? "—"}`, rightX, doc.y, { width: rightW, align: "right" });
-      doc.moveDown(0.6);
-      doc.y = Math.max(doc.y, headerY + 48);
+      // Rx card — header band with Rx #, date · appt #, PRESCRIBED BY
+      // row, and a green ISSUED status pill (matches the reference's
+      // Rx #96 / Rx #95 layout).
+      const rxCardY = doc.y;
+      const rxHeaderH = 100;
+      drawCardFrame(doc, {
+        x: leftX, y: rxCardY, w: usableW, h: rxHeaderH,
+        bg: "#FFFFFF", border: BRAND.border,
+      });
 
-      // Patient + Doctor side-by-side blocks.
-      const blockTop = doc.y;
-      const rightCol = 300, colWidth = 240;
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Patient Information", leftX, blockTop);
-      doc.font("Helvetica").fontSize(10).fillColor("#222");
-      const patientLines = [
-        ["Name", patient?.name],
-        ["ID", patient?.id != null ? String(patient.id) : ""],
-        ["Gender", patient?.gender],
-        ["Phone", patient?.phone],
-      ];
-      let py = doc.y;
-      for (const [k, v] of patientLines) {
-        doc.font("Helvetica-Bold").text(`${k}: `, leftX, py, { continued: true })
-          .font("Helvetica").text(String(v || "—"));
-        py = doc.y;
+      // Rx number (serif) + right-aligned issued date · appt #
+      doc.font(SERIF_BOLD).fontSize(18).fillColor(BRAND.tealDark)
+        .text(`Rx #${p.id ?? ""}`, leftX + 18, rxCardY + 16, { lineBreak: false });
+      doc.font("Helvetica").fontSize(10).fillColor(BRAND.textMuted)
+        .text(
+          `${formatDate(p.createdAt)}${p.visitId != null ? ` · Appt #${p.visitId}` : ""}`,
+          leftX + 18, rxCardY + 20,
+          { width: usableW - 36, align: "right", lineBreak: false },
+        );
+
+      // PRESCRIBED BY + STATUS row.
+      doc.font("Helvetica-Bold").fontSize(7.5).fillColor(BRAND.textMuted)
+        .text("PRESCRIBED BY", leftX + 18, rxCardY + 50, {
+          characterSpacing: 1.3, lineBreak: false,
+        });
+      doc.font("Helvetica-Bold").fontSize(8).fillColor(BRAND.textMuted)
+        .text("STATUS", leftX + 200, rxCardY + 50, {
+          characterSpacing: 1.3, lineBreak: false,
+        });
+      doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.textDark)
+        .text(doctor?.name ? (doctor.name.startsWith("Dr.") ? doctor.name : `Dr. ${doctor.name}`) : "—",
+          leftX + 18, rxCardY + 66, { width: 170, ellipsis: true, lineBreak: false });
+      drawStatusPill(doc, status, leftX + 200, rxCardY + 66, { kind: "success" });
+
+      // Decorative Rx mark in the lower-left of the header card (matches
+      // the reference's small calligraphic Rx above the medication table).
+      drawRxMark(doc, { x: leftX + 18, y: rxCardY + rxHeaderH - 4, size: 22 });
+
+      doc.y = rxCardY + rxHeaderH + 26;
+
+      // Clinical notes block (rendered as compact rows only when present).
+      const hasClinical = parsed.chiefComplaint || parsed.diagnosis || parsed.investigations;
+      if (hasClinical) {
+        doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+          .text("Clinical Notes", leftX, doc.y);
+        doc.moveDown(0.3);
+        const medRows = [
+          ["Chief Complaint", parsed.chiefComplaint || "—"],
+          ["Diagnosis", parsed.diagnosis || "—"],
+          ["Investigations", parsed.investigations || "—"],
+        ];
+        for (const [k, vv] of medRows) {
+          const y = doc.y;
+          doc.font("Helvetica-Bold").fontSize(8.5).fillColor(BRAND.textMuted)
+            .text(String(k).toUpperCase(), leftX, y + 2, {
+              width: 130, characterSpacing: 1, lineBreak: false,
+            });
+          doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+            .text(String(vv), leftX + 130, y, { width: usableW - 130 });
+          doc.y = Math.max(doc.y, y + 16);
+        }
+        doc.moveDown(0.4);
       }
-      const patientEndY = doc.y;
 
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Doctor Information", rightCol, blockTop);
-      doc.font("Helvetica").fontSize(10).fillColor("#222");
-      const doctorLines = [
-        ["Name", doctor?.name],
-        ["Phone", doctor?.phone],
-        ["Email", doctor?.email],
-      ];
-      if (doctor?.registrationNumber) doctorLines.push(["Registration Number", doctor.registrationNumber]);
-      let dy = doc.y;
-      for (const [k, v] of doctorLines) {
-        doc.font("Helvetica-Bold").text(`${k}: `, rightCol, dy, { continued: true, width: colWidth })
-          .font("Helvetica").text(String(v || "—"));
-        dy = doc.y;
-      }
-      const doctorEndY = doc.y;
-
-      const sectionEndY = Math.max(patientEndY, doctorEndY) + 8;
-      doc.moveTo(leftX, sectionEndY).lineTo(pageRight, sectionEndY).lineWidth(0.5).strokeColor("#bbb").stroke();
-      doc.y = sectionEndY + 10;
-
-      // Medical Information.
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Medical Information", leftX);
-      doc.moveDown(0.3);
-      const medRows = [
-        ["Chief Complaint", parsed.chiefComplaint || "Not Specified"],
-        ["Diagnosis", parsed.diagnosis || "Not Specified"],
-        ["Investigations", parsed.investigations || "Not Specified"],
-      ];
-      doc.font("Helvetica").fontSize(10).fillColor("#222");
-      for (const [k, v] of medRows) {
-        const y = doc.y;
-        doc.font("Helvetica-Bold").text(`${k}: `, leftX, y, { continued: true, width: pageRight - leftX })
-          .font("Helvetica").text(String(v));
-      }
-      doc.moveDown(0.5);
-
-      // Prescription Medications table — same column layout as single-Rx PDF.
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text("Prescription Medications");
-      doc.moveDown(0.3);
+      // Prescription Medications table — reference's 5-column layout:
+      //   #  |  MEDICATION (with Form · Route subline)  |  DOSAGE
+      //   |  FREQUENCY (rendered as a green pill)  |  DURATION
+      // No "Instructions" column on the reference; per-drug instructions
+      // flow into the post-table Notes block instead.
       const tableTop = doc.y;
       const cols = [
-        { label: "Medication", x: 50, w: 95 },
-        { label: "Dosage", x: 145, w: 55 },
-        { label: "Form", x: 200, w: 50 },
-        { label: "Route", x: 250, w: 50 },
-        { label: "Frequency", x: 300, w: 60 },
-        { label: "Duration", x: 360, w: 75 },
-        { label: "Instructions", x: 435, w: 110 },
+        { label: "#",          x: leftX,        w: 36 },
+        { label: "Medication", x: leftX + 36,  w: 175 },
+        { label: "Dosage",     x: leftX + 211, w: 95 },
+        { label: "Frequency",  x: leftX + 306, w: 120 },
+        { label: "Duration",   x: leftX + 426, w: usableW - 426 },
       ];
-      doc.rect(50, tableTop, 495, 18).fillColor("#f3f4f6").fill();
-      doc.fillColor("#333").font("Helvetica-Bold").fontSize(9);
-      for (const c of cols) doc.text(c.label, c.x + 3, tableTop + 5, { width: c.w - 6 });
+      doc.save();
+      doc.rect(leftX, tableTop, usableW, 24).fill(BRAND.teal);
+      doc.restore();
+      doc.fillColor("#FFFFFF").font("Helvetica-Bold").fontSize(8.5);
+      for (const col of cols) {
+        doc.text(col.label.toUpperCase(), col.x + 8, tableTop + 8, {
+          width: col.w - 16, characterSpacing: 1.1, lineBreak: false,
+        });
+      }
 
-      let rowY = tableTop + 18;
-      doc.font("Helvetica").fontSize(9).fillColor("#222");
+      let rowY = tableTop + 24;
       if (drugs.length === 0) {
-        doc.text("(no medications listed)", 53, rowY + 4);
-        rowY += 22;
+        doc.save();
+        doc.rect(leftX, rowY, usableW, 28).fill(BRAND.panelBg);
+        doc.restore();
+        doc.font("Helvetica-Oblique").fontSize(10).fillColor(BRAND.textMuted)
+          .text("(no medications listed)", leftX, rowY + 9, { width: usableW, align: "center" });
+        rowY += 28;
       } else {
-        for (const d of drugs) {
+        for (let di = 0; di < drugs.length; di++) {
+          const d = drugs[di];
           const strength = [d.strengthValue, d.strengthUnit].filter(Boolean).join("") || d.strength || "";
-          const dosageCell = [d.dosage || "—", strength || "—"].join(" ");
-          const cells = [
-            d.name || d.drug || "—",
-            dosageCell,
-            d.preparation || d.dosageForm || "—",
-            d.route || "—",
-            d.frequency || "—",
-            d.duration || "—",
-            d.instructions || "—",
-          ];
-          const heights = cells.map((val, i) => doc.heightOfString(String(val), { width: cols[i].w - 6 }));
-          const rowH = Math.max(18, ...heights) + 6;
-          if (rowY + rowH > 740) {
+          // DOSAGE: combine free-text dosage + strength on one line.
+          const dosageText = [d.dosage, strength].filter(Boolean).join(" ").trim() || "—";
+          // MEDICATION subline: Form · Route (e.g. "Topical · scalp").
+          const subParts = [d.preparation || d.dosageForm, d.route].filter(Boolean);
+          const subText = subParts.join(" · ");
+          const medName = d.name || d.drug || "—";
+          const freq = d.frequency || "—";
+          const duration = d.duration || "—";
+
+          // Row height — taller when there's a Form · Route subline, tight
+          // when it's a single-line medication. Matches the reference's
+          // natural row density (two-line rows ≈ 44pt, one-liners ≈ 32pt).
+          const rowH = subText ? 44 : 32;
+
+          if (rowY + rowH > contentBottom) {
             doc.addPage();
             rowY = 60;
+            doc.save();
+            doc.rect(leftX, rowY, usableW, 24).fill(BRAND.teal);
+            doc.restore();
+            doc.fillColor("#FFFFFF").font("Helvetica-Bold").fontSize(8.5);
+            for (const col of cols) {
+              doc.text(col.label.toUpperCase(), col.x + 8, rowY + 8, {
+                width: col.w - 16, characterSpacing: 1.1, lineBreak: false,
+              });
+            }
+            rowY += 24;
           }
-          cells.forEach((val, i) => {
-            doc.text(String(val), cols[i].x + 3, rowY + 3, { width: cols[i].w - 6 });
+          if (di % 2 === 1) {
+            doc.save();
+            doc.rect(leftX, rowY, usableW, rowH).fill(BRAND.panelBg);
+            doc.restore();
+          }
+          // # column — small muted number, vertically centred.
+          doc.font("Helvetica").fontSize(10).fillColor(BRAND.textMuted)
+            .text(String(di + 1), cols[0].x + 12, rowY + rowH / 2 - 6, {
+              width: cols[0].w - 16, lineBreak: false,
+            });
+          // MEDICATION — bold name + optional Form · Route subline.
+          doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND.tealDark)
+            .text(medName, cols[1].x + 8, subText ? rowY + 8 : rowY + rowH / 2 - 7, {
+              width: cols[1].w - 16, ellipsis: true, lineBreak: false,
+            });
+          if (subText) {
+            doc.font("Helvetica").fontSize(8.5).fillColor(BRAND.textMuted)
+              .text(subText, cols[1].x + 8, rowY + 24, {
+                width: cols[1].w - 16, ellipsis: true, lineBreak: false,
+              });
+          }
+          // DOSAGE — regular weight, dark body.
+          doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+            .text(dosageText, cols[2].x + 8, rowY + rowH / 2 - 6, {
+              width: cols[2].w - 16, ellipsis: true, lineBreak: false,
+            });
+          // FREQUENCY — green pill, vertically centred.
+          drawStatusPill(doc, freq, cols[3].x + 8, rowY + rowH / 2 - 8, {
+            kind: "success", fontSize: 8, padX: 8, padY: 3,
           });
-          doc.moveTo(50, rowY + rowH).lineTo(545, rowY + rowH).lineWidth(0.3).strokeColor("#e5e7eb").stroke();
+          // DURATION — regular weight.
+          doc.font("Helvetica").fontSize(10).fillColor(BRAND.textBody)
+            .text(duration, cols[4].x + 8, rowY + rowH / 2 - 6, {
+              width: cols[4].w - 16, ellipsis: true, lineBreak: false,
+            });
+          doc.moveTo(leftX, rowY + rowH).lineTo(pageRight, rowY + rowH)
+            .lineWidth(0.3).strokeColor(BRAND.borderSoft).stroke();
           rowY += rowH;
         }
       }
-      // Same cursor-reset as the standalone Rx PDF — after the drug table
-      // rows pdfkit's doc.x is parked at the Instructions column; without
-      // resetting it the Additional Advice / Notes body wraps from x≈435
-      // and tails off the right edge. Pin x to leftX before continuing.
+      doc.lineWidth(0.5).strokeColor(BRAND.border)
+        .rect(leftX, tableTop, usableW, rowY - tableTop).stroke();
       doc.x = leftX;
-      doc.y = rowY + 8;
-      const noteWidth = pageRight - leftX;
+      doc.y = rowY + 14;
 
-      // Additional Advice + Notes.
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-        .text("Additional Advice", leftX, doc.y, { width: noteWidth });
-      doc.font("Helvetica").fontSize(10).fillColor("#222")
-        .text(parsed.advice || "—", leftX, doc.y, { width: noteWidth });
-      doc.moveDown(0.5);
+      // Post-procedure care advice — amber callout (matches the reference's
+      // "Post-Procedure Care" callout under Rx #96).
+      if (parsed.advice) {
+        drawCalloutBox(doc, {
+          x: leftX, y: doc.y, w: usableW,
+          heading: "Post-Procedure Care",
+          body: parsed.advice,
+          kind: "warning",
+        });
+        doc.moveDown(0.8);
+      }
       doc.x = leftX;
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-        .text("Notes", leftX, doc.y, { width: noteWidth });
-      doc.font("Helvetica").fontSize(10).fillColor("#222")
-        .text(
-          parsed.notes || "No clinical notes recorded.",
-          leftX,
-          doc.y,
-          { width: noteWidth },
-        );
-      doc.moveDown(0.4);
-      doc.x = leftX;
-      doc.font("Helvetica-Bold").fontSize(9).fillColor("#222")
-        .text("Status: ", leftX, doc.y, { continued: true })
-        .font("Helvetica").text(status);
+      // Notes block — same amber callout shape as Post-Procedure Care so
+      // the two read as a coherent pair. The reference's Rx #95 panel uses
+      // a cream/amber "Notes:" box with the "No clinical notes recorded."
+      // fallback when clinical notes are absent. The pinned string stays
+      // verbatim for the vitest contract.
+      drawCalloutBox(doc, {
+        x: leftX, y: doc.y, w: usableW,
+        heading: "Notes",
+        body: parsed.notes || "No clinical notes recorded.",
+        kind: "warning",
+      });
+      doc.moveDown(0.8);
     }
   }
 
-  // ── Treatment plans ───────────────────────────────────────────────
+  // ── Treatment plans (dark-teal hero cards) ────────────────────────
+  // Reference uses a deep-teal card with cream/white text + a serif
+  // amount on the right. The left accent stripe is brighter teal so the
+  // cards read as a hierarchy of brand layers (header band > plan cards
+  // > body content).
   if (treatmentPlans.length > 0) {
-    sectionTitle(`Treatment Plans (${treatmentPlans.length})`);
+    // New page so the financial summary opens cleanly. currentSection set
+    // BEFORE addPage so the new page's footer carries the right label.
+    currentSection = "Treatment Plans & Wallet";
+    doc.addPage();
+    doc.y = 60;
+    sectionTitle("Treatment Plans & Wallet", "Financial summary");
+
+    drawSectionLabelWithRule(doc, `Treatment Plans · ${treatmentPlans.length}`, { x: leftX, w: usableW });
+    doc.moveDown(0.2);
+
     for (let i = 0; i < treatmentPlans.length; i++) {
       const t = treatmentPlans[i];
-      ensureSpace(60);
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-        .text(`Plan #${t.id}`, leftX, doc.y, { continued: true })
-        .font("Helvetica").fontSize(10).fillColor("#555")
-        .text(`   ·   ${t.service?.name || "—"}`);
-      doc.moveDown(0.3);
+      const rowH = 72;
+      ensureSpace(rowH + 12);
+      const ry = doc.y;
+
+      // Dark-teal hero card with a brighter teal left accent.
+      doc.save();
+      doc.roundedRect(leftX, ry, usableW, rowH, 6).fill(BRAND.tealDeep);
+      doc.roundedRect(leftX, ry, 4, rowH, 2).fill(BRAND.teal);
+      doc.restore();
+
+      // Plan title (serif voice, cream/white)
+      doc.font(SERIF_BOLD).fontSize(14).fillColor("#FFFFFF")
+        .text(`Plan #${t.id} · ${t.service?.name || "—"}`, leftX + 22, ry + 16, {
+          width: usableW - 240, ellipsis: true, lineBreak: false,
+        });
+      if (t.status) {
+        drawStatusPill(doc, t.status, leftX + 22, ry + 42, {
+          kind: "success", fontSize: 8, padX: 8,
+        });
+      }
+
+      // Right-aligned amount (serif, cream/white) — matches the reference's
+      // "₹ 1,25,000.00" treatment plan amount style.
+      if (t.totalPrice != null) {
+        doc.font(SERIF_BOLD).fontSize(20).fillColor("#FAF6F0")
+          .text(formatMoney(t.totalPrice, currency), leftX, ry + 24, {
+            width: usableW - 22, align: "right", lineBreak: false,
+          });
+      }
+
+      // Sessions / notes — small cream subtitle inline after the status pill.
+      const subBits = [];
       if (t.sessionsTotal != null || t.sessionsCompleted != null) {
-        kv("Sessions", `${t.sessionsCompleted ?? 0} / ${t.sessionsTotal ?? "—"}`);
+        subBits.push(`Sessions ${t.sessionsCompleted ?? 0} / ${t.sessionsTotal ?? "—"}`);
       }
-      if (t.totalPrice != null) kv("Total Price", formatMoney(t.totalPrice, currency));
-      if (t.status) kv("Status", t.status);
-      if (t.notes) kv("Notes", t.notes);
-      if (i < treatmentPlans.length - 1) {
-        doc.moveDown(0.4);
-        ensureSpace(8);
-        doc.moveTo(leftX, doc.y).lineTo(pageRight, doc.y)
-          .lineWidth(0.4).strokeColor("#e5e7eb").stroke();
-        doc.moveDown(0.5);
-      } else {
-        doc.moveDown(0.4);
+      if (t.notes) subBits.push(scrubZyluText(t.notes));
+      if (subBits.length) {
+        doc.font("Helvetica").fontSize(9).fillColor("#CFE3DE")
+          .text(subBits.join("   ·   "), leftX + 22 + 84, ry + 46, {
+            width: usableW - 280, lineBreak: false, ellipsis: true,
+          });
       }
+      doc.y = ry + rowH + 10;
     }
+    doc.moveDown(0.6);
   }
 
   // ── Wallet ────────────────────────────────────────────────────────
   if (hasWalletActivity) {
-    sectionTitle("Wallet");
-    kv("Balance", formatMoney(wallet.balance, currency));
-    kv("Currency", currency);
+    if (treatmentPlans.length === 0) {
+      currentSection = "Wallet";
+      doc.addPage();
+      doc.y = 60;
+      sectionTitle("Wallet", "Financial summary");
+    }
+    drawSectionLabelWithRule(doc, "Wallet", { x: leftX, w: usableW });
+    doc.moveDown(0.2);
+
+    const walletCardH = 86;
+    ensureSpace(walletCardH + 12);
+    const wy = doc.y;
+    // Deep-teal hero card matching the treatment-plan cards above —
+    // cream/white label + serif balance + credit-card glyph on the right.
+    doc.save();
+    doc.roundedRect(leftX, wy, usableW, walletCardH, 6).fill(BRAND.tealDeep);
+    doc.restore();
+    doc.font("Helvetica-Bold").fontSize(8).fillColor("#CFE3DE")
+      .text("CURRENT BALANCE", leftX + 22, wy + 18, {
+        characterSpacing: 1.5, lineBreak: false,
+      });
+    doc.font(SERIF_BOLD).fontSize(28).fillColor("#FAF6F0")
+      .text(formatMoney(wallet.balance, currency), leftX + 22, wy + 34, { lineBreak: false });
+    doc.font("Helvetica").fontSize(9).fillColor("#CFE3DE")
+      .text(`Currency · ${currency}`, leftX + 22, wy + 68, { lineBreak: false });
+
+    // Credit-card glyph on the right — cream rectangle with a magnetic
+    // stripe + accent strip beneath, matches the reference's wallet card.
+    const glyphX = pageRight - 80;
+    const glyphY = wy + 26;
+    doc.save();
+    doc.roundedRect(glyphX, glyphY, 56, 34, 5).fillAndStroke("#FAF6F0", BRAND.gold);
+    doc.rect(glyphX + 4, glyphY + 22, 14, 3).fill(BRAND.tealDeep);
+    doc.rect(glyphX + 32, glyphY + 22, 20, 3).fill(BRAND.gold);
+    doc.restore();
+    doc.y = wy + walletCardH + 14;
+
     if (transactions.length > 0) {
-      doc.moveDown(0.4);
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111").text(`Recent transactions (${transactions.length})`, leftX);
+      drawSectionLabelWithRule(doc, `Recent Transactions · ${transactions.length}`, { x: leftX, w: usableW });
       doc.moveDown(0.2);
       const tableTop = doc.y;
       const cols = [
@@ -1196,72 +1939,106 @@ async function renderPatientSummaryPdf({
         { label: "Amount", x: leftX + 200, w: 90 },
         { label: "Reason", x: leftX + 290, w: usableW - 290 },
       ];
-      doc.rect(leftX, tableTop, usableW, 18).fillColor("#f3f4f6").fill();
-      doc.fillColor("#333").font("Helvetica-Bold").fontSize(9);
-      for (const c of cols) doc.text(c.label, c.x + 3, tableTop + 5, { width: c.w - 6 });
-      let rowY = tableTop + 18;
-      doc.font("Helvetica").fontSize(9).fillColor("#222");
-      for (const tx of transactions) {
+      doc.save();
+      doc.rect(leftX, tableTop, usableW, 22).fill(BRAND.teal);
+      doc.restore();
+      doc.fillColor("#FFFFFF").font("Helvetica-Bold").fontSize(8.5);
+      for (const cc of cols) doc.text(cc.label, cc.x + 4, tableTop + 7, { width: cc.w - 8, lineBreak: false });
+      let rowY = tableTop + 22;
+      for (let ti = 0; ti < transactions.length; ti++) {
+        const tx = transactions[ti];
         const cells = [
           formatDate(tx.createdAt),
           String(tx.type || "").replace(/_/g, " "),
           `${tx.amount >= 0 ? "+" : ""}${formatMoney(tx.amount, currency)}`,
           tx.reason || "—",
         ];
-        const heights = cells.map((val, i) => doc.heightOfString(String(val), { width: cols[i].w - 6 }));
-        const rowH = Math.max(16, ...heights) + 6;
-        if (rowY + rowH > 770) {
+        const heights = cells.map((val, idx) => doc.heightOfString(String(val), { width: cols[idx].w - 8 }));
+        const rowH = Math.max(18, ...heights) + 6;
+        if (rowY + rowH > contentBottom) {
           doc.addPage();
           rowY = 60;
         }
-        cells.forEach((val, i) => {
-          doc.text(String(val), cols[i].x + 3, rowY + 3, { width: cols[i].w - 6 });
+        if (ti % 2 === 1) {
+          doc.save();
+          doc.rect(leftX, rowY, usableW, rowH).fill(BRAND.panelBg);
+          doc.restore();
+        }
+        const amtKind = (Number(tx.amount) || 0) >= 0 ? "success" : "danger";
+        doc.font("Helvetica").fontSize(9).fillColor(BRAND.textBody);
+        cells.forEach((val, idx) => {
+          // Color the amount column with semantic intent.
+          if (idx === 2) {
+            doc.fillColor(STATUS_PILL[amtKind].border)
+              .font("Helvetica-Bold")
+              .text(String(val), cols[idx].x + 4, rowY + 5, { width: cols[idx].w - 8 });
+            doc.font("Helvetica").fillColor(BRAND.textBody);
+          } else {
+            doc.text(String(val), cols[idx].x + 4, rowY + 5, { width: cols[idx].w - 8 });
+          }
         });
         doc.moveTo(leftX, rowY + rowH).lineTo(pageRight, rowY + rowH)
-          .lineWidth(0.3).strokeColor("#e5e7eb").stroke();
+          .lineWidth(0.3).strokeColor(BRAND.borderSoft).stroke();
         rowY += rowH;
       }
-      doc.y = rowY + 8;
+      doc.lineWidth(0.5).strokeColor(BRAND.border)
+        .rect(leftX, tableTop, usableW, rowY - tableTop).stroke();
+      doc.y = rowY + 12;
     }
   }
 
   // ── Memberships ───────────────────────────────────────────────────
   if (membershipList.length > 0) {
-    sectionTitle(`Memberships (${membershipList.length})`);
+    // currentSection set BEFORE the ensureSpace check that may trigger
+    // addPage, so the new page (if any) gets the right footer label.
+    currentSection = "Memberships";
+    ensureSpace(80);
+    sectionTitle("Memberships", `${membershipList.length} membership${membershipList.length === 1 ? "" : "s"}`);
     for (let i = 0; i < membershipList.length; i++) {
       const m = membershipList[i];
-      ensureSpace(60);
-      doc.font("Helvetica-Bold").fontSize(11).fillColor("#111")
-        .text(m.plan?.name || "Plan", leftX, doc.y, { continued: true })
-        .font("Helvetica").fontSize(10).fillColor("#555")
-        .text(`   ·   Membership #${m.id}`);
-      doc.moveDown(0.3);
-      if (m.status) kv("Status", m.status);
-      if (m.startDate) kv("Start", formatDate(m.startDate));
-      if (m.endDate) kv("End", formatDate(m.endDate));
-      if (m.plan?.price != null) kv("Price Paid", formatMoney(m.plan.price, m.plan.currency || currency));
-      if (m.balanceJson || m.balance) {
-        let balText = "";
-        try {
-          const bal = typeof m.balanceJson === "string" ? JSON.parse(m.balanceJson) : (m.balanceJson || m.balance);
-          if (bal && typeof bal === "object") {
-            balText = Object.entries(bal).map(([k, v]) => `${k}: ${v}`).join("   •   ");
-          }
-        } catch {
-          /* ignore */
-        }
-        if (balText) kv("Balance", balText);
+      const rowH = 70;
+      ensureSpace(rowH + 10);
+      const ry = doc.y;
+      drawCardFrame(doc, { x: leftX, y: ry, w: usableW, h: rowH, leftAccent: true });
+
+      doc.font("Helvetica-Bold").fontSize(13).fillColor(BRAND.tealDark)
+        .text(m.plan?.name || "Plan", leftX + 18, ry + 12, {
+          width: usableW - 200, ellipsis: true, lineBreak: false,
+        });
+      doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+        .text(`Membership #${m.id}`, leftX + 18, ry + 30, { lineBreak: false });
+
+      const mBits = [];
+      if (m.startDate) mBits.push(`Start · ${formatDate(m.startDate)}`);
+      if (m.endDate) mBits.push(`End · ${formatDate(m.endDate)}`);
+      doc.font("Helvetica").fontSize(9).fillColor(BRAND.textMuted)
+        .text(mBits.join("   ·   "), leftX + 18, ry + 46, {
+          width: usableW - 200, ellipsis: true, lineBreak: false,
+        });
+
+      if (m.status) drawStatusPill(doc, m.status, pageRight - 80, ry + 14);
+      if (m.plan?.price != null) {
+        doc.font("Helvetica-Bold").fontSize(14).fillColor(BRAND.tealDark)
+          .text(formatMoney(m.plan.price, m.plan.currency || currency), leftX, ry + 38, {
+            width: usableW - 16, align: "right", lineBreak: false,
+          });
       }
-      if (i < membershipList.length - 1) {
-        doc.moveDown(0.4);
-        ensureSpace(8);
-        doc.moveTo(leftX, doc.y).lineTo(pageRight, doc.y)
-          .lineWidth(0.4).strokeColor("#e5e7eb").stroke();
-        doc.moveDown(0.5);
-      } else {
-        doc.moveDown(0.4);
-      }
+      doc.y = ry + rowH + 8;
     }
+  }
+
+  // ── Branded footer pass (page numbers + section label) ────────────
+  const range = doc.bufferedPageRange();
+  for (let i = range.start; i < range.start + range.count; i++) {
+    doc.switchToPage(i);
+    drawBrandedFooter(doc, {
+      brandName,
+      sectionLabel: pageSectionLabels[i] || "Patient Summary",
+      pageIndex: i,
+      pageCount: range.count,
+      leftX,
+      rightX: pageRight,
+    });
   }
 
   doc.end();

--- a/backend/test/lib/pageCatalog.test.js
+++ b/backend/test/lib/pageCatalog.test.js
@@ -182,7 +182,7 @@ describe('canAccessPath', () => {
     expect(canAccessPath('/wellness/book-appointment', nursePerms)).toBe(false);
     expect(canAccessPath('/wellness/my-appointments', nursePerms)).toBe(false);
     // Pages that need permissions Nurse simply doesn't have stay barred.
-    expect(canAccessPath('/invoices', nursePerms)).toBe(false); // billing.read
+    expect(canAccessPath('/invoices', nursePerms)).toBe(false); // invoices.read
     expect(canAccessPath('/wellness/pos', nursePerms)).toBe(false); // pos.read
   });
 });
@@ -205,7 +205,7 @@ describe('getAccessiblePages', () => {
     expect(paths).toContain('/wellness/patients');
     expect(paths).toContain('/wellness/calendar');
     expect(paths).toContain('/wellness/prescriptions');
-    expect(paths).not.toContain('/invoices'); // needs billing.read
+    expect(paths).not.toContain('/invoices'); // needs invoices.read
     expect(paths).not.toContain('/wellness/pos'); // needs pos.read
   });
 

--- a/backend/test/lib/portalPermissions.test.js
+++ b/backend/test/lib/portalPermissions.test.js
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for backend/lib/portalPermissions.js — patient-portal RBAC
+ * resolver.
+ *
+ * Pins the contract that:
+ *   - getCustomerRolePermissions returns the union of RolePermission
+ *     rows on the tenant's CUSTOMER role.
+ *   - requirePortalPermission 401s when req.patient is missing
+ *     id/tenantId, 403s when the permission isn't granted, next()s when
+ *     it is.
+ *   - clearCustomerRoleCache invalidates the per-tenant cached set.
+ *   - Catalog validation rejects unknown (module, action) pairs at
+ *     middleware-factory creation time.
+ *
+ * Mocks the prisma singleton via monkey-patch (same pattern as
+ * roleResolution.test.js + eventBus.test.js).
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import {
+  requirePortalPermission,
+  getCustomerRolePermissions,
+  loadCustomerRolePermissions,
+  clearCustomerRoleCache,
+  _CACHE,
+} from '../../lib/portalPermissions.js';
+
+beforeEach(() => {
+  prisma.role = prisma.role || {};
+  prisma.role.findFirst = vi.fn();
+  clearCustomerRoleCache(null); // wipe between tests
+});
+
+describe('loadCustomerRolePermissions', () => {
+  test('returns empty Set when no CUSTOMER role exists for the tenant', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce(null);
+    const perms = await loadCustomerRolePermissions(99);
+    expect(perms).toBeInstanceOf(Set);
+    expect(perms.size).toBe(0);
+  });
+
+  test('returns a Set of "module.action" strings unioning the role grants', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce({
+      id: 7,
+      permissions: [
+        { module: 'my_prescriptions', action: 'read' },
+        { module: 'appointments', action: 'read' },
+        { module: 'services', action: 'read' },
+      ],
+    });
+    const perms = await loadCustomerRolePermissions(1);
+    expect(perms.has('my_prescriptions.read')).toBe(true);
+    expect(perms.has('appointments.read')).toBe(true);
+    expect(perms.has('services.read')).toBe(true);
+    expect(perms.has('patients.read')).toBe(false);
+  });
+
+  test('scopes the lookup by tenantId + key=CUSTOMER', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce({ id: 7, permissions: [] });
+    await loadCustomerRolePermissions(42);
+    expect(prisma.role.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: 42, key: 'CUSTOMER' },
+      }),
+    );
+  });
+});
+
+describe('getCustomerRolePermissions caching', () => {
+  test('caches by tenantId for 30s and hits the DB only once on repeat calls', async () => {
+    prisma.role.findFirst.mockResolvedValue({
+      id: 7,
+      permissions: [{ module: 'my_prescriptions', action: 'read' }],
+    });
+
+    const a = await getCustomerRolePermissions(1);
+    const b = await getCustomerRolePermissions(1);
+    expect(a).toBe(b); // same Set reference — served from cache
+    expect(prisma.role.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  test('clearCustomerRoleCache(tenantId) drops the entry so the next call re-reads', async () => {
+    prisma.role.findFirst.mockResolvedValue({
+      id: 7,
+      permissions: [{ module: 'my_prescriptions', action: 'read' }],
+    });
+    await getCustomerRolePermissions(1);
+    clearCustomerRoleCache(1);
+    await getCustomerRolePermissions(1);
+    expect(prisma.role.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  test('clearCustomerRoleCache(null) wipes the whole cache', async () => {
+    prisma.role.findFirst.mockResolvedValue({ id: 7, permissions: [] });
+    await getCustomerRolePermissions(1);
+    await getCustomerRolePermissions(2);
+    expect(_CACHE.size).toBe(2);
+    clearCustomerRoleCache(null);
+    expect(_CACHE.size).toBe(0);
+  });
+});
+
+describe('requirePortalPermission middleware', () => {
+  function mkRes() {
+    return {
+      statusCode: 200,
+      body: null,
+      status(c) {
+        this.statusCode = c;
+        return this;
+      },
+      json(b) {
+        this.body = b;
+        return this;
+      },
+    };
+  }
+
+  test('throws at factory time when the (module, action) is not in the catalog', () => {
+    expect(() => requirePortalPermission('not_a_real_module', 'read')).toThrow(
+      /Invalid permission/,
+    );
+  });
+
+  test('401s when req.patient is missing entirely', async () => {
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = {};
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('401s when req.patient.tenantId is missing (token never plumbed tenant through)', async () => {
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = { patient: { id: 1 } }; // no tenantId
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403s with PORTAL_RBAC_DENIED when the tenant CUSTOMER role lacks the permission', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce({
+      id: 7,
+      permissions: [{ module: 'appointments', action: 'read' }], // no my_prescriptions
+    });
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = { patient: { id: 1, tenantId: 1 } };
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('PORTAL_RBAC_DENIED');
+    expect(res.body.required).toBe('my_prescriptions.read');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('403s when the tenant has no CUSTOMER role at all (fail-closed default)', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce(null);
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = { patient: { id: 1, tenantId: 99 } };
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('next()s when the tenant CUSTOMER role grants the permission', async () => {
+    prisma.role.findFirst.mockResolvedValueOnce({
+      id: 7,
+      permissions: [{ module: 'my_prescriptions', action: 'read' }],
+    });
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = { patient: { id: 1, tenantId: 1 } };
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('fails closed (403) if the DB lookup throws', async () => {
+    prisma.role.findFirst.mockRejectedValueOnce(new Error('db down'));
+    const mw = requirePortalPermission('my_prescriptions', 'read');
+    const req = { patient: { id: 1, tenantId: 1 } };
+    const res = mkRes();
+    const next = vi.fn();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('PORTAL_PERMISSION_CHECK_FAILED');
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/lib/sensitivePermissions.test.js
+++ b/backend/test/lib/sensitivePermissions.test.js
@@ -35,9 +35,14 @@ describe('sensitivePermissions catalog', () => {
     expect(SENSITIVE_PERMISSIONS.has('developer.manage')).toBe(true);
     expect(SENSITIVE_PERMISSIONS.has('integrations.write')).toBe(true);
     expect(SENSITIVE_PERMISSIONS.has('integrations.manage')).toBe(true);
-    // BILLING / ACCOUNTING write-tier
-    expect(SENSITIVE_PERMISSIONS.has('billing.write')).toBe(true);
-    expect(SENSITIVE_PERMISSIONS.has('billing.manage')).toBe(true);
+    // INVOICES / GIFT_CARDS / PATIENT_WALLETS / ACCOUNTING write-tier
+    // (billing was split into three surface-specific modules in v3.8.x)
+    expect(SENSITIVE_PERMISSIONS.has('invoices.write')).toBe(true);
+    expect(SENSITIVE_PERMISSIONS.has('invoices.manage')).toBe(true);
+    expect(SENSITIVE_PERMISSIONS.has('gift_cards.write')).toBe(true);
+    expect(SENSITIVE_PERMISSIONS.has('gift_cards.manage')).toBe(true);
+    expect(SENSITIVE_PERMISSIONS.has('patient_wallets.write')).toBe(true);
+    expect(SENSITIVE_PERMISSIONS.has('patient_wallets.manage')).toBe(true);
     expect(SENSITIVE_PERMISSIONS.has('accounting.write')).toBe(true);
     // Clinical PII destruction
     expect(SENSITIVE_PERMISSIONS.has('patients.delete')).toBe(true);
@@ -73,9 +78,9 @@ describe('getSensitiveGrants', () => {
     const grants = getSensitiveGrants([
       { module: 'patients', action: 'read' },
       { module: 'staff', action: 'manage' },
-      { module: 'billing', action: 'write' },
+      { module: 'invoices', action: 'write' },
     ]);
-    expect(grants.sort()).toEqual(['billing.write', 'staff.manage'].sort());
+    expect(grants.sort()).toEqual(['invoices.write', 'staff.manage'].sort());
   });
 
   test('returns empty array for empty / invalid input', () => {

--- a/backend/test/services/pdfRenderer.test.js
+++ b/backend/test/services/pdfRenderer.test.js
@@ -188,8 +188,12 @@ describe('renderPrescriptionPdf', () => {
     const txt = extractPdfText(buf);
     expect(txt).toContain('Finasteride 1mg');
     expect(txt).toContain('Biotin 5mg');
-    expect(txt).toContain('Medication');
-    expect(txt).toContain('Frequency');
+    // Reference-aligned table uses uppercase column headers — "Medications"
+    // appears as the section title (substring matches both), "FREQUENCY"
+    // as the column header. Case-insensitive checks intentionally so the
+    // contract pins the labels' presence, not their exact casing.
+    expect(txt.toUpperCase()).toContain('MEDICATION');
+    expect(txt.toUpperCase()).toContain('FREQUENCY');
   });
 
   test('"no medications listed" placeholder when drugs list is empty', async () => {
@@ -921,8 +925,10 @@ describe('renderPatientSummaryPdf — visit photos', () => {
     });
     const txt = extractPdfText(buf);
     expect(txt).toContain('BEFORE (5)');
-    // Renderer caps at 3 per side; 5 − 3 = 2 surplus surfaced as caption.
-    expect(txt).toContain('+2 more');
+    // Renderer caps at 1 hero thumbnail per side (matches the reference
+    // Dr. Haror's visit-card design where each BEFORE / AFTER side gets
+    // ONE large image, not a strip); 5 − 1 = 4 surplus surfaced as caption.
+    expect(txt).toContain('+4 more');
   });
 
   test('falls back to placeholder when a buffer is missing for an URL', async () => {

--- a/e2e/tests/wellness-portal-prescriptions-rbac-api.spec.js
+++ b/e2e/tests/wellness-portal-prescriptions-rbac-api.spec.js
@@ -1,0 +1,335 @@
+// @ts-check
+/**
+ * Wellness patient-portal prescription RBAC — pins the `my_prescriptions.read`
+ * permission contract introduced in v3.8.x.
+ *
+ * Surface under test:
+ *   GET /api/wellness/portal/me/permissions  — patient-token gated, returns
+ *                                              tenant's CUSTOMER role grants
+ *   GET /api/wellness/portal/prescriptions       — gated on my_prescriptions.read
+ *   GET /api/wellness/portal/prescriptions/:id/pdf — same gate
+ *
+ * Why a dedicated permission: pre-fix the patient portal endpoints were
+ * gated only on `verifyPatientToken` (any valid patient JWT got every
+ * /portal/* route). Adding `my_prescriptions.read` as an explicit grant
+ * on the tenant's CUSTOMER role lets a clinic admin disable the patient-
+ * facing Rx tab without touching code. The handler still scopes by
+ * `patientId: req.patient.id` as defence-in-depth, so cross-patient
+ * leakage is structurally impossible regardless of RBAC misconfiguration.
+ *
+ * Tests:
+ *   1. /portal/me/permissions returns { permissions: string[] } and
+ *      includes 'my_prescriptions.read' for the seeded CUSTOMER role
+ *      (post-seed/post-backfill state)
+ *   2. With the grant: GET /portal/prescriptions returns 200 with an array
+ *   3. With the grant: PDF endpoint returns 200 application/pdf for an
+ *      Rx belonging to the requesting patient
+ *   4. Cross-patient defence: PDF for an Rx belonging to a DIFFERENT
+ *      patient returns 404 (not 200, not 500) even with a valid grant
+ *   5. Toggle: ADMIN revokes my_prescriptions.read from the CUSTOMER role,
+ *      portal Rx endpoint returns 403 PORTAL_RBAC_DENIED, ADMIN re-grants,
+ *      endpoint returns 200 again.
+ *
+ * Demo environment:
+ *   - WELLNESS_DEMO_OTP=1234 + WELLNESS_DEMO_OTP_PHONES allowlist (#238/#292)
+ *   - Demo patient at +919876500001 ("Demo Portal Patient")
+ *   - Staff fixture rishu@enhancedwellness.in seeds Rx; ADMIN-role for
+ *     the toggle test
+ *
+ * RUN_TAG: E2E_WC_PORTAL_RX_RBAC_<ts>
+ *
+ * Cleanup: clinical artefacts have no DELETE endpoints (#21). Patient
+ * names use the E2E prefix so global-teardown can sweep them. The Rx
+ * created here remains attached to the seeded demo patient — acceptable
+ * residue (scrub-test-data-pollution.js sweeps by RUN_TAG in details).
+ */
+const { test, expect } = require('@playwright/test');
+
+test.describe.configure({ mode: 'serial' });
+
+const BASE_URL = process.env.BASE_URL || 'https://crm.globusdemos.com';
+const API = `${BASE_URL}/api`;
+const REQUEST_TIMEOUT = 60000;
+const RUN_TAG = `E2E_WC_PORTAL_RX_RBAC_${Date.now()}`;
+
+const DEMO_PORTAL_PHONE = '+919876500001';
+const DEMO_OTP = process.env.WELLNESS_DEMO_OTP || '1234';
+
+const RISHU = { email: 'rishu@enhancedwellness.in', password: 'password123' };
+const ADMIN = { email: 'admin@wellness.demo', password: 'password123' };
+
+let staffToken = '';
+let adminToken = '';
+let portalToken = '';
+let demoPatientId = 0;
+let seededRxId = 0;
+let otherPatientId = 0;
+let otherRxId = 0;
+let customerRoleId = 0;
+
+const staffAuth = () => ({ Authorization: `Bearer ${staffToken}` });
+const adminAuth = () => ({ Authorization: `Bearer ${adminToken}` });
+const portalAuth = () => ({ Authorization: `Bearer ${portalToken}` });
+
+async function safeJson(res) {
+  try { return await res.json(); } catch (_e) { return null; }
+}
+
+test.beforeAll(async ({ request }) => {
+  // Staff login (rishu) — seeds Rx.
+  const login = await request.post(`${API}/auth/login`, {
+    data: RISHU,
+    timeout: REQUEST_TIMEOUT,
+  });
+  expect(login.ok(), 'rishu staff login must succeed').toBeTruthy();
+  staffToken = (await login.json()).token;
+
+  // Admin login (demo wellness admin) — toggles CUSTOMER role grants in
+  // the revoke/re-grant test. Optional; if the admin isn't seeded the
+  // toggle test self-skips.
+  const adminLogin = await request.post(`${API}/auth/login`, {
+    data: ADMIN,
+    timeout: REQUEST_TIMEOUT,
+  });
+  if (adminLogin.ok()) {
+    adminToken = (await adminLogin.json()).token;
+  }
+
+  // Mint a portal token via demo-OTP bypass.
+  const otpReq = await request.post(`${API}/wellness/portal/login/request-otp`, {
+    data: { phone: DEMO_PORTAL_PHONE },
+  });
+  expect(otpReq.ok(), 'request-otp must accept the demo phone').toBeTruthy();
+
+  const verify = await request.post(`${API}/wellness/portal/login/verify-otp`, {
+    data: { phone: DEMO_PORTAL_PHONE, otp: DEMO_OTP },
+  });
+  expect(
+    verify.ok(),
+    `verify-otp must accept demo OTP for ${DEMO_PORTAL_PHONE}; got ${verify.status()}: ${await verify.text()}`,
+  ).toBeTruthy();
+  const vBody = await verify.json();
+  portalToken = vBody.token;
+  demoPatientId = vBody.patient && vBody.patient.id;
+
+  // Seed a visit + Rx under the demo patient so the happy-path Rx + PDF
+  // tests have something to read.
+  const v = await request.post(`${API}/wellness/visits`, {
+    headers: { ...staffAuth(), 'Content-Type': 'application/json' },
+    data: {
+      patientId: demoPatientId,
+      visitDate: new Date().toISOString(),
+      status: 'completed',
+      notes: `${RUN_TAG} seed visit`,
+      amountCharged: 100,
+    },
+  });
+  if (v.ok()) {
+    const visit = await safeJson(v);
+    if (visit && visit.id) {
+      const rx = await request.post(`${API}/wellness/prescriptions`, {
+        headers: { ...staffAuth(), 'Content-Type': 'application/json' },
+        data: {
+          visitId: visit.id,
+          patientId: demoPatientId,
+          drugs: [{ name: `${RUN_TAG}_DRUG`, dose: '5mg', freq: 'OD' }],
+          instructions: `${RUN_TAG} Rx`,
+        },
+      });
+      if (rx.ok()) {
+        const rxBody = await safeJson(rx);
+        if (rxBody && rxBody.id) seededRxId = rxBody.id;
+      }
+    }
+  }
+
+  // Seed a SECOND patient + Rx for the cross-patient test.
+  const otherCreate = await request.post(`${API}/wellness/patients`, {
+    headers: { ...staffAuth(), 'Content-Type': 'application/json' },
+    data: {
+      name: `E2E ${RUN_TAG} Other`,
+      phone: `+9198777${String(Date.now()).slice(-5)}`,
+      source: 'walk-in',
+    },
+  });
+  if (otherCreate.ok()) {
+    const otherP = await safeJson(otherCreate);
+    if (otherP && otherP.id) {
+      otherPatientId = otherP.id;
+      const ov = await request.post(`${API}/wellness/visits`, {
+        headers: { ...staffAuth(), 'Content-Type': 'application/json' },
+        data: {
+          patientId: otherPatientId,
+          visitDate: new Date().toISOString(),
+          status: 'completed',
+          notes: `${RUN_TAG} other visit`,
+        },
+      });
+      if (ov.ok()) {
+        const oVisit = await safeJson(ov);
+        if (oVisit && oVisit.id) {
+          const oRx = await request.post(`${API}/wellness/prescriptions`, {
+            headers: { ...staffAuth(), 'Content-Type': 'application/json' },
+            data: {
+              visitId: oVisit.id,
+              patientId: otherPatientId,
+              drugs: [{ name: `${RUN_TAG}_OTHER_DRUG`, dose: '10mg', freq: 'OD' }],
+              instructions: `${RUN_TAG} OTHER Rx`,
+            },
+          });
+          if (oRx.ok()) {
+            const oRxBody = await safeJson(oRx);
+            if (oRxBody && oRxBody.id) otherRxId = oRxBody.id;
+          }
+        }
+      }
+    }
+  }
+
+  // Resolve CUSTOMER role id for the toggle test (admin-only — uses
+  // /api/roles?key=CUSTOMER). Optional; toggle test self-skips when
+  // adminToken is missing or the role can't be resolved.
+  if (adminToken) {
+    const rolesList = await request.get(`${API}/roles`, {
+      headers: adminAuth(),
+    });
+    if (rolesList.ok()) {
+      const rolesBody = await safeJson(rolesList);
+      const rows = (rolesBody && rolesBody.roles) || [];
+      const customer = rows.find((r) => r.key === 'CUSTOMER');
+      if (customer) customerRoleId = customer.id;
+    }
+  }
+});
+
+test.describe('GET /api/wellness/portal/me/permissions', () => {
+  test('returns { permissions: string[] } for a logged-in patient', async ({ request }) => {
+    test.skip(!portalToken, 'portal token unavailable');
+    const res = await request.get(`${API}/wellness/portal/me/permissions`, {
+      headers: portalAuth(),
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.permissions)).toBe(true);
+    // Sanity: every entry is the canonical "module.action" string.
+    for (const p of body.permissions) {
+      expect(typeof p).toBe('string');
+      expect(p).toMatch(/^[a-z_]+\.[a-z_]+$/);
+    }
+  });
+
+  test('401s when called without a portal token', async ({ request }) => {
+    const res = await request.get(`${API}/wellness/portal/me/permissions`);
+    expect(res.status()).toBe(401);
+  });
+});
+
+test.describe('GET /api/wellness/portal/prescriptions — RBAC gate', () => {
+  test('returns 200 with an array when CUSTOMER role grants my_prescriptions.read', async ({ request }) => {
+    test.skip(!portalToken, 'portal token unavailable');
+
+    // Probe current permission state — skip if the demo hasn't picked up
+    // the new my_prescriptions.read grant yet (transition window).
+    const permsRes = await request.get(`${API}/wellness/portal/me/permissions`, {
+      headers: portalAuth(),
+    });
+    const permsBody = await permsRes.json();
+    const granted = (permsBody.permissions || []).includes('my_prescriptions.read');
+    test.skip(!granted, 'my_prescriptions.read not yet granted to CUSTOMER on this tenant');
+
+    const res = await request.get(`${API}/wellness/portal/prescriptions`, {
+      headers: portalAuth(),
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    // Every row in the list belongs to the requesting patient.
+    for (const rx of body) {
+      expect(rx.patientId).toBe(demoPatientId);
+    }
+  });
+});
+
+test.describe('GET /api/wellness/portal/prescriptions/:id/pdf — RBAC + cross-patient gate', () => {
+  test('returns 200 application/pdf for an Rx belonging to the requesting patient', async ({ request }) => {
+    test.skip(!portalToken, 'portal token unavailable');
+    test.skip(!seededRxId, 'seeded Rx unavailable — visit/Rx create failed in beforeAll');
+
+    const permsRes = await request.get(`${API}/wellness/portal/me/permissions`, {
+      headers: portalAuth(),
+    });
+    const permsBody = await permsRes.json();
+    const granted = (permsBody.permissions || []).includes('my_prescriptions.read');
+    test.skip(!granted, 'my_prescriptions.read not yet granted to CUSTOMER on this tenant');
+
+    const res = await request.get(
+      `${API}/wellness/portal/prescriptions/${seededRxId}/pdf`,
+      { headers: portalAuth() },
+    );
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toMatch(/application\/pdf/);
+  });
+
+  test('returns 404 for an Rx belonging to a DIFFERENT patient (cross-patient defence)', async ({ request }) => {
+    test.skip(!portalToken, 'portal token unavailable');
+    test.skip(!otherRxId, 'other patient Rx unavailable');
+
+    const res = await request.get(
+      `${API}/wellness/portal/prescriptions/${otherRxId}/pdf`,
+      { headers: portalAuth() },
+    );
+    // Hardcoded handler scope: `where: { id, patientId: req.patient.id }`.
+    // Foreign Rx → findFirst returns null → 404, NOT 200, NOT 500.
+    expect(res.status()).toBe(404);
+  });
+});
+
+test.describe('CUSTOMER my_prescriptions.read revoke / re-grant', () => {
+  test('revoking my_prescriptions.read returns 403 on /portal/prescriptions; re-granting returns 200', async ({ request }) => {
+    test.skip(!portalToken, 'portal token unavailable');
+    test.skip(!adminToken, 'admin token unavailable — wellness-demo admin not seeded');
+    test.skip(!customerRoleId, 'CUSTOMER role id unresolved');
+
+    // Sanity: should be granted today.
+    const before = await request.get(`${API}/wellness/portal/me/permissions`, {
+      headers: portalAuth(),
+    });
+    const beforeBody = await before.json();
+    if (!(beforeBody.permissions || []).includes('my_prescriptions.read')) {
+      test.skip(true, 'my_prescriptions.read not granted in baseline — nothing to revoke');
+    }
+
+    // Revoke.
+    const revoke = await request.delete(
+      `${API}/roles/${customerRoleId}/permissions/my_prescriptions/read`,
+      { headers: adminAuth() },
+    );
+    expect(revoke.status()).toBe(200);
+
+    try {
+      const denied = await request.get(`${API}/wellness/portal/prescriptions`, {
+        headers: portalAuth(),
+      });
+      expect(denied.status()).toBe(403);
+      const dBody = await denied.json();
+      expect(dBody.code).toBe('PORTAL_RBAC_DENIED');
+      expect(dBody.required).toBe('my_prescriptions.read');
+    } finally {
+      // Re-grant — restore baseline even if the assertion above failed.
+      const regrant = await request.post(
+        `${API}/roles/${customerRoleId}/permissions`,
+        {
+          headers: { ...adminAuth(), 'Content-Type': 'application/json' },
+          data: { module: 'my_prescriptions', action: 'read' },
+        },
+      );
+      expect(regrant.status()).toBeLessThan(300);
+    }
+
+    // Post-restore: 200 again.
+    const restored = await request.get(`${API}/wellness/portal/prescriptions`, {
+      headers: portalAuth(),
+    });
+    expect(restored.status()).toBe(200);
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -305,6 +305,12 @@ const WellnessVisits = lazy(() => import("./pages/wellness/Visits"));
 const WellnessPrescriptions = lazy(
   () => import("./pages/wellness/Prescriptions"),
 );
+// Staff-authed self-view of own Rx — granted via `my_prescriptions.read`.
+// Companion to the patient portal's prescriptions tab for staff users who
+// are ALSO patients at this clinic.
+const WellnessMyPrescriptions = lazy(
+  () => import("./pages/wellness/MyPrescriptions"),
+);
 const WellnessPublicBooking = lazy(
   () => import("./pages/wellness/PublicBooking"),
 );
@@ -1450,6 +1456,22 @@ export default function App() {
                   </RoleGuard>
                 </WellnessOnly>
               } />
+              {/* Staff-authed self-view of own Rx. Sidebar surfacing comes
+                  from the page catalog entry (gated on my_prescriptions.read).
+                  Backend `/api/wellness/my-prescriptions[/:id/pdf]` is gated
+                  on the same permission + scoped to req.user.userId's linked
+                  Patient row. */}
+              <Route path="wellness/my-prescriptions" element={
+                <WellnessOnly>
+                  <RoleGuard
+                    requiredPermission={{ module: 'my_prescriptions', action: 'read' }}
+                    feature="My Prescriptions"
+                    lockedInPlace
+                  >
+                    <WellnessMyPrescriptions />
+                  </RoleGuard>
+                </WellnessOnly>
+              } />
               <Route path="wellness/locations" element={<WellnessOnly><WellnessLocations /></WellnessOnly>} />
               {/* Wave 11 Agent EE: Memberships catalog */}
               <Route path="wellness/memberships" element={
@@ -1467,7 +1489,7 @@ export default function App() {
               <Route path="wellness/wallet" element={
                 <WellnessOnly>
                   <RoleGuard
-                    requiredPermission={{ module: 'billing', action: 'read' }}
+                    requiredPermission={{ module: 'patient_wallets', action: 'read' }}
                     feature="Wallet ledger"
                     lockedInPlace
                   >
@@ -1478,7 +1500,7 @@ export default function App() {
               <Route path="wellness/giftcards" element={
                 <WellnessOnly>
                   <RoleGuard
-                    requiredPermission={{ module: 'billing', action: 'read' }}
+                    requiredPermission={{ module: 'gift_cards', action: 'read' }}
                     feature="Gift Cards"
                     lockedInPlace
                   >

--- a/frontend/src/__tests__/AutoConsumptionRules.test.jsx
+++ b/frontend/src/__tests__/AutoConsumptionRules.test.jsx
@@ -117,6 +117,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on
+// New rule / Edit / Delete keep passing. The SUT now hides these when the
+// viewer lacks products.manage.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['products.read', 'products.manage'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import AutoConsumptionRules from '../pages/wellness/AutoConsumptionRules';
 
 const SERVICE_PRP = { id: 501, name: 'PRP Hair Therapy' };

--- a/frontend/src/__tests__/InventoryAdjustments.test.jsx
+++ b/frontend/src/__tests__/InventoryAdjustments.test.jsx
@@ -121,6 +121,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on the
+// New-adjustment CTA + form keep passing. The SUT now hides these when the
+// viewer lacks inventory.write.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['inventory.read', 'inventory.write'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import InventoryAdjustments from '../pages/wellness/InventoryAdjustments';
 
 // Fixed-date adjustments — per CLAUDE.md tick 2026-05-07 wave-9 cron-learning

--- a/frontend/src/__tests__/InventoryReceipts.test.jsx
+++ b/frontend/src/__tests__/InventoryReceipts.test.jsx
@@ -41,6 +41,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on Record
+// receipt / Edit / Delete buttons keep passing. The SUT now hides these
+// when the viewer lacks inventory.{write,update,delete}.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['inventory.read', 'inventory.write', 'inventory.update', 'inventory.delete', 'inventory.manage'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import InventoryReceipts from '../pages/wellness/InventoryReceipts';
 
 const RECEIPT_DERMA = {

--- a/frontend/src/__tests__/Memberships.test.jsx
+++ b/frontend/src/__tests__/Memberships.test.jsx
@@ -263,7 +263,9 @@ describe('<Memberships /> — plan list', () => {
     fireEvent.change(search, { target: { value: 'nothing-matches' } });
     await waitFor(() => {
       expect(screen.queryByText('Gold Facial Pack 10x')).toBeNull();
-      expect(screen.getByText(/No plans match the current filter/i)).toBeInTheDocument();
+      // Empty-state copy is now filter-aware. A query that matches nothing
+      // surfaces the search-specific message.
+      expect(screen.getByText(/No plans match your search/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/ProductCategories.test.jsx
+++ b/frontend/src/__tests__/ProductCategories.test.jsx
@@ -46,6 +46,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default the test environment to a fully-permissioned viewer so existing
+// assertions on edit/delete row buttons keep passing. The SUT now hides
+// those buttons for viewers without products.manage; the no-permission
+// case has its own focused test further down.
+const usePermissionsMock = vi.fn(() => ({
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['products.read', 'products.manage'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+}));
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import ProductCategories from '../pages/wellness/ProductCategories';
 
 const ROOT_CATEGORY = {
@@ -104,6 +125,20 @@ function renderPage() {
   );
 }
 
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['products.read', 'products.manage'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+
 beforeEach(() => {
   fetchApiMock.mockReset();
   notifyError.mockReset();
@@ -111,6 +146,10 @@ beforeEach(() => {
   notifyInfo.mockReset();
   notifyConfirm.mockReset();
   notifyConfirm.mockImplementation(() => Promise.resolve(true));
+  // Default to fully-permissioned for existing tests; the read-only test
+  // overrides this with mockReturnValue locally.
+  usePermissionsMock.mockReset();
+  usePermissionsMock.mockReturnValue(FULL_PERMS);
 });
 afterEach(() => {});
 
@@ -364,5 +403,39 @@ describe('<ProductCategories /> — delete (notify.confirm)', () => {
     );
     expect(delCall).toBeUndefined();
     expect(notifySuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe('<ProductCategories /> — read-only mode (no products.manage)', () => {
+  it('hides Add Category + Edit + Delete buttons and shows "View only" badge', async () => {
+    usePermissionsMock.mockReturnValue({
+      isReady: true,
+      hasPermission: (m, a) => m === 'products' && a === 'read',
+      permissions: ['products.read'],
+      roles: [],
+      isOwner: false,
+      userType: null,
+      isLoading: false,
+      error: null,
+      refresh: () => Promise.resolve(),
+      hasAllPermissions: () => false,
+      hasAnyPermission: () => false,
+    });
+    installFetchMock();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Consumables')).toBeInTheDocument();
+    });
+
+    // Add Category CTA is hidden for viewers.
+    expect(screen.queryByRole('button', { name: /Add Category/i })).toBeNull();
+    // "View only" badge surfaces so the read-only mode is explicit.
+    expect(screen.getByText(/View only/i)).toBeInTheDocument();
+    // Row-level Edit / Delete buttons are hidden — the only buttons on the
+    // page should be the (non-row) header / search affordances. Concretely:
+    // a row with no buttons under it.
+    const row = screen.getByText('Consumables').closest('.glass');
+    expect(row.querySelectorAll('button').length).toBe(0);
   });
 });

--- a/frontend/src/__tests__/Products.test.jsx
+++ b/frontend/src/__tests__/Products.test.jsx
@@ -47,6 +47,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on Add /
+// Edit / Delete buttons keep passing. The SUT now hides these buttons for
+// users without products.{write,update,delete}.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['products.read', 'products.write', 'products.update', 'products.delete', 'products.manage'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import Products from '../pages/wellness/Products';
 
 const CATEGORIES = [

--- a/frontend/src/__tests__/ServiceCategories.test.jsx
+++ b/frontend/src/__tests__/ServiceCategories.test.jsx
@@ -118,6 +118,27 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on New
+// category / Edit / Delete keep passing. The SUT now hides these when the
+// viewer lacks services.write.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['services.read', 'services.write'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import ServiceCategories from '../pages/wellness/ServiceCategories';
 
 const ROOT_CATEGORY = {

--- a/frontend/src/__tests__/Services.test.jsx
+++ b/frontend/src/__tests__/Services.test.jsx
@@ -36,6 +36,27 @@ vi.mock('../utils/api', () => ({
   getAuthToken: vi.fn(() => 'test-token'),
 }));
 
+// Default to a fully-permissioned viewer so existing assertions on New
+// service / per-card Edit / Deactivate keep passing. The SUT now hides
+// these when the viewer lacks services.write.
+const FULL_PERMS = {
+  isReady: true,
+  hasPermission: () => true,
+  permissions: ['services.read', 'services.write'],
+  roles: [],
+  isOwner: false,
+  userType: null,
+  isLoading: false,
+  error: null,
+  refresh: () => Promise.resolve(),
+  hasAllPermissions: () => true,
+  hasAnyPermission: () => true,
+};
+const usePermissionsMock = vi.fn(() => FULL_PERMS);
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: (...args) => usePermissionsMock(...args),
+}));
+
 import { fetchApi } from '../utils/api';
 import Services from '../pages/wellness/Services';
 

--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 /**
  * frontend/src/components/Avatar.jsx
@@ -84,6 +84,7 @@ const Avatar = ({
   color,
   roleBadge,
   title,
+  imageUrl,
 }) => {
   const safeName = (name || '').toString();
   const initials = getInitials(safeName);
@@ -94,6 +95,14 @@ const Avatar = ({
   const roleKey = (roleBadge || '').toString().toUpperCase();
   const pipColor = ROLE_COLORS[roleKey] || ROLE_COLORS.USER;
   const pipLetter = roleKey ? roleKey.charAt(0) : '';
+
+  // If the upstream image 404s, expires, or the bucket key is stale, fall
+  // back to initials rather than rendering a broken-image icon. Reset the
+  // error flag when the URL itself changes so a freshly-uploaded picture
+  // gets a fair retry.
+  const [imageErrored, setImageErrored] = useState(false);
+  useEffect(() => { setImageErrored(false); }, [imageUrl]);
+  const showImage = !!imageUrl && !imageErrored;
 
   return (
     <span
@@ -116,10 +125,25 @@ const Avatar = ({
         lineHeight: 1,
         userSelect: 'none',
         flexShrink: 0,
+        overflow: 'hidden',
       }}
     >
-      <span aria-hidden="true">{initials}</span>
-      {roleBadge ? (
+      {showImage ? (
+        <img
+          src={imageUrl}
+          alt={safeName ? `${safeName} profile picture` : 'Profile picture'}
+          onError={() => setImageErrored(true)}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+        />
+      ) : (
+        <span aria-hidden="true">{initials}</span>
+      )}
+      {roleBadge && !showImage ? (
         <span
           data-testid="avatar-role-badge"
           aria-label={`Role: ${roleBadge}`}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -404,6 +404,7 @@ const Layout = () => {
               name={user?.name || user?.email || "User"}
               size={28}
               roleBadge={user?.role || undefined}
+              imageUrl={user?.profilePicture || undefined}
             />
             <span>{user?.name || user?.email || "User"}</span>
           </button>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -48,6 +48,7 @@ import {
   TrendingUp,
   BookOpen,
   PenTool,
+  Pill,
   ClipboardList,
   MessageSquare,
   Eye,
@@ -79,10 +80,6 @@ import {
   Calculator,
   // Used by the dynamic page-catalog → sidebar icon lookup for /portal
   UserCircle,
-  // Zylu-Gap #770/#779/#780/#781 — Cash Register admin
-  Banknote,
-  // Zylu-Gap #800 (WA-005) — Blocked WhatsApp numbers admin entry
-  Ban,
   // Cron PRD Priority A #1 — LLM Spend admin dashboard
   Activity,
   // #898 — Campaigns sidebar surfacing (Email / SMS / Push)
@@ -881,6 +878,7 @@ const PAGE_ICON_BY_PATH = {
   "/wellness/patients": HeartPulse,
   "/wellness/waitlist": Clock,
   "/wellness/prescriptions": PenTool,
+  "/wellness/my-prescriptions": Pill,
   "/wellness/visits": HeartPulse,
   "/signatures": FileSignature,
   "/wellness/inventory": Package,
@@ -1112,31 +1110,12 @@ function renderWellnessNav({
   // entries here can drop out. `isManager` here is shorthand: literal-
   // ADMIN passes isManager too.
   const categoryExtras = {
-    "Leads & Revenue": (
-      <Link
-        key="/wellness/whatsapp/blocked-numbers"
-        to="/wellness/whatsapp/blocked-numbers"
-        icon={Ban}
-        label="Blocked Numbers"
-        managerOnly
-      />
-    ),
-    // Cash Registers is an admin/manager surface (shift open/close,
-    // float reconciliation, petty-cash ledger). Regular users (doctors,
-    // nurses, telecallers, customers) don't operate the till and were
-    // previously seeing a sidebar link that routed nowhere — the page
-    // exists at pages/wellness/CashRegisters.jsx but isn't wired into
-    // App.jsx yet, so clicking it 404s. Gating to manager/admin closes
-    // both gaps until the route lands.
-    Finance: isManager ? (
-      <Link
-        key="/wellness/cash-registers"
-        to="/wellness/cash-registers"
-        icon={Banknote}
-        label="Cash Registers"
-        managerOnly
-      />
-    ) : null,
+    // Cash Registers used to live here as its own sidebar entry, but
+    // `/wellness/cash-registers` has no route mounted in App.jsx and the
+    // dedicated page 404'd on every click. The CashRegisters component
+    // is now embedded inside Point of Sale as an admin/manager
+    // "Manage registers" panel, so this slot intentionally has no
+    // Finance extras.
     Marketing: isManager ? (
       <Link
         key="/campaigns"
@@ -1665,7 +1644,7 @@ function renderGenericNav({
         to="/invoices"
         icon={Receipt}
         label="Invoices"
-        requiredPermission={{ module: "billing", action: "read" }}
+        requiredPermission={{ module: "invoices", action: "read" }}
       />
       <Link
         to="/estimates"

--- a/frontend/src/pages/AgentReports.jsx
+++ b/frontend/src/pages/AgentReports.jsx
@@ -61,8 +61,12 @@ export default function AgentReports() {
 
   const handleExportCSV = () => {
     const token = getAuthToken();
-    const baseUrl = import.meta.env.VITE_API_URL || '';
-    fetch(`${baseUrl}/api/reports/export-csv?type=agent-performance${dateParams()}`, { headers: { Authorization: `Bearer ${token}` } })
+    // Relative path keeps the request same-origin and goes through Vite's
+    // /api proxy (same as fetchApi). Prefixing with VITE_API_URL turns this
+    // into a cross-origin call → triggers a CORS preflight → backend's
+    // global auth guard 401s the unauthenticated OPTIONS → browser blocks
+    // the GET as a CORS error.
+    fetch(`/api/reports/export-csv?type=agent-performance${dateParams()}`, { headers: { Authorization: `Bearer ${token}` } })
       .then(res => res.blob())
       .then(blob => {
         const link = document.createElement('a');
@@ -75,8 +79,8 @@ export default function AgentReports() {
 
   const handleExportPDF = () => {
     const token = getAuthToken();
-    const baseUrl = import.meta.env.VITE_API_URL || '';
-    fetch(`${baseUrl}/api/reports/export-pdf?type=agent-performance${dateParams()}`, { headers: { Authorization: `Bearer ${token}` } })
+    // Relative path — see handleExportCSV above for rationale.
+    fetch(`/api/reports/export-pdf?type=agent-performance${dateParams()}`, { headers: { Authorization: `Bearer ${token}` } })
       .then(res => res.blob())
       .then(blob => {
         const link = document.createElement('a');

--- a/frontend/src/pages/Estimates.jsx
+++ b/frontend/src/pages/Estimates.jsx
@@ -221,8 +221,12 @@ export default function Estimates() {
   // user had to navigate into the row to reach the PDF action.
   const downloadPdf = (id, estimateNum) => {
     const token = getAuthToken();
-    const baseUrl = import.meta.env.VITE_API_URL || '';
-    fetch(`${baseUrl}/api/estimates/${id}/pdf`, {
+    // Relative path keeps the request same-origin and goes through Vite's
+    // /api proxy (same as fetchApi). Prefixing with VITE_API_URL turns this
+    // into a cross-origin call → triggers a CORS preflight → backend's
+    // global auth guard 401s the unauthenticated OPTIONS → browser blocks
+    // the GET as a CORS error.
+    fetch(`/api/estimates/${id}/pdf`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
       .then((res) => {

--- a/frontend/src/pages/Inbox.jsx
+++ b/frontend/src/pages/Inbox.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Mail, Phone, ArrowRight, User, Send, Clock, Play, Calendar, MessageSquare, MessageCircle, X, PhoneCall } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Mail, Phone, ArrowRight, User, Send, Clock, Play, Calendar, MessageSquare, MessageCircle, X, PhoneCall, Paperclip, Sparkles, Lightbulb } from 'lucide-react';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
 
@@ -21,6 +21,17 @@ export default function Inbox() {
   // rather than always-visible chrome.
   const [composeData, setComposeData] = useState({ to: '', cc: '', bcc: '', subject: '', body: '' });
   const [showCcBcc, setShowCcBcc] = useState(false);
+  // Custom themed autocomplete for the To: field. The native <datalist> dropdown
+  // can't be styled (renders browser-default white in dark mode) and escaped
+  // the modal's stacking context, hanging off the right edge of the viewport.
+  const [showToDropdown, setShowToDropdown] = useState(false);
+  // Compose attachments: File objects collected from the paperclip picker.
+  // Posted as multipart "attachments[]" when present; the backend caps at
+  // 5 files / 10 MB each (see communications.js composeAttachmentUpload).
+  const [composeAttachments, setComposeAttachments] = useState([]);
+  const composeFileInputRef = useRef(null);
+  const MAX_ATTACHMENTS = 5;
+  const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 
   // #624 — Sent folder UI: a sub-tab on the Emails tab toggles the
   // backend folder filter (?folder=sent | ?folder=inbox | omitted=all).
@@ -103,16 +114,108 @@ export default function Inbox() {
 
   const handleSendEmail = async (e) => {
     e.preventDefault();
-    await fetchApi('/api/communications/send-email', { method: 'POST', body: JSON.stringify(composeData) });
+
+    // Switch to multipart when attachments are present so the file buffers
+    // round-trip cleanly. fetchApi detects FormData and drops the JSON
+    // Content-Type so the browser can set the multipart boundary itself.
+    let requestBody;
+    if (composeAttachments.length > 0) {
+      const fd = new FormData();
+      fd.append('to', composeData.to);
+      if (composeData.cc) fd.append('cc', composeData.cc);
+      if (composeData.bcc) fd.append('bcc', composeData.bcc);
+      fd.append('subject', composeData.subject);
+      fd.append('body', composeData.body);
+      for (const file of composeAttachments) fd.append('attachments', file, file.name);
+      requestBody = fd;
+    } else {
+      requestBody = JSON.stringify(composeData);
+    }
+    await fetchApi('/api/communications/send-email', { method: 'POST', body: requestBody });
 
     notify.success(`Email Sent Successfully!\n\n[Epic #104] Tracking Pixel Active: You will be notified the instant ${composeData.to} opens or clicks links in this message.`);
 
-    setShowCompose(false);
-    setComposeData({ to: '', cc: '', bcc: '', subject: '', body: '' });
-    setShowCcBcc(false);
+    closeCompose();
     // Refresh
     const data = await fetchApi(inboxPath);
     setEmails(Array.isArray(data) ? data : []);
+  };
+
+  const handlePickAttachments = (e) => {
+    const incoming = Array.from(e.target.files || []);
+    if (incoming.length === 0) return;
+
+    const accepted = [];
+    const rejected = [];
+    let nextCount = composeAttachments.length;
+    for (const f of incoming) {
+      if (nextCount >= MAX_ATTACHMENTS) {
+        rejected.push(`${f.name} (max ${MAX_ATTACHMENTS} files)`);
+        continue;
+      }
+      if (f.size > MAX_ATTACHMENT_BYTES) {
+        rejected.push(`${f.name} (over 10 MB)`);
+        continue;
+      }
+      accepted.push(f);
+      nextCount += 1;
+    }
+    if (accepted.length > 0) setComposeAttachments(prev => [...prev, ...accepted]);
+    if (rejected.length > 0) notify.error(`Some files were skipped:\n${rejected.join('\n')}`);
+    // Reset the input value so picking the same file again still fires onChange.
+    e.target.value = '';
+  };
+
+  const handleRemoveAttachment = (idx) => {
+    setComposeAttachments(prev => prev.filter((_, i) => i !== idx));
+  };
+
+  // To: field is comma-separated for multi-recipient. The dropdown filters on
+  // (and replaces) only the LAST comma-separated token so the user can pick
+  // recipients one at a time without nuking what they've already typed.
+  const composeToTokens = composeData.to.split(',');
+  const composeToFilter = (composeToTokens[composeToTokens.length - 1] || '').trim().toLowerCase();
+  const filteredToContacts = contacts
+    .filter(c => c.email)
+    .filter(c => {
+      if (!composeToFilter) return true;
+      const email = (c.email || '').toLowerCase();
+      const name = (c.name || '').toLowerCase();
+      return email.includes(composeToFilter) || name.includes(composeToFilter);
+    })
+    .slice(0, 50);
+
+  const handleSelectToContact = (email) => {
+    setComposeData(prev => {
+      const parts = prev.to.split(',').map(s => s.trim()).filter(Boolean);
+      // Replace the last (in-progress) token with the picked email if the user
+      // was mid-typing; otherwise append.
+      if (parts.length === 0 || !prev.to.endsWith(',')) {
+        if (parts.length > 0) parts[parts.length - 1] = email;
+        else parts.push(email);
+      } else {
+        parts.push(email);
+      }
+      return { ...prev, to: parts.join(', ') };
+    });
+    setShowToDropdown(false);
+  };
+
+  // Single close path for the composer — header X, backdrop click, post-send.
+  // Keeps the state-reset list in one place so we can't drift between callers.
+  const closeCompose = () => {
+    setShowCompose(false);
+    setShowCcBcc(false);
+    setComposeData({ to: '', cc: '', bcc: '', subject: '', body: '' });
+    setComposeAttachments([]);
+    setAiSubjects([]);
+    setShowToDropdown(false);
+  };
+
+  const formatAttachmentSize = (bytes) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
   const handleSendSms = async (e) => {
@@ -547,10 +650,37 @@ export default function Inbox() {
       </div>
 
       {showCompose && (
-        <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'var(--overlay-bg)', backdropFilter: 'blur(8px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100, animation: 'fadeIn 0.2s ease-out' }}>
-          <div className="card" style={{ padding: '2.5rem', width: '600px', border: '1px solid rgba(59, 130, 246, 0.3)', boxShadow: '0 20px 40px rgba(0,0,0,0.5)' }}>
-            <h3 style={{ marginBottom: '1.5rem', fontSize: '1.5rem', fontWeight: 'bold', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Mail size={24} color="var(--accent-color)" /> New Message
+        <div
+          onClick={(e) => { if (e.target === e.currentTarget) closeCompose(); }}
+          style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'var(--overlay-bg)', backdropFilter: 'blur(8px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100, animation: 'fadeIn 0.2s ease-out' }}
+        >
+          <div className="card" style={{ padding: '2rem 2.25rem', width: '600px', border: '1px solid var(--border-color)', boxShadow: '0 20px 40px rgba(0,0,0,0.5)', position: 'relative' }}>
+            <button
+              type="button"
+              onClick={closeCompose}
+              aria-label="Close"
+              style={{
+                position: 'absolute',
+                top: '1rem',
+                right: '1rem',
+                width: 32,
+                height: 32,
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: 'transparent',
+                border: 'none',
+                borderRadius: 6,
+                color: 'var(--text-secondary)',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-color)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--text-secondary)'; }}
+            >
+              <X size={18} />
+            </button>
+            <h3 style={{ marginBottom: '1.5rem', fontSize: '1.25rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.55rem', paddingRight: '2rem' }}>
+              <Mail size={20} color="var(--accent-color)" /> New Message
             </h3>
             <form onSubmit={handleSendEmail} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
               <div>
@@ -569,10 +699,80 @@ export default function Inbox() {
                     </button>
                   )}
                 </div>
-                <input type="text" list="contacts-list" required className="input-field" value={composeData.to} onChange={e => setComposeData({...composeData, to: e.target.value})} placeholder="client@company.com (comma-separated for multiple)" />
-                <datalist id="contacts-list">
-                  {contacts.map(c => <option key={c.id} value={c.email}>{c.name}</option>)}
-                </datalist>
+                <div style={{ position: 'relative' }}>
+                  <input
+                    type="text"
+                    required
+                    className="input-field"
+                    value={composeData.to}
+                    onChange={e => { setComposeData({ ...composeData, to: e.target.value }); setShowToDropdown(true); }}
+                    onFocus={() => setShowToDropdown(true)}
+                    onBlur={() => setTimeout(() => setShowToDropdown(false), 120)}
+                    onKeyDown={(e) => { if (e.key === 'Escape') setShowToDropdown(false); }}
+                    placeholder="client@company.com (comma-separated for multiple)"
+                    autoComplete="off"
+                    aria-autocomplete="list"
+                    aria-expanded={showToDropdown && filteredToContacts.length > 0}
+                  />
+                  {showToDropdown && filteredToContacts.length > 0 && (
+                    <ul
+                      role="listbox"
+                      style={{
+                        position: 'absolute',
+                        top: 'calc(100% + 4px)',
+                        left: 0,
+                        right: 0,
+                        margin: 0,
+                        padding: '0.25rem 0',
+                        listStyle: 'none',
+                        // --tooltip-bg is the canonical near-solid popover
+                        // surface in this app (dark navy in dark mode, near-white
+                        // in light mode) so the dropdown stays legible against
+                        // the semi-transparent modal underneath.
+                        background: 'var(--tooltip-bg)',
+                        backdropFilter: 'blur(8px)',
+                        WebkitBackdropFilter: 'blur(8px)',
+                        border: '1px solid var(--border-color)',
+                        borderRadius: 6,
+                        boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+                        maxHeight: 260,
+                        overflowY: 'auto',
+                        zIndex: 10,
+                      }}
+                    >
+                      {filteredToContacts.map((c) => (
+                        <li
+                          key={c.id}
+                          role="option"
+                          // onMouseDown + preventDefault stops the input from
+                          // blurring before the click registers — without this
+                          // the dropdown closes before onClick fires.
+                          onMouseDown={(e) => { e.preventDefault(); handleSelectToContact(c.email); }}
+                          style={{
+                            padding: '0.5rem 0.75rem',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 2,
+                            borderRadius: 4,
+                            margin: '0 0.25rem',
+                          }}
+                          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-color)'; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        >
+                          <span style={{ color: 'var(--text-primary)', fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {c.email}
+                          </span>
+                          {c.name && (
+                            <span style={{ color: 'var(--text-secondary)', fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                              {c.name}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
               </div>
               {showCcBcc && (
                 <>
@@ -594,7 +794,83 @@ export default function Inbox() {
                 <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Message:</label>
                 <textarea required className="input-field" value={composeData.body} onChange={e => setComposeData({...composeData, body: e.target.value})} placeholder="Write your email here..." rows={6} style={{ resize: 'vertical' }} />
               </div>
-              
+
+              {/* Attachments — paperclip opens the native file picker; selected
+                  files render as removable chips. Sent as multipart
+                  `attachments[]` in handleSendEmail; max 5 files / 10 MB each. */}
+              <div>
+                <input
+                  ref={composeFileInputRef}
+                  type="file"
+                  multiple
+                  accept="image/jpeg,image/png,image/gif,image/webp,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv,text/plain,application/zip,.jpg,.jpeg,.png,.gif,.webp,.pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.zip"
+                  onChange={handlePickAttachments}
+                  style={{ display: 'none' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => composeFileInputRef.current?.click()}
+                  disabled={composeAttachments.length >= MAX_ATTACHMENTS}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.4rem',
+                    padding: '0.4rem 0.75rem',
+                    background: 'transparent',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--text-secondary)',
+                    fontSize: '0.8rem',
+                    cursor: composeAttachments.length >= MAX_ATTACHMENTS ? 'not-allowed' : 'pointer',
+                    opacity: composeAttachments.length >= MAX_ATTACHMENTS ? 0.6 : 1,
+                  }}
+                >
+                  <Paperclip size={14} /> Attach files
+                  {composeAttachments.length > 0 && (
+                    <span style={{ color: 'var(--accent-color)', fontWeight: 600 }}>
+                      ({composeAttachments.length}/{MAX_ATTACHMENTS})
+                    </span>
+                  )}
+                </button>
+                {composeAttachments.length > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.6rem' }}>
+                    {composeAttachments.map((f, i) => (
+                      <div
+                        key={`${f.name}-${i}`}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '0.4rem',
+                          padding: '0.3rem 0.6rem',
+                          background: 'rgba(59, 130, 246, 0.08)',
+                          border: '1px solid rgba(59, 130, 246, 0.3)',
+                          borderRadius: '14px',
+                          fontSize: '0.75rem',
+                          color: 'var(--text-primary)',
+                          maxWidth: '100%',
+                        }}
+                      >
+                        <Paperclip size={12} color="var(--accent-color)" />
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '180px' }}>
+                          {f.name}
+                        </span>
+                        <span style={{ color: 'var(--text-secondary)', fontSize: '0.7rem' }}>
+                          {formatAttachmentSize(f.size)}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveAttachment(i)}
+                          aria-label={`Remove ${f.name}`}
+                          style={{ background: 'transparent', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center' }}
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               {/* AI Subject Suggestions */}
               {aiSubjects.length > 0 && (
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.375rem' }}>
@@ -607,9 +883,26 @@ export default function Inbox() {
                 </div>
               )}
 
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '1rem', alignItems: 'center' }}>
-                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                  <select value={aiTone} onChange={e => setAiTone(e.target.value)} className="input-field" style={{ padding: '0.4rem 0.5rem', fontSize: '0.8rem', width: 'auto' }}>
+              {/* Action row — refined for a professional feel: muted ghost
+                  buttons for the secondary tools, single accent-filled primary
+                  on the right. Discard removed; the header X owns dismissal. */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.75rem', paddingTop: '1rem', borderTop: '1px solid var(--border-color)', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <select
+                    value={aiTone}
+                    onChange={e => setAiTone(e.target.value)}
+                    aria-label="AI tone"
+                    style={{
+                      padding: '0.45rem 0.6rem',
+                      fontSize: '0.8rem',
+                      width: 'auto',
+                      background: 'var(--input-bg)',
+                      color: 'var(--text-primary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: 6,
+                      cursor: 'pointer',
+                    }}
+                  >
                     <option value="professional">Professional</option>
                     <option value="friendly">Friendly</option>
                     <option value="formal">Formal</option>
@@ -617,19 +910,52 @@ export default function Inbox() {
                     <option value="persuasive">Persuasive</option>
                     <option value="concise">Concise</option>
                   </select>
-                  <button type="button" onClick={handleAIGenerate} disabled={aiLoading} className="btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', background: 'rgba(59, 130, 246, 0.2)', border: '1px solid var(--accent-color)', color: 'var(--accent-color)', padding: '0.5rem 1rem' }}>
-                    {aiLoading ? <span style={{ animation: 'pulse 1s infinite' }}>Generating...</span> : <>✨ AI Draft</>}
+                  <button
+                    type="button"
+                    onClick={handleAIGenerate}
+                    disabled={aiLoading}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '0.4rem',
+                      padding: '0.45rem 0.85rem',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                      background: 'transparent',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: 6,
+                      color: 'var(--text-primary)',
+                      cursor: aiLoading ? 'wait' : 'pointer',
+                      opacity: aiLoading ? 0.7 : 1,
+                    }}
+                  >
+                    <Sparkles size={14} color="var(--accent-color)" />
+                    {aiLoading ? 'Generating…' : 'AI Draft'}
                   </button>
-                  <button type="button" onClick={handleAISubjects} className="btn-secondary" style={{ padding: '0.5rem 0.75rem', fontSize: '0.8rem', border: '1px solid var(--border-color)', background: 'transparent', color: 'var(--text-secondary)', cursor: 'pointer' }}>
-                    💡 Subjects
+                  <button
+                    type="button"
+                    onClick={handleAISubjects}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '0.4rem',
+                      padding: '0.45rem 0.85rem',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                      background: 'transparent',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: 6,
+                      color: 'var(--text-primary)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <Lightbulb size={14} color="var(--text-secondary)" />
+                    Subjects
                   </button>
                 </div>
-                <div style={{ display: 'flex', gap: '1rem' }}>
-                  <button type="button" onClick={() => { setShowCompose(false); setShowCcBcc(false); setComposeData({ to: '', cc: '', bcc: '', subject: '', body: '' }); }} style={{ background: 'transparent', color: 'var(--text-secondary)', border: 'none', cursor: 'pointer', fontWeight: '500' }}>Discard</button>
-                  <button type="submit" className="btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <Send size={16} /> Send Email
-                  </button>
-                </div>
+                <button type="submit" className="btn-primary" style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', padding: '0.55rem 1.1rem', fontWeight: 500 }}>
+                  <Send size={16} /> Send Email
+                </button>
               </div>
             </form>
           </div>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -64,8 +64,12 @@ const Profile = () => {
     setDownloadingId(subId);
     try {
       const token = getAuthToken();
-      const baseUrl = import.meta.env.VITE_API_URL || '';
-      const url = `${baseUrl}/api/subscriptions/${subId}/invoice.pdf`;
+      // Relative path keeps the request same-origin and goes through Vite's
+      // /api proxy (same as fetchApi). Prefixing with VITE_API_URL turns this
+      // into a cross-origin call → triggers a CORS preflight → backend's
+      // global auth guard 401s the unauthenticated OPTIONS → browser blocks
+      // the GET as a CORS error.
+      const url = `/api/subscriptions/${subId}/invoice.pdf`;
       const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
       if (!res.ok) throw new Error(`Download failed (${res.status})`);
       const blob = await res.blob();
@@ -162,8 +166,10 @@ const Profile = () => {
       const form = new FormData();
       form.append('file', file);
       const token = getAuthToken();
-      const baseUrl = import.meta.env.VITE_API_URL || '';
-      const res = await fetch(`${baseUrl}/api/auth/me/profile-picture`, {
+      // Relative path keeps the request same-origin (see downloadInvoicePdf
+      // above for the full rationale — VITE_API_URL prefix → cross-origin →
+      // preflight 401 → CORS error).
+      const res = await fetch(`/api/auth/me/profile-picture`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: form,
@@ -184,7 +190,14 @@ const Profile = () => {
 
   const handleRemovePicture = async () => {
     if (!profile?.profilePicture) return;
-    if (!window.confirm('Remove your profile picture?')) return;
+    const ok = await notify.confirm({
+      title: 'Remove profile picture',
+      message: 'Your profile picture will be removed and replaced with your initials.',
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+    if (!ok) return;
 
     setUploadingPicture(true);
     try {

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -153,12 +153,16 @@ export default function Reports() {
 
   const exportFile = (format) => {
     const token = getAuthToken();
-    const baseUrl = import.meta.env.VITE_API_URL || '';
+    // Relative path keeps the request same-origin and goes through Vite's
+    // /api proxy (same as fetchApi). Prefixing with VITE_API_URL turns this
+    // into a cross-origin call → triggers a CORS preflight → backend's
+    // global auth guard 401s the unauthenticated OPTIONS → browser blocks
+    // the GET as a CORS error.
     const endpoint = format === 'pdf' ? 'export-pdf' : 'export-csv';
     const params = viewMode === 'table'
       ? `type=${detailType}${dateParams()}`
       : `metric=${metric}&groupBy=${groupBy}${dateParams()}`;
-    fetch(`${baseUrl}/api/reports/${endpoint}?${params}`, { headers: { Authorization: `Bearer ${token}` } })
+    fetch(`/api/reports/${endpoint}?${params}`, { headers: { Authorization: `Bearer ${token}` } })
       .then(res => {
         if (!res.ok) throw new Error(`${format.toUpperCase()} export failed`);
         return res.blob();

--- a/frontend/src/pages/RolesAdmin.jsx
+++ b/frontend/src/pages/RolesAdmin.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { LayoutGrid, Pencil, Plus, Shield, Trash2, Users, X, UserMinus, UserPlus, GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
@@ -23,13 +24,16 @@ const PERMISSION_MODULES_FALLBACK = [
   { module: 'tickets',       actions: ['read', 'write', 'update', 'delete'] },
   { module: 'marketing',     actions: ['read', 'write', 'update', 'delete', 'manage'] },
   { module: 'reports',       actions: ['read', 'write', 'delete', 'export'] },
-  { module: 'billing',       actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'invoices',         actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'gift_cards',       actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
+  { module: 'patient_wallets',  actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
   { module: 'patients',      actions: ['read', 'write', 'update', 'delete', 'export', 'manage'] },
   { module: 'appointments',     actions: ['read', 'write', 'update', 'delete', 'export'] },
   { module: 'my_appointments',  actions: ['read'] },
   { module: 'book_appointment', actions: ['write'] },
   { module: 'waitlist',         actions: ['read', 'write'] },
   { module: 'prescriptions', actions: ['read', 'write', 'update', 'delete'] },
+  { module: 'my_prescriptions', actions: ['read'] },
   { module: 'visits',        actions: ['read', 'write', 'update', 'delete'] },
   { module: 'products',      actions: ['read', 'write', 'update', 'delete', 'manage'] },
   { module: 'inventory',     actions: ['read', 'write', 'update', 'delete', 'manage'] },
@@ -53,11 +57,11 @@ const PERMISSION_DOMAINS_FALLBACK = [
   { domain: 'Communications',     modules: ['communications', 'email', 'sms', 'whatsapp'] },
   { domain: 'Marketing',          modules: ['marketing'] },
   { domain: 'Service & Support',  modules: ['tickets', 'knowledge_base', 'surveys', 'chatbots'] },
-  { domain: 'Financial',          modules: ['billing', 'accounting', 'payments', 'expenses'] },
+  { domain: 'Financial',          modules: ['invoices', 'gift_cards', 'patient_wallets', 'accounting', 'payments', 'expenses'] },
   { domain: 'Analytics',          modules: ['reports', 'dashboards', 'analytics'] },
   { domain: 'Automation',         modules: ['workflows', 'sequences'] },
   { domain: 'Documents',          modules: ['documents', 'contracts', 'signatures', 'estimates'] },
-  { domain: 'Wellness Clinical',  modules: ['patients', 'appointments', 'my_appointments', 'book_appointment', 'waitlist', 'services', 'prescriptions', 'consents', 'visits'] },
+  { domain: 'Wellness Clinical',  modules: ['patients', 'appointments', 'my_appointments', 'book_appointment', 'waitlist', 'services', 'prescriptions', 'my_prescriptions', 'consents', 'visits'] },
   { domain: 'Wellness Inventory', modules: ['products', 'inventory', 'pos'] },
   { domain: 'Admin & Platform',   modules: ['staff', 'roles', 'settings', 'audit', 'integrations', 'developer'] },
 ];
@@ -92,7 +96,9 @@ const MODULE_DESCRIPTIONS = {
   surveys:        'CSAT / NPS / custom surveys and responses.',
   chatbots:       'Live-chat bots, conversation flows, and handoff rules.',
   // Financial
-  billing:        'Invoices, recurring billing, credit notes.',
+  invoices:         'Patient + customer invoice records and the Invoices page.',
+  gift_cards:       'Gift card issuance ledger and the Gift Cards page.',
+  patient_wallets:  'Patient pre-paid wallet balances, top-ups, and ledger.',
   accounting:     'Ledger sync and accounting integrations (Tally / QuickBooks / Xero).',
   payments:       'Payment records and transaction history.',
   expenses:       'Employee expenses, approvals, and reimbursements.',
@@ -117,6 +123,7 @@ const MODULE_DESCRIPTIONS = {
   calendar:       'Day-grid calendar view (slot-click to book, drag to reschedule).',
   services:       'Service catalog, packages, and pricing.',
   prescriptions:  'Rx records, prescription PDFs, and dispense flow.',
+  my_prescriptions: 'Patient-portal "My Prescriptions" tab — patients see only their own Rx list and can download their own PDFs.',
   consents:       'Signed consent forms and consent canvas signature capture.',
   visits:         'Visit logs, clinical notes, treatment plans, and photo timeline.',
   // Wellness Inventory
@@ -149,8 +156,13 @@ const SENSITIVE_PERMISSIONS_CLIENT = new Set([
   'settings.manage',
   'developer.manage',
   'integrations.write', 'integrations.update', 'integrations.delete', 'integrations.manage',
-  // BILLING / ACCOUNTING mutate-tier — financial exposure
-  'billing.write', 'billing.update', 'billing.delete', 'billing.manage',
+  // INVOICES / GIFT_CARDS / PATIENT_WALLETS / ACCOUNTING mutate-tier —
+  // financial exposure. (`billing` was decomposed into the three
+  // surface-specific modules in v3.8.x; all three carry the same
+  // sensitive write-tier surface.)
+  'invoices.write', 'invoices.update', 'invoices.delete', 'invoices.manage',
+  'gift_cards.write', 'gift_cards.update', 'gift_cards.delete', 'gift_cards.manage',
+  'patient_wallets.write', 'patient_wallets.update', 'patient_wallets.delete', 'patient_wallets.manage',
   'accounting.write',
   // Clinical PII destruction
   'patients.delete',
@@ -175,10 +187,18 @@ const SENSITIVE_PERMISSION_REASONS = {
   'integrations.update': 'Can edit existing integration configurations.',
   'integrations.delete': 'Can disconnect third-party integrations.',
   'integrations.manage': 'Full integration administration.',
-  'billing.write': 'Can create invoices and billing records.',
-  'billing.update': 'Can modify invoices and billing records.',
-  'billing.delete': 'Can void or remove invoices.',
-  'billing.manage': 'Full billing administration.',
+  'invoices.write': 'Can create patient and customer invoices.',
+  'invoices.update': 'Can modify existing invoices (line items, totals, status).',
+  'invoices.delete': 'Can void or remove invoice records.',
+  'invoices.manage': 'Full invoice administration including write-offs and recurring billing.',
+  'gift_cards.write': 'Can issue new gift cards.',
+  'gift_cards.update': 'Can modify gift card balances, expiry, and assignment.',
+  'gift_cards.delete': 'Can void gift card records.',
+  'gift_cards.manage': 'Full gift card program administration.',
+  'patient_wallets.write': 'Can top up or debit patient wallet balances.',
+  'patient_wallets.update': 'Can adjust patient wallet entries and refund disputed transactions.',
+  'patient_wallets.delete': 'Can remove patient wallet ledger entries.',
+  'patient_wallets.manage': 'Full patient wallet administration.',
   'accounting.write': 'Can post to the accounting ledger / sync.',
   'patients.delete': 'Can permanently remove patient records (clinical PHI destruction).',
   'prescriptions.delete': 'Can permanently remove prescription records.',
@@ -929,21 +949,61 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
     Array.isArray(domains) && domains.length
       ? domains
       : PERMISSION_DOMAINS_FALLBACK;
-  // Hydrate from role.permissions (the list endpoint already includes them).
-  // We keep a Set of "module.action" strings for O(1) lookup + toggle.
+  // Build the set of currently-catalogued "module.action" strings so we
+  // can filter the role's stored grants through it. A grant whose module
+  // is no longer in the catalog (e.g. `billing.delete` after the v3.8.x
+  // split into invoices / gift_cards / patient_wallets) has no checkbox
+  // in the matrix, so the admin can't uncheck it — but if we leave it
+  // in `selected`, save serialises it and the bulk-update endpoint 400s
+  // with "Invalid permission: <legacy>.<action>". Filtering on hydrate
+  // means the UI's state matches what's actually renderable, and the
+  // next save cleanly drops the dead grants via the endpoint's atomic
+  // replace.
+  const catalogKeys = useMemo(() => {
+    const s = new Set();
+    for (const m of matrix) {
+      for (const a of m.actions || []) s.add(`${m.module}.${a}`);
+    }
+    return s;
+  }, [matrix]);
+
+  // Hydrate from role.permissions (the list endpoint already includes
+  // them), filtered through the catalogue so legacy grants don't leak
+  // into the save payload. We keep a Set of "module.action" strings
+  // for O(1) lookup + toggle.
   const initial = useMemo(() => {
     const s = new Set();
+    let droppedLegacy = 0;
     (role.permissions || []).forEach((p) => {
       const m = p?.module;
       const a = p?.action;
-      if (m && a) s.add(`${m}.${a}`);
+      if (!m || !a) return;
+      const key = `${m}.${a}`;
+      if (catalogKeys.has(key)) {
+        s.add(key);
+      } else {
+        droppedLegacy++;
+      }
     });
+    if (droppedLegacy > 0) {
+      console.warn(
+        `[RolesAdmin] role "${role.key || role.name}" had ${droppedLegacy} ` +
+          `legacy permission grant(s) for modules no longer in the catalog; ` +
+          `they'll be cleaned up on the next save.`,
+      );
+    }
     return s;
-  }, [role]);
+  }, [role, catalogKeys]);
 
   const [selected, setSelected] = useState(initial);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  // Search query filters the matrix on module name, description,
+  // page-catalog labels (the "Unlocks: …" line), and action names.
+  // Case-insensitive, substring match. Empty query renders everything.
+  // Filters DON'T touch `selected` — toggles on a search hit preserve
+  // grants on filtered-out modules unchanged.
+  const [searchQuery, setSearchQuery] = useState('');
   // SPEC §6a — when the admin clicks Save and the selection adds NET-
   // NEW sensitive grants, we stash them here and surface a confirmation
   // modal. Save only fires when the admin clicks Confirm. Cancel returns
@@ -987,6 +1047,31 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
     }
     return map;
   }, [pageCatalog]);
+
+  // Per-module search corpus: concatenated string of everything the
+  // search input matches against. Built once per matrix/page-catalog
+  // change so the filter pass is O(n) on every keystroke without
+  // re-deriving descriptions and page labels each time.
+  const searchCorpusByModule = useMemo(() => {
+    const map = new Map();
+    for (const { module, actions } of matrix) {
+      const parts = [
+        module,
+        MODULE_DESCRIPTIONS[module] || '',
+        Array.from(pagesByModule.get(module) || []).join(' '),
+        (actions || []).join(' '),
+      ];
+      map.set(module, parts.join(' ').toLowerCase());
+    }
+    return map;
+  }, [matrix, pagesByModule]);
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const matchesQuery = (module) => {
+    if (!normalizedQuery) return true;
+    const corpus = searchCorpusByModule.get(module);
+    return Boolean(corpus && corpus.includes(normalizedQuery));
+  };
 
   const notify = useNotify();
 
@@ -1065,10 +1150,77 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
       onClose={onClose}
       width={760}
     >
+      {/* Sticky search bar — pins to the top of the modal's scroll
+          container so it stays in reach while the admin scrolls
+          through 40+ modules. Filters by module name, description,
+          page-catalog "Unlocks" labels, and action names. */}
       <div
         style={{
-          maxHeight: '60vh',
-          overflowY: 'auto',
+          position: 'sticky',
+          top: 0,
+          zIndex: 2,
+          marginBottom: '0.75rem',
+          background: 'var(--surface-color)',
+          paddingBottom: '0.5rem',
+          // Negative margin + matching padding pulls the sticky band out
+          // to the ModalShell's left/right edges so the row visually
+          // anchors to the modal's chrome instead of looking like a
+          // floating widget inside the content padding.
+          marginLeft: '-1.25rem',
+          marginRight: '-1.25rem',
+          paddingLeft: '1.25rem',
+          paddingRight: '1.25rem',
+          paddingTop: '0.25rem',
+          borderBottom: '1px solid var(--border-color)',
+        }}
+      >
+        <div style={{ position: 'relative' }}>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search permissions (module, page, action)…"
+            aria-label="Search permissions"
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              padding: '0.55rem 2.2rem 0.55rem 0.85rem',
+              fontSize: '0.9rem',
+              borderRadius: 8,
+              border: '1px solid var(--border-color)',
+              background: 'var(--subtle-bg-2)',
+              color: 'var(--text-primary)',
+              outline: 'none',
+            }}
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              aria-label="Clear search"
+              title="Clear search"
+              style={{
+                position: 'absolute',
+                top: '50%',
+                right: '0.5rem',
+                transform: 'translateY(-50%)',
+                background: 'transparent',
+                border: 'none',
+                color: 'var(--text-secondary)',
+                cursor: 'pointer',
+                fontSize: '1.1rem',
+                lineHeight: 1,
+                padding: '0.2rem 0.35rem',
+              }}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
           padding: '0.25rem',
           marginBottom: '0.75rem',
         }}
@@ -1084,13 +1236,46 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
             .map(({ domain, modules: moduleNames }) => {
               const items = (moduleNames || [])
                 .map((name) => byName.get(name))
-                .filter(Boolean);
+                .filter(Boolean)
+                // Search filter — drop modules that don't match the
+                // current query. Empty query → matchesQuery returns
+                // true for all, so this no-ops.
+                .filter((m) => matchesQuery(m.module));
               items.forEach((m) => seen.add(m.module));
               return { domain, items };
             })
             .filter((s) => s.items.length > 0);
-          const orphans = matrix.filter((m) => !seen.has(m.module));
+          const orphans = matrix
+            .filter((m) => !seen.has(m.module))
+            .filter((m) => matchesQuery(m.module));
           if (orphans.length > 0) sections.push({ domain: 'Other', items: orphans });
+
+          // Empty state — search returned zero hits across every domain.
+          if (sections.length === 0) {
+            return (
+              <div
+                style={{
+                  padding: '2rem 1rem',
+                  textAlign: 'center',
+                  color: 'var(--text-secondary)',
+                  fontSize: '0.85rem',
+                }}
+              >
+                No permissions match <strong>“{searchQuery}”</strong>.
+                <div style={{ marginTop: '0.5rem' }}>
+                  <button
+                    type="button"
+                    onClick={() => setSearchQuery('')}
+                    className="btn-secondary"
+                    style={{ padding: '0.3rem 0.8rem', fontSize: '0.8rem' }}
+                  >
+                    Clear search
+                  </button>
+                </div>
+              </div>
+            );
+          }
+
           return sections.map(({ domain, items }) => (
             <div key={domain} style={{ marginBottom: '1.25rem' }}>
               <div
@@ -1289,6 +1474,11 @@ function PermissionsModal({ role, modules, domains, readOnly, onClose, onSaved }
       <ModalActions>
         <span style={{ flex: 1, fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
           {selected.size} permission{selected.size === 1 ? '' : 's'} selected
+          {normalizedQuery && (
+            <span style={{ marginLeft: '0.5rem', opacity: 0.8 }}>
+              · filtered by “{searchQuery.trim()}”
+            </span>
+          )}
         </span>
         <button type="button" onClick={onClose} className="btn-secondary" disabled={isLoading}>
           {readOnly ? 'Close' : 'Cancel'}
@@ -1975,7 +2165,13 @@ function ModalShell({ title, subtitle, onClose, width = 480, children }) {
     return () => window.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  return (
+  // Portal to document.body so a modal opened from inside another modal's
+  // scrollable body (e.g. SensitiveGrantsConfirmModal launched from
+  // PermissionsModal) becomes a DOM sibling of its parent, not a nested
+  // descendant. Without this, wheel events on the child's backdrop bubble
+  // up to the parent modal's `.glass` overflow:auto container and scroll
+  // the underlying matrix while the confirm dialog is open.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -2054,7 +2250,8 @@ function ModalShell({ title, subtitle, onClose, width = 480, children }) {
         {subtitle && <div style={{ marginBottom: '0.75rem' }} />}
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -966,319 +966,6 @@ export default function Settings() {
             <WellnessRoleTypesCard notify={notify} />
           )}
 
-          {/* Branding Card */}
-          <div
-            className="card"
-            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
-          >
-            <h3
-              style={{
-                fontSize: "1.25rem",
-                fontWeight: "600",
-                marginBottom: "1.5rem",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-              }}
-            >
-              <Palette size={20} color="var(--accent-color)" /> Branding
-            </h3>
-            <p
-              style={{
-                color: "var(--text-secondary)",
-                fontSize: "0.875rem",
-                marginBottom: "1.25rem",
-              }}
-            >
-              Upload your clinic logo and pick a brand color. These appear in
-              the sidebar and on branded PDFs.
-            </p>
-
-            {/* #479: Branding two-column (Logo | Brand color) collapses to
-              single-column under ~360px-each via auto-fit + minmax, fixing
-              the "B colo..." label clip + "Save c..." button-text clip on
-              ~425px viewports. */}
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns:
-                  "repeat(auto-fit, minmax(min(100%, 240px), 1fr))",
-                gap: "2rem",
-                alignItems: "start",
-              }}
-            >
-              {/* Logo */}
-              <div style={{ minWidth: 0 }}>
-                <label
-                  style={{
-                    display: "block",
-                    marginBottom: "0.5rem",
-                    fontSize: "0.875rem",
-                    color: "var(--text-secondary)",
-                    fontWeight: 500,
-                  }}
-                >
-                  <ImageIcon
-                    size={14}
-                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
-                  />{" "}
-                  Logo
-                </label>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "1rem",
-                    marginBottom: "0.75rem",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  {/* Preview tile — staged file wins over saved logo so the
-                    user can see what they're about to commit. Broken
-                    logoUrl falls back to a dashed placeholder instead of
-                    leaving the classic broken-image icon in place. */}
-                  {stagedPreviewUrl ? (
-                    <div style={{ position: "relative" }}>
-                      <img
-                        src={stagedPreviewUrl}
-                        alt="New logo preview"
-                        style={{
-                          width: 80,
-                          height: 80,
-                          borderRadius: 8,
-                          objectFit: "cover",
-                          border: "2px solid var(--accent-color)",
-                        }}
-                      />
-                      <span
-                        style={{
-                          position: "absolute",
-                          bottom: -8,
-                          left: "50%",
-                          transform: "translateX(-50%)",
-                          background: "var(--accent-color)",
-                          color: "#fff",
-                          fontSize: "0.65rem",
-                          padding: "0.1rem 0.45rem",
-                          borderRadius: 999,
-                          whiteSpace: "nowrap",
-                          fontWeight: 600,
-                        }}
-                      >
-                        Pending
-                      </span>
-                    </div>
-                  ) : branding.logoUrl && !logoBroken ? (
-                    <img
-                      src={branding.logoUrl}
-                      alt="Current logo"
-                      onError={() => setLogoBroken(true)}
-                      style={{
-                        width: 80,
-                        height: 80,
-                        borderRadius: 8,
-                        objectFit: "cover",
-                        border: "1px solid var(--border-color)",
-                      }}
-                    />
-                  ) : (
-                    <div
-                      style={{
-                        width: 80,
-                        height: 80,
-                        borderRadius: 8,
-                        border: "1px dashed var(--border-color)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        color: "var(--text-secondary)",
-                        fontSize: "0.7rem",
-                        textAlign: "center",
-                        flexDirection: "column",
-                        gap: "0.2rem",
-                      }}
-                    >
-                      <ImageIcon size={22} />
-                      <span>{logoBroken ? "Image broken" : "No logo"}</span>
-                    </div>
-                  )}
-
-                  {/* Hidden native input; visible buttons trigger it. */}
-                  <input
-                    ref={logoInputRef}
-                    type="file"
-                    accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
-                    onChange={handlePickLogo}
-                    style={{ display: "none" }}
-                  />
-
-                  <div
-                    style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}
-                  >
-                    {stagedLogo ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn-primary"
-                          onClick={handleSaveLogo}
-                          disabled={logoUploading}
-                          style={{ whiteSpace: "nowrap" }}
-                        >
-                          {logoUploading ? "Uploading…" : "Save logo"}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => logoInputRef.current?.click()}
-                          disabled={logoUploading}
-                          style={{
-                            padding: "0.5rem 0.9rem",
-                            background: "transparent",
-                            border: "1px solid var(--border-color)",
-                            borderRadius: 6,
-                            color: "var(--text-primary)",
-                            cursor: "pointer",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          Pick another
-                        </button>
-                        <button
-                          type="button"
-                          onClick={cancelStagedLogo}
-                          disabled={logoUploading}
-                          style={{
-                            padding: "0.5rem 0.9rem",
-                            background: "transparent",
-                            border: "1px solid var(--border-color)",
-                            borderRadius: 6,
-                            color: "var(--danger-color, #ef4444)",
-                            cursor: "pointer",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          Cancel
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        className="btn-primary"
-                        onClick={() => logoInputRef.current?.click()}
-                        disabled={logoUploading}
-                        style={{ whiteSpace: "nowrap" }}
-                      >
-                        {branding.logoUrl && !logoBroken
-                          ? "Replace logo"
-                          : "Upload logo"}
-                      </button>
-                    )}
-                  </div>
-                </div>
-                <p
-                  style={{
-                    color: "var(--text-secondary)",
-                    fontSize: "0.75rem",
-                  }}
-                >
-                  PNG, JPG, GIF, WEBP or SVG. Max 20 MB. Square works best.
-                </p>
-              </div>
-
-              {/* Brand color */}
-              <div style={{ minWidth: 0 }}>
-                <label
-                  style={{
-                    display: "block",
-                    marginBottom: "0.5rem",
-                    fontSize: "0.875rem",
-                    color: "var(--text-secondary)",
-                    fontWeight: 500,
-                  }}
-                >
-                  <Palette
-                    size={14}
-                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
-                  />{" "}
-                  Brand color
-                </label>
-                {/* #479: flexWrap + whiteSpace:nowrap on the Save button so the
-                  button stays as one piece ("Save c..." → "Save color") even
-                  when wrapped to its own line. min-width:0 on the hex input
-                  lets it shrink instead of pushing the button off-screen. */}
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem",
-                    marginBottom: "0.75rem",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <input
-                    type="color"
-                    value={
-                      /^#[0-9a-fA-F]{6}$/.test(branding.brandColor || "")
-                        ? branding.brandColor
-                        : DEFAULT_BRAND_COLOR
-                    }
-                    onChange={(e) =>
-                      setBranding({ ...branding, brandColor: e.target.value })
-                    }
-                    style={{
-                      width: 48,
-                      height: 40,
-                      border: "1px solid var(--border-color)",
-                      borderRadius: 8,
-                      cursor: "pointer",
-                      padding: 2,
-                      background: "var(--input-bg)",
-                    }}
-                  />
-                  <input
-                    type="text"
-                    className="input-field"
-                    placeholder={DEFAULT_BRAND_COLOR}
-                    value={branding.brandColor || ""}
-                    onChange={(e) =>
-                      setBranding({ ...branding, brandColor: e.target.value })
-                    }
-                    style={{ flex: "1 1 120px", minWidth: 0 }}
-                  />
-                  <button
-                    type="button"
-                    className="btn-primary"
-                    disabled={brandingSaving}
-                    onClick={handleSaveBrandColor}
-                    style={{ whiteSpace: "nowrap" }}
-                  >
-                    {brandingSaving ? "Saving..." : "Save color"}
-                  </button>
-                </div>
-                <p
-                  style={{
-                    color: "var(--text-secondary)",
-                    fontSize: "0.75rem",
-                  }}
-                >
-                  6-digit hex. Leave blank to fall back to the default theme
-                  accent.
-                </p>
-              </div>
-            </div>
-
-            {brandingMsg && (
-              <p
-                style={{
-                  marginTop: "1rem",
-                  fontSize: "0.85rem",
-                  color: "var(--accent-color)",
-                }}
-              >
-                {brandingMsg}
-              </p>
-            )}
-          </div>
-
           {/* Pipeline Stages Card */}
           <div
             className="card"
@@ -1983,6 +1670,319 @@ export default function Settings() {
 
           {/* Notification Preferences Card */}
           <NotificationPreferencesCard notify={notify} />
+
+          {/* Branding Card */}
+          <div
+            className="card"
+            style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}
+          >
+            <h3
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: "600",
+                marginBottom: "1.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <Palette size={20} color="var(--accent-color)" /> Branding
+            </h3>
+            <p
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "0.875rem",
+                marginBottom: "1.25rem",
+              }}
+            >
+              Upload your clinic logo and pick a brand color. These appear in
+              the sidebar and on branded PDFs.
+            </p>
+
+            {/* #479: Branding two-column (Logo | Brand color) collapses to
+              single-column under ~360px-each via auto-fit + minmax, fixing
+              the "B colo..." label clip + "Save c..." button-text clip on
+              ~425px viewports. */}
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns:
+                  "repeat(auto-fit, minmax(min(100%, 240px), 1fr))",
+                gap: "2rem",
+                alignItems: "start",
+              }}
+            >
+              {/* Logo */}
+              <div style={{ minWidth: 0 }}>
+                <label
+                  style={{
+                    display: "block",
+                    marginBottom: "0.5rem",
+                    fontSize: "0.875rem",
+                    color: "var(--text-secondary)",
+                    fontWeight: 500,
+                  }}
+                >
+                  <ImageIcon
+                    size={14}
+                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
+                  />{" "}
+                  Logo
+                </label>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "1rem",
+                    marginBottom: "0.75rem",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  {/* Preview tile — staged file wins over saved logo so the
+                    user can see what they're about to commit. Broken
+                    logoUrl falls back to a dashed placeholder instead of
+                    leaving the classic broken-image icon in place. */}
+                  {stagedPreviewUrl ? (
+                    <div style={{ position: "relative" }}>
+                      <img
+                        src={stagedPreviewUrl}
+                        alt="New logo preview"
+                        style={{
+                          width: 80,
+                          height: 80,
+                          borderRadius: 8,
+                          objectFit: "cover",
+                          border: "2px solid var(--accent-color)",
+                        }}
+                      />
+                      <span
+                        style={{
+                          position: "absolute",
+                          bottom: -8,
+                          left: "50%",
+                          transform: "translateX(-50%)",
+                          background: "var(--accent-color)",
+                          color: "#fff",
+                          fontSize: "0.65rem",
+                          padding: "0.1rem 0.45rem",
+                          borderRadius: 999,
+                          whiteSpace: "nowrap",
+                          fontWeight: 600,
+                        }}
+                      >
+                        Pending
+                      </span>
+                    </div>
+                  ) : branding.logoUrl && !logoBroken ? (
+                    <img
+                      src={branding.logoUrl}
+                      alt="Current logo"
+                      onError={() => setLogoBroken(true)}
+                      style={{
+                        width: 80,
+                        height: 80,
+                        borderRadius: 8,
+                        objectFit: "cover",
+                        border: "1px solid var(--border-color)",
+                      }}
+                    />
+                  ) : (
+                    <div
+                      style={{
+                        width: 80,
+                        height: 80,
+                        borderRadius: 8,
+                        border: "1px dashed var(--border-color)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "var(--text-secondary)",
+                        fontSize: "0.7rem",
+                        textAlign: "center",
+                        flexDirection: "column",
+                        gap: "0.2rem",
+                      }}
+                    >
+                      <ImageIcon size={22} />
+                      <span>{logoBroken ? "Image broken" : "No logo"}</span>
+                    </div>
+                  )}
+
+                  {/* Hidden native input; visible buttons trigger it. */}
+                  <input
+                    ref={logoInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+                    onChange={handlePickLogo}
+                    style={{ display: "none" }}
+                  />
+
+                  <div
+                    style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}
+                  >
+                    {stagedLogo ? (
+                      <>
+                        <button
+                          type="button"
+                          className="btn-primary"
+                          onClick={handleSaveLogo}
+                          disabled={logoUploading}
+                          style={{ whiteSpace: "nowrap" }}
+                        >
+                          {logoUploading ? "Uploading…" : "Save logo"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => logoInputRef.current?.click()}
+                          disabled={logoUploading}
+                          style={{
+                            padding: "0.5rem 0.9rem",
+                            background: "transparent",
+                            border: "1px solid var(--border-color)",
+                            borderRadius: 6,
+                            color: "var(--text-primary)",
+                            cursor: "pointer",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Pick another
+                        </button>
+                        <button
+                          type="button"
+                          onClick={cancelStagedLogo}
+                          disabled={logoUploading}
+                          style={{
+                            padding: "0.5rem 0.9rem",
+                            background: "transparent",
+                            border: "1px solid var(--border-color)",
+                            borderRadius: 6,
+                            color: "var(--danger-color, #ef4444)",
+                            cursor: "pointer",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn-primary"
+                        onClick={() => logoInputRef.current?.click()}
+                        disabled={logoUploading}
+                        style={{ whiteSpace: "nowrap" }}
+                      >
+                        {branding.logoUrl && !logoBroken
+                          ? "Replace logo"
+                          : "Upload logo"}
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <p
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  PNG, JPG, GIF, WEBP or SVG. Max 20 MB. Square works best.
+                </p>
+              </div>
+
+              {/* Brand color */}
+              <div style={{ minWidth: 0 }}>
+                <label
+                  style={{
+                    display: "block",
+                    marginBottom: "0.5rem",
+                    fontSize: "0.875rem",
+                    color: "var(--text-secondary)",
+                    fontWeight: 500,
+                  }}
+                >
+                  <Palette
+                    size={14}
+                    style={{ verticalAlign: "middle", marginRight: "0.35rem" }}
+                  />{" "}
+                  Brand color
+                </label>
+                {/* #479: flexWrap + whiteSpace:nowrap on the Save button so the
+                  button stays as one piece ("Save c..." → "Save color") even
+                  when wrapped to its own line. min-width:0 on the hex input
+                  lets it shrink instead of pushing the button off-screen. */}
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.75rem",
+                    marginBottom: "0.75rem",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <input
+                    type="color"
+                    value={
+                      /^#[0-9a-fA-F]{6}$/.test(branding.brandColor || "")
+                        ? branding.brandColor
+                        : DEFAULT_BRAND_COLOR
+                    }
+                    onChange={(e) =>
+                      setBranding({ ...branding, brandColor: e.target.value })
+                    }
+                    style={{
+                      width: 48,
+                      height: 40,
+                      border: "1px solid var(--border-color)",
+                      borderRadius: 8,
+                      cursor: "pointer",
+                      padding: 2,
+                      background: "var(--input-bg)",
+                    }}
+                  />
+                  <input
+                    type="text"
+                    className="input-field"
+                    placeholder={DEFAULT_BRAND_COLOR}
+                    value={branding.brandColor || ""}
+                    onChange={(e) =>
+                      setBranding({ ...branding, brandColor: e.target.value })
+                    }
+                    style={{ flex: "1 1 120px", minWidth: 0 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    disabled={brandingSaving}
+                    onClick={handleSaveBrandColor}
+                    style={{ whiteSpace: "nowrap" }}
+                  >
+                    {brandingSaving ? "Saving..." : "Save color"}
+                  </button>
+                </div>
+                <p
+                  style={{
+                    color: "var(--text-secondary)",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  6-digit hex. Leave blank to fall back to the default theme
+                  accent.
+                </p>
+              </div>
+            </div>
+
+            {brandingMsg && (
+              <p
+                style={{
+                  marginTop: "1rem",
+                  fontSize: "0.85rem",
+                  color: "var(--accent-color)",
+                }}
+              >
+                {brandingMsg}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/wellness/AutoConsumptionRules.jsx
+++ b/frontend/src/pages/wellness/AutoConsumptionRules.jsx
@@ -6,12 +6,16 @@ import { useEffect, useState } from 'react';
 import { Recycle, Plus, Pencil, Trash2 } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 
 const UNIT_OPTIONS = ['ml', 'gm', 'kg', 'piece', 'unit', 'bottle', 'tube', 'pack', 'ltr'];
 const EMPTY = { serviceId: '', productId: '', quantityPerVisit: '', unit: '', isActive: true };
 
 export default function AutoConsumptionRules() {
   const notify = useNotify();
+  // Backend gates POST/PUT/DELETE /auto-consumption-rules on products.manage.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManage = permsReady && hasPermission('products', 'manage');
   const [rules, setRules] = useState([]);
   const [services, setServices] = useState([]);
   const [products, setProducts] = useState([]);
@@ -103,19 +107,29 @@ export default function AutoConsumptionRules() {
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <header style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
             <Recycle size={24} /> Auto-consumption rules
+            {permsReady && !canManage && (
+              <span
+                title="You can view rules but can't make changes."
+                style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: 999, background: 'var(--subtle-bg)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)', fontWeight: 500 }}
+              >
+                View only
+              </span>
+            )}
           </h1>
           <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
             When a visit completes for the matching service, the listed product is automatically consumed in the configured quantity.
           </p>
         </div>
-        <button onClick={() => (showForm ? reset() : setShowForm(true))} style={primaryBtnStyle}>
-          <Plus size={16} /> {showForm ? 'Cancel' : 'New rule'}
-        </button>
+        {canManage && (
+          <button onClick={() => (showForm ? reset() : setShowForm(true))} style={primaryBtnStyle}>
+            <Plus size={16} /> {showForm ? 'Cancel' : 'New rule'}
+          </button>
+        )}
       </header>
 
-      {showForm && (
+      {showForm && canManage && (
         <form onSubmit={submit} className="glass" style={{ padding: '1.25rem', marginBottom: '1rem', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))', gap: '0.5rem' }}>
           <select required disabled={!!editingId} value={form.serviceId} onChange={(e) => setForm({ ...form, serviceId: e.target.value })} style={inputStyle}>
             <option value="">Service…</option>
@@ -165,7 +179,7 @@ export default function AutoConsumptionRules() {
                 <th style={cellStyle}>Unit</th>
                 <th style={cellStyle}>Stock</th>
                 <th style={cellStyle}>Status</th>
-                <th style={cellStyle}></th>
+                {canManage && <th style={cellStyle}></th>}
               </tr>
             </thead>
             <tbody>
@@ -177,10 +191,12 @@ export default function AutoConsumptionRules() {
                   <td style={cellStyle}>{r.unit || r.product?.unit || '—'}</td>
                   <td style={cellStyle}>{r.product?.currentStock ?? '—'}</td>
                   <td style={cellStyle}>{r.isActive ? 'Active' : 'Inactive'}</td>
-                  <td style={{ ...cellStyle, textAlign: 'right' }}>
-                    <button onClick={() => startEdit(r)} style={iconBtnStyle} aria-label="Edit rule"><Pencil size={14} /></button>
-                    <button onClick={() => remove(r)} style={iconBtnStyle} aria-label="Delete rule"><Trash2 size={14} /></button>
-                  </td>
+                  {canManage && (
+                    <td style={{ ...cellStyle, textAlign: 'right' }}>
+                      <button onClick={() => startEdit(r)} style={iconBtnStyle} aria-label="Edit rule"><Pencil size={14} /></button>
+                      <button onClick={() => remove(r)} style={iconBtnStyle} aria-label="Delete rule"><Trash2 size={14} /></button>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/wellness/BookAppointment.jsx
+++ b/frontend/src/pages/wellness/BookAppointment.jsx
@@ -1,24 +1,41 @@
 import { useEffect, useState, useContext } from 'react';
-import { Calendar, Clock, User, Stethoscope } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Calendar, Clock, Stethoscope, Info, Sparkles } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
 import { AuthContext } from '../../App';
 
+// Half-hour slots from 09:00 to 19:00 — used when the patient hasn't picked a
+// preferred doctor. Once a doctor IS chosen we use that doctor's actual
+// availability via /doctors/:id/time-slots. The static set keeps the
+// "any-doctor, admin will assign" path usable without a doctor lookup.
+const GENERIC_SLOTS = (() => {
+  const out = [];
+  for (let h = 9; h <= 19; h++) {
+    out.push(`${String(h).padStart(2, '0')}:00`);
+    if (h < 19) out.push(`${String(h).padStart(2, '0')}:30`);
+  }
+  return out;
+})();
+
 export default function BookAppointment() {
   const notify = useNotify();
-  const { user } = useContext(AuthContext);
+  const { user } = useContext(AuthContext); // eslint-disable-line no-unused-vars
 
   const [doctors, setDoctors] = useState([]);
   const [services, setServices] = useState([]);
+  const [memberships, setMemberships] = useState([]);
   const [myAppointments, setMyAppointments] = useState([]);
-  const [availableSlots, setAvailableSlots] = useState([]);
+  const [availableSlots, setAvailableSlots] = useState(GENERIC_SLOTS);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [slotsLoading, setSlotsLoading] = useState(false);
 
   const [formData, setFormData] = useState({
+    reason: '',
     doctorId: '',
     serviceId: '',
+    membershipId: '',
     appointmentDate: new Date().toISOString().split('T')[0],
     appointmentTime: ''
   });
@@ -30,15 +47,17 @@ export default function BookAppointment() {
   const loadData = async () => {
     try {
       setLoading(true);
-      const [doctorsData, servicesData, appointmentsData] = await Promise.all([
+      const [doctorsData, servicesData, appointmentsData, membershipsData] = await Promise.all([
         fetchApi('/api/wellness/doctors/availability?date=' + formData.appointmentDate).catch(() => []),
         fetchApi('/api/wellness/services').catch(() => []),
-        fetchApi('/api/wellness/appointments/my').catch(() => [])
+        fetchApi('/api/wellness/appointments/my').catch(() => []),
+        fetchApi('/api/wellness/appointments/my-memberships').catch(() => [])
       ]);
 
       setDoctors(Array.isArray(doctorsData) ? doctorsData : []);
       setServices(Array.isArray(servicesData) ? servicesData.filter(s => s.isActive !== false) : []);
       setMyAppointments(Array.isArray(appointmentsData) ? appointmentsData : []);
+      setMemberships(Array.isArray(membershipsData) ? membershipsData : []);
     } catch (err) {
       console.error('Failed to load data:', err);
       notify.error('Failed to load appointment data');
@@ -55,9 +74,12 @@ export default function BookAppointment() {
     } catch (err) {
       console.error('Failed to load doctors:', err);
     }
-    // Reload slots if doctor is already selected
+    // Reload slots if doctor is already selected; otherwise fall back to the
+    // generic preset (admin assigns the doctor at triage time).
     if (formData.doctorId) {
       loadTimeSlots(formData.doctorId, date);
+    } else {
+      setAvailableSlots(GENERIC_SLOTS);
     }
   };
 
@@ -87,14 +109,20 @@ export default function BookAppointment() {
     if (doctorId) {
       await loadTimeSlots(doctorId, formData.appointmentDate);
     } else {
-      setAvailableSlots([]);
+      // Patient cleared the doctor → revert to generic slots so they can still
+      // pick a preferred time. Admin will reconcile against an actual doctor.
+      setAvailableSlots(GENERIC_SLOTS);
     }
   };
 
   const handleBookAppointment = async (e) => {
     e.preventDefault();
-    if (!formData.doctorId) {
-      notify.error('Please select a doctor');
+    if (!formData.reason.trim()) {
+      notify.error('Please describe the reason for your appointment');
+      return;
+    }
+    if (!formData.appointmentTime) {
+      notify.error('Please pick a time');
       return;
     }
 
@@ -103,21 +131,31 @@ export default function BookAppointment() {
       const result = await fetchApi('/api/wellness/appointments/book', {
         method: 'POST',
         body: JSON.stringify({
-          doctorId: parseInt(formData.doctorId),
+          reason: formData.reason.trim(),
+          doctorId: formData.doctorId ? parseInt(formData.doctorId) : null,
           serviceId: formData.serviceId ? parseInt(formData.serviceId) : null,
+          membershipId: formData.membershipId ? parseInt(formData.membershipId) : null,
           appointmentDate: formData.appointmentDate,
           appointmentTime: formData.appointmentTime
         })
       });
 
       if (result.success) {
-        notify.success(`Appointment booked with Dr. ${result.appointment.doctorName}`);
+        const apt = result.appointment;
+        notify.success(
+          apt.doctorAssigned
+            ? `Appointment booked with Dr. ${apt.doctorName}`
+            : 'Appointment requested — our team will assign a doctor and confirm shortly.'
+        );
         setFormData({
+          reason: '',
           doctorId: '',
           serviceId: '',
+          membershipId: '',
           appointmentDate: new Date().toISOString().split('T')[0],
-          appointmentTime: '10:00'
+          appointmentTime: ''
         });
+        setAvailableSlots(GENERIC_SLOTS);
         loadData();
       }
     } catch (err) {
@@ -176,10 +214,38 @@ export default function BookAppointment() {
           </h2>
 
           <form onSubmit={handleBookAppointment} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
-            {/* Doctor Selection */}
+            {/* Reason — required. Triage-critical when doctor is left blank. */}
             <div>
               <label style={{ fontSize: '0.85rem', fontWeight: 500, color: 'var(--text-primary)', display: 'block', marginBottom: '0.5rem' }}>
-                Select Doctor *
+                Reason for Appointment *
+              </label>
+              <textarea
+                value={formData.reason}
+                onChange={(e) => setFormData({ ...formData, reason: e.target.value })}
+                placeholder="Briefly describe the issue or reason for your visit"
+                rows={3}
+                maxLength={1000}
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.7rem',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: 8,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                  resize: 'vertical',
+                  fontFamily: 'inherit',
+                  boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            {/* Doctor Selection — optional. Empty value means "any doctor"; admin will
+                assign based on the reason + specialty + availability. */}
+            <div>
+              <label style={{ fontSize: '0.85rem', fontWeight: 500, color: 'var(--text-primary)', display: 'block', marginBottom: '0.5rem' }}>
+                Preferred Doctor (Optional)
               </label>
               <select
                 value={formData.doctorId}
@@ -195,7 +261,7 @@ export default function BookAppointment() {
                   cursor: 'pointer'
                 }}
               >
-                <option value="">— Select a Doctor —</option>
+                <option value="">— No preference (admin will assign) —</option>
                 {doctors.map(doc => {
                   const name = (doc.name || '').trim();
                   const isDoctor = (doc.wellnessRole || '').toLowerCase() === 'doctor';
@@ -210,6 +276,23 @@ export default function BookAppointment() {
                   );
                 })}
               </select>
+              {!formData.doctorId && (
+                <div style={{
+                  marginTop: '0.5rem',
+                  padding: '0.5rem 0.7rem',
+                  background: 'rgba(59,130,246,0.08)',
+                  border: '1px solid rgba(59,130,246,0.2)',
+                  borderRadius: 6,
+                  fontSize: '0.78rem',
+                  color: 'var(--text-secondary)',
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '0.4rem'
+                }}>
+                  <Info size={13} style={{ marginTop: 2, flexShrink: 0 }} />
+                  <span>Our team will assign a doctor based on the reason you described and specialist availability.</span>
+                </div>
+              )}
             </div>
 
             {/* Service Selection */}
@@ -235,6 +318,53 @@ export default function BookAppointment() {
                 {services.map(svc => (
                   <option key={svc.id} value={svc.id}>
                     {svc.name} {svc.basePrice ? `(₹${svc.basePrice})` : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Membership — optional. Loaded from /appointments/my-memberships, which
+                returns only active+unexpired rows for the current patient. */}
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+                <label style={{ fontSize: '0.85rem', fontWeight: 500, color: 'var(--text-primary)' }}>
+                  Membership (Optional)
+                </label>
+                <Link
+                  to="/wellness/memberships"
+                  style={{
+                    fontSize: '0.78rem',
+                    color: 'var(--primary-color, var(--accent-color, #6366f1))',
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.25rem'
+                  }}
+                >
+                  <Sparkles size={12} /> Manage memberships
+                </Link>
+              </div>
+              <select
+                value={formData.membershipId}
+                onChange={(e) => setFormData({ ...formData, membershipId: e.target.value })}
+                disabled={memberships.length === 0}
+                style={{
+                  width: '100%',
+                  padding: '0.7rem',
+                  background: memberships.length === 0 ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: 8,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                  cursor: memberships.length === 0 ? 'not-allowed' : 'pointer'
+                }}
+              >
+                <option value="">
+                  {memberships.length === 0 ? '— No active memberships —' : '— None —'}
+                </option>
+                {memberships.map(m => (
+                  <option key={m.id} value={m.id}>
+                    {m.planName} (valid until {new Date(m.endDate).toLocaleDateString()})
                   </option>
                 ))}
               </select>
@@ -269,24 +399,20 @@ export default function BookAppointment() {
                 <select
                   value={formData.appointmentTime}
                   onChange={(e) => setFormData({ ...formData, appointmentTime: e.target.value })}
-                  disabled={!formData.doctorId || availableSlots.length === 0}
+                  disabled={availableSlots.length === 0}
                   style={{
                     width: '100%',
                     padding: '0.7rem',
-                    background: !formData.doctorId || availableSlots.length === 0 ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.05)',
+                    background: availableSlots.length === 0 ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.05)',
                     border: '1px solid rgba(255,255,255,0.1)',
                     borderRadius: 8,
                     color: 'var(--text-primary)',
                     fontSize: '0.9rem',
-                    cursor: !formData.doctorId || availableSlots.length === 0 ? 'not-allowed' : 'pointer'
+                    cursor: availableSlots.length === 0 ? 'not-allowed' : 'pointer'
                   }}
                 >
                   <option value="">
-                    {!formData.doctorId
-                      ? '— Select a doctor first —'
-                      : availableSlots.length === 0
-                      ? '— No available slots —'
-                      : '— Select a time —'}
+                    {availableSlots.length === 0 ? '— No available slots —' : '— Select a time —'}
                   </option>
                   {availableSlots.map(slot => (
                     <option key={slot} value={slot}>
@@ -297,24 +423,30 @@ export default function BookAppointment() {
               </div>
             </div>
 
-            {/* Submit Button */}
-            <button
-              type="submit"
-              disabled={submitting || !formData.doctorId}
-              style={{
-                padding: '0.85rem 1.5rem',
-                background: submitting || !formData.doctorId ? '#999' : 'var(--primary-color, var(--accent-color, #6366f1))',
-                color: '#fff',
-                border: 'none',
-                borderRadius: 8,
-                cursor: submitting || !formData.doctorId ? 'not-allowed' : 'pointer',
-                fontWeight: 600,
-                fontSize: '0.95rem',
-                transition: 'all 0.2s'
-              }}
-            >
-              {submitting ? 'Booking...' : 'Confirm Appointment'}
-            </button>
+            {/* Submit Button. Required: reason + time. Doctor + service +
+                membership are all optional. */}
+            {(() => {
+              const canSubmit = !submitting && formData.reason.trim() && formData.appointmentTime;
+              return (
+                <button
+                  type="submit"
+                  disabled={!canSubmit}
+                  style={{
+                    padding: '0.85rem 1.5rem',
+                    background: canSubmit ? 'var(--primary-color, var(--accent-color, #6366f1))' : '#999',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: 8,
+                    cursor: canSubmit ? 'pointer' : 'not-allowed',
+                    fontWeight: 600,
+                    fontSize: '0.95rem',
+                    transition: 'all 0.2s'
+                  }}
+                >
+                  {submitting ? 'Booking...' : 'Confirm Appointment'}
+                </button>
+              );
+            })()}
           </form>
         </div>
 
@@ -361,11 +493,16 @@ export default function BookAppointment() {
                 >
                   <div>
                     <div style={{ fontWeight: 600, fontSize: '0.95rem', marginBottom: '0.5rem' }}>
-                      Dr. {apt.doctorName}
+                      {apt.doctorAssigned === false ? apt.doctorName : `Dr. ${apt.doctorName}`}
                     </div>
                     <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', marginBottom: '0.25rem' }}>
                       📋 {apt.serviceName}
                     </div>
+                    {apt.reason && (
+                      <div style={{ fontSize: '0.82rem', color: 'var(--text-secondary)', marginBottom: '0.25rem', fontStyle: 'italic' }}>
+                        💬 {apt.reason}
+                      </div>
+                    )}
                     <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
                       📅 {new Date(apt.appointmentDate).toLocaleDateString()} at{' '}
                       {new Date(apt.appointmentDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}

--- a/frontend/src/pages/wellness/CashRegisters.jsx
+++ b/frontend/src/pages/wellness/CashRegisters.jsx
@@ -84,6 +84,15 @@ import { useNotify } from '../../utils/notify';
 import { formatMoney } from '../../utils/money';
 import { formatDateTime } from '../../utils/date';
 import { AuthContext } from '../../App';
+// Shared date-range filter (Today / Yesterday / This Week / This Month /
+// Last 7 / Last 30 / Custom …) — reused from PatientDetail's Case
+// History tab and the Wallet ledger so behaviour stays consistent
+// across the wellness surface.
+import {
+  DateRangeFilter,
+  resolveDateRange,
+  EMPTY_DATE_FILTER,
+} from '../../components/wellness/DateRangeFilter';
 
 const EMPTY_REGISTER_FORM = { name: '', locationId: '', openingFloat: '0' };
 const TX_TABS = [
@@ -92,7 +101,15 @@ const TX_TABS = [
   { key: 'expenses', label: 'Expenses Cash' },
 ];
 
-export default function CashRegisters() {
+/**
+ * Props:
+ *   embedded — when true, renders without the outer page padding +
+ *              hides the "Cash Registers" page heading so the component
+ *              can be slotted into another page (e.g. PointOfSale as a
+ *              collapsible "Manage registers" section). The host page
+ *              provides its own framing. Default false = standalone page.
+ */
+export default function CashRegisters({ embedded = false } = {}) {
   const { user } = useContext(AuthContext) || {};
   const isAdminOrManager =
     user && (user.role === 'ADMIN' || user.role === 'MANAGER');
@@ -123,8 +140,11 @@ export default function CashRegisters() {
   const [closingNotes, setClosingNotes] = useState('');
   const [closingShift, setClosingShift] = useState(false);
 
-  // Transactions tab
+  // Transactions tab + date window. The window applies BEFORE the
+  // payment-method bucketing so the tab counts (Bookings / Partial /
+  // Expenses) reflect only rows in the active range.
   const [txTab, setTxTab] = useState('bookings');
+  const [txDateFilter, setTxDateFilter] = useState(EMPTY_DATE_FILTER);
 
   // ── Loaders ───────────────────────────────────────────────────────
   const loadRegisters = async () => {
@@ -395,7 +415,19 @@ export default function CashRegisters() {
   // Expenses: cash outflows from the drawer — empty until #779 backend
   // ships the deposit/withdraw ledger.
   const transactions = useMemo(() => {
-    const sales = Array.isArray(selectedShift?.sales) ? selectedShift.sales : [];
+    const allSales = Array.isArray(selectedShift?.sales) ? selectedShift.sales : [];
+    // Apply the shared date-range filter first so the per-payment-method
+    // tab counts below reflect only the active window. `[null, null]` ==
+    // "All time" preset — short-circuit and keep every row.
+    const [rangeStart, rangeEnd] = resolveDateRange(txDateFilter);
+    const sales = (rangeStart && rangeEnd)
+      ? allSales.filter((s) => {
+          if (!s.createdAt) return false;
+          const t = new Date(s.createdAt).getTime();
+          if (Number.isNaN(t)) return false;
+          return t >= rangeStart.getTime() && t <= rangeEnd.getTime();
+        })
+      : allSales;
     const bookings = sales.filter(
       (s) => s.paymentMethod === 'CASH' && s.status === 'COMPLETED',
     );
@@ -403,7 +435,7 @@ export default function CashRegisters() {
       (s) => s.paymentMethod === 'COMBINED' && s.status === 'COMPLETED',
     );
     return { bookings, partial, expenses: [] };
-  }, [selectedShift]);
+  }, [selectedShift, txDateFilter]);
 
   const visibleTransactions = transactions[txTab] || [];
 
@@ -420,34 +452,49 @@ export default function CashRegisters() {
 
   // ── Render ────────────────────────────────────────────────────────
   return (
-    <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
+    <div
+      style={
+        embedded
+          ? { animation: 'fadeIn 0.3s ease-out' }
+          : { padding: '2rem', animation: 'fadeIn 0.5s ease-out' }
+      }
+    >
       <header
         style={{
           marginBottom: '1.5rem',
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: embedded ? 'center' : 'flex-start',
           flexWrap: 'wrap',
           gap: '1rem',
         }}
       >
-        <div>
-          <h1
-            style={{
-              fontSize: '1.75rem',
-              fontWeight: 600,
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-            }}
-          >
-            <Banknote size={24} /> Cash Registers
-          </h1>
-          <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
-            {registers.length} register{registers.length !== 1 ? 's' : ''} —
-            open a shift to start ringing up cash sales.
-          </p>
-        </div>
+        {/* When embedded, the host page (e.g. POS) supplies the page
+            title — render only the count + "New register" affordance so
+            the panel doesn't duplicate the parent's H1. */}
+        {!embedded ? (
+          <div>
+            <h1
+              style={{
+                fontSize: '1.75rem',
+                fontWeight: 600,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+              }}
+            >
+              <Banknote size={24} /> Cash Registers
+            </h1>
+            <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
+              {registers.length} register{registers.length !== 1 ? 's' : ''} —
+              open a shift to start ringing up cash sales.
+            </p>
+          </div>
+        ) : (
+          <div style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+            {registers.length} register{registers.length !== 1 ? 's' : ''} configured
+          </div>
+        )}
         {isAdminOrManager && (
           <button
             onClick={() => (showForm ? resetForm() : startCreate())}
@@ -510,8 +557,8 @@ export default function CashRegisters() {
             disabled={saving}
             style={{
               ...primaryButtonStyle,
-              background: 'var(--success-color)',
               gridColumn: '1 / -1',
+              justifyContent: 'center',
             }}
           >
             {saving
@@ -548,9 +595,13 @@ export default function CashRegisters() {
                 padding: '1.25rem',
                 cursor: 'pointer',
                 opacity: reg.isActive ? 1 : 0.55,
+                // Unselected: visible 1px border so cards stay distinct
+                // against the cream wellness light-mode background where
+                // .glass alone provides almost no contrast. Selected:
+                // 2px teal accent that visually overrides the 1px line.
                 border: isSelected
                   ? '2px solid var(--primary-color, var(--accent-color))'
-                  : '1px solid transparent',
+                  : '1px solid var(--border-color)',
               }}
               data-testid={`register-card-${reg.id}`}
             >
@@ -873,10 +924,7 @@ export default function CashRegisters() {
                 <button
                   type="submit"
                   disabled={closingShift}
-                  style={{
-                    ...primaryButtonStyle,
-                    background: 'var(--accent-color)',
-                  }}
+                  style={primaryButtonStyle}
                 >
                   <Lock size={14} />
                   {closingShift ? 'Closing…' : 'Close shift'}
@@ -887,18 +935,47 @@ export default function CashRegisters() {
 
           {/* #781 — Recent Transactions split into 3 buckets */}
           <div>
-            <h3
+            <div
               style={{
-                fontSize: '1rem',
-                fontWeight: 600,
-                marginBottom: '0.5rem',
                 display: 'flex',
                 alignItems: 'center',
-                gap: '0.4rem',
+                justifyContent: 'space-between',
+                gap: '0.75rem',
+                flexWrap: 'wrap',
+                marginBottom: '0.5rem',
               }}
             >
-              <Receipt size={16} /> Recent transactions
-            </h3>
+              <h3
+                style={{
+                  fontSize: '1rem',
+                  fontWeight: 600,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.4rem',
+                  margin: 0,
+                }}
+              >
+                <Receipt size={16} /> Recent transactions
+              </h3>
+              {/* Shared DateRangeFilter — same control used on Case
+                  History + Wallet ledger. Defaults to "All time"; selecting
+                  a preset narrows the per-tab counts below + the visible
+                  list. "Custom" opens the two-month range picker. */}
+              <div
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.4rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <DateRangeFilter
+                  value={txDateFilter}
+                  onChange={setTxDateFilter}
+                  label={null}
+                />
+              </div>
+            </div>
             <div
               role="tablist"
               style={{
@@ -958,9 +1035,16 @@ export default function CashRegisters() {
               selectedShift &&
               visibleTransactions.length === 0 && (
                 <div style={emptyStateStyle}>
-                  {txTab === 'expenses'
-                    ? 'No deposit/withdrawal entries yet. (Cash expense ledger ships with the #779 backend follow-up.)'
-                    : `No ${txTab === 'bookings' ? 'cash bookings' : 'partial-cash sales'} yet on this shift.`}
+                  {txTab === 'expenses' ? (
+                    'No deposit/withdrawal entries yet. (Cash expense ledger ships with the #779 backend follow-up.)'
+                  ) : (
+                    <>
+                      No {txTab === 'bookings' ? 'cash bookings' : 'partial-cash sales'}{' '}
+                      {txDateFilter && txDateFilter.preset !== 'all'
+                        ? 'in the selected date range.'
+                        : 'yet on this shift.'}
+                    </>
+                  )}
                 </div>
               )}
 

--- a/frontend/src/pages/wellness/InventoryAdjustments.jsx
+++ b/frontend/src/pages/wellness/InventoryAdjustments.jsx
@@ -12,12 +12,17 @@ import { useEffect, useState } from 'react';
 import { ScaleIcon, Plus } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 
 const REASONS = ['SHRINKAGE', 'DAMAGE', 'EXPIRY', 'RECOUNT', 'TRANSFER_OUT', 'TRANSFER_IN', 'MANUAL'];
 const EMPTY = { productId: '', quantityDelta: '', reason: 'RECOUNT', notes: '' };
 
 export default function InventoryAdjustments() {
   const notify = useNotify();
+  // Backend gates POST /inventory/adjustments on inventory.write.
+  // The page is otherwise read-only (no edit/delete affordances exist).
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canWriteInventory = permsReady && hasPermission('inventory', 'write');
   const [adjustments, setAdjustments] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -84,16 +89,26 @@ export default function InventoryAdjustments() {
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <header style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
             <ScaleIcon size={24} /> Inventory adjustments
+            {permsReady && !canWriteInventory && (
+              <span
+                title="You can view adjustments but can't make changes."
+                style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: 999, background: 'var(--subtle-bg)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)', fontWeight: 500 }}
+              >
+                View only
+              </span>
+            )}
           </h1>
           <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
             Signed deltas — positive credits stock, negative debits. Use this for shrinkage, damage, recounts, transfers.
           </p>
         </div>
-        <button onClick={() => setShowForm((v) => !v)} style={primaryBtnStyle}>
-          <Plus size={16} /> {showForm ? 'Cancel' : 'New adjustment'}
-        </button>
+        {canWriteInventory && (
+          <button onClick={() => setShowForm((v) => !v)} style={primaryBtnStyle}>
+            <Plus size={16} /> {showForm ? 'Cancel' : 'New adjustment'}
+          </button>
+        )}
       </header>
 
       <div className="glass" style={{ padding: '0.85rem 1rem', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap' }}>
@@ -106,7 +121,7 @@ export default function InventoryAdjustments() {
         <button onClick={load} style={secondaryBtnStyle}>Apply</button>
       </div>
 
-      {showForm && (
+      {showForm && canWriteInventory && (
         <form onSubmit={submit} className="glass" style={{ padding: '1.25rem', marginBottom: '1rem', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))', gap: '0.5rem' }}>
           <select required value={form.productId} onChange={(e) => setForm({ ...form, productId: e.target.value })} style={inputStyle}>
             <option value="">Select product…</option>

--- a/frontend/src/pages/wellness/InventoryReceipts.jsx
+++ b/frontend/src/pages/wellness/InventoryReceipts.jsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 import { DateRangeFilter, resolveDateRangeYmd, EMPTY_DATE_FILTER } from '../../components/wellness/DateRangeFilter';
 
 const EMPTY = {
@@ -20,6 +21,13 @@ const EDIT_WINDOW_MS = 5 * 60 * 1000;
 
 export default function InventoryReceipts() {
   const notify = useNotify();
+  // Backend gates: POST→inventory.write, PUT→inventory.update,
+  // DELETE / reverse →inventory.delete. Fail closed until perms resolve.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canWriteInventory  = permsReady && hasPermission('inventory', 'write');
+  const canUpdateInventory = permsReady && hasPermission('inventory', 'update');
+  const canDeleteInventory = permsReady && hasPermission('inventory', 'delete');
+  const canMutateInventory = canWriteInventory || canUpdateInventory || canDeleteInventory;
   const [receipts, setReceipts] = useState([]);
   const [products, setProducts] = useState([]);
   const [vendors, setVendors] = useState([]);
@@ -192,8 +200,16 @@ export default function InventoryReceipts() {
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <header style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
             <ArrowDownToLine size={24} /> Inventory receipts
+            {permsReady && !canMutateInventory && (
+              <span
+                title="You can view receipts but can't make changes."
+                style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: 999, background: 'var(--subtle-bg)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)', fontWeight: 500 }}
+              >
+                View only
+              </span>
+            )}
           </h1>
           <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
             Keep track of every product you buy — invoice number, supplier, batch, and what it cost.
@@ -202,9 +218,11 @@ export default function InventoryReceipts() {
             {filtered.length} of {receipts.length} receipt{receipts.length === 1 ? '' : 's'} in window — total cost ₹{Number(totalCost).toLocaleString('en-IN', { maximumFractionDigits: 2 })}
           </p>
         </div>
-        <button onClick={startCreate} style={primaryBtnStyle}>
-          <Plus size={16} /> {showForm && !editing ? 'Cancel' : 'Record receipt'}
-        </button>
+        {canWriteInventory && (
+          <button onClick={startCreate} style={primaryBtnStyle}>
+            <Plus size={16} /> {showForm && !editing ? 'Cancel' : 'Record receipt'}
+          </button>
+        )}
       </header>
 
       <div
@@ -326,8 +344,12 @@ export default function InventoryReceipts() {
                   <td style={cellStyle}>{new Date(r.receivedAt).toLocaleDateString()}</td>
                   <td style={{ ...cellStyle, textAlign: 'right', whiteSpace: 'nowrap' }}>
                     <button onClick={() => setViewing(r)} style={iconBtnStyle} title="View details" aria-label={`View ${r.receiptNumber}`}><Eye size={14} /></button>
-                    <button onClick={() => startEdit(r)} style={iconBtnStyle} title="Edit" aria-label={`Edit ${r.receiptNumber}`}><Pencil size={14} /></button>
-                    <button onClick={() => remove(r)} style={iconBtnStyle} title="Delete" aria-label={`Delete ${r.receiptNumber}`}><Trash2 size={14} /></button>
+                    {canUpdateInventory && (
+                      <button onClick={() => startEdit(r)} style={iconBtnStyle} title="Edit" aria-label={`Edit ${r.receiptNumber}`}><Pencil size={14} /></button>
+                    )}
+                    {canDeleteInventory && (
+                      <button onClick={() => remove(r)} style={iconBtnStyle} title="Delete" aria-label={`Delete ${r.receiptNumber}`}><Trash2 size={14} /></button>
+                    )}
                   </td>
                 </tr>
               ))}
@@ -336,7 +358,7 @@ export default function InventoryReceipts() {
         )}
       </div>
 
-      {viewing && <DetailModal receipt={viewing} onClose={() => setViewing(null)} onCopy={copy} copiedKey={copiedKey} onEdit={() => startEdit(viewing)} />}
+      {viewing && <DetailModal receipt={viewing} onClose={() => setViewing(null)} onCopy={copy} copiedKey={copiedKey} onEdit={canUpdateInventory ? () => startEdit(viewing) : null} />}
     </div>
   );
 }
@@ -395,7 +417,9 @@ function DetailModal({ receipt: r, onClose, onCopy, copiedKey, onEdit }) {
             )}
           </div>
           <div style={{ display: 'flex', gap: '0.25rem' }}>
-            <button onClick={onEdit} style={iconBtnStyle} title="Edit" aria-label="Edit"><Pencil size={14} /></button>
+            {onEdit && (
+              <button onClick={onEdit} style={iconBtnStyle} title="Edit" aria-label="Edit"><Pencil size={14} /></button>
+            )}
             <button onClick={onClose} style={iconBtnStyle} aria-label="Close"><X size={16} /></button>
           </div>
         </header>

--- a/frontend/src/pages/wellness/Memberships.jsx
+++ b/frontend/src/pages/wellness/Memberships.jsx
@@ -4,12 +4,37 @@ import { useContext } from 'react';
 import {
   Crown, Plus, Pencil, Trash2, X, Save, Search, Check, Monitor,
   MoreVertical, Power, HelpCircle, Users, Package, Calendar, IndianRupee,
-  ChevronDown, ChevronUp,
+  ChevronDown, ChevronUp, CreditCard,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 import { formatMoney } from '../../utils/money';
 import { AuthContext } from '../../App';
+
+// Razorpay checkout SDK loader — same pattern as BuyGiftCards.jsx.
+// Lazy-loaded on first purchase attempt so the script isn't fetched
+// for catalog browsing.
+const RAZORPAY_SDK_URL = 'https://checkout.razorpay.com/v1/checkout.js';
+function loadRazorpaySdk() {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') return reject(new Error('No window'));
+    if (window.Razorpay) return resolve(window.Razorpay);
+    const existing = document.querySelector(`script[src="${RAZORPAY_SDK_URL}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(window.Razorpay));
+      existing.addEventListener('error', () => reject(new Error('Razorpay SDK failed to load')));
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = RAZORPAY_SDK_URL;
+    script.async = true;
+    script.onload = () => resolve(window.Razorpay);
+    script.onerror = () => reject(new Error('Razorpay SDK failed to load'));
+    document.body.appendChild(script);
+  });
+}
 
 // Empty form. The entitlements field is a non-trivial nested shape:
 // an array of { serviceId, quantity } rows. The UI keeps it as a
@@ -68,31 +93,147 @@ function durationLabel(days) {
 
 export default function Memberships() {
   const notify = useNotify();
+  const navigate = useNavigate();
   const { user } = useContext(AuthContext) || {};
   const isAdmin = user?.role === 'ADMIN' || user?.role === 'MANAGER';
+  // "View Members" routes to /wellness/patients (since members ARE patients
+  // until a dedicated members list ships). Backend gates the /patients
+  // endpoints on patients.read via phiReadGate, so showing the button when
+  // the user can't reach the destination would just dump them on a page that
+  // 403s every API call. Hide it when they don't have read access.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canViewPatients = permsReady && hasPermission('patients', 'read');
 
   const [plans, setPlans] = useState([]);
   const [services, setServices] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState('Active'); // All / Active / Expired / Inactive
+  // Filter set differs by role — admins see catalog-management filters;
+  // users see their own selection state. Default tab is "Active" for both,
+  // since that's the most useful first view in either role.
+  const [filter, setFilter] = useState('Active');
   const [query, setQuery] = useState('');
   const [openMenuId, setOpenMenuId] = useState(null);
   const [editingPlan, setEditingPlan] = useState(null); // null = closed, {} = new, plan = edit
   const [detailPlan, setDetailPlan] = useState(null);
 
+  // User-side "owned" plans — backed by real Membership rows in the DB
+  // now that purchase goes through Razorpay. Was previously a
+  // localStorage wishlist; the localStorage path is gone since the
+  // payment modal creates a real Membership on successful confirm.
+  // Admins don't read this; they use the catalog filters.
+  const [myMemberships, setMyMemberships] = useState([]);
+  const ownedPlanIds = useMemo(
+    () => new Set(myMemberships.map((m) => m.planId).filter(Boolean)),
+    [myMemberships],
+  );
+
+  // Plan currently in the payment modal (null = closed).
+  const [purchasePlan, setPurchasePlan] = useState(null);
+  const [paying, setPaying] = useState(false);
+
   const load = () => {
     setLoading(true);
+    // The membership listing call below is admin-only (phiReadGate via
+    // /patients/:id/memberships) — for non-admin viewers we fall back to
+    // /appointments/my-memberships which is scoped to the caller's own
+    // patient row. Admins don't render the "Selected" tab anyway so the
+    // null fetch is fine for them.
+    const memberCall = isAdmin
+      ? Promise.resolve([])
+      : fetchApi('/api/wellness/appointments/my-memberships').catch(() => []);
     Promise.all([
       fetchApi('/api/wellness/membership-plans?includeInactive=1').catch(() => []),
       fetchApi('/api/wellness/services').catch(() => []),
+      memberCall,
     ])
-      .then(([p, s]) => {
+      .then(([p, s, m]) => {
         setPlans(Array.isArray(p) ? p : []);
         setServices(Array.isArray(s) ? s : []);
+        setMyMemberships(Array.isArray(m) ? m : []);
       })
       .finally(() => setLoading(false));
   };
-  useEffect(load, []);
+  useEffect(load, [isAdmin]);
+
+  // Razorpay handshake. Opens an order, launches the checkout modal, and
+  // on success POSTs the signature back so the backend creates the
+  // Membership row. Closing the Razorpay modal without paying just
+  // resets state — no Membership is created.
+  const startPurchase = async (plan) => {
+    if (!plan || paying) return;
+    setPaying(true);
+    try {
+      const order = await fetchApi(
+        `/api/wellness/membership-plans/${plan.id}/purchase/order`,
+        { method: 'POST' },
+      );
+      if (!order?.orderId || !order?.paymentId || !order?.key) {
+        throw new Error(order?.error || 'Failed to create payment order');
+      }
+
+      let Razorpay;
+      try {
+        Razorpay = await loadRazorpaySdk();
+      } catch (sdkErr) {
+        throw new Error(sdkErr.message || 'Razorpay SDK failed to load');
+      }
+
+      await new Promise((resolve) => {
+        const options = {
+          key: order.key,
+          order_id: order.orderId,
+          amount: order.amount,
+          currency: order.currency,
+          name: 'Membership Purchase',
+          description: plan.name,
+          prefill: {
+            name: user?.name || '',
+            email: user?.email || '',
+          },
+          theme: { color: '#265855' },
+          handler: async (response) => {
+            try {
+              const confirm = await fetchApi(
+                `/api/wellness/membership-plans/${plan.id}/purchase/confirm`,
+                {
+                  method: 'POST',
+                  body: JSON.stringify({
+                    paymentId: order.paymentId,
+                    razorpay_order_id: response.razorpay_order_id,
+                    razorpay_payment_id: response.razorpay_payment_id,
+                    razorpay_signature: response.razorpay_signature,
+                  }),
+                },
+              );
+              if (confirm?.success) {
+                notify.success(`${plan.name} activated. You can apply it when booking an appointment.`);
+                setPurchasePlan(null);
+                await load();
+              } else {
+                notify.error(confirm?.error || 'Payment verification failed');
+              }
+            } catch (err) {
+              notify.error(err?.message || 'Payment verification failed');
+            } finally {
+              setPaying(false);
+              resolve();
+            }
+          },
+          modal: {
+            ondismiss: () => {
+              setPaying(false);
+              resolve();
+            },
+          },
+        };
+        const rzp = new Razorpay(options);
+        rzp.open();
+      });
+    } catch (err) {
+      notify.error(err?.message || 'Failed to start payment');
+      setPaying(false);
+    }
+  };
 
   // Close the per-card three-dot menu when the user clicks outside it.
   useEffect(() => {
@@ -102,23 +243,60 @@ export default function Memberships() {
     return () => document.removeEventListener('click', onDoc);
   }, [openMenuId]);
 
+  // Filter tabs differ by role:
+  //   Admin   → All / Active / Expired / Inactive (catalog-management view)
+  //   User    → Active / My memberships ("Active" only surfaces plans the
+  //             user doesn't already own, so the tab stays actionable
+  //             instead of duplicating the owned tab)
+  // The Expired tab on the admin side still always reads 0 because the
+  // MembershipPlan model has no expiry — only individual Memberships do. It
+  // stays for visual parity with the design.
+  const filterTabs = isAdmin
+    ? ['All', 'Active', 'Expired', 'Inactive']
+    : ['Active', 'My memberships'];
+
   const counts = useMemo(() => {
-    return {
-      All: plans.length,
-      Active: plans.filter((p) => p.isActive).length,
-      Inactive: plans.filter((p) => !p.isActive).length,
-      // MembershipPlan has no expiry concept — only individual Memberships do.
-      // The Expired filter exists for visual parity with the design; on a
-      // pure-plans page it always reads 0 unless we extend the data model.
-      Expired: 0,
-    };
-  }, [plans]);
+    if (isAdmin) {
+      return {
+        All: plans.length,
+        Active: plans.filter((p) => p.isActive).length,
+        Inactive: plans.filter((p) => !p.isActive).length,
+        Expired: 0,
+      };
+    }
+    // User-side counts: Active = active plans the user doesn't already own;
+    // My memberships = plans the user has bought. Inactive / expired plans
+    // are hidden from users.
+    const activeForUser = plans.filter((p) => p.isActive && !ownedPlanIds.has(p.id));
+    const owned = plans.filter((p) => ownedPlanIds.has(p.id));
+    return { Active: activeForUser.length, 'My memberships': owned.length };
+  }, [plans, isAdmin, ownedPlanIds]);
+
+  // Reset to a valid filter if the user role changes mid-session (e.g. an
+  // admin demotes themselves) or the current filter doesn't exist for the
+  // current role. Without this, a stale "Inactive" filter on a non-admin
+  // viewer would render zero rows with no way to recover.
+  useEffect(() => {
+    if (!filterTabs.includes(filter)) setFilter(filterTabs[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin]);
 
   const visiblePlans = useMemo(() => {
     let rows = plans;
-    if (filter === 'Active') rows = rows.filter((p) => p.isActive);
-    else if (filter === 'Inactive') rows = rows.filter((p) => !p.isActive);
-    else if (filter === 'Expired') rows = []; // see counts comment above
+    if (isAdmin) {
+      if (filter === 'Active') rows = rows.filter((p) => p.isActive);
+      else if (filter === 'Inactive') rows = rows.filter((p) => !p.isActive);
+      else if (filter === 'Expired') rows = []; // see counts comment above
+    } else {
+      // User view: hide inactive plans entirely, then split by ownership.
+      const activeOnly = rows.filter((p) => p.isActive);
+      if (filter === 'My memberships') {
+        rows = activeOnly.filter((p) => ownedPlanIds.has(p.id));
+      } else {
+        // Active tab = available-to-buy (i.e. active AND not yet owned).
+        rows = activeOnly.filter((p) => !ownedPlanIds.has(p.id));
+      }
+    }
     if (query.trim()) {
       const q = query.trim().toLowerCase();
       rows = rows.filter((p) =>
@@ -127,7 +305,7 @@ export default function Memberships() {
       );
     }
     return rows;
-  }, [plans, filter, query]);
+  }, [plans, filter, query, isAdmin, ownedPlanIds]);
 
   const softDeletePlan = async (plan, label = 'Deactivated') => {
     try {
@@ -198,7 +376,7 @@ export default function Memberships() {
           />
         </div>
         <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
-          {['All', 'Active', 'Expired', 'Inactive'].map((f) => {
+          {filterTabs.map((f) => {
             const active = filter === f;
             return (
               <button
@@ -208,9 +386,9 @@ export default function Memberships() {
                 style={{
                   display: 'inline-flex', alignItems: 'center', gap: '0.3rem',
                   padding: '0.45rem 0.95rem',
-                  background: active ? '#111' : 'transparent',
+                  background: active ? 'var(--primary-color, var(--accent-color))' : 'transparent',
                   color: active ? '#fff' : 'var(--text-primary)',
-                  border: active ? '1px solid #111' : '1px solid var(--border-color, rgba(255,255,255,0.18))',
+                  border: active ? '1px solid transparent' : '1px solid var(--border-color, rgba(255,255,255,0.18))',
                   borderRadius: 999, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500,
                 }}
               >
@@ -220,27 +398,46 @@ export default function Memberships() {
             );
           })}
         </div>
-        <button
-          type="button"
-          onClick={() => notify.info('Member-level view is coming soon — for now, see /wellness/patients to drill into a member.')}
-          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: '0.4rem', padding: '0.5rem 1rem', background: 'transparent', border: '1px solid var(--border-color, rgba(255,255,255,0.18))', borderRadius: 8, color: 'var(--text-primary)', cursor: 'pointer', fontSize: '0.85rem' }}
-        >
-          <Users size={14} /> View Members
-        </button>
+        {canViewPatients && (
+          <button
+            type="button"
+            // A dedicated members list isn't built yet, but members are
+            // patients — taking the user to the Patients page is the most
+            // useful version of "view members" we can ship today. Only
+            // surfaced when the viewer has patients.read; otherwise the
+            // destination would just 403 on every API call.
+            onClick={() => {
+              notify.info("Opening Patients — each member's plan and visits are on their patient page.");
+              navigate('/wellness/patients');
+            }}
+            style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: '0.4rem', padding: '0.5rem 1rem', background: 'transparent', border: '1px solid var(--border-color, rgba(255,255,255,0.18))', borderRadius: 8, color: 'var(--text-primary)', cursor: 'pointer', fontSize: '0.85rem' }}
+          >
+            <Users size={14} /> View Members
+          </button>
+        )}
       </div>
 
       {loading ? (
         <p style={{ color: 'var(--text-secondary)' }}>Loading membership plans…</p>
       ) : visiblePlans.length === 0 ? (
         <div className="glass" style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>
-          {query.trim() || filter !== 'Active'
-            ? 'No plans match the current filter.'
-            : (
-              <>
-                No active membership plans yet.
-                {isAdmin && <> Tap the <strong>+</strong> button below to create one.</>}
-              </>
-            )}
+          {/* Empty-state copy is filter-aware so users get a useful next-step
+              instead of the generic "no matches" line — especially on the
+              user-side "Selected" tab when they haven't picked anything yet. */}
+          {query.trim()
+            ? 'No plans match your search.'
+            : !isAdmin && filter === 'My memberships'
+              ? "You don't have a membership yet. Open the Active tab to browse what's available."
+              : !isAdmin && filter === 'Active'
+                ? 'No membership plans are available right now. Please check back later.'
+                : filter !== 'Active'
+                  ? 'No plans match the current filter.'
+                  : (
+                      <>
+                        No active membership plans yet.
+                        {isAdmin && <> Tap the <strong>+</strong> button below to create one.</>}
+                      </>
+                    )}
         </div>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1.25rem' }}>
@@ -249,6 +446,7 @@ export default function Memberships() {
               key={p.id}
               plan={p}
               isAdmin={isAdmin}
+              isOwned={ownedPlanIds.has(p.id)}
               menuOpen={openMenuId === p.id}
               onToggleMenu={(e) => { e.stopPropagation(); setOpenMenuId(openMenuId === p.id ? null : p.id); }}
               onCloseMenu={() => setOpenMenuId(null)}
@@ -256,6 +454,7 @@ export default function Memberships() {
               onEdit={() => { setOpenMenuId(null); setEditingPlan(p); }}
               onDelete={() => { setOpenMenuId(null); handleDelete(p); }}
               onDeactivate={() => { setOpenMenuId(null); handleDeactivate(p); }}
+              onBuy={() => setPurchasePlan(p)}
             />
           ))}
         </div>
@@ -294,8 +493,23 @@ export default function Memberships() {
         <PlanDetailModal
           plan={detailPlan}
           services={services}
+          isAdmin={isAdmin}
+          isOwned={ownedPlanIds.has(detailPlan.id)}
           onClose={() => setDetailPlan(null)}
           onEdit={() => { setDetailPlan(null); setEditingPlan(detailPlan); }}
+          onBuy={() => {
+            setPurchasePlan(detailPlan);
+            setDetailPlan(null);
+          }}
+        />
+      )}
+
+      {purchasePlan && (
+        <PurchaseModal
+          plan={purchasePlan}
+          paying={paying}
+          onClose={() => { if (!paying) setPurchasePlan(null); }}
+          onPay={() => startPurchase(purchasePlan)}
         />
       )}
     </div>
@@ -304,7 +518,7 @@ export default function Memberships() {
 
 // ── Card ──────────────────────────────────────────────────────────
 
-function PlanCard({ plan, isAdmin, menuOpen, onToggleMenu, onCloseMenu, onView, onEdit, onDelete, onDeactivate }) {
+function PlanCard({ plan, isAdmin, isOwned, menuOpen, onToggleMenu, onCloseMenu, onView, onEdit, onDelete, onDeactivate, onBuy }) {
   const gradient = planGradient(plan);
   const isActive = plan.isActive !== false;
   return (
@@ -323,9 +537,11 @@ function PlanCard({ plan, isAdmin, menuOpen, onToggleMenu, onCloseMenu, onView, 
       }}
       onClick={onView}
     >
-      {/* "Active" diagonal ribbon — top-left. Only renders on active rows
-          (matches the design where inactive cards just look dimmed). */}
-      {isActive && (
+      {/* Diagonal ribbon — top-left. For non-admin viewers who've already
+          bought the plan it flips to "Active" (accent color) so the
+          owned state is visible at a glance. Admin views ignore ownership —
+          they only see catalog Active state. */}
+      {(isActive || (isOwned && !isAdmin)) && (
         <div
           style={{
             position: 'absolute', top: 0, left: 0, width: 90, height: 90,
@@ -335,12 +551,13 @@ function PlanCard({ plan, isAdmin, menuOpen, onToggleMenu, onCloseMenu, onView, 
           <div style={{
             position: 'absolute', top: 12, left: -28, width: 110,
             transform: 'rotate(-45deg)', transformOrigin: 'center',
-            background: '#16a34a', color: '#fff', fontSize: '0.65rem',
+            background: (!isAdmin && isOwned) ? 'var(--primary-color, var(--accent-color))' : '#16a34a',
+            color: '#fff', fontSize: '0.65rem',
             fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase',
             padding: '3px 0', textAlign: 'center',
             boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
           }}>
-            Active
+            {(!isAdmin && isOwned) ? 'Owned' : 'Active'}
           </div>
         </div>
       )}
@@ -390,10 +607,58 @@ function PlanCard({ plan, isAdmin, menuOpen, onToggleMenu, onCloseMenu, onView, 
         <div style={{ fontSize: '0.95rem', fontWeight: 500 }}>{formatMoney(plan.price, plan.currency || 'INR')}</div>
       </div>
 
-      <div style={{ marginTop: '0.5rem', display: 'flex', justifyContent: 'flex-end' }}>
-        <span style={{ fontSize: '0.85rem', textDecoration: 'underline', textUnderlineOffset: '3px' }}>
+      {/* Footer action row. Admins only see "View Details" since picking a
+          plan isn't meaningful for them. Non-admin viewers see an inline
+          Select / Selected button so they can act on the plan directly
+          without opening the detail modal — the modal stays available for
+          plan information but is no longer the only path. */}
+      <div
+        style={{ marginTop: '0.5rem', display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: '0.75rem' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onView}
+          style={{
+            background: 'transparent', border: 'none', color: '#fff',
+            fontSize: '0.85rem', cursor: 'pointer',
+            textDecoration: 'underline', textUnderlineOffset: '3px', padding: 0,
+          }}
+        >
           View Details
-        </span>
+        </button>
+        {!isAdmin && (
+          isOwned ? (
+            <span
+              title="You own this plan"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: '0.35rem',
+                padding: '0.4rem 0.85rem',
+                background: 'rgba(255,255,255,0.92)',
+                color: '#111', borderRadius: 8,
+                fontSize: '0.8rem', fontWeight: 600,
+              }}
+            >
+              <Check size={13} /> Owned
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={onBuy}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: '0.35rem',
+                padding: '0.4rem 0.85rem',
+                background: 'rgba(0,0,0,0.35)',
+                color: '#fff',
+                border: '1px solid rgba(255,255,255,0.35)',
+                borderRadius: 8,
+                cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600,
+              }}
+            >
+              <CreditCard size={13} /> Buy
+            </button>
+          )
+        )}
       </div>
     </div>
   );
@@ -422,7 +687,7 @@ function MenuItem({ icon, label, onClick, danger }) {
 
 // ── Detail modal ──────────────────────────────────────────────────
 
-function PlanDetailModal({ plan, services, onClose, onEdit }) {
+function PlanDetailModal({ plan, services, isAdmin, isOwned, onClose, onEdit, onBuy }) {
   const entitlements = useMemo(() => {
     try {
       const parsed = JSON.parse(plan.entitlements || '[]');
@@ -472,29 +737,34 @@ function PlanDetailModal({ plan, services, onClose, onEdit }) {
 
   return createPortal((
     <div
-      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
+      style={{ position: 'fixed', inset: 0, background: 'var(--overlay-bg, rgba(0,0,0,0.45))', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
       onClick={onClose}
     >
       <div style={{
         maxWidth: 540, width: '100%', maxHeight: '92vh', overflow: 'auto',
         borderRadius: 14, position: 'relative',
-        background: '#fff', color: '#111',
+        // Theme-aware surface: --tooltip-bg is the canonical near-solid popover
+        // surface (dark navy in dark mode, near-white in light mode), so the
+        // modal stays legible against the page underneath in both themes.
+        background: 'var(--tooltip-bg, #fff)',
+        color: 'var(--text-primary, #111)',
+        border: '1px solid var(--border-color, rgba(0,0,0,0.08))',
         boxShadow: '0 25px 50px rgba(0,0,0,0.35)',
       }} onClick={(e) => e.stopPropagation()}>
-        <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', top: 14, right: 14, background: 'transparent', border: 'none', color: '#444', cursor: 'pointer', display: 'flex', zIndex: 2 }}>
+        <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', top: 14, right: 14, background: 'transparent', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', display: 'flex', zIndex: 2 }}>
           <X size={20} />
         </button>
 
         <div style={{ padding: '1.5rem 1.5rem 1rem' }}>
           {/* Plan header — monitor pill, name, price */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', color: '#444', fontSize: '0.95rem', marginTop: '0.25rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', color: 'var(--text-secondary)', fontSize: '0.95rem', marginTop: '0.25rem' }}>
             <Monitor size={18} /> {durationLabel(plan.durationDays)}
           </div>
           <h2 style={{ fontSize: '1.45rem', fontWeight: 600, marginTop: '0.75rem', textTransform: 'capitalize' }}>{plan.name}</h2>
           <div style={{ fontSize: '1.25rem', fontWeight: 600, marginTop: '0.35rem' }}>{formatMoney(plan.price, plan.currency || 'INR')}</div>
         </div>
 
-        <div style={{ height: 1, background: '#e5e7eb', margin: '0 1.5rem' }} />
+        <div style={{ height: 1, background: 'var(--border-color)', margin: '0 1.5rem' }} />
 
         {/* Prepaid Card section. Fields the schema doesn't have yet are
             derived sensibly — Promotional Money = price, Credit Amount
@@ -563,10 +833,81 @@ function PlanDetailModal({ plan, services, onClose, onEdit }) {
         </Accordion>
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', padding: '0 1.5rem 1.25rem' }}>
-          <button onClick={onClose} style={{ padding: '0.5rem 1rem', borderRadius: 8, border: '1px solid #d1d5db', background: '#fff', color: '#111', cursor: 'pointer', fontSize: '0.85rem' }}>Close</button>
-          <button onClick={onEdit} style={{ padding: '0.5rem 1rem', borderRadius: 8, border: 'none', background: '#111', color: '#fff', cursor: 'pointer', fontSize: '0.85rem', display: 'inline-flex', alignItems: 'center', gap: '0.35rem', fontWeight: 600 }}>
-            <Pencil size={14} /> Edit plan
+          <button
+            onClick={onClose}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: 8,
+              border: '1px solid var(--border-color)',
+              background: 'transparent',
+              color: 'var(--text-primary)',
+              cursor: 'pointer',
+              fontSize: '0.85rem',
+            }}
+          >
+            Close
           </button>
+          {/* Role-aware primary CTA — admins/managers edit the plan; users
+              buy it (Razorpay handshake). The primary button uses theme
+              accent colors instead of hardcoded #111/#fff so it renders
+              correctly in both light + dark mode. */}
+          {isAdmin ? (
+            <button
+              onClick={onEdit}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: 8,
+                border: 'none',
+                background: 'var(--primary-color, var(--accent-color))',
+                color: '#fff',
+                cursor: 'pointer',
+                fontSize: '0.85rem',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.35rem',
+                fontWeight: 600,
+              }}
+            >
+              <Pencil size={14} /> Edit plan
+            </button>
+          ) : isOwned ? (
+            <span
+              title="You own this plan"
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: 8,
+                border: '1px solid var(--border-color)',
+                background: 'var(--subtle-bg)',
+                color: 'var(--text-primary)',
+                fontSize: '0.85rem',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.35rem',
+                fontWeight: 600,
+              }}
+            >
+              <Check size={14} /> Owned
+            </span>
+          ) : (
+            <button
+              onClick={onBuy}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: 8,
+                border: 'none',
+                background: 'var(--primary-color, var(--accent-color))',
+                color: '#fff',
+                cursor: 'pointer',
+                fontSize: '0.85rem',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.35rem',
+                fontWeight: 600,
+              }}
+            >
+              <CreditCard size={14} /> Buy plan
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -576,19 +917,19 @@ function PlanDetailModal({ plan, services, onClose, onEdit }) {
 function CardRow({ label, value }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem' }}>
-      <span style={{ color: '#555' }}>{label} :</span>
-      <strong style={{ color: '#111' }}>{value}</strong>
+      <span style={{ color: 'var(--text-secondary)' }}>{label} :</span>
+      <strong style={{ color: 'var(--text-primary)' }}>{value}</strong>
     </div>
   );
 }
 
 function Accordion({ label, open, onToggle, children }) {
   return (
-    <div style={{ borderTop: '1px solid #e5e7eb' }}>
+    <div style={{ borderTop: '1px solid var(--border-color)' }}>
       <button
         type="button"
         onClick={onToggle}
-        style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.85rem 1.5rem', background: 'transparent', border: 'none', color: '#111', cursor: 'pointer', fontSize: '0.95rem', fontWeight: 600 }}
+        style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.85rem 1.5rem', background: 'transparent', border: 'none', color: 'var(--text-primary)', cursor: 'pointer', fontSize: '0.95rem', fontWeight: 600 }}
       >
         <span>{label}</span>
         {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
@@ -604,18 +945,121 @@ function Accordion({ label, open, onToggle, children }) {
 
 function PlanRow({ title, trailingLabel, trailingValue }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.75rem 0.85rem', borderRadius: 10, background: '#f3f4f6', marginBottom: '0.5rem' }}>
-      <div style={{ fontSize: '0.95rem', fontWeight: 600, color: '#111' }}>{title}</div>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.75rem 0.85rem', borderRadius: 10, background: 'var(--subtle-bg)', marginBottom: '0.5rem' }}>
+      <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-primary)' }}>{title}</div>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem' }}>
-        <span style={{ fontSize: '0.85rem', color: '#555' }}>{trailingLabel}</span>
-        <span style={{ fontSize: '0.85rem', fontWeight: 700, color: '#111' }}>{trailingValue}</span>
+        <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>{trailingLabel}</span>
+        <span style={{ fontSize: '0.85rem', fontWeight: 700, color: 'var(--text-primary)' }}>{trailingValue}</span>
       </div>
     </div>
   );
 }
 
 function RowEmpty({ children }) {
-  return <div style={{ padding: '0.6rem 0.85rem', color: '#555', fontSize: '0.85rem', fontStyle: 'italic' }}>{children}</div>;
+  return <div style={{ padding: '0.6rem 0.85rem', color: 'var(--text-secondary)', fontSize: '0.85rem', fontStyle: 'italic' }}>{children}</div>;
+}
+
+// ── Payment modal ─────────────────────────────────────────────────
+// Confirmation step that fronts the Razorpay checkout. The actual
+// gateway handshake (order create, SDK load, checkout open, confirm
+// POST) lives on the parent so this stays a thin, dismissable surface.
+
+function PurchaseModal({ plan, paying, onClose, onPay }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape' && !paying) onClose(); };
+    document.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.removeEventListener('keydown', onKey); document.body.style.overflow = prev; };
+  }, [onClose, paying]);
+
+  return createPortal((
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Buy membership plan"
+      data-testid="membership-purchase-modal"
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
+      onClick={(e) => { if (e.target === e.currentTarget && !paying) onClose(); }}
+    >
+      <div
+        className="glass"
+        style={{
+          background: 'var(--tooltip-bg, var(--surface-color, #fff))',
+          color: 'var(--text-primary, #111)',
+          borderRadius: 12,
+          border: '1px solid var(--border-color, rgba(0,0,0,0.08))',
+          padding: '1.5rem',
+          maxWidth: 460,
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+        }}
+      >
+        <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ fontSize: '1.15rem', fontWeight: 600, margin: 0, display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
+            <Crown size={18} /> Buy {plan.name}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            disabled={paying}
+            style={{
+              background: 'transparent', border: 'none',
+              cursor: paying ? 'not-allowed' : 'pointer',
+              color: 'var(--text-secondary)',
+              padding: 4,
+            }}
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+          You'll pay <strong style={{ color: 'var(--text-primary)' }}>{formatMoney(plan.price, plan.currency || 'INR')}</strong> via Razorpay. The membership activates immediately on payment success and can be applied at appointment booking.
+        </div>
+
+        <div style={{
+          padding: '0.85rem 1rem',
+          borderRadius: 8,
+          background: 'var(--subtle-bg, rgba(0,0,0,0.04))',
+          border: '1px solid var(--border-color, rgba(0,0,0,0.08))',
+          fontSize: '0.85rem',
+          display: 'grid',
+          gap: '0.35rem',
+        }}>
+          <div><strong>{plan.name}</strong> <span style={{ color: 'var(--text-secondary)' }}>· {durationLabel(plan.durationDays)}</span></div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 600 }}>{formatMoney(plan.price, plan.currency || 'INR')}</div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onPay}
+          disabled={paying}
+          data-testid="membership-pay-now"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '0.5rem',
+            background: paying ? 'rgba(99,102,241,0.4)' : 'var(--primary-color, var(--accent-color))',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0.7rem 1rem',
+            fontWeight: 600,
+            cursor: paying ? 'not-allowed' : 'pointer',
+            fontSize: '0.9rem',
+          }}
+        >
+          <CreditCard size={14} />
+          {paying ? 'Opening Razorpay…' : `Pay ${formatMoney(plan.price, plan.currency || 'INR')} with Razorpay`}
+        </button>
+      </div>
+    </div>
+  ), document.body);
 }
 
 // ── Create / edit modal ───────────────────────────────────────────

--- a/frontend/src/pages/wellness/MyPrescriptions.jsx
+++ b/frontend/src/pages/wellness/MyPrescriptions.jsx
@@ -1,0 +1,261 @@
+// Staff-authed self-view of own prescriptions — companion to the
+// patient-portal PatientPortal.jsx prescriptions tab.
+//
+// Backend: GET /api/wellness/my-prescriptions
+//          GET /api/wellness/my-prescriptions/:id/pdf
+//          Both gated on `my_prescriptions.read` (RBAC), staff JWT,
+//          scoped to the logged-in user's linked Patient record.
+//
+// Empty states distinguish:
+//   - "no Rx yet" (user IS linked to a Patient, no prescriptions)
+//   - "profile not linked" (no Patient.userId match in this tenant)
+// The second case isn't an error — it tells the staff member their
+// clinic hasn't linked their User account to a Patient record yet,
+// with a clear next-step ("ask the clinic to link your profile").
+
+import { useEffect, useState, useCallback } from 'react';
+import {
+  Pill,
+  Download,
+  FileText,
+  AlertCircle,
+} from 'lucide-react';
+import { fetchApi } from '../../utils/api';
+import { useNotify } from '../../utils/notify';
+import { formatDate } from '../../utils/date';
+
+export default function MyPrescriptions() {
+  const notify = useNotify();
+  const [data, setData] = useState({ patient: null, prescriptions: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetchApi('/api/wellness/my-prescriptions');
+      setData({
+        patient: res?.patient || null,
+        prescriptions: Array.isArray(res?.prescriptions) ? res.prescriptions : [],
+      });
+    } catch (ex) {
+      setError(ex.message || 'Failed to load prescriptions');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const downloadRx = async (rxId) => {
+    try {
+      // Bypass fetchApi for binary response; reuse the same auth header.
+      const token = localStorage.getItem('token');
+      const r = await fetch(`/api/wellness/my-prescriptions/${rxId}/pdf`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!r.ok) throw new Error('PDF download failed');
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `prescription-${rxId}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (ex) {
+      notify.error?.(`Could not download: ${ex.message}`);
+    }
+  };
+
+  const { patient, prescriptions } = data;
+
+  return (
+    <div style={{ padding: '2rem', animation: 'fadeIn 0.4s ease-out' }}>
+      <header style={{ marginBottom: '1.5rem' }}>
+        <h1
+          style={{
+            fontSize: '1.75rem',
+            fontWeight: 600,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+          }}
+        >
+          <Pill size={24} /> My Prescriptions
+        </h1>
+        <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
+          Prescriptions written for you at this clinic. Tap a card to download
+          the signed PDF.
+        </p>
+      </header>
+
+      {loading && <div style={{ padding: '1rem' }}>Loading…</div>}
+
+      {!loading && error && (
+        <div className="glass" style={errorBoxStyle} role="alert">
+          <AlertCircle size={18} /> {error}
+        </div>
+      )}
+
+      {/* Profile-not-linked empty state — staff user with no Patient.userId
+          match in this tenant. Informational; tells them what to do. */}
+      {!loading && !error && !patient && (
+        <div className="glass" style={emptyBoxStyle}>
+          <FileText size={28} style={{ marginBottom: '0.5rem', opacity: 0.5 }} />
+          <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
+            No patient profile linked
+          </div>
+          <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+            Your staff account isn&rsquo;t linked to a patient record at this
+            clinic yet. Ask the front desk to link your profile so your
+            prescriptions appear here.
+          </div>
+        </div>
+      )}
+
+      {/* No-prescriptions empty state — linked Patient exists, just no
+          Rx on file yet. */}
+      {!loading && !error && patient && prescriptions.length === 0 && (
+        <div className="glass" style={emptyBoxStyle}>
+          <Pill size={28} style={{ marginBottom: '0.5rem', opacity: 0.5 }} />
+          <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
+            No prescriptions on file yet
+          </div>
+          <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+            Anything your doctor writes for you will appear here.
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && prescriptions.length > 0 && (
+        <div style={{ display: 'grid', gap: '0.75rem' }}>
+          {prescriptions.map((rx) => {
+            let drugs = [];
+            try {
+              drugs = JSON.parse(rx.drugs || '[]');
+            } catch {
+              drugs = [];
+            }
+            return (
+              <div key={rx.id} className="glass" style={{ padding: '1rem' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: '1rem',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <div>
+                    <div
+                      style={{
+                        fontWeight: 600,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.4rem',
+                      }}
+                    >
+                      <Pill size={15} /> Prescription #{rx.id}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: '0.8rem',
+                        color: 'var(--text-secondary)',
+                        marginTop: '0.2rem',
+                      }}
+                    >
+                      {formatDate(rx.createdAt)}
+                      {rx.doctor?.name && ` · Dr ${rx.doctor.name}`}
+                      {rx.visit?.service?.name && ` · ${rx.visit.service.name}`}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => downloadRx(rx.id)}
+                    style={pdfButtonStyle}
+                  >
+                    <Download size={13} /> PDF
+                  </button>
+                </div>
+                {drugs.length > 0 && (
+                  <ul
+                    style={{
+                      listStyle: 'none',
+                      padding: 0,
+                      marginTop: '0.75rem',
+                      display: 'grid',
+                      gap: '0.35rem',
+                    }}
+                  >
+                    {drugs.map((d, i) => (
+                      <li
+                        key={i}
+                        style={{
+                          fontSize: '0.85rem',
+                          padding: '0.4rem 0.6rem',
+                          background: 'var(--subtle-bg-2)',
+                          borderRadius: 6,
+                        }}
+                      >
+                        <strong>{d.name}</strong>
+                        {d.dosage && ` — ${d.dosage}`}
+                        {d.frequency && `, ${d.frequency}`}
+                        {d.duration && ` for ${d.duration}`}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {rx.instructions && (
+                  <p
+                    style={{
+                      fontSize: '0.85rem',
+                      color: 'var(--text-secondary)',
+                      marginTop: '0.6rem',
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    {rx.instructions}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const emptyBoxStyle = {
+  padding: '2rem',
+  textAlign: 'center',
+  color: 'var(--text-primary)',
+};
+
+const errorBoxStyle = {
+  padding: '1rem',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  color: 'var(--text-primary)',
+  borderLeft: '3px solid var(--danger-color, #ef4444)',
+};
+
+const pdfButtonStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.3rem',
+  padding: '0.4rem 0.8rem',
+  background: 'var(--primary-color, var(--accent-color))',
+  border: 'none',
+  borderRadius: 6,
+  color: '#fff',
+  cursor: 'pointer',
+  fontSize: '0.8rem',
+};

--- a/frontend/src/pages/wellness/PatientPortal.jsx
+++ b/frontend/src/pages/wellness/PatientPortal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   HeartPulse,
   Phone,
@@ -277,19 +277,52 @@ function Dashboard({ token, onLogout }) {
   const [me, setMe] = useState(null);
   const [visits, setVisits] = useState([]);
   const [prescriptions, setPrescriptions] = useState([]);
+  // Patient permission set resolved from /portal/me/permissions. Driven by
+  // the tenant's CUSTOMER role permissions (see backend/lib/portalPermissions.js).
+  // Tabs that require a permission render only when that permission is in
+  // this set — the backend still enforces the same gate, this is just
+  // sidebar/tab visibility.
+  const [permissions, setPermissions] = useState(null);
   const [loading, setLoading] = useState(true);
+
+  const hasPerm = useCallback(
+    (key) => Array.isArray(permissions) && permissions.includes(key),
+    [permissions],
+  );
 
   const loadAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [m, v, p] = await Promise.all([
+      // Always-permitted fetches first (profile + permissions). Without
+      // permissions resolved we can't decide whether to attempt the Rx
+      // fetch, so this MUST resolve before the gated calls below.
+      const [m, perms] = await Promise.all([
         portalFetch('/api/wellness/portal/me', token),
-        portalFetch('/api/wellness/portal/visits', token),
-        portalFetch('/api/wellness/portal/prescriptions', token),
+        portalFetch('/api/wellness/portal/me/permissions', token),
       ]);
+      const permList = Array.isArray(perms?.permissions) ? perms.permissions : [];
       setMe(m);
+      setPermissions(permList);
+
+      // Visits is always shown for now (no per-tab gate yet); Rx is
+      // gated on `my_prescriptions.read`. Skip the gated fetches when
+      // the permission is missing so we don't surface a 403 toast.
+      const v = await portalFetch('/api/wellness/portal/visits', token);
       setVisits(v || []);
-      setPrescriptions(p || []);
+
+      if (permList.includes('my_prescriptions.read')) {
+        try {
+          const p = await portalFetch('/api/wellness/portal/prescriptions', token);
+          setPrescriptions(p || []);
+        } catch (rxEx) {
+          // 403 here means the permission was revoked between the perms
+          // fetch and the Rx fetch (rare race). Treat as "no access" and
+          // leave the list empty; the tab is already hidden by hasPerm.
+          if (!/forbidden|denied/i.test(rxEx.message || '')) throw rxEx;
+        }
+      } else {
+        setPrescriptions([]);
+      }
     } catch (ex) {
       if (/token/i.test(ex.message)) onLogout();
     } finally {
@@ -326,12 +359,38 @@ function Dashboard({ token, onLogout }) {
     }
   };
 
-  const tabs = [
-    { key: 'visits', label: 'My Visits', icon: CalendarIcon },
-    { key: 'prescriptions', label: 'Prescriptions', icon: Pill },
-    { key: 'plan', label: 'Treatment Plan', icon: ClipboardList },
-    { key: 'consent', label: 'Consent Forms', icon: ShieldCheck },
-  ];
+  // Tab list — each entry can declare a `permission` it depends on.
+  // Filter out tabs the patient lacks permission for so the nav doesn't
+  // show a link the backend will 403 on. `permissions === null` (still
+  // loading) hides gated tabs to avoid a flash of unavailable UI.
+  // useMemo'd so the array reference stays stable across renders — the
+  // useEffect below depends on `tabs` and would re-run every render
+  // otherwise.
+  const tabs = useMemo(() => {
+    const allTabs = [
+      { key: 'visits', label: 'My Visits', icon: CalendarIcon },
+      {
+        key: 'prescriptions',
+        label: 'Prescriptions',
+        icon: Pill,
+        permission: 'my_prescriptions.read',
+      },
+      { key: 'plan', label: 'Treatment Plan', icon: ClipboardList },
+      { key: 'consent', label: 'Consent Forms', icon: ShieldCheck },
+    ];
+    return allTabs.filter((t) => !t.permission || hasPerm(t.permission));
+  }, [hasPerm]);
+
+  // If the currently-selected tab got filtered out (permission revoked
+  // mid-session, or initial load resolved without the grant), fall back
+  // to the first visible tab so the main panel never tries to render a
+  // hidden tab's content.
+  useEffect(() => {
+    if (permissions === null) return;
+    if (!tabs.find((t) => t.key === tab)) {
+      setTab(tabs[0]?.key || 'visits');
+    }
+  }, [permissions, tab, tabs]);
 
   return (
     <div style={{ minHeight: '100vh', background: 'var(--bg-color, #0b1220)' }}>

--- a/frontend/src/pages/wellness/Patients.jsx
+++ b/frontend/src/pages/wellness/Patients.jsx
@@ -408,31 +408,77 @@ export default function Patients() {
   return (
     <div style={{ padding: "2rem", animation: "fadeIn 0.5s ease-out" }}>
       <header
+        className="glass"
         style={{
           marginBottom: "1.5rem",
+          padding: "1.25rem 1.5rem",
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
-          gap: "1rem",
+          gap: "1.25rem",
           flexWrap: "wrap",
         }}
       >
-        <div>
-          <h1
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem", minWidth: 0 }}>
+          {/* Teal icon chip — gives the page header a visual anchor instead
+              of letting the title float as bare text. Matches the wellness
+              primary palette so the chip reads as brand, not decoration. */}
+          <div
+            aria-hidden="true"
             style={{
-              fontFamily: "var(--font-family)",
-              fontSize: "1.75rem",
-              fontWeight: 600,
+              width: 48,
+              height: 48,
+              borderRadius: 14,
+              background: "var(--primary-color, var(--accent-color))",
+              color: "#fff",
               display: "flex",
               alignItems: "center",
-              gap: "0.5rem",
+              justifyContent: "center",
+              flexShrink: 0,
+              boxShadow: "0 6px 16px rgba(38, 88, 85, 0.28)",
             }}
           >
-            <Users size={24} /> Patients
-          </h1>
-          <p style={{ color: "var(--text-secondary)", marginTop: "0.25rem" }}>
-            {total.toLocaleString()} total
-          </p>
+            <Users size={24} />
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <h1
+              style={{
+                fontFamily: "var(--font-family)",
+                fontSize: "1.5rem",
+                fontWeight: 600,
+                margin: 0,
+                lineHeight: 1.2,
+              }}
+            >
+              Patients
+            </h1>
+            <div
+              style={{
+                marginTop: "0.4rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                flexWrap: "wrap",
+              }}
+            >
+              <span
+                style={{
+                  background: "rgba(38, 88, 85, 0.14)",
+                  color: "var(--primary-color, var(--accent-color))",
+                  padding: "2px 10px",
+                  borderRadius: 999,
+                  fontSize: "0.72rem",
+                  fontWeight: 600,
+                  letterSpacing: "0.02em",
+                }}
+              >
+                {total.toLocaleString()}
+              </span>
+              <span style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>
+                {total === 1 ? "patient on record" : "patients on record"}
+              </span>
+            </div>
+          </div>
         </div>
         <div style={{ display: "flex", gap: "0.5rem", alignItems: "center", flexWrap: "wrap" }}>
           <CsvImportExportToolbar
@@ -760,7 +806,14 @@ export default function Patients() {
                 <th style={{ ...thStyle, width: "10%" }}>Gender</th>
                 <th style={{ ...thStyle, width: "14%" }}>Source</th>
                 <th style={{ ...thStyle, width: "12%" }}>Added</th>
-                <th style={{ ...thStyle, width: "6%", textAlign: "center" }}>Actions</th>
+                {/* Fixed px width — 6% was too narrow on a typical viewport
+                    (~65px), truncating the "ACTIONS" header to "ACTIO..." and
+                    clipping the Edit/Delete icons. The clipped icon fragments
+                    rendered as visual "..." after the icons. overflow:visible
+                    + textOverflow:clip prevents the .stable-table CSS rule
+                    (which sets overflow:hidden + text-overflow:ellipsis on
+                    every td) from reintroducing the artifact. */}
+                <th style={{ ...thStyle, width: 110, textAlign: "center", overflow: "visible", textOverflow: "clip" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -798,7 +851,7 @@ export default function Patients() {
                   <td style={tdStyle}>
                     {formatDate(p.createdAt)}
                   </td>
-                  <td style={{ ...tdStyle, textAlign: "center" }}>
+                  <td style={{ ...tdStyle, textAlign: "center", overflow: "visible", textOverflow: "clip" }}>
                     <div style={{ display: "inline-flex", gap: "0.25rem", alignItems: "center" }}>
                       <button
                         onClick={() => startEdit(p)}

--- a/frontend/src/pages/wellness/PointOfSale.jsx
+++ b/frontend/src/pages/wellness/PointOfSale.jsx
@@ -44,11 +44,21 @@ import {
   Tag,
   ShieldAlert,
   MapPin,
+  Banknote,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
 import { formatMoney } from '../../utils/money';
 import { AuthContext } from '../../App';
+// Embedded admin-only "Manage registers" panel. Renders without its
+// outer page chrome when given `embedded`. Previously lived at its own
+// /wellness/cash-registers route but that route was never mounted in
+// App.jsx — sidebar 404'd, surface was unreachable. Folded into POS so
+// register CRUD, shift open/close, petty cash, and recent transactions
+// are accessible from the same surface where sales are rung up.
+import CashRegisters from './CashRegisters';
 
 const LINE_TYPES = [
   { value: 'SERVICE', label: 'Service' },
@@ -101,6 +111,11 @@ export default function PointOfSale() {
   const [busy, setBusy] = useState(false);
   const [lastReceipt, setLastReceipt] = useState(null);
   const notify = useNotify();
+
+  // Admin/manager-only "Manage registers" panel toggle. Renders the
+  // CashRegisters component embedded (no page chrome) when expanded.
+  // Default collapsed so the cashier-focused sale flow stays primary.
+  const [showRegistersPanel, setShowRegistersPanel] = useState(false);
 
   // Wave 7C extras (PRD Gap §2 items 2 + 10)
   const [guestCheckout, setGuestCheckout] = useState(false);
@@ -520,14 +535,84 @@ export default function PointOfSale() {
 
   return (
     <div style={{ padding: '2rem', animation: 'fadeIn 0.4s ease-out' }}>
-      <header style={{ marginBottom: '1.25rem' }}>
-        <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <Calculator size={24} /> Point of Sale
-        </h1>
-        <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
-          Cash-and-carry checkout. Open a shift, ring up sales, close the shift to reconcile the cash drawer.
-        </p>
+      <header
+        style={{
+          marginBottom: '1.25rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          flexWrap: 'wrap',
+          gap: '1rem',
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Calculator size={24} /> Point of Sale
+          </h1>
+          <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
+            Cash-and-carry checkout. Open a shift, ring up sales, close the shift to reconcile the cash drawer.
+          </p>
+        </div>
+        {/* Admin/manager-only "Manage registers" disclosure. Folds the
+            former /wellness/cash-registers page into this surface.
+            Collapsing the panel refreshes shift + register state so any
+            register CRUD / shift open-close performed inside the panel
+            reflects in the POS sale flow below without a manual reload. */}
+        {isAdminOrManager && (
+          <button
+            type="button"
+            onClick={() => {
+              setShowRegistersPanel((prev) => {
+                const next = !prev;
+                if (prev && !next) {
+                  // panel just closed — refresh POS-tracked state
+                  loadRegisters();
+                  loadCurrentShift();
+                }
+                return next;
+              });
+            }}
+            aria-expanded={showRegistersPanel}
+            aria-controls="pos-registers-panel"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              padding: '0.55rem 0.9rem',
+              background: showRegistersPanel
+                ? 'var(--primary-color, var(--accent-color))'
+                : 'rgba(255,255,255,0.05)',
+              color: showRegistersPanel ? '#fff' : 'var(--text-primary)',
+              border: '1px solid var(--border-color)',
+              borderRadius: 8,
+              cursor: 'pointer',
+              fontSize: '0.9rem',
+              fontWeight: 500,
+            }}
+          >
+            <Banknote size={16} /> Manage registers
+            {showRegistersPanel ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+        )}
       </header>
+
+      {/* Embedded register management panel — admin/manager only.
+          Renders the full CashRegisters surface (CRUD + shift open/close
+          + petty cash deposit/withdraw + transactions list) inline so
+          the operator never has to leave the POS page. */}
+      {isAdminOrManager && showRegistersPanel && (
+        <section
+          id="pos-registers-panel"
+          className="glass"
+          style={{
+            padding: '1.25rem',
+            marginBottom: '1.5rem',
+            borderLeft: '3px solid var(--primary-color, var(--accent-color))',
+          }}
+        >
+          <CashRegisters embedded />
+        </section>
+      )}
 
       {/* Shift status banner */}
       {currentShift ? (

--- a/frontend/src/pages/wellness/ProductCategories.jsx
+++ b/frontend/src/pages/wellness/ProductCategories.jsx
@@ -10,10 +10,17 @@ import {
 } from "lucide-react";
 import { fetchApi, getAuthToken } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
+import { usePermissions } from "../../hooks/usePermissions";
 
 export default function ProductCategories() {
   const notify = useNotify();
   const fileInputRef = useRef(null);
+  // Hide create/edit/delete affordances when the viewer can read but not
+  // manage products. Showing a button that 403s on click is hostile UX;
+  // hiding it (vs. disabling) keeps the page clean and signals read-only
+  // intent. A small "View only" badge in the header makes the mode explicit.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManage = permsReady ? hasPermission("products", "manage") : false;
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
@@ -173,29 +180,48 @@ export default function ProductCategories() {
           marginBottom: "2rem",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
           <Layers size={28} color="var(--accent-color)" />
           <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>
             Product Categories
           </h1>
+          {permsReady && !canManage && (
+            <span
+              title="You can view categories but can't make changes."
+              style={{
+                fontSize: "0.7rem",
+                padding: "0.2rem 0.55rem",
+                borderRadius: 999,
+                background: "var(--subtle-bg)",
+                color: "var(--text-secondary)",
+                border: "1px solid var(--border-color)",
+                letterSpacing: "0.02em",
+                fontWeight: 500,
+              }}
+            >
+              View only
+            </span>
+          )}
         </div>
-        <button
-          onClick={() => handleOpenModal()}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "0.5rem",
-            padding: "0.6rem 1.25rem",
-            background: "var(--primary-color, var(--accent-color))",
-            color: "#fff",
-            border: "none",
-            borderRadius: 8,
-            fontWeight: 500,
-            cursor: "pointer",
-          }}
-        >
-          <Plus size={16} /> Add Category
-        </button>
+        {canManage && (
+          <button
+            onClick={() => handleOpenModal()}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.6rem 1.25rem",
+              background: "var(--primary-color, var(--accent-color))",
+              color: "#fff",
+              border: "none",
+              borderRadius: 8,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            <Plus size={16} /> Add Category
+          </button>
+        )}
       </div>
 
       <div style={{ position: "relative", marginBottom: "1rem", maxWidth: 400 }}>
@@ -302,34 +328,38 @@ export default function ProductCategories() {
                   {cat._count?.children || 0} subcategories
                 </div>
               </div>
-              <div style={{ display: "flex", gap: "0.5rem" }}>
-                <button
-                  onClick={() => handleOpenModal(cat)}
-                  style={{
-                    padding: "0.5rem 0.75rem",
-                    background: "rgba(168, 85, 247, 0.1)",
-                    border: "none",
-                    borderRadius: 6,
-                    cursor: "pointer",
-                    color: "var(--accent-color)",
-                  }}
-                >
-                  <Edit2 size={16} />
-                </button>
-                <button
-                  onClick={() => handleDelete(cat.id)}
-                  style={{
-                    padding: "0.5rem 0.75rem",
-                    background: "rgba(239, 68, 68, 0.1)",
-                    border: "none",
-                    borderRadius: 6,
-                    cursor: "pointer",
-                    color: "#ef4444",
-                  }}
-                >
-                  <Trash2 size={16} />
-                </button>
-              </div>
+              {canManage && (
+                <div style={{ display: "flex", gap: "0.5rem" }}>
+                  <button
+                    onClick={() => handleOpenModal(cat)}
+                    aria-label={`Edit ${cat.name}`}
+                    style={{
+                      padding: "0.5rem 0.75rem",
+                      background: "rgba(168, 85, 247, 0.1)",
+                      border: "none",
+                      borderRadius: 6,
+                      cursor: "pointer",
+                      color: "var(--accent-color)",
+                    }}
+                  >
+                    <Edit2 size={16} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(cat.id)}
+                    aria-label={`Delete ${cat.name}`}
+                    style={{
+                      padding: "0.5rem 0.75rem",
+                      background: "rgba(239, 68, 68, 0.1)",
+                      border: "none",
+                      borderRadius: 6,
+                      cursor: "pointer",
+                      color: "#ef4444",
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/pages/wellness/Products.jsx
+++ b/frontend/src/pages/wellness/Products.jsx
@@ -2,10 +2,20 @@
 import { Package, Plus, Edit2, Trash2, AlertCircle, Search, Upload } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 
 export default function Products() {
   const notify = useNotify();
   const fileInputRef = useRef(null);
+  // Backend routes inventory.js gate POST=products.write,
+  // PUT=products.update, DELETE=products.delete. We default to fail-closed
+  // (canX=false until perms resolve) so buttons don't flash visible during
+  // the initial permission fetch.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canWriteProducts  = permsReady && hasPermission('products', 'write');
+  const canUpdateProducts = permsReady && hasPermission('products', 'update');
+  const canDeleteProducts = permsReady && hasPermission('products', 'delete');
+  const canMutateProducts = canWriteProducts || canUpdateProducts || canDeleteProducts;
   const [products, setProducts] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -235,27 +245,45 @@ export default function Products() {
   return (
     <div style={{ maxWidth: 1400, margin: '0 auto', padding: '2rem 1rem' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
           <Package size={28} color="var(--accent-color)" />
           <h1 style={{ fontSize: '1.5rem', fontWeight: 600, margin: 0 }}>Products</h1>
+          {permsReady && !canMutateProducts && (
+            <span
+              title="You can view products but can't make changes."
+              style={{
+                fontSize: '0.7rem',
+                padding: '0.2rem 0.55rem',
+                borderRadius: 999,
+                background: 'var(--subtle-bg)',
+                color: 'var(--text-secondary)',
+                border: '1px solid var(--border-color)',
+                fontWeight: 500,
+              }}
+            >
+              View only
+            </span>
+          )}
         </div>
-        <button
-          onClick={() => handleOpenModal()}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            padding: '0.6rem 1.25rem',
-            background: 'var(--accent-color)',
-            color: '#fff',
-            border: 'none',
-            borderRadius: 8,
-            fontWeight: 500,
-            cursor: 'pointer',
-          }}
-        >
-          <Plus size={16} /> Add Product
-        </button>
+        {canWriteProducts && (
+          <button
+            onClick={() => handleOpenModal()}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.6rem 1.25rem',
+              background: 'var(--accent-color)',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 8,
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            <Plus size={16} /> Add Product
+          </button>
+        )}
       </div>
 
       <div style={{ display: 'flex', gap: '1rem', marginBottom: '2rem' }}>
@@ -313,7 +341,9 @@ export default function Products() {
                 <th style={{ textAlign: 'right', padding: '1rem', fontWeight: 600 }}>Price</th>
                 <th style={{ textAlign: 'center', padding: '1rem', fontWeight: 600 }}>Stock</th>
                 <th style={{ textAlign: 'center', padding: '1rem', fontWeight: 600 }}>Type</th>
-                <th style={{ textAlign: 'center', padding: '1rem', fontWeight: 600 }}>Actions</th>
+                {(canUpdateProducts || canDeleteProducts) && (
+                  <th style={{ textAlign: 'center', padding: '1rem', fontWeight: 600 }}>Actions</th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -358,36 +388,44 @@ export default function Products() {
                     </span>
                   </td>
                   <td style={{ padding: '1rem', textAlign: 'center', fontSize: '0.85rem' }}>{product.productType || '-'}</td>
-                  <td style={{ padding: '1rem', textAlign: 'center' }}>
-                    <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
-                      <button
-                        onClick={() => handleOpenModal(product)}
-                        style={{
-                          padding: '0.4rem 0.6rem',
-                          background: 'rgba(168, 85, 247, 0.1)',
-                          border: 'none',
-                          borderRadius: 6,
-                          cursor: 'pointer',
-                          color: 'var(--accent-color)',
-                        }}
-                      >
-                        <Edit2 size={14} />
-                      </button>
-                      <button
-                        onClick={() => handleDelete(product.id)}
-                        style={{
-                          padding: '0.4rem 0.6rem',
-                          background: 'rgba(239, 68, 68, 0.1)',
-                          border: 'none',
-                          borderRadius: 6,
-                          cursor: 'pointer',
-                          color: '#ef4444',
-                        }}
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </div>
-                  </td>
+                  {(canUpdateProducts || canDeleteProducts) && (
+                    <td style={{ padding: '1rem', textAlign: 'center' }}>
+                      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+                        {canUpdateProducts && (
+                          <button
+                            onClick={() => handleOpenModal(product)}
+                            aria-label={`Edit ${product.name}`}
+                            style={{
+                              padding: '0.4rem 0.6rem',
+                              background: 'rgba(168, 85, 247, 0.1)',
+                              border: 'none',
+                              borderRadius: 6,
+                              cursor: 'pointer',
+                              color: 'var(--accent-color)',
+                            }}
+                          >
+                            <Edit2 size={14} />
+                          </button>
+                        )}
+                        {canDeleteProducts && (
+                          <button
+                            onClick={() => handleDelete(product.id)}
+                            aria-label={`Delete ${product.name}`}
+                            style={{
+                              padding: '0.4rem 0.6rem',
+                              background: 'rgba(239, 68, 68, 0.1)',
+                              border: 'none',
+                              borderRadius: 6,
+                              cursor: 'pointer',
+                              color: '#ef4444',
+                            }}
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/wellness/ServiceCategories.jsx
+++ b/frontend/src/pages/wellness/ServiceCategories.jsx
@@ -26,6 +26,7 @@ const TH_STYLE = { padding: '0.6rem 0.75rem', fontWeight: 600, color: 'var(--tex
 const TD_STYLE = { padding: '0.6rem 0.75rem', verticalAlign: 'middle' };
 import { fetchApi, getAuthToken } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 
 const EMPTY_FORM = { name: '', parentId: '', displayOrder: 0, isActive: true, imageUrl: '' };
 
@@ -51,6 +52,11 @@ async function uploadImageFile(file) {
 
 export default function ServiceCategories() {
   const notify = useNotify();
+  // Backend gates POST/PUT/DELETE on adminGate (verifyWellnessRole or
+  // services.write RBAC). Fail closed until perms resolve so buttons
+  // don't flash visible during the initial fetch.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManageServices = permsReady && hasPermission('services', 'write');
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
@@ -172,19 +178,29 @@ export default function ServiceCategories() {
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <header style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
             <Stethoscope size={24} /> Service categories
+            {permsReady && !canManageServices && (
+              <span
+                title="You can view categories but can't make changes."
+                style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: 999, background: 'var(--subtle-bg)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)', fontWeight: 500 }}
+              >
+                View only
+              </span>
+            )}
           </h1>
           <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
             {q.trim() ? `${filtered.length} of ${categories.length}` : categories.length} categor{(q.trim() ? filtered.length : categories.length) === 1 ? 'y' : 'ies'} — hierarchical taxonomy for the service catalogue.
           </p>
         </div>
-        <button onClick={() => (showAdd ? resetForm() : setShowAdd(true))} style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', padding: '0.5rem 1rem', background: 'var(--primary-color, var(--accent-color))', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' }}>
-          <Plus size={16} /> {showAdd ? 'Cancel' : 'New category'}
-        </button>
+        {canManageServices && (
+          <button onClick={() => (showAdd ? resetForm() : setShowAdd(true))} style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', padding: '0.5rem 1rem', background: 'var(--primary-color, var(--accent-color))', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' }}>
+            <Plus size={16} /> {showAdd ? 'Cancel' : 'New category'}
+          </button>
+        )}
       </header>
 
-      {showAdd && (
+      {showAdd && canManageServices && (
         <form onSubmit={submit} style={{ background: 'var(--bg-elev)', padding: '1rem', borderRadius: 8, marginBottom: '1.5rem', display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))' }}>
           <input required placeholder="Name (e.g. Hair Restoration)" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
           <select value={form.parentId || ''} onChange={(e) => setForm({ ...form, parentId: e.target.value })}>
@@ -286,7 +302,7 @@ export default function ServiceCategories() {
               <th style={TH_STYLE}>Order</th>
               <th style={TH_STYLE}>Services</th>
               <th style={TH_STYLE}>Status</th>
-              <th style={{ ...TH_STYLE, textAlign: 'right' }}>Actions</th>
+              {canManageServices && <th style={{ ...TH_STYLE, textAlign: 'right' }}>Actions</th>}
             </tr>
           </thead>
           <tbody>
@@ -316,16 +332,18 @@ export default function ServiceCategories() {
                       {c.isActive ? 'Active' : 'Inactive'}
                     </span>
                   </td>
-                  <td style={{ ...TD_STYLE, textAlign: 'right', whiteSpace: 'nowrap' }}>
-                    <div style={{ display: 'inline-flex', gap: '0.4rem' }}>
-                      <button onClick={() => startEdit(c)} title="Edit" aria-label={`Edit ${c.name}`} style={ICON_BTN_STYLE}>
-                        <Pencil size={14} />
-                      </button>
-                      <button onClick={() => remove(c)} title="Delete" aria-label={`Delete ${c.name}`} style={DANGER_ICON_BTN_STYLE}>
-                        <Trash2 size={14} />
-                      </button>
-                    </div>
-                  </td>
+                  {canManageServices && (
+                    <td style={{ ...TD_STYLE, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                      <div style={{ display: 'inline-flex', gap: '0.4rem' }}>
+                        <button onClick={() => startEdit(c)} title="Edit" aria-label={`Edit ${c.name}`} style={ICON_BTN_STYLE}>
+                          <Pencil size={14} />
+                        </button>
+                        <button onClick={() => remove(c)} title="Delete" aria-label={`Delete ${c.name}`} style={DANGER_ICON_BTN_STYLE}>
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </td>
+                  )}
                 </tr>
               );
             })}

--- a/frontend/src/pages/wellness/Services.jsx
+++ b/frontend/src/pages/wellness/Services.jsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
+import { usePermissions } from '../../hooks/usePermissions';
 
 // Parse Service.imageUrls (Prisma stores a JSON-stringified array of URLs).
 // `allImagesOf` returns the full array; `firstImageOf` is a convenience
@@ -79,6 +80,10 @@ const statusColor = { active: '#10b981', completed: '#6366f1', paused: '#f59e0b'
 
 export default function Services() {
   const notify = useNotify();
+  // Backend gates POST/PUT/DELETE on adminOrPerm('services', 'write').
+  // One flag for everything since this route doesn't split write/update/delete.
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManageServices = permsReady && hasPermission('services', 'write');
   const [searchParams] = useSearchParams();
   const initialTab = searchParams.get('tab') || 'catalog';
   const [tab, setTab] = useState(initialTab); // catalog | packages | activetreatments
@@ -152,23 +157,33 @@ export default function Services() {
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <header style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
             <Sparkles size={24} /> Service catalog
+            {permsReady && !canManageServices && (
+              <span
+                title="You can view services but can't make changes."
+                style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: 999, background: 'var(--subtle-bg)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)', fontWeight: 500 }}
+              >
+                View only
+              </span>
+            )}
           </h1>
           <p style={{ color: 'var(--text-secondary)', marginTop: '0.25rem' }}>Each service has a price, duration, and target marketing radius.</p>
         </div>
-        {tab === 'catalog' && (
+        {tab === 'catalog' && canManageServices && (
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
             {/* Issue #816: services CSV. No active filter, so we pass an empty
                 filters object — the export reflects the same all-active view
-                as the catalog tab. */}
+                as the catalog tab. CsvImportExportToolbar wraps Import POST
+                and the destructive backend hits services.write too, so it is
+                gated alongside New service. */}
             <CsvImportExportToolbar entity="services" label="Services" formats={['csv', 'xlsx']} onImported={load} />
             <button onClick={() => setShowAdd(!showAdd)} style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', padding: '0.5rem 1rem', background: 'var(--primary-color, var(--accent-color))', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' }}>
               <Plus size={16} /> {showAdd ? 'Cancel' : 'New service'}
             </button>
           </div>
         )}
-        {tab === 'packages' && (
+        {tab === 'packages' && canManageServices && (
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
             {/* Issue #816: packages CSV. */}
             <CsvImportExportToolbar entity="packages" label="Packages" formats={['csv', 'xlsx']} />
@@ -266,6 +281,8 @@ function TabBtn({ active, onClick, icon: Icon, label }) {
 }
 
 function CatalogTab({ services, loading, categories, categoriesLoading, showAdd, form, setForm, submit, onChanged, onOpenService, editRequestId, clearEditRequest }) {
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManageServices = permsReady && hasPermission('services', 'write');
   const notify = useNotify();
   // Sort selector — backend returns services in its default order (name
   // alphabetical). Users asked for a "newest first" option so the most
@@ -291,7 +308,7 @@ function CatalogTab({ services, loading, categories, categoriesLoading, showAdd,
       {/* Visually-hidden section heading so screen readers see h1 -> h2 hierarchy
           before the per-service h3 cards (a11y: heading-order). */}
       <h2 style={srOnly}>Available services</h2>
-      {showAdd && (() => {
+      {showAdd && canManageServices && (() => {
         // #115: visible labels for every field; basePrice must be > 0 before save.
         const fieldLabel = { display: 'block', fontSize: '0.7rem', fontWeight: 500, color: 'var(--text-secondary)', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.04em' };
         // #115: ₹1 minimum is sensible for a clinic; reject 0/blank/negative
@@ -435,6 +452,8 @@ function CatalogTab({ services, loading, categories, categoriesLoading, showAdd,
 
 function ServiceCard({ service, onChanged, onOpen, editRequested, onEditConsumed }) {
   const notify = useNotify();
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManageServices = permsReady && hasPermission('services', 'write');
   const [editing, setEditing] = useState(false);
   // Hydrate the draft with a flat `imageUrl` (first of the JSON array) so
   // the inline ImageUploadField stays controlled.
@@ -562,8 +581,12 @@ function ServiceCard({ service, onChanged, onOpen, editRequested, onEditConsumed
         <span style={{ background: tierColor[service.ticketTier], color: '#fff', padding: '0.15rem 0.5rem', borderRadius: 4, fontSize: '0.65rem', textTransform: 'uppercase', fontWeight: 600, lineHeight: 1.4 }}>
           {service.ticketTier}
         </span>
-        <button onClick={(e) => { e.stopPropagation(); setEditing(true); }} aria-label={`Edit service ${service.name}`} title="Edit" style={iconBtn}><Pencil size={12} /></button>
-        <button onClick={(e) => { e.stopPropagation(); remove(); }} aria-label={`Deactivate service ${service.name}`} title="Deactivate" style={{ ...iconBtn, color: 'var(--danger-color)' }}><Trash2 size={12} /></button>
+        {canManageServices && (
+          <>
+            <button onClick={(e) => { e.stopPropagation(); setEditing(true); }} aria-label={`Edit service ${service.name}`} title="Edit" style={iconBtn}><Pencil size={12} /></button>
+            <button onClick={(e) => { e.stopPropagation(); remove(); }} aria-label={`Deactivate service ${service.name}`} title="Deactivate" style={{ ...iconBtn, color: 'var(--danger-color)' }}><Trash2 size={12} /></button>
+          </>
+        )}
       </div>
       {imageSrc && (
         <img
@@ -589,6 +612,8 @@ function ServiceCard({ service, onChanged, onOpen, editRequested, onEditConsumed
 
 function ServiceDetailModal({ service, categories, onClose, onChanged, onEdit }) {
   const notify = useNotify();
+  const { hasPermission, isReady: permsReady } = usePermissions();
+  const canManageServices = permsReady && hasPermission('services', 'write');
   const images = allImagesOf(service);
   const [activeIdx, setActiveIdx] = useState(0);
   const [deleting, setDeleting] = useState(false);
@@ -708,24 +733,26 @@ function ServiceDetailModal({ service, categories, onClose, onChanged, onEdit })
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
-          <button
-            type="button"
-            onClick={() => onEdit && onEdit(service)}
-            disabled={!onEdit}
-            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem', padding: '0.55rem 1rem', background: 'var(--primary-color, var(--accent-color))', color: '#fff', border: 'none', borderRadius: 8, cursor: onEdit ? 'pointer' : 'not-allowed', fontWeight: 600, fontSize: '0.85rem' }}
-          >
-            <Pencil size={14} /> Edit
-          </button>
-          <button
-            type="button"
-            onClick={handleDelete}
-            disabled={deleting}
-            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem', padding: '0.55rem 1rem', background: 'rgba(239,68,68,0.15)', color: '#ef4444', border: '1px solid rgba(239,68,68,0.35)', borderRadius: 8, cursor: deleting ? 'wait' : 'pointer', fontWeight: 600, fontSize: '0.85rem' }}
-          >
-            <Trash2 size={14} /> {deleting ? 'Deactivating…' : 'Deactivate'}
-          </button>
-        </div>
+        {canManageServices && (
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+            <button
+              type="button"
+              onClick={() => onEdit && onEdit(service)}
+              disabled={!onEdit}
+              style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem', padding: '0.55rem 1rem', background: 'var(--primary-color, var(--accent-color))', color: '#fff', border: 'none', borderRadius: 8, cursor: onEdit ? 'pointer' : 'not-allowed', fontWeight: 600, fontSize: '0.85rem' }}
+            >
+              <Pencil size={14} /> Edit
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem', padding: '0.55rem 1rem', background: 'rgba(239,68,68,0.15)', color: '#ef4444', border: '1px solid rgba(239,68,68,0.35)', borderRadius: 8, cursor: deleting ? 'wait' : 'pointer', fontWeight: 600, fontSize: '0.85rem' }}
+            >
+              <Trash2 size={14} /> {deleting ? 'Deactivating…' : 'Deactivate'}
+            </button>
+          </div>
+        )}
 
         <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '0.75rem', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
           Service ID: {service.id} {service.createdAt && <> · Added {formatDate(service.createdAt)}</>}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -181,8 +181,13 @@ export function setActiveTenantId(id) {
 // bother the user.
 export const fetchApi = async (url, options = {}) => {
   const token = getAuthToken();
+  // FormData carries its own multipart boundary in the Content-Type header,
+  // which the browser sets on send. Forcing application/json here would clobber
+  // that boundary and the backend would parse zero fields. Detect FormData
+  // and let the browser pick the header.
+  const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
   const headers = {
-    'Content-Type': 'application/json',
+    ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
     ...(options.headers || {}),
   };
 
@@ -241,7 +246,16 @@ export const fetchApi = async (url, options = {}) => {
     const serverMsg = errData.error || errData.message;
     let userMsg;
     if (response.status === 403) {
-      userMsg = serverMsg || 'You don’t have permission to do that.';
+      // RBAC errors return a technical "requires module.action" string that's
+      // not meaningful to end users. Detect the canonical RBAC codes and
+      // surface a friendly fixed message instead. The raw err.message stays
+      // on the thrown Error for any caller that wants the technical detail
+      // (logging, dev consoles); only the user-facing toast is rewritten.
+      if (errData.code === 'RBAC_DENIED' || errData.code === 'CUSTOMER_ACCESS_DENIED' || errData.code === 'PERMISSION_CHECK_FAILED') {
+        userMsg = "You don't have permission to do this. Please contact your administrator if you need access.";
+      } else {
+        userMsg = serverMsg || 'You don’t have permission to do that.';
+      }
     } else if (response.status === 404) {
       userMsg = serverMsg || 'Not found.';
     } else if (response.status >= 500) {


### PR DESCRIPTION
[x] Added RBAC support for patient portal prescriptions with permission-based access checks, staff self-prescription APIs, and portal permission-aware navigation.
[x] Introduced a new My Prescriptions page with secure PDF downloads, audit logging, and patient-profile validation handling.
[x] Redesigned prescription and patient summary PDFs with a unified branded layout, improved visit cards, membership sections, transaction tables, and enhanced visual styling.
[x] Split the legacy billing permission module into dedicated invoices, gift_cards, and patient_wallets modules, and added the new my_prescriptions.read permission.
[x] Updated RBAC catalogs, role management, seed scripts, cache invalidation, and backfill utilities to support the new permission structure.
[x] Enhanced Memberships with Razorpay self-purchase flow and real membership data support for non-admin users.
[x] Improved appointment booking with optional doctor selection, required visit reason, membership support, and fallback slot generation.
[x] Added permission-aware read-only states across Products, Services, Categories, and Inventory modules, along with POS cash register integration.
[x] Enhanced communications and settings workflows with file attachments, themed recipient autocomplete, FormData support, [x] improved avatars, and same-origin API handling.
[x] Updated Prisma schema, CI workflows, E2E coverage, and frontend tests to support portal RBAC, membership-linked visits, and permission-aware UI behavior.