### PR TITLE
Travel itenary suggest, LLm routes, marketing flyer editor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -276,6 +276,8 @@ jobs:
             tests/travel-tmc-diagnostic-api.spec.js \
             tests/travel-digilocker-stub-api.spec.js \
             tests/travel-itineraries-api.spec.js \
+            tests/travel-itinerary-suggest-api.spec.js \
+            tests/travel-flight-plugin-api.spec.js \
             tests/travel-trips-api.spec.js \
             tests/travel-cost-master-api.spec.js \
             tests/travel-suppliers-api.spec.js \
@@ -312,6 +314,8 @@ jobs:
             tests/security-headers-api.spec.js \
             tests/travel-flyer-public-api.spec.js \
             tests/travel-pois-api.spec.js \
+            tests/webhook-credential-api.spec.js \
+            tests/wellness-portal-notifications-api.spec.js \
             tests/teardown-completeness.spec.js \
             tests/demo-hygiene-api.spec.js
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -449,6 +449,8 @@ jobs:
             tests/travel-tmc-diagnostic-api.spec.js \
             tests/travel-digilocker-stub-api.spec.js \
             tests/travel-itineraries-api.spec.js \
+            tests/travel-itinerary-suggest-api.spec.js \
+            tests/travel-flight-plugin-api.spec.js \
             tests/travel-trips-api.spec.js \
             tests/travel-cost-master-api.spec.js \
             tests/travel-suppliers-api.spec.js \
@@ -485,6 +487,8 @@ jobs:
             tests/security-headers-api.spec.js \
             tests/travel-flyer-public-api.spec.js \
             tests/travel-pois-api.spec.js \
+            tests/webhook-credential-api.spec.js \
+            tests/wellness-portal-notifications-api.spec.js \
             tests/teardown-completeness.spec.js \
             tests/demo-hygiene-api.spec.js
           echo "::notice::API specs passed"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -390,18 +390,20 @@ CRM_BASE_URL=http://localhost:5000
 CRM_SANDBOX_API_KEY=
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# ─── Outbound webhook HMAC signing (OPTIONAL but REQUIRED for GlobusPhone) ────
+# ─── Outbound webhook HMAC signing — LEGACY GLOBAL FALLBACK ──────────────────
 # ═══════════════════════════════════════════════════════════════════════════════
-# Used by: backend/lib/webhookDelivery.js. Shared HMAC secret for Stripe-style
-# signing of every outbound webhook POST. When set, each delivery carries:
-#   X-Globussoft-Signature: t=<unix_epoch_sec>,v1=<hmac_sha256_hex>
-# signed over "<t>.<rawBody>". Partner receivers (e.g. GlobusPhone) configure
-# the SAME value as their inbound verification secret (GlobusPhone calls it
-# WEBHOOK_HMAC_SECRET_CRM) and reject mismatched/absent signatures.
+# DEPRECATED as the primary mechanism. Signing is now PER-TENANT: each CRM admin
+# generates their own secret from the dashboard (Settings → Webhook Signing
+# Credential), stored as a WebhookCredential row (encrypted at rest). Delivery is
+# also gated on an active subscription/trial — see lib/webhookEntitlement.js.
 #
-# When UNSET, deliveries are still sent but UNSIGNED — backwards-compatible with
-# subscribers that don't verify (safe for dev/staging). Set it in production so
-# GlobusPhone accepts the webhooks instead of returning 401.
+# This env var is now only a FALLBACK used by lib/webhookEntitlement.js's
+# resolveTenantWebhookSecret() when a tenant has NO active WebhookCredential —
+# it keeps the single pre-migration GlobusPhone integration working until that
+# tenant generates its own credential. Once every tenant has a credential, this
+# can be removed. The signing wire format is unchanged:
+#   X-Globussoft-Signature: t=<unix_epoch_sec>,v1=<hmac_sha256_hex>  over "<t>.<rawBody>"
+# Receivers (e.g. GlobusPhone) still configure the secret as WEBHOOK_HMAC_SECRET_CRM.
 # Generate a fresh 64-hex value with: openssl rand -hex 32
 WEBHOOK_HMAC_SECRET=
 
@@ -431,6 +433,145 @@ AUDIT_FAIL_LEVELS=
 # find-phone-collisions.js, merge-duplicate-patients.js) to target one
 # tenant. Pure ops-side; never read by the running server.
 TENANT_ID=
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ═══ TRAVEL CRM — CLIENT-PENDING CREDENTIALS (ask Yasin / Travel Stall) ═══════════
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Every key below is TRAVEL-vertical only. Leaving it BLANK keeps the matching
+# integration in safe "stub mode" (synthetic data) — the app boots + runs fine
+# without them and NOTHING in the wellness or generic verticals is affected.
+# Each key is annotated with: the client-doc reference + what filling it unlocks.
+# Plain-language client doc: docs/TRAVEL_CRM_WHAT_WE_NEED_FROM_YOU.md
+# Technical reference:        docs/TRAVEL_CRM_CLIENT_REQUIREMENTS.md
+#
+# A blank value = stub mode. A real value = live mode. That's the only switch.
+
+# ─── Q9 · WhatsApp / Wati BSP ─────────────────────────────────────────────────
+# Unlocks: auto-WhatsApp on 7 crons + 3 endpoints (OTP, reminders, itinerary +
+# flyer + quote share, boarding-pass delivery). WHATSAPP_VERIFY_TOKEN already
+# defined above. Provide EITHER the Wati set OR the Meta set.
+WATI_API_KEY=
+WATI_ACCOUNT_ID=
+WATI_BASE_URL=https://live-mt-server.wati.io
+# Meta Cloud API alternative (3 WABAs: TMC / RFU / ops-shared):
+WHATSAPP_ACCESS_TOKEN=
+WHATSAPP_APP_ID=
+WHATSAPP_APP_SECRET=
+WHATSAPP_PHONE_NUMBER_ID_TMC=
+WHATSAPP_PHONE_NUMBER_ID_RFU=
+WHATSAPP_PHONE_NUMBER_ID_OPS=
+WHATSAPP_WABA_ID_TMC=
+WHATSAPP_WABA_ID_RFU=
+WHATSAPP_WABA_ID_OPS=
+
+# ─── Q11 · LLM provider keys ──────────────────────────────────────────────────
+# Unlocks REAL output (vs [STUB-*] text) for: talking-points, form-vs-call,
+# itinerary draft + the new itinerary-suggest, TMC report narrative.
+# GEMINI_API_KEY + OPENAI_API_KEY already defined above. Add the other two:
+ANTHROPIC_API_KEY=
+PERPLEXITY_API_KEY=
+# Real provider model IDs per routing label (lib/llmRouter.js). OPTIONAL —
+# sensible defaults are built in; override only when a provider renames a model
+# (a rename becomes a config change, never a code change). When the matching key
+# above is set AND NODE_ENV is not "test", the router calls the REAL provider
+# automatically — no code change needed.
+LLM_MODEL_CLAUDE_OPUS=
+LLM_MODEL_CLAUDE_HAIKU=
+LLM_MODEL_GPT=
+LLM_MODEL_GEMINI=
+LLM_MODEL_PERPLEXITY=
+
+# ─── Q19 · RateHawk (hotel wholesaler) ───────────────────────────────────────
+# Unlocks: live lowest-rate hotel results in the RFU/holiday quote engine.
+RATEHAWK_API_KEY=
+RATEHAWK_API_ID=
+RATEHAWK_BASE_URL=https://api.worldota.net/api/b2b/v3
+
+# ─── Q1 · Callified.ai (AI qualification calling) ────────────────────────────
+# Unlocks: real auto-calls + transcript/summary. Sandbox keys above are dev-only.
+CALLIFIED_API_KEY=
+CALLIFIED_API_BASE_URL=https://api.callified.ai
+CALLIFIED_WEBHOOK_SECRET=
+CALLIFIED_TENANT_TOKEN=
+
+# ─── Q1 · AdsGPT (marketing reports) ─────────────────────────────────────────
+# Unlocks: real ad spend / leads / CPL on the marketing dashboard.
+ADSGPT_API_KEY=
+ADSGPT_ACCOUNT_ID=
+ADSGPT_API_BASE_URL=https://api.adsgpt.io
+# Per-platform ad-account IDs (comma-separated or per-platform):
+ADSGPT_META_ACCOUNT_ID=
+ADSGPT_GOOGLE_ACCOUNT_ID=
+ADSGPT_LINKEDIN_ACCOUNT_ID=
+ADSGPT_YOUTUBE_ACCOUNT_ID=
+
+# ─── Q3 · DigiLocker (Aadhaar) — CLIENT_ID/SECRET already defined above ──────
+# (see DIGILOCKER_CLIENT_ID / DIGILOCKER_CLIENT_SECRET). Filling them swaps the
+# Aadhaar verification flow from stub to real.
+
+# ─── Passport OCR (vendor pick PC-1) ─────────────────────────────────────────
+# Unlocks: real passport field extraction. Choose google OR azure.
+PASSPORT_OCR_PROVIDER=stub
+GOOGLE_DOCUMENT_AI_KEY=
+GOOGLE_DOCUMENT_AI_PROCESSOR_ID=
+AZURE_FORM_RECOGNIZER_KEY=
+AZURE_FORM_RECOGNIZER_ENDPOINT=
+
+# ─── Booking.com direct (Phase 1.5) ──────────────────────────────────────────
+# Unlocks: extra hotel inventory alongside RateHawk. 2-4 wk vendor onboarding.
+BOOKING_AFFILIATE_ID=
+BOOKING_API_KEY=
+BOOKING_API_SECRET=
+
+# ─── RFU ground services (Q-RFUG-1 / Q-RFUG-7) ───────────────────────────────
+# Unlocks: real Saudi cab (Zikr) + high-speed-train (Haramain) prices/booking.
+ZIKR_CABS_API_KEY=
+ZIKR_CABS_API_SECRET=
+ZIKR_CABS_WEBHOOK_SECRET=
+ZIKR_CABS_BASE_URL=
+HARAMAIN_RAIL_API_KEY=
+HARAMAIN_RAIL_BASE_URL=
+
+# ─── Q8 · Excel Software for Travel (accounting bridge) ──────────────────────
+# Unlocks: auto-push invoices into the client's accountant system.
+# Mode: "api" | "csv" | "stub" (default stub until vendor docs land).
+EXCEL_SOFTWARE_MODE=stub
+EXCEL_SOFTWARE_API_KEY=
+EXCEL_SOFTWARE_BASE_URL=
+
+# ─── Marketing Flyer Studio — asset storage (DD-5.2) ─────────────────────────
+# Flyer image uploads (POST /api/travel/flyer-templates/upload). When
+# AWS_S3_BUCKET_NAME is set, services/s3Service uploads to S3 (public-read —
+# appropriate for shareable marketing flyers); otherwise the endpoint writes to
+# local disk under backend/uploads/flyer-assets/ (works with zero config). These
+# are the exact names s3Service.js reads.
+AWS_S3_BUCKET_NAME=
+AWS_S3_URL=
+AWS_REGION=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# AI image generation for flyers (DD-5.3): "stub" | "openai" (DALL·E, reuses
+# OPENAI_API_KEY) | "stability". Not yet wired — a later slice.
+AI_IMAGE_PROVIDER=stub
+STABILITY_API_KEY=
+
+# ─── Itinerary visual editor map (optional — Leaflet/OSM is free default) ────
+# Only needed if you want premium Mapbox tiles or auto POI seeding.
+MAPBOX_TOKEN=
+OPENTRIPMAP_API_KEY=
+
+# ─── Airline web check-in automation (P1B) — feature flag ────────────────────
+# Leave OFF until DC-1 (Playwright vs MCP) + DC-5 (airline ToS counsel review)
+# are decided. When "1", the (stubbed) per-airline adapters become callable.
+AIRLINE_AUTOMATION_ENABLED=
+
+# ─── TMC booking CTA (T18 · Google Workspace) ────────────────────────────────
+# Unlocks: real Google Meet slot-picker on the readiness report. Falls back to
+# VITE_TMC_BOOKING_URL (a static link) when blank.
+GOOGLE_WORKSPACE_CLIENT_ID=
+GOOGLE_WORKSPACE_CLIENT_SECRET=
+GOOGLE_WORKSPACE_CALENDAR_IDS=
 
 # Same shape as TENANT_ID but slug-based. Used by
 # backend/scripts/seed-fast2sms-config.js to find the tenant by slug.

--- a/backend/lib/eventBus.js
+++ b/backend/lib/eventBus.js
@@ -299,7 +299,14 @@ async function executeAction(rule, payload, tenantId, io) {
 
     case "send_webhook": {
       const { deliverSingle } = require("./webhookDelivery");
-      await deliverSingle(config.url, rule.triggerType, payload, tenantId);
+      // Sign with the tenant's per-tenant secret (same as deliverWebhooks) so
+      // every outbound webhook from this tenant carries one consistent
+      // signature a partner can verify. Not subscription-gated here — this is
+      // a user-authored automation action, distinct from the Webhook-model
+      // lead-sync stream which IS gated in deliverWebhooks().
+      const { resolveTenantWebhookSecret } = require("./webhookEntitlement");
+      const { secret } = await resolveTenantWebhookSecret(tenantId);
+      await deliverSingle(config.url, rule.triggerType, payload, tenantId, secret);
       break;
     }
 

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -64,13 +64,13 @@ const { getBudgetCap, evaluateCap } = require("./tenantSettings");
 // always returns the primary's model identifier so consumers can
 // pin the contract; fallback wiring lands with real-mode.
 const TASK_ROUTING = {
-  "search":            { primary: "perplexity-sonar",  fallback: null },
-  "citation":          { primary: "perplexity-sonar",  fallback: null },
-  "reasoning":         { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-  "talking-points":    { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-  "form-vs-call":      { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-  "bulk-text":         { primary: "gemini-flash",      fallback: "claude-haiku" },
-  "call-summary":      { primary: "gemini-flash",      fallback: null },
+  "search": { primary: "perplexity-sonar", fallback: null },
+  "citation": { primary: "perplexity-sonar", fallback: null },
+  "reasoning": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+  "talking-points": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+  "form-vs-call": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+  "bulk-text": { primary: "gemini-flash", fallback: "claude-haiku" },
+  "call-summary": { primary: "gemini-flash", fallback: null },
   // Itinerary-suggest (PRD_TRAVEL_ITINERARY_UPGRADES FR-3.6 + AI_SURFACES §3
   // table). 2K in / 4K out — larger out than bulk-text because the full
   // itinerary JSON shape (daySplit + poiSuggestions + thematicNotes) lands
@@ -78,7 +78,7 @@ const TASK_ROUTING = {
   // routing table for Travel Stall's bulk-shape Gemini calls. Real-mode
   // swap lives in backend/services/itinerarySuggestLLM.js (S14 — same
   // commit). Real call gated on Q-IT-2 / Q11 GEMINI_API_KEY.
-  "itinerary-suggest": { primary: "gemini-flash",      fallback: "claude-haiku" },
+  "itinerary-suggest": { primary: "gemini-flash", fallback: "claude-haiku" },
   // Marketing-flyer-copy (PRD_TRAVEL_MARKETING_FLYER FR-3.6.1 + AC-6.8).
   // 1K in / 1K out — short-form headline + body + CTA JSON. Routed to
   // gemini-flash for low-cost bulk-shape Gemini calls per PRD §9.1.
@@ -86,7 +86,7 @@ const TASK_ROUTING = {
   // (S15 — same commit); this scaffold's stub-text path returns a tagged
   // synthetic string for routeRequest text-envelope callers. Real call
   // gated on Q-AI-3 / Q11 GEMINI_API_KEY.
-  "marketing-flyer-copy": { primary: "gemini-flash",      fallback: "claude-haiku" },
+  "marketing-flyer-copy": { primary: "gemini-flash", fallback: "claude-haiku" },
   // Marketing-flyer-image (PRD_TRAVEL_MARKETING_FLYER FR-3.6.3).
   // AI image-gen for flyer hero blocks. Primary: DALL-E 3 (OpenAI API).
   // Fallback: Stability AI XL. Structured-image path lives in
@@ -100,7 +100,7 @@ const TASK_ROUTING = {
   // product call to split into its own `image-llm` integration cap so a
   // runaway image-gen burst doesn't silently exhaust the text-LLM
   // budget. Until then both share the 'llm' cap envelope.
-  "marketing-flyer-image": { primary: "dall-e-3",         fallback: "stability-xl" },
+  "marketing-flyer-image": { primary: "dall-e-3", fallback: "stability-xl" },
   // Catch-all for unrecognized tasks → reasoning model (Claude)
   // matches PRD's preference for a high-quality default.
 };
@@ -113,15 +113,15 @@ const VALID_TASKS = Object.keys(TASK_ROUTING);
 // (per-tenant key support); ENV stays as the dev/CI fallback.
 const ENV_FOR_MODEL = {
   "perplexity-sonar": "PERPLEXITY_API_KEY",
-  "claude-opus-4-7":  "ANTHROPIC_API_KEY",
-  "gpt-4":            "OPENAI_API_KEY",
-  "gemini-flash":     "GEMINI_API_KEY",
-  "claude-haiku":     "ANTHROPIC_API_KEY",
+  "claude-opus-4-7": "ANTHROPIC_API_KEY",
+  "gpt-4": "OPENAI_API_KEY",
+  "gemini-flash": "GEMINI_API_KEY",
+  "claude-haiku": "ANTHROPIC_API_KEY",
   // S16 — image-gen providers for marketing-flyer-image task class
   // (PRD_TRAVEL_MARKETING_FLYER FR-3.6.3). DALL-E 3 reuses the OpenAI
   // key (same env var as gpt-4); Stability XL needs its own dedicated key.
-  "dall-e-3":         "OPENAI_API_KEY",
-  "stability-xl":     "STABILITY_API_KEY",
+  "dall-e-3": "OPENAI_API_KEY",
+  "stability-xl": "STABILITY_API_KEY",
 };
 
 /**
@@ -306,11 +306,25 @@ async function routeRequest({ task, payload, tenantId } = {}) {
 
   const { model, reason } = pickModel(task);
 
-  // STUB: real provider call. When the matching API key lands in
-  // env (or in SupplierCredential per PRD §9.1), swap this block
-  // for `return realProviderCall(model, payload)`.
-  // Synthetic response shape matches what the real providers return
-  // after normalization: { text, finishReason, usage, model, stub }.
+  // Real-mode: when the task's provider key is present in env AND we're not
+  // under test, call the REAL provider — so the moment a key lands the output
+  // is real with ZERO further code changes (no "swap the stub later" landmine).
+  // No key (dev / CI / demo-without-keys) OR NODE_ENV==='test' falls through to
+  // the deterministic stub below, keeping unit + e2e runs offline + repeatable.
+  if (process.env.NODE_ENV !== "test" && llmEnabled(task)) {
+    try {
+      return await realProviderCall({ task, model, payload, tenantId });
+    } catch (e) {
+      console.error(`[llm-router] real provider call failed (task=${task} model=${model}): ${e.message}`);
+      const err = new Error(`LLM provider call failed: ${e.message}`);
+      err.code = "LLM_PROVIDER_ERROR";
+      throw err;
+    }
+  }
+
+  // STUB: deterministic synthetic response used when no provider key is set
+  // (or under test). Same envelope shape as the real path:
+  // { text, finishReason, usage, model, stub }.
   const stubText = buildStubText(task, payload);
   const tokensIn = estimateTokens(JSON.stringify(payload || {}));
   const tokensOut = estimateTokens(stubText);
@@ -433,6 +447,177 @@ function estimateTokens(s) {
   return Math.ceil(String(s).length / 4);
 }
 
+// ── Real-mode provider calls ─────────────────────────────────────────
+//
+// Activated by routeRequest when the task's provider key is present (and not
+// under test). The REAL provider model id per routing label is env-overridable
+// so a model rename is a config change, never a code change (no stale-model
+// landmine). Defaults track the current model generation.
+const MODEL_ID_ENV = {
+  "claude-opus-4-7": ["LLM_MODEL_CLAUDE_OPUS", "claude-opus-4-8"],
+  "claude-haiku": ["LLM_MODEL_CLAUDE_HAIKU", "claude-haiku-4-5-20251001"],
+  "gpt-4": ["LLM_MODEL_GPT", "gpt-4o"],
+  "gemini-flash": ["LLM_MODEL_GEMINI", "gemini-2.5-flash"],
+  "perplexity-sonar": ["LLM_MODEL_PERPLEXITY", "sonar"],
+};
+
+function resolveRealModelId(label) {
+  const entry = MODEL_ID_ENV[label];
+  if (!entry) return label;
+  const [envVar, dflt] = entry;
+  return process.env[envVar] || dflt;
+}
+
+function providerForModel(label) {
+  if (label.startsWith("claude")) return "anthropic";
+  if (label.startsWith("gpt")) return "openai";
+  if (label.startsWith("gemini")) return "gemini";
+  if (label.startsWith("perplexity") || label === "sonar") return "perplexity";
+  return "anthropic";
+}
+
+// Build a task-appropriate { system, user } prompt. The payload's __-prefixed
+// hint keys (e.g. __userId / __surface) are stripped — only real content is
+// sent to the provider.
+function buildPrompt(task, payload) {
+  const content = {};
+  for (const [k, v] of Object.entries(payload || {})) {
+    if (!String(k).startsWith("__")) content[k] = v;
+  }
+  const SYS = {
+    "talking-points": "You are a senior travel advisor. Given a lead's diagnostic profile, produce concise, actionable talking points for the advisor's next call. Plain text, 3-6 short bullets.",
+    "form-vs-call": "You compare a customer's web-form answers against their phone-call answers, summarise the level of match, and flag any mismatches. Plain text.",
+    "itinerary-suggest": "You are an expert travel planner. Given a destination, number of days, budget per person, and traveller profile, write a concise day-by-day itinerary summary in prose. Do NOT invent specific prices.",
+    "bulk-text": "You write clear, customer-facing travel copy. Plain text.",
+    "call-summary": "You summarise a sales/advisory call in a few sentences. Plain text.",
+    "reasoning": "You are a careful reasoning assistant for a travel CRM. Plain text.",
+    "search": "You answer with concise, well-sourced information. Plain text.",
+    "citation": "You answer with concise, well-sourced information. Plain text.",
+  };
+  const system = SYS[task] || SYS.reasoning;
+  const user = `Task: ${task}\nContext (JSON):\n${JSON.stringify(content)}`;
+  return { system, user };
+}
+
+async function httpJson(url, opts, timeoutMs = 30000) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...opts, signal: ctrl.signal });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg = (body && (body.error?.message || body.error)) || res.statusText || `HTTP ${res.status}`;
+      throw new Error(`${res.status} ${msg}`);
+    }
+    return body;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function callAnthropic(modelId, system, user, apiKey, maxTokens) {
+  const body = await httpJson("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
+    body: JSON.stringify({ model: modelId, max_tokens: maxTokens, system, messages: [{ role: "user", content: user }] }),
+  });
+  const text = (body.content || []).map((c) => c.text || "").join("").trim();
+  const u = body.usage || {};
+  return { text, tokensIn: u.input_tokens || 0, tokensOut: u.output_tokens || 0 };
+}
+
+// OpenAI + Perplexity share the OpenAI chat-completions wire format.
+async function callOpenAICompatible(baseUrl, modelId, system, user, apiKey, maxTokens) {
+  const body = await httpJson(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: maxTokens,
+      messages: [{ role: "system", content: system }, { role: "user", content: user }],
+    }),
+  });
+  const text = (body.choices && body.choices[0] && body.choices[0].message && body.choices[0].message.content || "").trim();
+  const u = body.usage || {};
+  return { text, tokensIn: u.prompt_tokens || 0, tokensOut: u.completion_tokens || 0 };
+}
+
+async function callGemini(modelId, system, user, apiKey, maxTokens) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const body = await httpJson(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: system }] },
+      contents: [{ role: "user", parts: [{ text: user }] }],
+      generationConfig: { maxOutputTokens: maxTokens },
+    }),
+  });
+  const parts = (body.candidates && body.candidates[0] && body.candidates[0].content && body.candidates[0].content.parts) || [];
+  const text = parts.map((p) => p.text || "").join("").trim();
+  const m = body.usageMetadata || {};
+  return { text, tokensIn: m.promptTokenCount || 0, tokensOut: m.candidatesTokenCount || 0 };
+}
+
+async function realProviderCall({ task, model, payload, tenantId }) {
+  const provider = providerForModel(model);
+  const envVar = ENV_FOR_MODEL[model];
+  const apiKey = envVar && process.env[envVar];
+  if (!apiKey) throw new Error(`no API key for ${model}`);
+  const modelId = resolveRealModelId(model);
+  const { system, user } = buildPrompt(task, payload);
+  const maxTokens = 4096;
+
+  let out;
+  if (provider === "anthropic") out = await callAnthropic(modelId, system, user, apiKey, maxTokens);
+  else if (provider === "openai") out = await callOpenAICompatible("https://api.openai.com/v1", modelId, system, user, apiKey, maxTokens);
+  else if (provider === "perplexity") out = await callOpenAICompatible("https://api.perplexity.ai", modelId, system, user, apiKey, maxTokens);
+  else if (provider === "gemini") out = await callGemini(modelId, system, user, apiKey, maxTokens);
+  else throw new Error(`unknown provider for ${model}`);
+
+  const tokensIn = out.tokensIn || estimateTokens(JSON.stringify(payload || {}));
+  const tokensOut = out.tokensOut || estimateTokens(out.text);
+
+  // Token-only telemetry — NEVER log payload content (PII discipline).
+  console.log(
+    `[llm-router] task=${task} model=${model} (${modelId}) tenant=${tenantId || "?"} ` +
+    `tokens_in=${tokensIn} tokens_out=${tokensOut} cost_estimate=$0.0000 stub=false reason=real`,
+  );
+
+  // Persist one LlmCallLog row (best-effort, fire-and-forget) — mirrors the
+  // stub path so the admin spend dashboard counts real calls too.
+  try {
+    const prisma = require("./prisma");
+    prisma.llmCallLog
+      .create({
+        data: {
+          tenantId: tenantId || 1,
+          task,
+          model,
+          reason: "real",
+          promptTokens: tokensIn,
+          completionTokens: tokensOut,
+          totalTokens: tokensIn + tokensOut,
+          costEstimate: 0, // real per-token pricing is a follow-up; tokens are real
+          stub: false,
+          userId: (payload && payload.__userId) || null,
+          surface: (payload && payload.__surface) || null,
+        },
+      })
+      .catch((e) => console.error(`[llm-router] LlmCallLog persist failed (non-fatal): ${e.message}`));
+  } catch (e) {
+    console.error(`[llm-router] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+
+  return {
+    text: out.text || "",
+    finishReason: "stop",
+    usage: { promptTokens: tokensIn, completionTokens: tokensOut, totalTokens: tokensIn + tokensOut },
+    model,
+    stub: false,
+  };
+}
+
 module.exports = {
   TASK_ROUTING,
   VALID_TASKS,
@@ -446,4 +631,7 @@ module.exports = {
   buildStubText,
   estimateTokens,
   computeMonthlySpendCents,
+  buildPrompt,
+  resolveRealModelId,
+  providerForModel,
 };

--- a/backend/lib/patientNotificationService.js
+++ b/backend/lib/patientNotificationService.js
@@ -1,0 +1,91 @@
+// Patient-portal notification inbox service.
+//
+// Backs the wellness portal endpoints in routes/wellness.js
+// (/portal/me/notifications*) and is the single producer/consumer surface for
+// the PatientNotification table — patient-scoped, distinct from the staff
+// Notification table (lib/notificationService.js / routes/notifications.js).
+//
+// Purely additive: nothing here touches staff notifications, so wiring a
+// producer (createPatientNotification) into a wellness flow later cannot affect
+// the existing staff notification bell.
+const prisma = require("./prisma");
+
+// Hard cap so a malicious/buggy ?limit can't ask for the whole table.
+const MAX_LIMIT = 200;
+
+/**
+ * Create a notification for a patient. Safe to call from any wellness flow
+ * (appointment booked, prescription ready, payment received, etc.).
+ *
+ * @param {object} args
+ * @param {number} args.patientId
+ * @param {number} args.tenantId
+ * @param {string} args.title
+ * @param {string} args.message
+ * @param {string} [args.type='info']  info|appointment|prescription|payment|system
+ * @param {string|null} [args.link]
+ */
+async function createPatientNotification({ patientId, tenantId, title, message, type = "info", link = null }) {
+  if (!patientId || !tenantId) throw new Error("patientId and tenantId are required");
+  if (!title || !message) throw new Error("title and message are required");
+  return prisma.patientNotification.create({
+    data: { patientId, tenantId, title, message, type, link: link || null },
+  });
+}
+
+/**
+ * List a patient's notifications (newest first) + the live unread count.
+ * @returns {Promise<{ items: object[], unreadCount: number }>}
+ */
+async function listPatientNotifications(patientId, { limit = 50, unreadOnly = false } = {}) {
+  const take = Math.min(Math.max(parseInt(limit, 10) || 50, 1), MAX_LIMIT);
+  const where = { patientId };
+  if (unreadOnly) where.isRead = false;
+  const [items, unreadCount] = await Promise.all([
+    prisma.patientNotification.findMany({ where, orderBy: { createdAt: "desc" }, take }),
+    prisma.patientNotification.count({ where: { patientId, isRead: false } }),
+  ]);
+  return { items, unreadCount };
+}
+
+/**
+ * Mark ONE notification read — scoped to patientId so a patient can never
+ * touch another patient's row. Returns the updated row, or null when the id
+ * doesn't belong to this patient (caller maps to 404).
+ */
+async function markPatientNotificationRead(patientId, id) {
+  const existing = await prisma.patientNotification.findFirst({ where: { id, patientId } });
+  if (!existing) return null;
+  if (existing.isRead) return existing; // idempotent — already read
+  return prisma.patientNotification.update({
+    where: { id: existing.id },
+    data: { isRead: true, readAt: new Date() },
+  });
+}
+
+/**
+ * Mark ALL of a patient's unread notifications read. Returns the count updated.
+ */
+async function markAllPatientNotificationsRead(patientId) {
+  const r = await prisma.patientNotification.updateMany({
+    where: { patientId, isRead: false },
+    data: { isRead: true, readAt: new Date() },
+  });
+  return r.count;
+}
+
+// Public projection — strips tenantId so the portal response keeps the same
+// "no internal scoping fields" shape as /portal/me.
+function toPublic(n) {
+  if (!n) return n;
+  const { tenantId: _t, ...rest } = n;
+  return rest;
+}
+
+module.exports = {
+  createPatientNotification,
+  listPatientNotifications,
+  markPatientNotificationRead,
+  markAllPatientNotificationsRead,
+  toPublic,
+};

--- a/backend/lib/webhookDelivery.js
+++ b/backend/lib/webhookDelivery.js
@@ -57,8 +57,29 @@ async function deliverWebhooks(event, payload, tenantId) {
       },
     });
 
+    if (webhooks.length === 0) return;
+
+    // Subscription gate — lead sync only flows for subscribed tenants. When
+    // the subscription expires / is cancelled (and no active trial), delivery
+    // stops automatically here, without any cron or manual toggle. See
+    // lib/webhookEntitlement.js for the live-state policy (paid sub OR trial).
+    const { isTenantWebhookEntitled, resolveTenantWebhookSecret } = require("./webhookEntitlement");
+    const { entitled, reason } = await isTenantWebhookEntitled(tenantId);
+    if (!entitled) {
+      console.log(
+        `[Webhook] tenant ${tenantId} not entitled (${reason}) — skipping ${webhooks.length} ${event} deliveries`
+      );
+      return;
+    }
+
+    // Resolve the tenant's signing secret ONCE (not per-delivery): the
+    // per-tenant WebhookCredential, else the legacy global env secret, else
+    // null (→ unsigned). All of this tenant's webhooks share one secret so a
+    // partner (GlobusPhone) verifies with a single configured value.
+    const { secret } = await resolveTenantWebhookSecret(tenantId);
+
     for (const wh of webhooks) {
-      await deliverSingle(wh.targetUrl, event, payload, tenantId);
+      await deliverSingle(wh.targetUrl, event, payload, tenantId, secret);
     }
   } catch (e) {
     console.error(`[Webhook] Error querying webhooks for ${event}:`, e.message);
@@ -68,20 +89,26 @@ async function deliverWebhooks(event, payload, tenantId) {
 /**
  * Fire a single outbound webhook HTTP POST.
  *
- * [GP-CRM integration] Task 10 — Stripe-style HMAC signing. When
- * WEBHOOK_HMAC_SECRET is set, the delivery includes:
+ * [GP-CRM integration] Task 10 — Stripe-style HMAC signing. When a signing
+ * secret is available, the delivery includes:
  *   X-Globussoft-Signature: t=<unix_epoch_sec>,v1=<hmac_sha256_hex>
  * The signed string is "<t>.<bodyStr>" — bodyStr being the exact bytes of the
  * POST body. Partners verify HMAC-SHA256(secret, "<t>.<body>") == v1. When the
  * secret is absent, deliveries are sent unsigned — backwards-compatible with
  * every pre-integration subscriber and with partners that don't yet verify.
  *
- * @param {string} url       Target URL
- * @param {string} event     Event name
- * @param {object} payload   Event data
- * @param {number} tenantId  Tenant scope
+ * Secret precedence: the explicit `secret` argument (resolved per-tenant by
+ * deliverWebhooks via lib/webhookEntitlement.js) wins; when omitted it falls
+ * back to process.env.WEBHOOK_HMAC_SECRET (legacy global path — also what the
+ * existing HMAC unit tests exercise by calling the 4-arg form).
+ *
+ * @param {string}  url       Target URL
+ * @param {string}  event     Event name
+ * @param {object}  payload   Event data
+ * @param {number}  tenantId  Tenant scope
+ * @param {string} [secret]   Per-tenant HMAC secret; env fallback when undefined
  */
-async function deliverSingle(url, event, payload, tenantId) {
+async function deliverSingle(url, event, payload, tenantId, secret) {
   if (!url) {
     console.warn("[Webhook] No URL provided, skipping delivery");
     return;
@@ -107,7 +134,9 @@ async function deliverSingle(url, event, payload, tenantId) {
       "X-CRM-Tenant": String(tenantId),
     };
 
-    const hmacSecret = process.env.WEBHOOK_HMAC_SECRET || "";
+    // Explicit per-tenant secret wins; fall back to the legacy global env
+    // secret when the caller didn't pass one (4-arg legacy invocations).
+    const hmacSecret = (secret != null ? secret : process.env.WEBHOOK_HMAC_SECRET) || "";
     if (hmacSecret) {
       const sig = crypto
         .createHmac("sha256", hmacSecret)

--- a/backend/lib/webhookEntitlement.js
+++ b/backend/lib/webhookEntitlement.js
@@ -1,0 +1,103 @@
+// Webhook subscription-entitlement + per-tenant signing-secret resolution.
+//
+// Single source of truth for two questions, reused by BOTH the credential-
+// management routes (routes/developer.js) and the background delivery path
+// (lib/webhookDelivery.js → deliverWebhooks):
+//
+//   1. isTenantWebhookEntitled(tenantId)  — is this tenant allowed to send
+//      webhooks right now? Gate is: a live PAID subscription OR an active
+//      (non-expired) free trial. (Trial counts per the product decision.)
+//
+//   2. resolveTenantWebhookSecret(tenantId) — the raw HMAC secret to sign
+//      this tenant's outbound webhooks with: the decrypted secret of the
+//      tenant's ACTIVE WebhookCredential, else the legacy global
+//      process.env.WEBHOOK_HMAC_SECRET, else null (→ delivered unsigned).
+//
+// Why compute LIVE state instead of reading User.subscriptionStatus: that
+// denormalized column is only re-settled lazily when /subscriptions/status
+// is read (reconcileSubscriptions). The background delivery path never hits
+// that route, so an elapsed-but-still-"ACTIVE"-flagged user would otherwise
+// keep receiving webhooks after their period ended. Querying the Subscription
+// window (startDate/endDate) directly is authoritative without needing to run
+// the reconcile transaction on every webhook fire.
+const prisma = require("./prisma");
+const { decrypt } = require("./fieldEncryption");
+
+/**
+ * Is the tenant currently entitled to send outbound webhooks?
+ *
+ * @param {number} tenantId
+ * @returns {Promise<{ entitled: boolean, reason: string }>}
+ *   reason ∈ 'active_subscription' | 'active_trial' | 'no_active_subscription'
+ */
+async function isTenantWebhookEntitled(tenantId) {
+  if (!tenantId) return { entitled: false, reason: "no_active_subscription" };
+  const now = new Date();
+
+  // 1. A live PAID subscription: status ACTIVE and now within [startDate, endDate).
+  //    endDate null is treated as open-ended coverage.
+  const activeSub = await prisma.subscription.findFirst({
+    where: {
+      tenantId,
+      status: "ACTIVE",
+      startDate: { lte: now },
+      OR: [{ endDate: null }, { endDate: { gt: now } }],
+    },
+    select: { id: true },
+  });
+  if (activeSub) return { entitled: true, reason: "active_subscription" };
+
+  // 2. Else an active (non-expired) free trial on any user of the tenant.
+  //    trialEndsAt null is treated as still-trialing (mirrors checkSubscription,
+  //    which only expires a trial once trialEndsAt is set AND has passed).
+  const trialUser = await prisma.user.findFirst({
+    where: {
+      tenantId,
+      subscriptionStatus: "TRIAL",
+      OR: [{ trialEndsAt: null }, { trialEndsAt: { gt: now } }],
+    },
+    select: { id: true },
+  });
+  if (trialUser) return { entitled: true, reason: "active_trial" };
+
+  return { entitled: false, reason: "no_active_subscription" };
+}
+
+/**
+ * Resolve the raw HMAC signing secret for a tenant's outbound webhooks.
+ *
+ * Precedence:
+ *   1. The tenant's ACTIVE WebhookCredential (decrypted) — the new model.
+ *   2. process.env.WEBHOOK_HMAC_SECRET — legacy global fallback, kept so the
+ *      single pre-migration GlobusPhone integration keeps working until it
+ *      has generated a per-tenant credential.
+ *   3. null — no secret available → deliverSingle sends the webhook UNSIGNED.
+ *
+ * A REVOKED credential resolves to NO tenant secret (it is intentionally not
+ * matched); the caller then falls back to env-or-null. Combined with the
+ * entitlement gate in deliverWebhooks, a revoked credential effectively stops
+ * signed delivery to a verifying receiver.
+ *
+ * @param {number} tenantId
+ * @returns {Promise<{ secret: (string|null), source: ('credential'|'env'|'none') }>}
+ */
+async function resolveTenantWebhookSecret(tenantId) {
+  if (tenantId) {
+    const cred = await prisma.webhookCredential.findFirst({
+      where: { tenantId, status: "ACTIVE" },
+      select: { secret: true },
+    });
+    if (cred && cred.secret) {
+      // decrypt() is a no-op for plaintext (no ENC:v1: prefix) and for the
+      // key-unset case, so this works whether or not WELLNESS_FIELD_KEY is set.
+      return { secret: decrypt(cred.secret), source: "credential" };
+    }
+  }
+
+  const envSecret = process.env.WEBHOOK_HMAC_SECRET;
+  if (envSecret) return { secret: envSecret, source: "env" };
+
+  return { secret: null, source: "none" };
+}
+
+module.exports = { isTenantWebhookEntitled, resolveTenantWebhookSecret };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1803,19 +1803,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@prisma/config/node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
-      }
-    },
     "node_modules/@prisma/config/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,6 +103,8 @@ model Tenant {
   attachments           Attachment[]
   apiKeys               ApiKey[]
   webhooks              Webhook[]
+  webhookCredential     WebhookCredential?
+  patientNotifications  PatientNotification[]
   invoices              Invoice[]
   integrations          Integration[]
   customEntities        CustomEntity[]
@@ -504,6 +506,7 @@ model User {
   tickets           Ticket[]           @relation("AssignedTickets")
   apiKeys           ApiKey[]
   webhooks          Webhook[]
+  webhookCredentials WebhookCredential[] @relation("UserWebhookCredentials")
   tasks             Task[]
   expenses          Expense[]
   approvedExpenses  Expense[]          @relation("ExpenseApprover")
@@ -1002,6 +1005,11 @@ model ApiKey {
   // req.requireSubBrandMatch(targetSubBrand) helper — a key with subBrand='tmc'
   // posting a lead with subBrand='rfu' is rejected 403 SUB_BRAND_MISMATCH.
   subBrand  String?
+  // #908 (PRD_FLIGHT_PLUGIN_CHROME_EXTENSION FR-4/FR-5) — scopes a key to a
+  // specific consumer. null = tenant-wide (legacy / partner API); when set
+  // (e.g. "flight-plugin") the matching endpoint enforces it. Additive nullable
+  // so existing keys keep working unchanged.
+  purpose   String?
   createdAt DateTime  @default(now())
   lastUsed  DateTime?
 
@@ -1026,6 +1034,36 @@ model Webhook {
 
   userId Int
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+}
+
+// Per-tenant HMAC signing credential for outbound webhooks (the lead-sync
+// stream GlobusPhone consumes). Replaces the single global
+// `process.env.WEBHOOK_HMAC_SECRET`: each tenant's outbound webhooks are
+// signed with THIS tenant's `secret` instead. One row per tenant
+// (`tenantId @unique`) — rotation/regeneration overwrites `secret` in place;
+// revoke flips `status` to REVOKED (kept for audit, but delivery stops).
+//
+// Show-once model (Stripe/GitHub/AWS): the raw secret is only ever returned
+// in the generate/rotate HTTP response — never re-served afterwards. It is
+// stored encrypted-at-rest via lib/fieldEncryption.js (AES-256-GCM, opt-in
+// via WELLNESS_FIELD_KEY) because the SERVER still needs it to sign; the
+// `ENC:v1:...` wrapper means a plaintext secret (key unset) and an encrypted
+// one coexist transparently. Delivery is also subscription-gated — see
+// lib/webhookEntitlement.js + lib/webhookDelivery.js deliverWebhooks().
+model WebhookCredential {
+  id            Int       @id @default(autoincrement())
+  tenantId      Int       @unique // one signing secret per tenant
+  tenant        Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  secret        String    @db.Text // raw 64-hex OR "ENC:v1:..." (fieldEncryption)
+  signingId     String    @unique // public, non-secret ref e.g. "whid_<hex>"
+  status        String    @default("ACTIVE") // ACTIVE | REVOKED
+  lastRotatedAt DateTime?
+  createdById   Int
+  createdBy     User      @relation("UserWebhookCredentials", fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 
   @@index([tenantId])
 }
@@ -1442,6 +1480,35 @@ model Notification {
   @@index([userId, isRead])
   @@index([tenantId, userId, isRead])
   @@index([tenantId, createdAt])
+}
+
+// Patient-facing notification inbox (wellness patient portal + Android app).
+//
+// DELIBERATELY SEPARATE from the staff `Notification` model above: that one is
+// keyed on `userId` (staff Users) and is consumed by the web notification bell
+// + /api/notifications. Patients are a distinct `Patient` model (not Users) and
+// portal JWTs are rejected by the staff verifyToken middleware, so they could
+// never use that table. This additive table is patient-scoped (patientId) and
+// served by the portal endpoints in routes/wellness.js (/portal/me/notifications*)
+// behind verifyPatientToken — nothing in the staff notification path is touched.
+model PatientNotification {
+  id        Int       @id @default(autoincrement())
+  title     String
+  message   String    @db.Text
+  type      String    @default("info") // info | appointment | prescription | payment | system
+  link      String? // optional deep-link the app/portal can navigate to
+  isRead    Boolean   @default(false)
+  readAt    DateTime?
+  createdAt DateTime  @default(now())
+
+  patientId Int
+  patient   Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  tenantId Int
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([patientId, isRead])
+  @@index([patientId, createdAt])
 }
 
 model AuditLog {
@@ -3283,6 +3350,9 @@ model Patient {
   // the route handler filters by patient.deletedAt at read time, so dangling
   // tag links resurrect on patient restore.
   tags PatientTag[]
+
+  // Patient-portal notification inbox (additive — see PatientNotification).
+  patientNotifications PatientNotification[]
 
   /// One Patient per (tenant, normalized phone number). DB-level dedup gate guarding against the recurring "same patient created N times by overlapping intake flows" inflation pattern. Cross-tenant duplicates allowed — different clinics can each have a Patient with phone +91-9876543210.
   // #401 — DB-level dedup gate. Pre-this-constraint, the dedup logic

--- a/backend/prisma/seed-wellness.js
+++ b/backend/prisma/seed-wellness.js
@@ -20,6 +20,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 const { PrismaClient } = require("@prisma/client");
 const bcrypt = require("bcryptjs");
 const crypto = require("crypto");
+const { encrypt } = require("../lib/fieldEncryption");
 
 // Verify DATABASE_URL is set
 if (!process.env.DATABASE_URL) {
@@ -381,11 +382,11 @@ async function main() {
   // Requires WELLNESS_DEMO_OTP env var to actually unlock; this just ensures
   // the patient row exists so verify-otp can resolve a tenant.
   const demoPortalPhone = "+919876500001";
-  const existingDemo = await prisma.patient.findFirst({
+  let demoPortalPatient = await prisma.patient.findFirst({
     where: { tenantId: tenant.id, phone: demoPortalPhone },
   });
-  if (!existingDemo) {
-    await prisma.patient.create({
+  if (!demoPortalPatient) {
+    demoPortalPatient = await prisma.patient.create({
       data: {
         name: "Demo Portal Patient",
         email: "demo.portal@enhancedwellness.in",
@@ -399,6 +400,26 @@ async function main() {
       },
     });
     console.log(`[seed-wellness] demo portal patient seeded at ${demoPortalPhone}`);
+  }
+
+  // 4a-bis. Demo patient-portal notifications (Option A inbox). Additive +
+  // idempotent: only seed when this patient has none, so re-runs don't pile up.
+  // Gives the patient app / portal a non-empty inbox to render + the e2e spec
+  // deterministic rows to read.
+  if (demoPortalPatient) {
+    const notifCount = await prisma.patientNotification.count({
+      where: { patientId: demoPortalPatient.id },
+    });
+    if (notifCount === 0) {
+      await prisma.patientNotification.createMany({
+        data: [
+          { patientId: demoPortalPatient.id, tenantId: tenant.id, type: "appointment", title: "Appointment confirmed", message: "Your consultation at Enhanced Wellness (Ranchi) is confirmed for tomorrow at 11:00 AM.", link: "/portal/visits" },
+          { patientId: demoPortalPatient.id, tenantId: tenant.id, type: "prescription", title: "Prescription ready", message: "Dr. Harsh has issued a new prescription. Tap to view your medicines and dosage.", link: "/portal/prescriptions" },
+          { patientId: demoPortalPatient.id, tenantId: tenant.id, type: "payment", title: "Payment receipt", message: "We received your payment of ₹1,500. Thank you!", link: "/portal/visits", isRead: true },
+        ],
+      });
+      console.log(`[seed-wellness] seeded 3 demo patient-portal notifications`);
+    }
   }
 
   // 4. Patients (50) — only seed if we have fewer than 10 already (idempotency)
@@ -698,6 +719,33 @@ async function main() {
     console.log("[seed-wellness] partner API keys (give these to the respective teams):");
     for (const k of printedKeys) {
       console.log(`  ${k.fresh ? "[NEW]    " : "[exists] "}${k.name.padEnd(32)} ${k.key}`);
+    }
+
+    // 8a-bis. Migrate the legacy global webhook secret to a per-tenant
+    // WebhookCredential so this tenant's GlobusPhone integration keeps working
+    // under the new subscription-gated, per-tenant signing model (see
+    // lib/webhookEntitlement.js + lib/webhookDelivery.js). Idempotent: only
+    // seeds when (a) the env secret is set and (b) no credential exists yet, so
+    // a real generated/rotated secret is never overwritten by a re-seed.
+    const legacySecret = process.env.WEBHOOK_HMAC_SECRET;
+    if (legacySecret) {
+      const existingCred = await prisma.webhookCredential.findUnique({
+        where: { tenantId: tenant.id },
+      });
+      if (!existingCred) {
+        await prisma.webhookCredential.create({
+          data: {
+            tenantId: tenant.id,
+            secret: encrypt(legacySecret), // ENC:v1:... when WELLNESS_FIELD_KEY set, else raw
+            signingId: `whid_${crypto.randomBytes(8).toString("hex")}`,
+            status: "ACTIVE",
+            createdById: adminUser.id,
+          },
+        });
+        console.log("[seed-wellness] migrated WEBHOOK_HMAC_SECRET → per-tenant WebhookCredential (Enhanced Wellness)");
+      } else {
+        console.log("[seed-wellness] WebhookCredential already present — left untouched");
+      }
     }
   }
 

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -1,0 +1,202 @@
+const express = require("express");
+const crypto = require("crypto");
+const { verifyToken, verifyRole } = require("../middleware/auth");
+const { encrypt } = require("../lib/fieldEncryption");
+const { isTenantWebhookEntitled } = require("../lib/webhookEntitlement");
+
+const router = express.Router();
+const prisma = require("../lib/prisma");
+
+// ── Webhook Signing Credential (per-tenant HMAC secret) ──────────────
+//
+// Lives under /api/settings (surfaced in the Settings page → "Webhook Signing
+// Credential" card) rather than the Developer page. Replaces the single global
+// process.env.WEBHOOK_HMAC_SECRET: each tenant gets its OWN HMAC secret,
+// generated + managed by an ADMIN, used to sign every outbound webhook for that
+// tenant (see lib/webhookDelivery.js + lib/webhookEntitlement.js).
+//
+// Show-once model (Stripe/GitHub/AWS): the raw secret is returned ONLY in the
+// generate/rotate response — never re-served. The GET below exposes status +
+// metadata, never secret bytes. Lost secret ⇒ rotate + reconfigure the
+// receiver. Generation/rotation are subscription-gated (402 when the tenant
+// has no active paid subscription and no active trial). ADMIN-only.
+
+// Static config a receiver (e.g. GlobusPhone) needs to verify our signatures.
+const WEBHOOK_SIGNING_INFO = {
+  header: "X-Globussoft-Signature",
+  algorithm: "HMAC-SHA256",
+  signedPayload: "<t>.<rawBody>", // HMAC-SHA256(secret, "<t>.<body>") == v1
+  receiverEnvVar: "WEBHOOK_HMAC_SECRET_CRM", // GlobusPhone's inbound-verify env name
+};
+
+// Public, non-secret reference id for a credential — lets a config/UI name
+// "which key" without exposing the secret. Not used in signing.
+function newSigningId() {
+  return `whid_${crypto.randomBytes(8).toString("hex")}`;
+}
+
+// 64-hex (32-byte) HMAC secret, matching the `openssl rand -hex 32` the env
+// docs recommended for the legacy global secret.
+function newWebhookSecret() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+// Public projection of a credential row — NEVER includes the raw secret.
+// secretMasked is a non-recoverable hint derived from the PUBLIC signingId.
+function publicCredentialView(cred) {
+  if (!cred) return { exists: false, status: null, signingId: null, lastRotatedAt: null, createdAt: null, secretMasked: null };
+  return {
+    exists: true,
+    status: cred.status,
+    signingId: cred.signingId,
+    lastRotatedAt: cred.lastRotatedAt,
+    createdAt: cred.createdAt,
+    secretMasked: `whsec_••••••${cred.signingId.slice(-4)}`,
+  };
+}
+
+// GET — current tenant's signing credential status + entitlement. Safe to
+// call in any state (no credential / revoked / active); never leaks the secret.
+router.get("/webhook-credential", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const { tenantId } = req.user;
+    const cred = await prisma.webhookCredential.findUnique({ where: { tenantId } });
+    const { entitled, reason } = await isTenantWebhookEntitled(tenantId);
+    res.json({
+      ...publicCredentialView(cred),
+      entitled,
+      entitlementReason: reason,
+      signing: WEBHOOK_SIGNING_INFO,
+    });
+  } catch (err) {
+    console.error("[settings/webhook-credential GET]", err);
+    res.status(500).json({ error: "Failed to read webhook credential." });
+  }
+});
+
+// POST — generate the tenant's signing secret. Entitlement-gated. Returns the
+// raw secret ONCE (the only time it is ever exposed). 409 if an ACTIVE
+// credential already exists (rotate instead); a previously REVOKED row is
+// reactivated with a fresh secret.
+router.post("/webhook-credential", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const { tenantId, userId } = req.user;
+
+    const { entitled, reason } = await isTenantWebhookEntitled(tenantId);
+    if (!entitled) {
+      return res.status(402).json({
+        error: "No active subscription. Webhook generation requires an active subscription or trial.",
+        code: "NO_ACTIVE_SUBSCRIPTION",
+        entitlementReason: reason,
+        upgradeUrl: "/pricing",
+      });
+    }
+
+    const existing = await prisma.webhookCredential.findUnique({ where: { tenantId } });
+    if (existing && existing.status === "ACTIVE") {
+      return res.status(409).json({
+        error: "A signing credential already exists. Rotate it instead of generating a new one.",
+        code: "CREDENTIAL_EXISTS",
+      });
+    }
+
+    const rawSecret = newWebhookSecret();
+    const signingId = newSigningId();
+    const data = {
+      secret: encrypt(rawSecret), // ENC:v1:... when WELLNESS_FIELD_KEY set, else raw
+      signingId,
+      status: "ACTIVE",
+      createdById: userId,
+    };
+
+    const cred = existing
+      ? await prisma.webhookCredential.update({
+          where: { tenantId },
+          data: { ...data, lastRotatedAt: new Date() }, // reactivating a revoked row
+        })
+      : await prisma.webhookCredential.create({ data: { ...data, tenantId } });
+
+    // The raw secret is surfaced HERE and nowhere else — show-once.
+    res.status(201).json({
+      ...publicCredentialView(cred),
+      secret: rawSecret,
+      signing: WEBHOOK_SIGNING_INFO,
+      warning: "Save this secret now — it will not be shown again. If you lose it, rotate the credential.",
+    });
+  } catch (err) {
+    console.error("[settings/webhook-credential POST]", err);
+    res.status(500).json({ error: "Failed to generate webhook credential." });
+  }
+});
+
+// POST /rotate — replace the secret. Entitlement-gated. Returns the new raw
+// secret once; the old value becomes unrecoverable. Also reactivates a
+// revoked credential (status → ACTIVE).
+router.post("/webhook-credential/rotate", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const { tenantId } = req.user;
+
+    const { entitled, reason } = await isTenantWebhookEntitled(tenantId);
+    if (!entitled) {
+      return res.status(402).json({
+        error: "No active subscription. Rotating a signing secret requires an active subscription or trial.",
+        code: "NO_ACTIVE_SUBSCRIPTION",
+        entitlementReason: reason,
+        upgradeUrl: "/pricing",
+      });
+    }
+
+    const existing = await prisma.webhookCredential.findUnique({ where: { tenantId } });
+    if (!existing) {
+      return res.status(404).json({
+        error: "No signing credential to rotate. Generate one first.",
+        code: "CREDENTIAL_NOT_FOUND",
+      });
+    }
+
+    const rawSecret = newWebhookSecret();
+    const cred = await prisma.webhookCredential.update({
+      where: { tenantId },
+      data: {
+        secret: encrypt(rawSecret),
+        signingId: newSigningId(),
+        status: "ACTIVE",
+        lastRotatedAt: new Date(),
+      },
+    });
+
+    res.json({
+      ...publicCredentialView(cred),
+      secret: rawSecret,
+      signing: WEBHOOK_SIGNING_INFO,
+      warning: "Save this secret now — it will not be shown again. Update your receiver (e.g. GlobusPhone) with the new value.",
+    });
+  } catch (err) {
+    console.error("[settings/webhook-credential rotate]", err);
+    res.status(500).json({ error: "Failed to rotate webhook credential." });
+  }
+});
+
+// DELETE — revoke. Delivery stops immediately (the entitlement+secret resolver
+// in webhookDelivery.js will no longer match an ACTIVE credential). The row is
+// kept (status REVOKED) rather than deleted so it can be reactivated by
+// generating/rotating. No entitlement gate — revoking must always be possible.
+router.delete("/webhook-credential", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const { tenantId } = req.user;
+    const existing = await prisma.webhookCredential.findUnique({ where: { tenantId } });
+    if (!existing) {
+      return res.status(404).json({ error: "No signing credential found.", code: "CREDENTIAL_NOT_FOUND" });
+    }
+    const cred = await prisma.webhookCredential.update({
+      where: { tenantId },
+      data: { status: "REVOKED" },
+    });
+    res.json({ success: true, ...publicCredentialView(cred) });
+  } catch (err) {
+    console.error("[settings/webhook-credential DELETE]", err);
+    res.status(500).json({ error: "Failed to revoke webhook credential." });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/travel_flight_quotes.js
+++ b/backend/routes/travel_flight_quotes.js
@@ -1,0 +1,135 @@
+// Travel CRM — Flight Quotation plugin endpoint.
+//
+// PRD_FLIGHT_PLUGIN_CHROME_EXTENSION FR-5 + FR-6. The CRM-side receiver for
+// the (separate-repo) Chrome flight plugin: the plugin scrapes a fare off an
+// airline site and POSTs the RAW fare here; this endpoint applies per-tenant +
+// per-sub-brand markup via lib/travelPricing and persists a flight
+// ItineraryItem. The plugin NEVER computes markup client-side — pricing math
+// has a single source of truth (FR-6 / §2.3).
+//
+// Mounted at /api/v1/flight-plugin (server.js), authed with X-API-Key via
+// middleware/externalAuth — the same partner-API pattern as /api/v1/external.
+// The key must be scoped to the flight plugin (ApiKey.purpose === "flight-plugin")
+// OR be a legacy tenant-wide key (purpose === null) for back-compat.
+//
+// Endpoint:
+//   POST /api/v1/flight-plugin/quotes
+//     body { airline, fareClass?, pricePerPax, currency?, departAt?, returnAt?,
+//            route: { from, to }, fareUrl?, screenshotUrl?, itineraryId, advisorId? }
+//     201  { itineraryItemId, totalWithMarkup, currency }
+//
+// Sub-brand-scoped keys are enforced via req.requireSubBrandMatchOrSend (a key
+// scoped to 'tmc' can't add an item to an 'rfu' itinerary → 403). ItineraryItem
+// has no `currency` column, so the fare currency is stored in detailsJson.
+
+const express = require("express");
+const router = express.Router();
+const externalAuth = require("../middleware/externalAuth");
+const prisma = require("../lib/prisma");
+const { pickMarkup } = require("../lib/travelPricing");
+
+const FLIGHT_PLUGIN_PURPOSE = "flight-plugin";
+
+// Gate: only a flight-plugin-scoped key (or a legacy tenant-wide key with no
+// purpose set) may post flight quotes. A partner key minted for a different
+// purpose is rejected so a leaked key can't fabricate itinerary items.
+function requireFlightPluginKey(req, res, next) {
+  const purpose = req.apiKey?.purpose || null;
+  if (purpose !== null && purpose !== FLIGHT_PLUGIN_PURPOSE) {
+    return res.status(403).json({ error: "API key is not scoped for the flight plugin", code: "WRONG_KEY_PURPOSE" });
+  }
+  next();
+}
+
+router.post("/quotes", externalAuth, requireFlightPluginKey, async (req, res) => {
+  try {
+    const b = req.body || {};
+    const airline = typeof b.airline === "string" ? b.airline.trim() : "";
+    const pricePerPax = Number(b.pricePerPax);
+    const itineraryId = parseInt(b.itineraryId, 10);
+    const from = b.route && b.route.from ? String(b.route.from).trim() : "";
+    const to = b.route && b.route.to ? String(b.route.to).trim() : "";
+
+    if (!airline) return res.status(400).json({ error: "airline is required", code: "MISSING_AIRLINE" });
+    if (!Number.isFinite(pricePerPax) || pricePerPax < 0) {
+      return res.status(400).json({ error: "pricePerPax must be a non-negative number", code: "INVALID_PRICE" });
+    }
+    if (!Number.isInteger(itineraryId)) {
+      return res.status(400).json({ error: "itineraryId is required", code: "MISSING_ITINERARY" });
+    }
+    if (!from || !to) {
+      return res.status(400).json({ error: "route.from and route.to are required", code: "MISSING_ROUTE" });
+    }
+
+    const currency = typeof b.currency === "string" && b.currency.trim() ? b.currency.trim().toUpperCase() : "INR";
+    const fareClass = typeof b.fareClass === "string" ? b.fareClass.trim() : null;
+
+    // The itinerary must belong to the key's tenant; its subBrand drives markup.
+    const itin = await prisma.itinerary.findFirst({
+      where: { id: itineraryId, tenantId: req.tenantId },
+      select: { id: true, subBrand: true },
+    });
+    if (!itin) return res.status(404).json({ error: "Itinerary not found", code: "ITINERARY_NOT_FOUND" });
+
+    // Sub-brand-scoped key isolation (partner-API pattern). Tenant-wide keys pass.
+    if (typeof req.requireSubBrandMatchOrSend === "function") {
+      if (!req.requireSubBrandMatchOrSend(itin.subBrand, res)) return; // 403 already sent
+    }
+
+    // FR-6 — markup computed server-side (single source of truth). Fetch the
+    // tenant's active markup rules; pickMarkup filters by subBrand + scope.
+    const rules = await prisma.travelMarkupRule.findMany({
+      where: { tenantId: req.tenantId, isActive: true },
+    });
+    const advisorId = b.advisorId != null ? parseInt(b.advisorId, 10) : (req.apiKey && req.apiKey.userId) || null;
+    const { markupAmount } = pickMarkup(
+      rules,
+      itin.subBrand,
+      "flight",
+      pricePerPax,
+      Number.isInteger(advisorId) ? advisorId : null,
+    );
+    const totalWithMarkup = Math.round((pricePerPax + markupAmount) * 100) / 100;
+
+    const position = await prisma.itineraryItem.count({ where: { itineraryId: itin.id } });
+    const detailsJson = JSON.stringify({
+      airline,
+      fareClass,
+      route: { from, to },
+      departAt: b.departAt || null,
+      returnAt: b.returnAt || null,
+      currency,
+      fareUrl: b.fareUrl || null,
+      screenshotUrl: b.screenshotUrl || null,
+      source: "flight-plugin",
+    });
+    const description = `${airline} ${from}→${to}${fareClass ? ` (${fareClass})` : ""}`;
+
+    const item = await prisma.itineraryItem.create({
+      data: {
+        itineraryId: itin.id,
+        itemType: "flight",
+        position,
+        description,
+        detailsJson,
+        unitCost: pricePerPax,
+        markup: markupAmount,
+        totalPrice: totalWithMarkup,
+        unit: "per_person",
+        quantity: 1,
+      },
+    });
+
+    // Touch the itinerary so the detail page surfaces the new item promptly.
+    await prisma.itinerary
+      .update({ where: { id: itin.id }, data: { updatedAt: new Date() } })
+      .catch(() => {});
+
+    return res.status(201).json({ itineraryItemId: item.id, totalWithMarkup, currency });
+  } catch (e) {
+    console.error("[flight-plugin] quote error:", e.message);
+    res.status(500).json({ error: "Failed to record flight quote" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/travel_flyer_templates.js
+++ b/backend/routes/travel_flyer_templates.js
@@ -110,6 +110,26 @@ const {
   buildOutputCacheKey,
 } = require("../lib/flyerExport");
 const { renderFlyerPdf } = require("../lib/flyerPdfRender");
+const multer = require("multer");
+const fs = require("fs");
+const path = require("path");
+const s3 = require("../services/s3Service");
+
+// Flyer asset upload (PRD_TRAVEL_MARKETING_FLYER FR-3.2.2). memoryStorage so the
+// buffer can route to S3 (when AWS_S3_BUCKET_NAME is set) OR local disk (dev /
+// no creds) — works now, uses S3 the moment the bucket env lands, no code change.
+const FLYER_IMAGE_MIMES = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml"];
+const flyerImageUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter: (_req, file, cb) => {
+    if (FLYER_IMAGE_MIMES.includes(file.mimetype)) cb(null, true);
+    else cb(new Error("Only JPG, PNG, GIF, WebP, or SVG images are allowed"));
+  },
+});
+function flyerImageExt(mime) {
+  return ({ "image/jpeg": ".jpg", "image/png": ".png", "image/gif": ".gif", "image/webp": ".webp", "image/svg+xml": ".svg" })[mime] || ".img";
+}
 
 /**
  * Parse a `@db.Text` column expected to contain JSON. Accepts:
@@ -199,6 +219,54 @@ function withTemplateHash(row) {
   }
   return { ...row, templateHash: hashTemplateShape({ palette, layout, assets }) };
 }
+
+// POST /api/travel/flyer-templates/upload
+//
+// FR-3.2.2 — upload a flyer asset image (multipart/form-data, field "image").
+// Storage: AWS S3 via services/s3Service when AWS_S3_BUCKET_NAME is configured
+// (marketing flyers are public-shareable assets, so s3Service's public-read ACL
+// is appropriate here); otherwise written to local disk under
+// backend/uploads/flyer-assets/tenant-<id>/ (served by the /uploads static
+// mount). ADMIN/MANAGER + travel-vertical only (matches the studio RBAC).
+// Returns { url, storage }.
+router.post(
+  "/flyer-templates/upload",
+  verifyToken,
+  verifyRole(["ADMIN", "MANAGER"]),
+  requireTravelTenant,
+  (req, res) => {
+    flyerImageUpload.single("image")(req, res, async (err) => {
+      if (err) {
+        const code = err.code === "LIMIT_FILE_SIZE" ? "FILE_TOO_LARGE" : "INVALID_UPLOAD";
+        return res.status(400).json({ error: err.message || "Upload failed", code });
+      }
+      if (!req.file) {
+        return res.status(400).json({ error: "image file is required (field 'image')", code: "MISSING_FILE" });
+      }
+      try {
+        const tenantId = req.travelTenant.id;
+        if (s3.BUCKET_NAME) {
+          const url = await s3.uploadImage(
+            req.file.buffer,
+            req.file.originalname || "flyer-asset",
+            req.file.mimetype,
+            `flyer-assets/tenant-${tenantId}`,
+          );
+          return res.status(201).json({ url, storage: "s3" });
+        }
+        // Local-disk fallback (no S3 configured).
+        const dir = path.join(__dirname, "..", "uploads", "flyer-assets", `tenant-${tenantId}`);
+        await fs.promises.mkdir(dir, { recursive: true });
+        const fileName = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}${flyerImageExt(req.file.mimetype)}`;
+        await fs.promises.writeFile(path.join(dir, fileName), req.file.buffer);
+        return res.status(201).json({ url: `/uploads/flyer-assets/tenant-${tenantId}/${fileName}`, storage: "local" });
+      } catch (e) {
+        console.error("[flyer-upload] store error:", e.message);
+        return res.status(500).json({ error: "Failed to store image", code: "UPLOAD_STORE_FAILED" });
+      }
+    });
+  },
+);
 
 // GET /api/travel/flyer-templates
 // Honors ?subBrand=tmc, ?isActive=true/false.

--- a/backend/routes/travel_itineraries.js
+++ b/backend/routes/travel_itineraries.js
@@ -1161,13 +1161,13 @@ router.get("/itineraries/stats", verifyToken, requireTravelTenant, async (req, r
     const zeroed = {
       total: 0,
       byStatus: {
-        draft:        { count: 0, totalValue: 0 },
-        sent:         { count: 0, totalValue: 0 },
-        revised:      { count: 0, totalValue: 0 },
-        accepted:     { count: 0, totalValue: 0 },
-        rejected:     { count: 0, totalValue: 0 },
+        draft: { count: 0, totalValue: 0 },
+        sent: { count: 0, totalValue: 0 },
+        revised: { count: 0, totalValue: 0 },
+        accepted: { count: 0, totalValue: 0 },
+        rejected: { count: 0, totalValue: 0 },
         advance_paid: { count: 0, totalValue: 0 },
-        fully_paid:   { count: 0, totalValue: 0 },
+        fully_paid: { count: 0, totalValue: 0 },
       },
       bySubBrand: {},
       grandTotalValue: 0,
@@ -1205,13 +1205,13 @@ router.get("/itineraries/stats", verifyToken, requireTravelTenant, async (req, r
     const round2 = (n) => Math.round((Number(n) + Number.EPSILON) * 100) / 100;
 
     const byStatus = {
-      draft:        { count: 0, totalValue: 0 },
-      sent:         { count: 0, totalValue: 0 },
-      revised:      { count: 0, totalValue: 0 },
-      accepted:     { count: 0, totalValue: 0 },
-      rejected:     { count: 0, totalValue: 0 },
+      draft: { count: 0, totalValue: 0 },
+      sent: { count: 0, totalValue: 0 },
+      revised: { count: 0, totalValue: 0 },
+      accepted: { count: 0, totalValue: 0 },
+      rejected: { count: 0, totalValue: 0 },
       advance_paid: { count: 0, totalValue: 0 },
-      fully_paid:   { count: 0, totalValue: 0 },
+      fully_paid: { count: 0, totalValue: 0 },
     };
     const bySubBrand = {};
     let grandTotalValue = 0;
@@ -1982,7 +1982,7 @@ router.patch("/itineraries/:id/items/:itemId", verifyToken, requireTravelTenant,
     if (!existing) return res.status(404).json({ error: "Item not found", code: "ITEM_NOT_FOUND" });
 
     const data = {};
-    const { itemType, position, description, detailsJson, supplierId, unitCost, markup, gstAmount, unit, quantity, direction, totalPrice } = req.body || {};
+    const { itemType, position, description, detailsJson, supplierId, unitCost, markup, gstAmount, unit, quantity, direction, dayNumber, latitude, longitude, totalPrice } = req.body || {};
     if (itemType !== undefined) {
       assertValidItemType(itemType);
       data.itemType = itemType;
@@ -2009,6 +2009,44 @@ router.patch("/itineraries/:id/items/:itemId", verifyToken, requireTravelTenant,
         return res.status(400).json({ error: `direction must be one of: ${VALID_ITEM_DIRECTIONS.join(", ")}`, code: "INVALID_DIRECTION" });
       }
       data.direction = direction ? String(direction) : null;
+    }
+
+    // FR-3.3 day-by-day editor + FR-3.4 map preview
+    // (PRD_TRAVEL_ITINERARY_UPGRADES). The visual editor moves items across
+    // day cards (dayNumber) and plots them on the map (latitude/longitude).
+    // All three are additive nullable columns (S8); "" / null clears them.
+    if (dayNumber !== undefined) {
+      if (dayNumber === null || dayNumber === "") {
+        data.dayNumber = null;
+      } else {
+        const dn = parseInt(dayNumber, 10);
+        if (!Number.isInteger(dn) || dn < 1 || dn > 365) {
+          return res.status(400).json({ error: "dayNumber must be an integer between 1 and 365", code: "INVALID_DAY_NUMBER" });
+        }
+        data.dayNumber = dn;
+      }
+    }
+    if (latitude !== undefined) {
+      if (latitude === null || latitude === "") {
+        data.latitude = null;
+      } else {
+        const lat = Number(latitude);
+        if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+          return res.status(400).json({ error: "latitude must be between -90 and 90", code: "INVALID_LATITUDE" });
+        }
+        data.latitude = lat;
+      }
+    }
+    if (longitude !== undefined) {
+      if (longitude === null || longitude === "") {
+        data.longitude = null;
+      } else {
+        const lng = Number(longitude);
+        if (!Number.isFinite(lng) || lng < -180 || lng > 180) {
+          return res.status(400).json({ error: "longitude must be between -180 and 180", code: "INVALID_LONGITUDE" });
+        }
+        data.longitude = lng;
+      }
     }
 
     // Recompute the line total whenever a price-affecting field changes,
@@ -2357,9 +2395,9 @@ async function autoCreateWebCheckinsForItinerary(itineraryId, tenantId) {
     }
     const airlineCode = String(
       details.airlineCode
-        || (typeof details.flightNumber === "string"
-          && details.flightNumber.match(/^[A-Z0-9]{2}/)?.[0])
-        || "",
+      || (typeof details.flightNumber === "string"
+        && details.flightNumber.match(/^[A-Z0-9]{2}/)?.[0])
+      || "",
     ).toUpperCase();
     const dep = new Date(details.departureAt);
     if (!Number.isFinite(dep.getTime())) {
@@ -2388,7 +2426,7 @@ async function autoCreateWebCheckinsForItinerary(itineraryId, tenantId) {
     } catch (e) {
       console.error(
         `[travel-itin] webcheckin auto-create for itinerary ${itineraryId} ` +
-          `(PNR ${details.pnr}) failed (non-fatal):`,
+        `(PNR ${details.pnr}) failed (non-fatal):`,
         e.message,
       );
       skipped++;
@@ -2477,6 +2515,136 @@ router.post("/itineraries/:id/accept", verifyToken, requireTravelTenant, async (
   }
 });
 
+// FR-3.4(d) response shape: { summary, days: [{ dayNumber, items: [...] }] }.
+// Deterministic (no Date.now / Math.random) so the stub is test-pinnable
+// and demo screenshots stay stable. Each item uses a valid ItineraryItem
+// itemType (flight|hotel|activity) so the operator can materialise an
+// accepted day straight through POST /itineraries/:id/items unchanged.
+function buildSuggestionSkeleton({ destination, days, budgetPerPax, summary }) {
+  const perDayHotel =
+    budgetPerPax != null && days > 0
+      ? Math.round((budgetPerPax / days) * 100) / 100
+      : null;
+  const dayList = [];
+  for (let d = 1; d <= days; d++) {
+    const items = [];
+    if (d === 1) {
+      items.push({ itemType: "flight", description: `Arrival in ${destination}`, suggestedSupplierName: null, estimatedCost: null, latitude: null, longitude: null });
+    }
+    items.push({ itemType: "hotel", description: `Night ${d} — stay in ${destination}`, suggestedSupplierName: null, estimatedCost: perDayHotel, latitude: null, longitude: null });
+    items.push({ itemType: "activity", description: `Day ${d} — sightseeing in ${destination}`, suggestedSupplierName: null, estimatedCost: null, latitude: null, longitude: null });
+    if (d === days) {
+      items.push({ itemType: "flight", description: `Departure from ${destination}`, suggestedSupplierName: null, estimatedCost: null, latitude: null, longitude: null });
+    }
+    dayList.push({ dayNumber: d, items });
+  }
+  return { summary, days: dayList };
+}
+
+// POST /api/travel/itineraries/suggest
+//
+// PRD_TRAVEL_ITINERARY_UPGRADES FR-3.4 — LLM "Suggest itinerary".
+// Operator supplies destination + days + (optional) budget-per-pax +
+// traveller profile + sub-brand; returns a STRUCTURED day-by-day draft
+// for review. Per FR-3.4(e) this is SUGGESTED only — NOTHING is written
+// to the DB. The operator materialises accepted days via the existing
+// POST /itineraries + /:id/items endpoints.
+//
+// itinerary-suggest task class → gemini-flash provider slot (PRD §9.1;
+// PRD names gemini-2.5-flash). Until Q11 keys land, llmRouter returns a
+// [STUB-ITINERARY-SUGGEST] summary and we assemble a deterministic
+// day-by-day skeleton here (FR-3.4(g) — mirrors /draft/regen's stub).
+//
+// No diagnostic-first guard: this is an internal operator drafting tool,
+// not a customer-facing quote artifact (that guard lives on itinerary
+// CREATE). Sub-brand, when supplied, is validated + access-checked.
+// Travel-tenant only (requireTravelTenant → 403 WRONG_VERTICAL for
+// generic/wellness).
+router.post(
+  "/itineraries/suggest",
+  verifyToken,
+  requireTravelTenant,
+  async (req, res) => {
+    try {
+      const { destination, days, budgetPerPax, travellerProfile, subBrand } = req.body || {};
+
+      const dest = typeof destination === "string" ? destination.trim() : "";
+      if (!dest) {
+        return res.status(400).json({ error: "destination is required", code: "MISSING_DESTINATION" });
+      }
+      const numDays = parseInt(days, 10);
+      if (!Number.isInteger(numDays) || numDays < 1 || numDays > 30) {
+        return res.status(400).json({ error: "days must be an integer between 1 and 30", code: "INVALID_DAYS" });
+      }
+
+      let resolvedSubBrand = null;
+      if (subBrand != null && String(subBrand).trim() !== "") {
+        assertValidSubBrand(String(subBrand).trim()); // throws 400 INVALID_SUB_BRAND (caught below)
+        resolvedSubBrand = String(subBrand).trim();
+        const allowed = await getSubBrandAccessSet(req.user.userId);
+        if (!canAccessSubBrand(allowed, resolvedSubBrand)) {
+          return res.status(403).json({ error: "Sub-brand access denied", code: "SUB_BRAND_DENIED" });
+        }
+      }
+
+      let budgetNum = null;
+      if (budgetPerPax != null && budgetPerPax !== "") {
+        budgetNum = Number(budgetPerPax);
+        if (!Number.isFinite(budgetNum) || budgetNum < 0) {
+          return res.status(400).json({ error: "budgetPerPax must be a non-negative number", code: "INVALID_BUDGET" });
+        }
+      }
+      const profile = typeof travellerProfile === "string" ? travellerProfile.slice(0, 2000) : null;
+
+      let result;
+      try {
+        result = await llmRouter.routeRequest({
+          task: "itinerary-suggest",
+          payload: {
+            destination: dest,
+            days: numDays,
+            budgetPerPax: budgetNum,
+            travellerProfile: profile,
+            subBrand: resolvedSubBrand,
+            __userId: req.user.userId,
+            __surface: "itinerary-suggest",
+          },
+          tenantId: req.travelTenant.id,
+        });
+      } catch (e) {
+        if (e.code === "LLM_BUDGET_EXCEEDED") {
+          return res.status(429).json({
+            error: "Monthly AI budget reached for this tenant.",
+            code: "LLM_BUDGET_EXCEEDED",
+            spentCents: e.spentCents,
+            capCents: e.capCents,
+          });
+        }
+        throw e;
+      }
+
+      const suggestion = buildSuggestionSkeleton({
+        destination: dest,
+        days: numDays,
+        budgetPerPax: budgetNum,
+        summary: result.text,
+      });
+
+      return res.status(200).json({
+        suggestion,
+        subBrand: resolvedSubBrand,
+        model: result.model,
+        stub: Boolean(result.stub),
+        generatedAt: new Date().toISOString(),
+      });
+    } catch (e) {
+      if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+      console.error("[travel-itin] suggest error:", e.message);
+      res.status(500).json({ error: "Failed to generate itinerary suggestion" });
+    }
+  },
+);
+
 // POST /api/travel/itineraries/:id/draft/regen
 //
 // PRD §4.3 + §9.1: regenerate the customer-facing draft summary block
@@ -2528,9 +2696,9 @@ router.post(
       // structure alone, just without the recipient framing.
       const contact = full.contactId
         ? await prisma.contact.findFirst({
-            where: { id: full.contactId, tenantId: req.travelTenant.id },
-            select: { name: true },
-          })
+          where: { id: full.contactId, tenantId: req.travelTenant.id },
+          select: { name: true },
+        })
         : null;
 
       // PII-minimal payload — mirrors talking-points pattern. NO contact
@@ -2765,7 +2933,7 @@ router.post("/itineraries/:id/share", verifyToken, requireTravelTenant, async (r
     const cfg = resolveForSubBrand(tenantCfgRow, itin.subBrand);
     console.log(
       `[travel-itin] share token minted for itin ${full.id} (sub-brand=${itin.subBrand}) — ` +
-        `would WhatsApp-blast via wabaId=${cfg.wabaId || "(no-config)"} pending Wati creds`,
+      `would WhatsApp-blast via wabaId=${cfg.wabaId || "(no-config)"} pending Wati creds`,
     );
     res.json({ shareToken: token, shareUrl });
   } catch (e) {
@@ -2808,9 +2976,9 @@ router.get("/itineraries/:id/pdf", verifyToken, requireTravelTenant, async (req,
     }
     const contact = full.contactId
       ? await prisma.contact.findUnique({
-          where: { id: full.contactId },
-          select: { name: true, email: true, phone: true },
-        })
+        where: { id: full.contactId },
+        select: { name: true, email: true, phone: true },
+      })
       : { name: "Customer", email: null, phone: null };
     const pdfBuf = await renderTravelItineraryPdf(full, contact);
     res.setHeader("Content-Type", "application/pdf");
@@ -4421,7 +4589,7 @@ router.post(
             detailsObj.notes = String(src.notes);
           }
           if (src.suggestedSupplierName != null
-              && String(src.suggestedSupplierName).trim() !== "") {
+            && String(src.suggestedSupplierName).trim() !== "") {
             detailsObj.suggestedSupplierName = String(src.suggestedSupplierName);
           }
           if (src.durationMinutes != null && src.durationMinutes !== "") {

--- a/backend/routes/travel_rfu_profiles.js
+++ b/backend/routes/travel_rfu_profiles.js
@@ -68,6 +68,27 @@ router.get("/rfu-profiles", verifyToken, requireTravelTenant, requireRfuAccess, 
     }
     const take = Math.min(parseInt(req.query.limit, 10) || 50, 200);
     const skip = parseInt(req.query.offset, 10) || 0;
+    // S3 (PRD_TRAVEL_SECURITY_ARCHITECTURE) — opt-in PII-light list projection.
+    // ?fields=summary returns only list-safe columns and DROPS the sensitive
+    // ones (passport, visa history, frequent-flyer, budget, medical notes,
+    // emergency contact, past complaints). Opt-in + additive: the DEFAULT
+    // response shape is unchanged, so every existing caller is byte-identical.
+    // Travel-only endpoint (requireTravelTenant + requireRfuAccess) — never
+    // reached by the wellness or generic verticals.
+    const findArgs = { where, orderBy: { id: "desc" }, take, skip };
+    if (req.query.fields === "summary") {
+      findArgs.select = {
+        id: true,
+        tenantId: true,
+        contactId: true,
+        productTier: true,
+        travelStyle: true,
+        seatPref: true,
+        mealPref: true,
+        createdAt: true,
+        updatedAt: true,
+      };
+    }
     const isSummary = req.query.fields === "summary";
     const findManyArgs = { where, orderBy: { id: "desc" }, take, skip };
     if (isSummary) {

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -40,6 +40,14 @@ const { writeAudit, diffFields } = require("../lib/audit");
 const listProjection = require("../lib/listProjection");
 const { isFullShape } = listProjection;
 const { verifyToken } = require("../middleware/auth");
+// Patient-portal notification inbox (additive — patient-scoped, separate from
+// the staff Notification table). Backs /portal/me/notifications* below.
+const {
+  listPatientNotifications,
+  markPatientNotificationRead,
+  markAllPatientNotificationsRead,
+  toPublic: toPublicNotification,
+} = require("../lib/patientNotificationService");
 // #679/#680/#681/#682 PII masking helpers + viewer policy. Used on list views
 // (Locations, Patients list, Telecaller Queue) so low-trust viewers
 // (telecaller / helper / generic USER on wellness tenant) see masked
@@ -10402,6 +10410,65 @@ router.get("/portal/me/permissions", verifyPatientToken, async (req, res) => {
   } catch (e) {
     console.error("[wellness] portal/me/permissions error:", e.message);
     res.status(500).json({ error: "Failed to load permissions" });
+  }
+});
+
+// ── Patient notification inbox (Option A: REST inbox for the patient app) ──
+//
+// Patient-scoped notifications served from the PatientNotification table —
+// distinct from the staff /api/notifications bell (which the portal JWT can't
+// reach by design). All three sit behind verifyPatientToken and scope every
+// query to req.patient.id, so a patient only ever sees / mutates their own
+// rows. The Android app's Room-backed inbox + the web portal can consume these.
+
+// GET /portal/me/notifications — newest-first inbox + live unread count.
+//   ?limit=N (default 50, capped 200)   ?unreadOnly=true
+router.get("/portal/me/notifications", verifyPatientToken, async (req, res) => {
+  try {
+    const unreadOnly = req.query.unreadOnly === "true" || req.query.unreadOnly === "1";
+    const { items, unreadCount } = await listPatientNotifications(req.patient.id, {
+      limit: req.query.limit,
+      unreadOnly,
+    });
+    res.json({
+      notifications: items.map(toPublicNotification),
+      unreadCount,
+      count: items.length,
+    });
+  } catch (e) {
+    console.error("[wellness] portal/me/notifications error:", e.message);
+    res.status(500).json({ error: "Failed to load notifications" });
+  }
+});
+
+// PUT /portal/me/notifications/:id/read — mark ONE read (scoped to patient).
+router.put("/portal/me/notifications/:id/read", verifyPatientToken, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id)) {
+      return res.status(400).json({ error: "Invalid notification id", code: "INVALID_ID" });
+    }
+    const updated = await markPatientNotificationRead(req.patient.id, id);
+    if (!updated) {
+      // Either no such id, or it belongs to another patient — same 404 either
+      // way so a patient can't probe other patients' notification ids.
+      return res.status(404).json({ error: "Notification not found", code: "NOTIFICATION_NOT_FOUND" });
+    }
+    res.json(toPublicNotification(updated));
+  } catch (e) {
+    console.error("[wellness] portal/me/notifications/:id/read error:", e.message);
+    res.status(500).json({ error: "Failed to update notification" });
+  }
+});
+
+// POST /portal/me/notifications/mark-all-read — mark all unread read.
+router.post("/portal/me/notifications/mark-all-read", verifyPatientToken, async (req, res) => {
+  try {
+    const marked = await markAllPatientNotificationsRead(req.patient.id);
+    res.json({ success: true, marked });
+  } catch (e) {
+    console.error("[wellness] portal/me/notifications/mark-all-read error:", e.message);
+    res.status(500).json({ error: "Failed to mark all read" });
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -426,6 +426,7 @@ const dealsDocumentsRoutes = require("./routes/deals_documents");
 const marketingRoutes = require("./routes/marketing");
 const reportsRoutes = require("./routes/reports");
 const developerRoutes = require("./routes/developer");
+const settingsRoutes = require("./routes/settings");
 const billingRoutes = require("./routes/billing");
 const v1InvoicesRoutes = require("./routes/v1_invoices");
 const searchRoutes = require("./routes/search");
@@ -603,6 +604,8 @@ const attendanceRoutes = require("./routes/attendance");
 const leaveRoutes = require("./routes/leave");
 // External partner API v1 (Callified.ai, Globus Phone, etc. — API key auth)
 const externalRoutes = require("./routes/external");
+// Flight Quotation plugin endpoint (#908) — API key auth via X-API-Key
+const travelFlightQuotesRoutes = require("./routes/travel_flight_quotes");
 // Voyagr (OJR) CMS lead-capture API v1 — API key auth via X-API-Key
 // (mirror partner-API pattern). See docs/MANUAL_CODING_BACKLOG.md cluster F1.
 // CORS: voyagr's server-to-server call (Next.js API route → CRM) has no
@@ -660,7 +663,7 @@ app.use("/api", (req, res, next) => {
   // promotes a contact to a portal user. Removing the entry routes the
   // unauthenticated case through the global guard's 401 (RFC 7235), and
   // the authenticated case continues unaffected.
-  const openPaths = ["/auth/login", "/auth/signup", "/auth/register", "/auth/customer/register", "/auth/public/tenants", "/auth/forgot-password", "/auth/reset-password", "/auth/2fa/verify", "/health", "/marketplace-leads/webhook", "/sms/webhook", "/whatsapp/webhook", "/telephony/webhook", "/push/subscribe/visitor", "/push/vapid-key", "/communications/track/", "/sso/google/callback", "/sso/microsoft/callback", "/sso/google/start", "/sso/microsoft/start", "/email/inbound", "/calendar/google/callback", "/calendar/outlook/callback", "/voice/webhook", "/portal/login", "/portal/forgot", "/portal/reset", "/portal/me", "/portal/tickets", "/portal/invoices", "/portal/contracts", "/portal/travel", "/portal/kyc", "/signatures/sign", "/surveys/respond", "/surveys/public", "/chatbots/chat", "/web-visitors/track", "/payments/webhook", "/accounting/webhook", "/scim/v2", "/booking-pages/public", "/knowledge-base/public", "/live-chat/visitor", "/document-views/track", "/zapier/webhook", "/marketing/submit", "/v1/external", "/v1/voyagr", "/wellness/public", "/wellness/portal", "/attendance/biometric/webhook", "/travel/microsites/public", "/travel/diagnostics/public", "/travel/itineraries/public", "/travel/inbound/leads", "/v1/flyers/public", "/security/csp-report"];
+  const openPaths = ["/auth/login", "/auth/signup", "/auth/register", "/auth/customer/register", "/auth/public/tenants", "/auth/forgot-password", "/auth/reset-password", "/auth/2fa/verify", "/health", "/marketplace-leads/webhook", "/sms/webhook", "/whatsapp/webhook", "/telephony/webhook", "/push/subscribe/visitor", "/push/vapid-key", "/communications/track/", "/sso/google/callback", "/sso/microsoft/callback", "/sso/google/start", "/sso/microsoft/start", "/email/inbound", "/calendar/google/callback", "/calendar/outlook/callback", "/voice/webhook", "/portal/login", "/portal/forgot", "/portal/reset", "/portal/me", "/portal/tickets", "/portal/invoices", "/portal/contracts", "/portal/travel", "/portal/kyc", "/signatures/sign", "/surveys/respond", "/surveys/public", "/chatbots/chat", "/web-visitors/track", "/payments/webhook", "/accounting/webhook", "/scim/v2", "/booking-pages/public", "/knowledge-base/public", "/live-chat/visitor", "/document-views/track", "/zapier/webhook", "/marketing/submit", "/v1/external", "/v1/voyagr", "/v1/flight-plugin", "/wellness/public", "/wellness/portal", "/attendance/biometric/webhook", "/travel/microsites/public", "/travel/diagnostics/public", "/travel/itineraries/public", "/travel/inbound/leads", "/v1/flyers/public", "/security/csp-report"];
   if (openPaths.some(p => req.path.startsWith(p))) return next();
   // Public marketing catalog — the /pricing page hits GET /subscriptions/plans
   // anonymously. Admin CRUD (POST/PUT/DELETE + GET /plans/admin) stays gated
@@ -737,6 +740,7 @@ app.use("/api/deals_documents", dealsDocumentsRoutes);
 app.use("/api/marketing", marketingRoutes);
 app.use("/api/reports", reportsRoutes);
 app.use("/api/developer", developerRoutes);
+app.use("/api/settings", settingsRoutes);
 app.use("/api/billing", billingRoutes);
 // PRD Gap §2 items 7a-d — `/api/v1/invoices` stable public-API alias for the
 // legacy /api/billing surface. Includes a NEW POST /:id/payments endpoint
@@ -956,6 +960,9 @@ app.use("/api/v1/external", externalRoutes);
 // verifyToken via /v1/voyagr entry in openPaths above; uses its own
 // X-API-Key middleware).
 app.use("/api/v1/voyagr", voyagrRoutes);
+// Flight Quotation plugin endpoint (#908 FR-5) — X-API-Key auth (externalAuth);
+// applies markup server-side + persists a flight ItineraryItem.
+app.use("/api/v1/flight-plugin", travelFlightQuotesRoutes);
 // Admin tooling (ADMIN-only ops triggers + read APIs)
 app.use("/api/admin", adminRoutes);
 

--- a/backend/test/lib/eventBus.test.js
+++ b/backend/test/lib/eventBus.test.js
@@ -343,6 +343,9 @@ beforeAll(() => {
   prisma.approvalRequest = { create: vi.fn() };
   prisma.auditLog = { create: vi.fn() };
   prisma.webhook = { findMany: vi.fn() };
+  // send_webhook now resolves the tenant's signing secret via
+  // lib/webhookEntitlement.resolveTenantWebhookSecret → webhookCredential.findFirst.
+  prisma.webhookCredential = { findFirst: vi.fn() };
 });
 
 beforeEach(() => {
@@ -356,6 +359,9 @@ beforeEach(() => {
   });
   prisma.auditLog.create.mockReset().mockResolvedValue({});
   prisma.webhook.findMany.mockReset().mockResolvedValue([]);
+  // Default: no per-tenant credential → send_webhook falls back to the env/null
+  // secret (unsigned) without a real DB hit.
+  prisma.webhookCredential.findFirst.mockReset().mockResolvedValue(null);
 });
 
 describe('emitEvent — prisma async tail (rule fan-out + webhook delivery)', () => {

--- a/backend/test/lib/llmRouter.test.js
+++ b/backend/test/lib/llmRouter.test.js
@@ -142,7 +142,7 @@ describe('llmRouter — module shape', () => {
     expect(typeof r.TASK_ROUTING).toBe('object');
   });
 
-  test('TASK_ROUTING matches PRD §9.1 exactly (per-task primary + fallback)', () => {
+  test('TASK_ROUTING matches PRD §9.1 + itinerary-suggest extension (per-task primary + fallback)', () => {
     const r = loadRouter();
     // Pins PRD §9.1 (docs/TRAVEL_CRM_PRD.md lines 700-708) + the
     // 'itinerary-suggest' extension landed for S14 (PRD_TRAVEL_ITINERARY_UPGRADES
@@ -158,16 +158,13 @@ describe('llmRouter — module shape', () => {
     // fallback; image-gen for flyer hero blocks routed via
     // backend/services/marketingFlyerImageLLM.js for structured-image shape).
     expect(r.TASK_ROUTING).toEqual({
-      "search":                { primary: "perplexity-sonar",  fallback: null },
-      "citation":              { primary: "perplexity-sonar",  fallback: null },
-      "reasoning":             { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-      "talking-points":        { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-      "form-vs-call":          { primary: "claude-opus-4-7",   fallback: "gpt-4" },
-      "bulk-text":             { primary: "gemini-flash",      fallback: "claude-haiku" },
-      "call-summary":          { primary: "gemini-flash",      fallback: null },
-      "itinerary-suggest":     { primary: "gemini-flash",      fallback: "claude-haiku" },
-      "marketing-flyer-copy":  { primary: "gemini-flash",      fallback: "claude-haiku" },
-      "marketing-flyer-image": { primary: "dall-e-3",          fallback: "stability-xl" },
+      "search": { primary: "perplexity-sonar", fallback: null },
+      "citation": { primary: "perplexity-sonar", fallback: null },
+      "reasoning": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+      "talking-points": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+      "form-vs-call": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+      "bulk-text": { primary: "gemini-flash", fallback: "claude-haiku" },
+      "call-summary": { primary: "gemini-flash", fallback: null },
     });
   });
 
@@ -218,6 +215,24 @@ describe('llmEnabled', () => {
     expect(await r.llmEnabled('bulk-text')).toBe(true);
     // But "reasoning" goes to Claude — Gemini key alone isn't enough.
     expect(await r.llmEnabled('reasoning')).toBe(false);
+  });
+
+  test('"itinerary-suggest" follows the Gemini key (gemini-flash provider slot)', () => {
+    delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    process.env.GEMINI_API_KEY = 'AIzaSy-real';
+    const r = loadRouter();
+    expect(r.llmEnabled('itinerary-suggest')).toBe(true);
+  });
+
+  test('returns false for an unknown task even when every env is set', async () => {
+    delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    process.env.GEMINI_API_KEY = 'AIzaSy-real';
+    const r = loadRouter();
+    expect(r.llmEnabled('itinerary-suggest')).toBe(true);
   });
 
   test('returns false for an unknown task even when every env is set', async () => {
@@ -295,7 +310,7 @@ describe('getLlmKey — S45 per-tenant SupplierCredential resolution', () => {
 
   test('Prisma failure → ENV fallback (never throws)', async () => {
     process.env.GEMINI_API_KEY = 'AIzaSy-fallback-on-error';
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     prismaMock.supplierCredential.findFirst.mockRejectedValueOnce(
       new Error('DB connection lost'),
     );
@@ -353,6 +368,15 @@ describe('pickModel', () => {
     });
   });
 
+  test('"itinerary-suggest" → gemini-flash with reason "primary"', () => {
+    const r = loadRouter();
+    expect(r.pickModel('itinerary-suggest')).toEqual({
+      task: 'itinerary-suggest',
+      model: 'gemini-flash',
+      reason: 'primary',
+    });
+  });
+
   test('every TASK_ROUTING key resolves to a non-empty primary model', () => {
     const r = loadRouter();
     for (const task of r.VALID_TASKS) {
@@ -374,7 +398,7 @@ describe('routeRequest', () => {
   test('returns the { text, finishReason, usage, model, stub } envelope for every valid task', async () => {
     // Suppress the structured log line for this test — we're verifying
     // the envelope shape, not the log.
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const r = loadRouter();
     for (const task of r.VALID_TASKS) {
       const out = await r.routeRequest({ task, payload: { sample: 'x' }, tenantId: 7 });
@@ -396,7 +420,7 @@ describe('routeRequest', () => {
   });
 
   test('text always includes the [STUB-<TASK>] tag prefix', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const r = loadRouter();
     for (const task of r.VALID_TASKS) {
       const out = await r.routeRequest({ task, payload: {}, tenantId: 1 });
@@ -406,7 +430,7 @@ describe('routeRequest', () => {
   });
 
   test('usage.totalTokens === promptTokens + completionTokens', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const r = loadRouter();
     for (const task of r.VALID_TASKS) {
       const out = await r.routeRequest({ task, payload: { x: 'a'.repeat(100) }, tenantId: 1 });
@@ -418,8 +442,8 @@ describe('routeRequest', () => {
   });
 
   test('unknown task does NOT throw — logs warning + routes to reasoning catch-all', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     const r = loadRouter();
     const out = await r.routeRequest({
       task: 'not-a-real-task',
@@ -436,7 +460,7 @@ describe('routeRequest', () => {
   });
 
   test('two calls with the same (task, payload) return the same stubText (deterministic)', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const r = loadRouter();
     const payload = { leadId: 42, name: 'demo' };
     const a = await r.routeRequest({ task: 'talking-points', payload, tenantId: 1 });
@@ -447,7 +471,7 @@ describe('routeRequest', () => {
   });
 
   test('emits the structured cost-attribution log line', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const r = loadRouter();
     await r.routeRequest({ task: 'talking-points', payload: { x: 1 }, tenantId: 99 });
     // At least one log call matches the [llm-router] format.
@@ -491,7 +515,7 @@ describe('estimateTokens', () => {
 // path is non-fatal.
 describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
   test('writes one row per call with the right shape', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     prismaMock.llmCallLog.create.mockClear();
     const r = loadRouter();
     await r.routeRequest({ task: 'talking-points', payload: { sample: 'x' }, tenantId: 42 });
@@ -518,7 +542,7 @@ describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
   });
 
   test('__userId + __surface payload hints land on the row', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     prismaMock.llmCallLog.create.mockClear();
     const r = loadRouter();
     await r.routeRequest({
@@ -534,7 +558,7 @@ describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
   });
 
   test('missing __userId / __surface → null columns', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     prismaMock.llmCallLog.create.mockClear();
     const r = loadRouter();
     await r.routeRequest({ task: 'reasoning', payload: { sample: 'x' }, tenantId: 1 });
@@ -546,8 +570,8 @@ describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
   });
 
   test('DB-write rejection does NOT throw out of routeRequest', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     prismaMock.llmCallLog.create.mockRejectedValueOnce(new Error('DB transient failure'));
     const r = loadRouter();
     // Should resolve normally — the persist is fire-and-forget + the
@@ -576,8 +600,8 @@ describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
 // error with code LLM_BUDGET_EXCEEDED; ≥80% triggers a console.warn.
 describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () => {
   test('returns normally when spend is well under cap (zero warn)', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     // Clear stale call history from prior tests (this describe is the
     // first to assert aggregate.toHaveBeenCalledTimes; earlier tests
     // exercised the route enough to accumulate calls).
@@ -611,8 +635,8 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
   });
 
   test('emits 80%-threshold warning when spend is ≥80% but under cap', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     // Cap: 10000 cents ($100).
     prismaMock.tenantSetting.findUnique.mockResolvedValueOnce({ value: '10000' });
     // Spend: $95 → 9500 cents (95% — alertThreshold true, still withinCap).
@@ -633,8 +657,8 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
   });
 
   test('throws LLM_BUDGET_EXCEEDED when spend reaches cap', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     // Cap: 10000 cents ($100).
     prismaMock.tenantSetting.findUnique.mockResolvedValueOnce({ value: '10000' });
     // Spend: $105 → 10500 cents (over cap).
@@ -663,8 +687,8 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
   });
 
   test('falls back to env-default cap ($100/10000c) when TenantSetting row absent', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     // No row → getBudgetCap returns DEFAULTS (10000 cents for LLM unless
     // env override set; the budget-cap test in tenantSettings.test.js pins
     // that fallback).
@@ -684,7 +708,7 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
   });
 
   test('skips cap check entirely when tenantId is omitted', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     prismaMock.tenantSetting.findUnique.mockClear();
     prismaMock.llmCallLog.aggregate.mockClear();
     const r = loadRouter();
@@ -696,5 +720,56 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
     expect(prismaMock.tenantSetting.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.llmCallLog.aggregate).not.toHaveBeenCalled();
     logSpy.mockRestore();
+  });
+});
+
+// Real-mode: when a provider key is present AND NODE_ENV !== 'test', routeRequest
+// calls the real provider (no "swap the stub later" code change). Under test it
+// MUST still stub — so unit + e2e runs never make a live call.
+describe('routeRequest — real provider call (key present, not under test)', () => {
+  test('calls the real provider and returns stub:false when a key is set', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const prevNodeEnv = process.env.NODE_ENV;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: 'text', text: 'REAL talking points from Claude.' }],
+        usage: { input_tokens: 12, output_tokens: 34 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.NODE_ENV = 'production';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-real';
+    try {
+      const r = loadRouter();
+      const out = await r.routeRequest({ task: 'talking-points', payload: { leadId: 7 }, tenantId: 3 });
+      expect(out.stub).toBe(false);
+      expect(out.text).toBe('REAL talking points from Claude.');
+      expect(out.model).toBe('claude-opus-4-7');
+      expect(out.usage.promptTokens).toBe(12);
+      expect(out.usage.completionTokens).toBe(34);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0][0])).toContain('api.anthropic.com');
+    } finally {
+      process.env.NODE_ENV = prevNodeEnv;
+      vi.unstubAllGlobals();
+      logSpy.mockRestore();
+    }
+  });
+
+  test('still stubs under NODE_ENV=test even with a key set (no live call)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-real'; // NODE_ENV stays 'test' (vitest default)
+    try {
+      const r = loadRouter();
+      const out = await r.routeRequest({ task: 'talking-points', payload: {}, tenantId: 1 });
+      expect(out.stub).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      logSpy.mockRestore();
+    }
   });
 });

--- a/backend/test/lib/notificationService.test.js
+++ b/backend/test/lib/notificationService.test.js
@@ -26,7 +26,14 @@
 import { describe, test, expect, vi, beforeAll, beforeEach } from 'vitest';
 
 vi.hoisted(() => {
-  process.env.SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || 'test-sendgrid-key';
+  // FORCE the fixture key (don't `|| ` it). The email-channel tests assert the
+  // Authorization header is EXACTLY `Bearer test-sendgrid-key`, so an ambient
+  // SENDGRID_API_KEY must never leak in. The test harness loads the project
+  // `.env` (for DATABASE_URL etc.) before this runs, and a dev `.env` that
+  // carries a real SendGrid key would otherwise override the fixture and fail
+  // the exact-match assertion. vi.hoisted runs before the SUT import, so this
+  // value is what notificationService.js captures at module load.
+  process.env.SENDGRID_API_KEY = 'test-sendgrid-key';
 });
 import { createRequire } from 'node:module';
 import prisma from '../../lib/prisma.js';

--- a/backend/test/lib/patientNotificationService.test.js
+++ b/backend/test/lib/patientNotificationService.test.js
@@ -1,0 +1,137 @@
+// Unit tests for lib/patientNotificationService.js — the patient-portal
+// notification inbox service (PatientNotification table). Mocking strategy:
+// monkey-patch the prisma singleton (vi.mock doesn't intercept the SUT's CJS
+// require('./prisma') in this vitest setup), same pattern as the other lib
+// tests in this folder.
+import { describe, test, expect, vi, beforeAll, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import svc from '../../lib/patientNotificationService.js';
+
+const {
+  createPatientNotification,
+  listPatientNotifications,
+  markPatientNotificationRead,
+  markAllPatientNotificationsRead,
+  toPublic,
+} = svc;
+
+beforeAll(() => {
+  prisma.patientNotification = {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    count: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  for (const fn of Object.values(prisma.patientNotification)) fn.mockReset();
+});
+
+describe('createPatientNotification', () => {
+  test('creates with defaults (type=info, link=null)', async () => {
+    prisma.patientNotification.create.mockResolvedValue({ id: 1 });
+    await createPatientNotification({ patientId: 5, tenantId: 2, title: 'Hi', message: 'There' });
+    expect(prisma.patientNotification.create).toHaveBeenCalledWith({
+      data: { patientId: 5, tenantId: 2, title: 'Hi', message: 'There', type: 'info', link: null },
+    });
+  });
+
+  test('passes through explicit type + link', async () => {
+    prisma.patientNotification.create.mockResolvedValue({ id: 2 });
+    await createPatientNotification({ patientId: 5, tenantId: 2, title: 'Rx', message: 'ready', type: 'prescription', link: '/portal/prescriptions' });
+    const data = prisma.patientNotification.create.mock.calls[0][0].data;
+    expect(data.type).toBe('prescription');
+    expect(data.link).toBe('/portal/prescriptions');
+  });
+
+  test('throws when patientId / tenantId missing', async () => {
+    await expect(createPatientNotification({ tenantId: 2, title: 'x', message: 'y' })).rejects.toThrow(/patientId and tenantId/);
+    await expect(createPatientNotification({ patientId: 5, title: 'x', message: 'y' })).rejects.toThrow(/patientId and tenantId/);
+  });
+
+  test('throws when title / message missing', async () => {
+    await expect(createPatientNotification({ patientId: 5, tenantId: 2, message: 'y' })).rejects.toThrow(/title and message/);
+  });
+});
+
+describe('listPatientNotifications', () => {
+  test('scopes to patientId, newest-first, returns items + unreadCount', async () => {
+    prisma.patientNotification.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    prisma.patientNotification.count.mockResolvedValue(1);
+    const r = await listPatientNotifications(7);
+    expect(r.items.length).toBe(2);
+    expect(r.unreadCount).toBe(1);
+    const findArg = prisma.patientNotification.findMany.mock.calls[0][0];
+    expect(findArg.where).toEqual({ patientId: 7 });
+    expect(findArg.orderBy).toEqual({ createdAt: 'desc' });
+    // unread count query is always patientId + isRead:false regardless of filter
+    expect(prisma.patientNotification.count.mock.calls[0][0].where).toEqual({ patientId: 7, isRead: false });
+  });
+
+  test('unreadOnly adds isRead:false to the list filter', async () => {
+    prisma.patientNotification.findMany.mockResolvedValue([]);
+    prisma.patientNotification.count.mockResolvedValue(0);
+    await listPatientNotifications(7, { unreadOnly: true });
+    expect(prisma.patientNotification.findMany.mock.calls[0][0].where).toEqual({ patientId: 7, isRead: false });
+  });
+
+  test('limit is clamped to [1, 200]', async () => {
+    prisma.patientNotification.findMany.mockResolvedValue([]);
+    prisma.patientNotification.count.mockResolvedValue(0);
+    await listPatientNotifications(7, { limit: 9999 });
+    expect(prisma.patientNotification.findMany.mock.calls[0][0].take).toBe(200);
+    await listPatientNotifications(7, { limit: 0 });
+    expect(prisma.patientNotification.findMany.mock.calls[1][0].take).toBe(50); // 0 → falsy → default 50
+  });
+});
+
+describe('markPatientNotificationRead', () => {
+  test('returns null when the id does not belong to the patient (cross-patient guard)', async () => {
+    prisma.patientNotification.findFirst.mockResolvedValue(null);
+    const r = await markPatientNotificationRead(7, 123);
+    expect(r).toBeNull();
+    // lookup is scoped by BOTH id AND patientId
+    expect(prisma.patientNotification.findFirst.mock.calls[0][0].where).toEqual({ id: 123, patientId: 7 });
+    expect(prisma.patientNotification.update).not.toHaveBeenCalled();
+  });
+
+  test('marks unread → read with readAt timestamp', async () => {
+    prisma.patientNotification.findFirst.mockResolvedValue({ id: 123, patientId: 7, isRead: false });
+    prisma.patientNotification.update.mockResolvedValue({ id: 123, isRead: true });
+    await markPatientNotificationRead(7, 123);
+    const upd = prisma.patientNotification.update.mock.calls[0][0];
+    expect(upd.where).toEqual({ id: 123 });
+    expect(upd.data.isRead).toBe(true);
+    expect(upd.data.readAt).toBeInstanceOf(Date);
+  });
+
+  test('idempotent — already-read returns existing without a second update', async () => {
+    prisma.patientNotification.findFirst.mockResolvedValue({ id: 123, patientId: 7, isRead: true });
+    const r = await markPatientNotificationRead(7, 123);
+    expect(r.isRead).toBe(true);
+    expect(prisma.patientNotification.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('markAllPatientNotificationsRead', () => {
+  test('updates only this patient unread rows + returns count', async () => {
+    prisma.patientNotification.updateMany.mockResolvedValue({ count: 4 });
+    const n = await markAllPatientNotificationsRead(7);
+    expect(n).toBe(4);
+    const arg = prisma.patientNotification.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ patientId: 7, isRead: false });
+    expect(arg.data.isRead).toBe(true);
+  });
+});
+
+describe('toPublic', () => {
+  test('strips tenantId from the row', () => {
+    expect(toPublic({ id: 1, title: 't', tenantId: 2, patientId: 7 })).toEqual({ id: 1, title: 't', patientId: 7 });
+  });
+  test('passes null/undefined through', () => {
+    expect(toPublic(null)).toBeNull();
+  });
+});

--- a/backend/test/lib/webhookDelivery-hmac.test.js
+++ b/backend/test/lib/webhookDelivery-hmac.test.js
@@ -112,3 +112,40 @@ describe('webhookDelivery — HMAC signing present', () => {
     expect(bodyTsUnix).toBe(tSec);
   });
 });
+
+// ── Explicit per-tenant secret argument (multi-tenant signing) ──────────
+//
+// deliverSingle gained an optional 5th `secret` param: deliverWebhooks resolves
+// the tenant's WebhookCredential secret and passes it in. The explicit arg wins
+// over process.env.WEBHOOK_HMAC_SECRET; when omitted, the env path (above) still
+// applies — that's the legacy 4-arg behaviour the rest of this file pins.
+describe('webhookDelivery — explicit secret argument', () => {
+  test('signs with the explicit secret argument when provided', async () => {
+    const tenantSecret = 'per-tenant-xyz';
+    await deliverSingle('https://receiver.test/wh', 'lead.new', { id: 1 }, 9, tenantSecret);
+    const [, opts] = global.fetch.mock.calls[0];
+    const m = opts.headers['X-Globussoft-Signature'].match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+    expect(m).toBeTruthy();
+    const expected = createHmac('sha256', tenantSecret).update(`${m[1]}.${opts.body}`).digest('hex');
+    expect(m[2]).toBe(expected);
+  });
+
+  test('explicit secret argument OVERRIDES process.env.WEBHOOK_HMAC_SECRET', async () => {
+    process.env.WEBHOOK_HMAC_SECRET = 'env-secret-should-lose';
+    const tenantSecret = 'arg-secret-should-win';
+    await deliverSingle('https://receiver.test/wh', 'lead.new', { id: 1 }, 9, tenantSecret);
+    const [, opts] = global.fetch.mock.calls[0];
+    const m = opts.headers['X-Globussoft-Signature'].match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+    const expectedArg = createHmac('sha256', tenantSecret).update(`${m[1]}.${opts.body}`).digest('hex');
+    const expectedEnv = createHmac('sha256', 'env-secret-should-lose').update(`${m[1]}.${opts.body}`).digest('hex');
+    expect(m[2]).toBe(expectedArg);
+    expect(m[2]).not.toBe(expectedEnv);
+  });
+
+  test('no signature when neither explicit secret nor env secret is set', async () => {
+    // explicit secret undefined + env unset → unsigned (legacy backwards-compat)
+    await deliverSingle('https://receiver.test/wh', 'lead.new', { id: 1 }, 9, undefined);
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.headers['X-Globussoft-Signature']).toBeUndefined();
+  });
+});

--- a/backend/test/lib/webhookDelivery.test.js
+++ b/backend/test/lib/webhookDelivery.test.js
@@ -10,10 +10,21 @@ const { deliverWebhooks, deliverSingle } = wh;
 
 beforeAll(() => {
   prisma.webhook = { findMany: vi.fn() };
+  // deliverWebhooks now resolves entitlement + per-tenant secret via
+  // lib/webhookEntitlement.js (same prisma singleton). Stub those surfaces so
+  // the delivery-path tests below see an ENTITLED tenant with NO per-tenant
+  // credential (→ env/null secret) unless a test overrides them.
+  prisma.subscription = { findFirst: vi.fn() };
+  prisma.user = { findFirst: vi.fn() };
+  prisma.webhookCredential = { findFirst: vi.fn() };
 });
 
 beforeEach(() => {
   prisma.webhook.findMany.mockReset();
+  // Default: entitled via an active paid subscription, no per-tenant credential.
+  prisma.subscription.findFirst.mockReset().mockResolvedValue({ id: 1 });
+  prisma.user.findFirst.mockReset().mockResolvedValue(null);
+  prisma.webhookCredential.findFirst.mockReset().mockResolvedValue(null);
   global.fetch = vi.fn();
 });
 
@@ -229,5 +240,86 @@ describe('lib/webhookDelivery — boundary / shape', () => {
       deliverWebhooks('contact.created', { id: 2 }, 9),
     ]);
     expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subscription gating + per-tenant secret resolution (multi-tenant webhook
+// signing). deliverWebhooks now: (1) skips ALL delivery when the tenant is not
+// entitled (no active sub AND no active trial), and (2) signs with the tenant's
+// own WebhookCredential secret when present.
+// ---------------------------------------------------------------------------
+describe('lib/webhookDelivery — subscription gating', () => {
+  test('skips all deliveries when the tenant is NOT entitled', async () => {
+    prisma.webhook.findMany.mockResolvedValue([
+      { id: 1, targetUrl: 'https://a.example/wh' },
+      { id: 2, targetUrl: 'https://b.example/wh' },
+    ]);
+    // Not entitled: no active subscription AND no active trial.
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    prisma.user.findFirst.mockResolvedValue(null);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await deliverWebhooks('deal.won', { id: 5 }, 9);
+
+    expect(global.fetch).not.toHaveBeenCalled(); // gate stopped delivery
+    logSpy.mockRestore();
+  });
+
+  test('delivers when entitled via an active TRIAL (no paid subscription)', async () => {
+    prisma.webhook.findMany.mockResolvedValue([{ id: 1, targetUrl: 'https://a.example/wh' }]);
+    prisma.subscription.findFirst.mockResolvedValue(null); // no paid sub
+    prisma.user.findFirst.mockResolvedValue({ id: 7 }); // active trial user
+    global.fetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deliverWebhooks('deal.won', { id: 5 }, 9);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('entitlement check runs only when ≥1 webhook matches (no DB cost for empty results)', async () => {
+    prisma.webhook.findMany.mockResolvedValue([]);
+    await deliverWebhooks('deal.won', { id: 5 }, 9);
+    expect(prisma.subscription.findFirst).not.toHaveBeenCalled();
+    expect(prisma.webhookCredential.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('lib/webhookDelivery — per-tenant secret signing', () => {
+  const crypto = require('node:crypto');
+
+  test("signs with the tenant's WebhookCredential secret (not the global env secret)", async () => {
+    const tenantSecret = 'tenant-specific-secret-abc';
+    process.env.WEBHOOK_HMAC_SECRET = 'GLOBAL-should-not-be-used';
+    prisma.webhook.findMany.mockResolvedValue([{ id: 1, targetUrl: 'https://a.example/wh' }]);
+    prisma.subscription.findFirst.mockResolvedValue({ id: 1 }); // entitled
+    prisma.webhookCredential.findFirst.mockResolvedValue({ secret: tenantSecret });
+    global.fetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deliverWebhooks('deal.won', { dealId: 5 }, 9);
+
+    const [, opts] = global.fetch.mock.calls[0];
+    const sig = opts.headers['X-Globussoft-Signature'];
+    const m = sig.match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+    expect(m).toBeTruthy();
+    const expected = crypto.createHmac('sha256', tenantSecret).update(`${m[1]}.${opts.body}`).digest('hex');
+    expect(m[2]).toBe(expected); // signed with the TENANT secret
+    delete process.env.WEBHOOK_HMAC_SECRET;
+  });
+
+  test('falls back to the global env secret when the tenant has no credential', async () => {
+    process.env.WEBHOOK_HMAC_SECRET = 'global-fallback-secret';
+    prisma.webhook.findMany.mockResolvedValue([{ id: 1, targetUrl: 'https://a.example/wh' }]);
+    prisma.subscription.findFirst.mockResolvedValue({ id: 1 });
+    prisma.webhookCredential.findFirst.mockResolvedValue(null); // no per-tenant credential
+    global.fetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deliverWebhooks('deal.won', { dealId: 5 }, 9);
+
+    const [, opts] = global.fetch.mock.calls[0];
+    const m = opts.headers['X-Globussoft-Signature'].match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+    const expected = crypto.createHmac('sha256', 'global-fallback-secret').update(`${m[1]}.${opts.body}`).digest('hex');
+    expect(m[2]).toBe(expected);
+    delete process.env.WEBHOOK_HMAC_SECRET;
   });
 });

--- a/backend/test/lib/webhookEntitlement.test.js
+++ b/backend/test/lib/webhookEntitlement.test.js
@@ -1,0 +1,116 @@
+// Unit tests for lib/webhookEntitlement.js — the subscription-entitlement +
+// per-tenant signing-secret resolver shared by routes/developer.js and
+// lib/webhookDelivery.js.
+//
+// Mocking strategy: monkey-patch the prisma singleton (vi.mock doesn't
+// intercept the SUT's CJS require('./prisma') in this vitest setup), same as
+// webhookDelivery.test.js. The SUT also requires('./fieldEncryption'); we let
+// the real decrypt() run — it's a no-op for plaintext (no ENC:v1: prefix) and
+// when WELLNESS_FIELD_KEY is unset, so a plaintext stored secret round-trips
+// unchanged.
+import { describe, test, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import ent from '../../lib/webhookEntitlement.js';
+
+const { isTenantWebhookEntitled, resolveTenantWebhookSecret } = ent;
+
+beforeAll(() => {
+  prisma.subscription = { findFirst: vi.fn() };
+  prisma.user = { findFirst: vi.fn() };
+  prisma.webhookCredential = { findFirst: vi.fn() };
+});
+
+beforeEach(() => {
+  prisma.subscription.findFirst.mockReset();
+  prisma.user.findFirst.mockReset();
+  prisma.webhookCredential.findFirst.mockReset();
+  delete process.env.WEBHOOK_HMAC_SECRET;
+});
+
+afterEach(() => {
+  delete process.env.WEBHOOK_HMAC_SECRET;
+  vi.restoreAllMocks();
+});
+
+describe('isTenantWebhookEntitled', () => {
+  test('entitled via an active paid subscription', async () => {
+    prisma.subscription.findFirst.mockResolvedValue({ id: 1 });
+    const r = await isTenantWebhookEntitled(9);
+    expect(r).toEqual({ entitled: true, reason: 'active_subscription' });
+    // Short-circuits: trial lookup not needed.
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+  });
+
+  test('entitled via an active trial when no paid subscription', async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    prisma.user.findFirst.mockResolvedValue({ id: 7 });
+    const r = await isTenantWebhookEntitled(9);
+    expect(r).toEqual({ entitled: true, reason: 'active_trial' });
+  });
+
+  test('NOT entitled when neither active subscription nor active trial', async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    prisma.user.findFirst.mockResolvedValue(null);
+    const r = await isTenantWebhookEntitled(9);
+    expect(r).toEqual({ entitled: false, reason: 'no_active_subscription' });
+  });
+
+  test('subscription query uses a live [startDate, endDate) window', async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    prisma.user.findFirst.mockResolvedValue(null);
+    await isTenantWebhookEntitled(9);
+    const where = prisma.subscription.findFirst.mock.calls[0][0].where;
+    expect(where.tenantId).toBe(9);
+    expect(where.status).toBe('ACTIVE');
+    expect(where.startDate).toHaveProperty('lte'); // started
+    // endDate is open-ended (null) OR strictly in the future.
+    expect(where.OR).toEqual([{ endDate: null }, { endDate: { gt: expect.any(Date) } }]);
+  });
+
+  test('falsy tenantId is not entitled (defensive, no DB call)', async () => {
+    const r = await isTenantWebhookEntitled(0);
+    expect(r).toEqual({ entitled: false, reason: 'no_active_subscription' });
+    expect(prisma.subscription.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveTenantWebhookSecret', () => {
+  test("returns the tenant's ACTIVE WebhookCredential secret (source=credential)", async () => {
+    prisma.webhookCredential.findFirst.mockResolvedValue({ secret: 'tenant-raw-secret' });
+    const r = await resolveTenantWebhookSecret(9);
+    expect(r).toEqual({ secret: 'tenant-raw-secret', source: 'credential' });
+    // Only ACTIVE credentials are matched.
+    expect(prisma.webhookCredential.findFirst.mock.calls[0][0].where).toEqual({ tenantId: 9, status: 'ACTIVE' });
+  });
+
+  test('falls back to env secret when no credential (source=env)', async () => {
+    prisma.webhookCredential.findFirst.mockResolvedValue(null);
+    process.env.WEBHOOK_HMAC_SECRET = 'env-global-secret';
+    const r = await resolveTenantWebhookSecret(9);
+    expect(r).toEqual({ secret: 'env-global-secret', source: 'env' });
+  });
+
+  test('returns null secret when neither credential nor env (source=none)', async () => {
+    prisma.webhookCredential.findFirst.mockResolvedValue(null);
+    const r = await resolveTenantWebhookSecret(9);
+    expect(r).toEqual({ secret: null, source: 'none' });
+  });
+
+  test('credential secret wins over env secret', async () => {
+    prisma.webhookCredential.findFirst.mockResolvedValue({ secret: 'cred-wins' });
+    process.env.WEBHOOK_HMAC_SECRET = 'env-loses';
+    const r = await resolveTenantWebhookSecret(9);
+    expect(r.secret).toBe('cred-wins');
+    expect(r.source).toBe('credential');
+  });
+
+  test('a plaintext (non-ENC) stored secret round-trips unchanged through decrypt', async () => {
+    // decrypt() is a no-op for values without the ENC:v1: prefix, so a secret
+    // stored while WELLNESS_FIELD_KEY was unset resolves to itself. (Real
+    // AES round-tripping is covered by fieldEncryption's own unit tests.)
+    prisma.webhookCredential.findFirst.mockResolvedValue({ secret: '9f64d2aa-plaintext' });
+    const r = await resolveTenantWebhookSecret(9);
+    expect(r.secret).toBe('9f64d2aa-plaintext');
+    expect(r.source).toBe('credential');
+  });
+});

--- a/backend/test/routes/portal.test.js
+++ b/backend/test/routes/portal.test.js
@@ -198,8 +198,9 @@ describe('POST /login — body validation + auth', () => {
     expect(res.body.contact).toEqual({
       id: 99, name: 'Alice Sharma',
       email: 'alice@example.com', company: 'Acme Co',
-      // /login response includes the contact's avatarUrl (null when the
-      // contact hasn't uploaded one yet).
+      // Login response includes the portal avatar (routes/portal.js maps
+      // `avatarUrl: contact.avatarUrl || null`). This mock contact has no
+      // avatarUrl set, so the route returns null.
       avatarUrl: null,
     });
     // Token claim shape — tenantId MUST come from contact row, NOT request body

--- a/backend/test/routes/travel-flyer-templates.test.js
+++ b/backend/test/routes/travel-flyer-templates.test.js
@@ -91,10 +91,12 @@ import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { createRequire } from 'node:module';
+import fs from 'node:fs';
 
 const requireCJS = createRequire(import.meta.url);
 const JWT_SECRET = process.env.JWT_SECRET || 'enterprise_super_secret_key_2026';
 const templatesRouter = requireCJS('../../routes/travel_flyer_templates');
+const s3Mod = requireCJS('../../services/s3Service');
 
 function makeApp() {
   const app = express();
@@ -660,6 +662,53 @@ describe('DELETE /api/travel/flyer-templates/:id (ADMIN-only hard delete)', () =
     expect(res.body).toMatchObject({ code: 'RBAC_DENIED' });
     expect(prisma.travelFlyerTemplate.findFirst).not.toHaveBeenCalled();
     expect(prisma.travelFlyerTemplate.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/travel/flyer-templates/upload (FR-3.2.2 image upload)', () => {
+  test('missing file → 400 MISSING_FILE', async () => {
+    const res = await request(makeApp())
+      .post('/api/travel/flyer-templates/upload')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'MISSING_FILE' });
+  });
+
+  test('non-image file is rejected with 400', async () => {
+    const res = await request(makeApp())
+      .post('/api/travel/flyer-templates/upload')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .attach('image', Buffer.from('hello'), { filename: 'notes.txt', contentType: 'text/plain' });
+    expect(res.status).toBe(400);
+  });
+
+  test('USER role is blocked (ADMIN/MANAGER only) → 403', async () => {
+    const res = await request(makeApp())
+      .post('/api/travel/flyer-templates/upload')
+      .set('Authorization', `Bearer ${tokenFor('USER')}`);
+    expect(res.status).toBe(403);
+  });
+
+  test('happy path stores the image + returns 201 with a url', async () => {
+    // Mock BOTH storage paths so the result is deterministic regardless of
+    // whether AWS_S3_BUCKET_NAME happens to be set in the run env.
+    const mkdir = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
+    const writeFile = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+    const uploadImage = vi.spyOn(s3Mod, 'uploadImage').mockResolvedValue('https://s3.example/flyer-assets/x.png');
+    try {
+      const png = Buffer.from('89504e470d0a1a0a', 'hex'); // PNG magic bytes
+      const res = await request(makeApp())
+        .post('/api/travel/flyer-templates/upload')
+        .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+        .attach('image', png, { filename: 'logo.png', contentType: 'image/png' });
+      expect(res.status).toBe(201);
+      expect(typeof res.body.url).toBe('string');
+      expect(res.body.url.length).toBeGreaterThan(0);
+    } finally {
+      mkdir.mockRestore();
+      writeFile.mockRestore();
+      uploadImage.mockRestore();
+    }
   });
 });
 

--- a/backend/test/routes/travel-itinerary-totals.test.js
+++ b/backend/test/routes/travel-itinerary-totals.test.js
@@ -8,7 +8,7 @@
  * Contracts asserted:
  *   - Read-only — no audit log writes, no eventBus emits.
  *   - Aggregates ItineraryItem rows for one itinerary; buckets per
- *     itemType (all 6 keys from VALID_ITEM_TYPES present + zero-filled
+ *     itemType (all 12 keys from VALID_ITEM_TYPES present + zero-filled
  *     when absent — stable shape for the planned dashboard tile).
  *   - Sums unitCost / markup / gstAmount / totalPrice per bucket and
  *     across the whole itinerary (`grand`); null money fields treated
@@ -112,9 +112,10 @@ function makeItem(overrides = {}) {
   };
 }
 
-// Mirrors VALID_ITEM_TYPES in backend/routes/travel_itineraries.js — every
-// bucket must be present + zero-filled in the empty-itinerary response for a
-// stable consumer shape, and the route widens this enum over time.
+// Mirrors VALID_ITEM_TYPES in backend/routes/travel_itineraries.js — the
+// totals route zero-fills one byItemType bucket per supported type, so this
+// list must stay in lockstep with the route's enum (widened from the original
+// 6 to 12: train/bus/cab/sightseeing/meals/other added).
 const ALL_TYPES = [
   'flight', 'train', 'bus', 'cab', 'transfer', 'hotel',
   'sightseeing', 'activity', 'meals', 'visa', 'insurance', 'other',
@@ -134,7 +135,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/travel/itineraries/:id/totals — happy paths', () => {
-  test('empty itinerary → totalItems=0, all-zero grand, every byItemType bucket present + zero-filled', async () => {
+  test('empty itinerary → totalItems=0, all-zero grand, all 12 byItemType buckets present + zero-filled', async () => {
     prisma.itinerary.findFirst.mockResolvedValueOnce(parentItinerary());
     prisma.itineraryItem.findMany.mockResolvedValue([]);
 
@@ -148,7 +149,7 @@ describe('GET /api/travel/itineraries/:id/totals — happy paths', () => {
       totalItems: 0,
       grand: { totalUnitCost: 0, totalMarkup: 0, totalGstAmount: 0, totalPrice: 0 },
     });
-    // Every bucket must be present + zero-filled for stable consumer shape.
+    // All 12 buckets must be present + zero-filled for stable consumer shape.
     expect(Object.keys(res.body.byItemType).sort()).toEqual([...ALL_TYPES].sort());
     for (const t of ALL_TYPES) {
       expect(res.body.byItemType[t]).toEqual({
@@ -230,7 +231,7 @@ describe('GET /api/travel/itineraries/:id/totals — happy paths', () => {
     });
   });
 
-  test('?itemType=hotel filter narrows the prisma where + still returns all 6 buckets', async () => {
+  test('?itemType=hotel filter narrows the prisma where + still returns all buckets', async () => {
     prisma.itinerary.findFirst.mockResolvedValueOnce(parentItinerary());
     prisma.itineraryItem.findMany.mockResolvedValue([
       makeItem({

--- a/docs/TRAVEL_CRM_CLIENT_REQUIREMENTS.md
+++ b/docs/TRAVEL_CRM_CLIENT_REQUIREMENTS.md
@@ -1,0 +1,240 @@
+# Travel CRM — Client Requirements & Dependency List
+
+**Date:** 2026-06-09
+**Purpose:** Single source of truth for **everything the engineering team needs from the client (Yasin / Travel Stall)** before each remaining Travel-CRM gap can ship. Derived from a full code-level audit of all ~25 travel PRDs against `HEAD`.
+**Companion docs:** [TRAVEL_CRM_PRD.md](TRAVEL_CRM_PRD.md) · [TRAVEL_CRM_PENDING_FEATURES.md](TRAVEL_CRM_PENDING_FEATURES.md) · [TRAVEL_BIG_SCOPE_BACKLOG.md](TRAVEL_BIG_SCOPE_BACKLOG.md) · [CREDS_TRACKER.md](CREDS_TRACKER.md) · [DECISIONS_TRACKER.md](DECISIONS_TRACKER.md)
+
+---
+
+## How to read this doc
+
+Every blocked item is tagged by **what kind of input it needs from the client**:
+
+| Tag             | Meaning                                                            | Who acts             |
+| --------------- | ------------------------------------------------------------------ | -------------------- |
+| 🔑 **CRED**     | An API key / account / token / vendor onboarding                   | Yasin (or vendor)    |
+| 🧭 **DECISION** | A product/architecture choice only the client can make             | Yasin + GS lead      |
+| 📝 **CONTENT**  | Copy / data / config the client owns (brand text, mappings, rates) | Yasin's team         |
+| ⚖️ **LEGAL**    | Counsel sign-off on wording                                        | Travel Stall counsel |
+| 🟢 **NONE**     | Nothing needed from client — engineering can build now             | GS engineering       |
+
+**Engineering rule for everything below:** new code is **additive and behind the existing stub-mode pattern** (same recipe already used for DigiLocker / RateHawk / Callified). A cred/decision drop becomes a 1-line swap, and _nothing already shipped breaks_ while we wait.
+
+---
+
+## ⭐ TL;DR — the one message to send Yasin
+
+Bundle these so we get them in one round-trip. Each unblocks one or more modules below.
+
+1. 🔑 **WhatsApp / Wati (Q9)** — Wati account number + API key + 3 per-sub-brand sender IDs **OR** Meta: System-User access token + 3× phoneNumberId + 3× wabaId + App ID/Secret + webhook verify token. _(Unblocks 7 crons + 3 endpoints + flyer/quote share across the whole vertical.)_
+2. 🔑 **Brand assets pack (Q22)** — per sub-brand (TMC / RFU / Travel Stall / Visa Sure): logo SVG+PNG (light/dark), colour palette (hex), fonts, PDF letterhead. _(Unblocks branding, marketing flyer, theme, all PDF templates, Visa Sure reports.)_
+3. 🔑 **RateHawk (Q19)** — API key + API ID + production base URL.
+
+4. 🔑 **DigiLocker (Q3)** — `DIGILOCKER_CLIENT_ID` + `DIGILOCKER_CLIENT_SECRET`.
+5. 🔑 **LLM keys (Q11)** — OpenAI + Anthropic + Google AI Studio + Perplexity API keys.
+6. 🧭 **Big-module decisions** — see the per-module DECISION rows in Tier 1 (B2B portal topology, Purchase-Order approval flow, Flight-plugin Web-Store account, airline-automation tech + ToS, hotel-portal scrape-vs-API, flyer editor library, Excel Software API-vs-CSV).
+7. ⚖️ **One legal session** — Aadhaar consent copy + TRAI pre-call disclosure + passport-OCR consent + RFU portal ToS + airline web-checkin ToS (all in §Legal below).
+
+---
+
+# 🔴 Tier 1 — Big modules (the headline gaps)
+
+For each: **what the client must provide** + **what engineering can start now without them**.
+
+### 1. B2B Agent Portal + Corporate Portal — `PRD_TRAVEL_B2B_AGENT_PORTAL`
+
+**State:** 0% — no models/routes. **Est:** ~25-45 eng-days after decisions.
+
+Required from client:
+
+- 🧭 **DD-5.1 Portal topology** — separate React app (`apps/b2b-portal/`) **vs** route prefix (`/portal/b2b/*`) on the existing app.
+- 🧭 **DD-5.4 Travel-policy editor surface** — in-app form vs JSON upload vs spreadsheet upload.
+- 🧭 **DD-5.5 Approval-workflow shape** — single-approver vs multi-stage vs per-corporate-configurable.
+- 🧭 **DD-5.6 Expense-report format** — canonical CSV vs per-corporate column template.
+- 🧭 **DD-5.7 Traveler-profile scope** — per-corporate-scoped vs cross-corp shared.
+- 📝 **Commission model** — sub-agent commission %, tiers, settlement cadence, TDS threshold.
+- 📝 **Corporate account structure** — roles (HR/Finance/Approver/Traveler), per-corporate travel-policy rules (budget caps, class limits, approval thresholds).
+- 🧭 **OQ-9.1…9.7** — sub-agent hierarchy depth, corporate SSO need, multi-tenancy boundary.
+
+🟢 **Engineering can start now (low risk, no client input):** Prisma models behind a feature flag (`SubAgent`, `CorporateAccount`, `CorporateUser`, `SubAgentCommission`, `CorporatePolicy`, `CorporateApprovalRequest`) as additive nullable tables — _only once DD-5.1 topology is chosen_ (topology changes the auth/route shape, so we should NOT scaffold before that one decision).
+
+---
+
+### 2. Purchase Orders module — `PRD_PURCHASE_ORDERS`
+
+**State:** 0% — PRD self-marks "NOT STARTED, design call needed." **Est:** ~8-12 eng-days after decisions.
+
+Required from client:
+
+- 🧭 **DD-5.1…5.8** — PO state machine (draft→approved→confirmed→settled), who approves, auto-PO-on-booking yes/no, PO numbering scheme.
+- 📝 **Supplier payment terms** per supplier (already partly in `TravelSupplier`).
+- 🧭 **OQ-9.2 / 9.3 / 9.10** — PO ↔ payable reconciliation tolerance, multi-currency PO handling.
+
+🟢 **Engineering can start now:** nothing safely — the model shape depends on the approval-flow decision. Build after the design call.
+
+---
+
+### 3. Flight Quotation Chrome plugin — `PRD_FLIGHT_PLUGIN_CHROME_EXTENSION`
+
+**State:** 0% — separate repo. **Est:** ~12-16 eng-days after decisions.
+
+Required from client:
+
+- 🧭 **DC-1 Repo location** — separate repo `globussoft-flight-plugin` vs subdir.
+- 🔑 **DC-2 Chrome Web Store publisher account** — GS-owned vs Travel-Stall-owned (or private signed-CRX distribution).
+- 🧭 **DC-3 Airline priority list** — which Google-Flights carriers to support first.
+- 📝 **Per-airline / per-route / per-fare-bucket markup config** (can also be entered in-CRM later).
+
+🟢 **Engineering can start now (CRM-side, ~2 days, no client input):** the backend `POST /api/v1/flight-plugin/quotes` endpoint + `ApiKey` `purpose='flight-plugin'` enum + admin key-issuance UI — these can ship independent of the plugin itself and de-risk the integration. **The plugin (Manifest V3 + adapters) is blocked on DC-1/DC-2.**
+
+---
+
+### 4. Airline web check-in automation (P1B) — `PRD_AIRLINE_WEBCHECKIN_AUTOMATION`
+
+**State:** tracking layer (P1A) shipped; automation engine 0%. **Est:** ~5-7 eng-days + ongoing per-airline maintenance.
+
+Required from client:
+
+- 🧭 **DC-1** — Playwright headless vs MCP-via-LLM automation approach.
+- 🧭 **DC-2** — airline priority (recommended: IndiGo + Air India + Vistara + Emirates).
+- 🧭 **DC-3** — containerization / deploy model for the automation worker.
+- ⚖️ **DC-5** — counsel ToS review of the 4 airlines' terms before production automation.
+- 🔑 Airline portal credentials / PNR-access where the carrier requires a registered agent login (stored in the supplier vault).
+
+🟢 **Engineering can start now:** the `webCheckinAutomation.js` engine skeleton + `WebCheckinAutomationRun` model + `automationSkipped`/`completedAt` columns + manual re-trigger endpoint + per-airline health dashboard — **additive, safe**, leaving the actual per-airline adapter bodies stubbed until DC-1/DC-5. (Tracking + manual upload already work, so this won't disrupt the live flow.)
+
+---
+
+### 5. RFU 5-portal Saudi hotel orchestrator — `PRD_RFU_GROUND_SERVICES`
+
+**State:** 0% (Zikr Cabs + Haramain HSR exist as read-only stubs). **Est:** ~10-15 eng-days.
+
+Required from client:
+
+- 🧭 **Q-RFUG-2…6** — per-portal **scrape vs partner-API** decision for Almosafer / Tajawal / MyHoliday2 / Pilgrims Choice / Reservation House.
+- ⚖️ ToS review of each of the 5 portals (pairs with the legal session).
+- 🔑 **Q-RFUG-1** — Zikr Cabs onboarding (~SAR 5k setup): prod + sandbox keys + webhook secret + API PDF.
+- 🔑 **Q-RFUG-7/8** — confirm Haramain HSR has a B2B partner program; if yes, creds + group-tier docs (3-6 wk vendor onboarding).
+
+🟢 **Engineering can start now:** the orchestrator fan-out shell + `SaudiHotelRateCache` + `TravelContractedRate` models + normalizer + dedupe + cache cron — **all runnable against stubs**, swapping per-portal adapters as decisions land. Zikr/HSR write paths stay `NOT_YET_ENABLED` until creds.
+
+---
+
+### 6. Marketing Flyer canvas editor — `PRD_TRAVEL_MARKETING_FLYER`
+
+**State:** shell + template CRUD only. **Est:** ~10 days (Polotno) / ~20+ days (in-house).
+
+Required from client:
+
+- 🧭 **DD-5.1 Editor library** — **Polotno embed (faster, licence cost)** vs in-house build. _Do not start the editor until this is answered — it's the single biggest cost fork._
+- 🔑 **DD-5.2 / Q-MF-1 Asset storage** — S3 vs Cloudinary account + creds (local disk OK for pilot).
+- 🔑 **DD-5.3 / Q-MF-2 AI image provider** — DALL·E vs Stable Diffusion vs Midjourney API key.
+- 🔑 **Q22 brand assets** (above) for brand-locked templates.
+- 🔑 **Q9 WhatsApp** for flyer share.
+
+🟢 **Engineering can start now:** the `Asset` model + Multer upload pipeline + tag search + PDF/PNG render via existing `pdfRenderer` (text-only) + brand-lock plumbing — safe groundwork. **The canvas editor itself waits on DD-5.1.**
+
+---
+
+### 7. Visual day-by-day itinerary editor — `PRD_TRAVEL_ITINERARY_UPGRADES`
+
+**State:** template library + sightseeing master shipped; 3-pane editor + map + AI-suggest MISSING. **Est:** ~10 eng-days.
+
+Required from client:
+
+- 🟢 **NONE to start.** Schema already has `ItineraryItem.dayNumber` / `latitude` / `longitude`. Leaflet + OpenStreetMap is free (no key).
+- 🔑 _(optional, later)_ **Q-IT-1** Mapbox key if we want premium tiles (Leaflet/OSM is the default, free).
+- ⚖️ _(optional, later)_ **Q-IT-3** OpenTripMap licence review (~1 hr) only if we auto-import POI seed data.
+- 🔑 **Q11 LLM keys** to make the AI "suggest itinerary" return real plans (stub works for dev/demo).
+
+✅ **This is where engineering starts NOW** — see §Implementation below.
+
+---
+
+### 8. Excel Software accounting bridge — `PRD_EXCEL_SOFTWARE_ACCOUNTING`
+
+**State:** ~0%. **Est:** ~2-3 eng-days after docs.
+
+Required from client:
+
+- 🔑 / 🧭 **Q8** — vendor REST API docs **+ DC-1 path decision (API webhook vs nightly CSV)** + sample export format + sandbox keys.
+
+🟢 **Engineering can start now:** nothing meaningful — the file/field shape is defined entirely by the vendor's spec. Build after Q8 docs arrive.
+
+---
+
+# 🟡 Tier 2 — Integrations already coded as stubs (just need credentials)
+
+These are **fully wired in stub mode**; a credential drop is a ~½-1 day swap each. **No engineering design needed — purely waiting on the client.**
+
+| Integration            | PRD                            | Exact credential ask                                                                                                                 |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| WhatsApp / Wati        | `WHATSAPP_INTEGRATION_PRD`     | 🔑 Q9 — account no. + API key + 3 sender IDs **or** Meta token + 3× phoneNumberId + 3× wabaId + App ID/Secret + webhook verify token |
+| RateHawk hotels        | `PRD_RATEHAWK_INTEGRATION`     | 🔑 Q19 — API key + API ID + prod base URL                                                                                            |
+|  |
+| DigiLocker Aadhaar     | `DIGILOCKER_INTEGRATION_SPEC`  | 🔑 Q3 — `DIGILOCKER_CLIENT_ID` + `DIGILOCKER_CLIENT_SECRET`                                                                          |
+| Passport OCR           | `PRD_PASSPORT_OCR`             | 🧭 PC-1 vendor (Google Document AI vs Azure FR) + 🔑 keys                                                                            |
+| Booking.com direct     | `PRD_BOOKING_EXPEDIA_DIRECT`   | 🔑 Affiliate ID + API key + API secret (2-4 wk Partner-Centre onboarding)                                                            |
+| LLM real-mode          | PRD §9.1                       | 🔑 Q11 — OpenAI + Anthropic + Google AI Studio + Perplexity keys                                                                     |
+| Razorpay subscriptions | `PRD_PLANS_BILLING_SELF_SERVE` | 🔑 Q-PB-2 — confirm `rzp_live_*` key has subscription scope, or new key                                                              |
+
+> ⚠️ Note for Tier 2: a few of these (Callified, AdsGPT) also have **engineering gaps beyond the credential** — the dispatcher cron, schema columns, webhook endpoint, and report endpoints aren't built yet. The credential unblocks the swap, but those modules still need ~3-5 eng-days each on top. See [TRAVEL_CRM_PENDING_FEATURES.md](TRAVEL_CRM_PENDING_FEATURES.md).
+
+---
+
+# 🟠 Tier 3 — Partial features inside otherwise-shipped PRDs
+
+Mostly engineering work, but these specific items **need client content/data** to be meaningful:
+
+| Area                                      | PRD                                                                                 | Client ask                                                                                                                                             |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Per-sub-brand branding / theme / Visa PDF | `PRD_TRAVEL_PER_SUBBRAND_BRANDING`, `PRD_THEME_MANAGEMENT`, `PRD_VISA_SURE_PHASE_3` | 🔑 **Q22 brand assets** (logos/palettes/fonts/letterhead per sub-brand)                                                                                |
+| TMC curriculum recommendations            | `PRD_TMC_CURRICULUM_MAPPING`                                                        | 📝 **PC-1** initial curriculum-mapping CSV from academic team (engine returns empty without it)                                                        |
+| TMC readiness report credibility          | `PRD_TMC_DIAGNOSTIC_SALES_ROUTING_ENGINE`                                           | 📝 **T19** real curriculum-hook copy for 5 starter trips; 📝 **T20** Q3 growth-area→skill map confirmation; 📝 **T21** verbatim LLM prompt source      |
+| TMC booking CTA                           | same                                                                                | 🔑 **T18** Google Workspace project + OAuth consent + team calendars (for the Meet slot-picker)                                                        |
+| GST compliance accuracy                   | `PRD_TRAVEL_GST_COMPLIANCE`, `PRD_TRAVEL_BILLING`                                   | 📝 per-sub-brand **GSTINs** + place-of-supply **state codes** + **SAC/HSN** confirmations + sample **CA/Tally export** + **LUT reference** for exports |
+| Visa Sure go-live                         | `PRD_VISA_SURE_PHASE_3`                                                             | 📝 **15Q question bank + scoring rules**; 📝 document-checklist templates per visa type                                                                |
+| UAT                                       | `TRAVEL_CRM_PRD`                                                                    | 📝 **Q15** named UAT lead + 3 test users per brand                                                                                                     |
+
+🟢 **Most Tier-3 _engineering_ (per-line GST breakdown, opaque IDs, PII list projections, quote templates, pipeline a11y, etc.) needs nothing from the client** and can be scheduled independently — see [TRAVEL_CRM_PENDING_FEATURES.md](TRAVEL_CRM_PENDING_FEATURES.md) §"Codeable today."
+
+---
+
+# ⚖️ Legal — one bundled counsel session
+
+Schedule a single ~30-45 min session covering all of these (each is a string-swap once approved):
+
+1. **Aadhaar consent legal copy** — draft exists at [TRAVEL_AADHAAR_CONSENT_DRAFT.md](TRAVEL_AADHAAR_CONSENT_DRAFT.md) (Q2), needs sign-off.
+2. **TRAI pre-call recording disclosure** wording — `PRD_AI_CALLING_CALLIFIED` DC-5.
+3. **AI-decline / "this call is automated" wording** — same PRD DC-4.
+4. **Passport-OCR consent text** — `PRD_PASSPORT_OCR` PC-3 (bundles with #1).
+5. **RFU 5-portal ToS review** — scrape-vs-partner-API per Saudi hotel portal (Q-RFUG-2…6).
+6. **Airline web check-in ToS review** — 4 carriers (`PRD_AIRLINE_WEBCHECKIN_AUTOMATION` DC-5).
+
+---
+
+# 🛠️ Implementation plan — what we build now vs. what waits
+
+**Guiding principle:** ship the **unblocked** work additively while the client gathers the above. Nothing below modifies a shipped code path destructively.
+
+### Phase A — start immediately (no client input, low breakage risk)
+
+1. **Itinerary Upgrades module** (Tier 1 #7) — AI `itinerary-suggest` task class + endpoint (stub-mode), then the 3-pane visual day-by-day editor + Leaflet/OSM map. ← **IN PROGRESS**
+2. **Airline-automation skeleton** (Tier 1 #4) — engine + models + health dashboard, adapters stubbed.
+3. **RFU hotel-orchestrator shell** (Tier 1 #5) — fan-out + cache + normalizer against stubs.
+4. **Flight-plugin CRM side** (Tier 1 #3) — endpoint + API-key issuance UI (plugin itself waits on DC-1/DC-2).
+5. **Tier-3 no-client-input wins** — per-line GST breakdown, quote templates, pipeline a11y/URL-persistence, security S3/S35/S36.
+
+### Phase B — unblocks on a single decision each
+
+- Marketing Flyer editor (after DD-5.1 Polotno-vs-in-house)
+- B2B portal models (after DD-5.1 topology)
+- Purchase Orders (after the approval-flow design call)
+
+### Phase C — unblocks on credential/content drops (Tier 2 + Tier 3 content)
+
+- All stub→real swaps as creds land; brand-dependent PDFs/themes as Q22 lands; TMC/GST/Visa content as data lands.
+
+---
+
+_Maintainer note: when a credential or decision lands, update [CREDS_TRACKER.md](CREDS_TRACKER.md) / [DECISIONS_TRACKER.md](DECISIONS_TRACKER.md) and flip the matching row here. This doc is the client-facing index; those two are the internal ledgers._

--- a/docs/TRAVEL_CRM_WHAT_WE_NEED_FROM_YOU.md
+++ b/docs/TRAVEL_CRM_WHAT_WE_NEED_FROM_YOU.md
@@ -1,0 +1,80 @@
+# What We Need From You — Travel CRM
+
+**For:** Yasin / Travel Stall
+**Date:** 9 June 2026
+
+Your travel software is **mostly built and working**. To switch on the remaining features, we need a few things from your side. Most are simply **logins to services you already use**, a handful of **decisions only you can make**, and some **material from your team** (like your logos and prices).
+
+Nothing here is urgent-or-broken — the system runs today on safe "demo" placeholders. Each item below just turns a placeholder into the real thing. We've grouped them and explained **why each one matters**, in plain language.
+
+> 🔴 = needed first (unlocks the most) 🟡 = soon 🟢 = can wait
+
+---
+
+## Part 1 — Logins & accounts (so the software can talk to your other services)
+
+These are accounts/keys you (or your vendors) already have. Sending them lets the system do its job automatically instead of showing sample data.
+
+| # | What we need | Why it matters | What to send us |
+|---|---|---|---|
+| 🔴 1 | **WhatsApp Business account** (Wati or Meta) | So the system can **automatically message your customers** — booking confirmations, payment reminders, OTP codes, itineraries, check-in alerts. Right now these are written but not sending. | Your Wati account number + API key **and** the WhatsApp phone number for each brand (TMC, RFU, ops). |
+| 🔴 2 | **Your brand kit** (logos, colours, fonts) for each brand | So **every quote, invoice, report, email and the app itself look like your brands** (TMC / RFU / Travel Stall / Visa Sure) — not plain/unbranded. This is the single biggest "make it look real" item. | Logo files (high-res), your colour codes, fonts, and a letterhead — for each of the 4 brands. |
+| 🔴 3 | **Hotel supplier login (RateHawk)** | So staff see **live, real hotel prices** when building Umrah/holiday quotes, instead of sample prices. | Your RateHawk API key + account ID. |
+| 🟡 4 | **AI provider keys** (the companies that power the "smart" features) | So features like lead summaries, suggested itineraries and call talking-points show **real AI output** instead of demo text. | The API keys for OpenAI, Anthropic (Claude), Google AI, and Perplexity. (You hold these accounts.) |
+| 🟡 5 | **AI-calling account (Callified)** | So the system can **auto-call and qualify new leads** in Hindi/English/Urdu and attach a summary to the lead. | Callified account access + the call script / "personality" you want for each brand. |
+| 🟡 6 | **Ads-reporting account (AdsGPT)** | So your **marketing dashboard shows real ad spend, leads, and cost-per-lead** for each platform (Instagram, Facebook, etc.). | AdsGPT access + your ad-account IDs for each platform. |
+| 🟡 7 | **DigiLocker partner login** | So parents/pilgrims can **verify Aadhaar the safe, legal way** (no risky photo uploads). | Your DigiLocker partner ID + secret key. |
+| 🟢 8 | **Your accounting software details** (Excel Software for Travel) | So invoices **flow automatically into your accountant's system** — no manual re-entry. | Their technical documentation + one sample export file + a test login. |
+| 🟢 9 | **Saudi ground-transport & train partners** (Zikr Cabs, Haramain train) | So RFU Umrah quotes can include **real cab and high-speed-train prices**. | Vendor sign-up + keys. (Note: the cab partner has a ~SAR 5,000 setup fee — worth starting early.) |
+| 🟢 10 | **Booking.com partner account** | An **extra source of hotel inventory** alongside RateHawk. | Affiliate ID + keys. (Their approval takes a few weeks — best to start now.) |
+
+---
+
+## Part 2 — Decisions only you can make
+
+These are short choices. We've given our recommendation in **bold** — you can just say "go with your recommendation" or pick the other option. We can't build these features correctly until you decide, because the choice changes how we build them.
+
+| # | The question | Our recommendation | Why we're asking |
+|---|---|---|---|
+| 🟡 A | **Sub-agent & corporate portal** — do you want a separate login area for sub-agents and corporate clients (with commissions, approvals, travel policies)? If yes, how are commissions and approvals handled? | Confirm if this is in scope now or later | This is a large module; we shouldn't start until you confirm you want it and tell us your commission % and approval rules. |
+| 🟡 B | **Marketing flyer designer** — use a **ready-made design tool** (faster to launch, small monthly fee) or build our own from scratch (slower, no fee)? | **Ready-made tool** | Saves weeks of work. We just need your yes on the small recurring cost. |
+| 🟡 C | **Saudi hotel websites (5 of them)** — for each, do we have an **official partner login**, or should we read the public prices from their site? | Tell us per site | Determines whether we connect officially or read public pages — affects what's allowed and how reliable it is. |
+| 🟢 D | **Automatic airline web check-in** — which airlines first? And are you OK to proceed **once our lawyer confirms** each airline's terms allow it? | **IndiGo, Air India, Vistara, Emirates first** | We auto-check-in passengers; we need your airline priority and a legal green-light. |
+| 🟢 E | **Flight-quote browser tool** — who owns the Google Chrome store account it's published under (you or us)? Which airlines first? | We can host it privately for you | Needed before we publish the staff browser plug-in. |
+| 🟢 F | **Supplier purchase orders** — how should a purchase order to a supplier be approved, and who signs off? | Quick call to map your process | We build the approval steps to match how you actually work. |
+
+---
+
+## Part 3 — Material from your team
+
+These are things only your team has — text, prices, and data. The software has the "shelves" ready; we just need you to put your content on them.
+
+| # | What we need | Why it matters |
+|---|---|---|
+| 🔴 1 | **TMC curriculum content** — the "what your students will gain" write-up for each of your 5 starter trips, mapped to school boards (CBSE/IB/IGCSE). | The school readiness report can't make credible curriculum claims without your academic team's wording. This blocks the TMC school-trip launch. |
+| 🟡 2 | **Your GST details** — GST numbers for each brand, your state, sample of how your accountant wants the tax export, and your tax/HSN codes. | So invoices are tax-correct and filing-ready for your accountant. |
+| 🟡 3 | **Visa Sure setup** — the 15 readiness questions + how you score them, and the document checklist for each visa type. | So the Visa Sure section can go live with your actual process. |
+| 🟢 4 | **Test users** — a few people per brand to try the system before go-live. | So we can do a proper trial run (UAT) before launch. |
+
+---
+
+## Part 4 — One lawyer session
+
+A single ~30–45 minute call with your lawyer to approve the wording for a few legally-sensitive things. We'll send drafts in advance so it's quick.
+
+1. **Aadhaar consent text** — the message customers agree to before Aadhaar verification.
+2. **"This call may be recorded / is automated"** announcement for AI calls (required by Indian telecom rules).
+3. **Passport-photo consent** wording.
+4. **Permission to use the airline and hotel websites** for automatic check-in and price look-ups.
+
+---
+
+## The short version
+
+If you can send us **just the first 3 items in Part 1** (WhatsApp account, your brand kit, and the RateHawk hotel login) and answer **decisions A and B in Part 2**, that alone switches on the largest share of the remaining features. Everything else can follow at a comfortable pace.
+
+We're happy to hop on a call and collect most of these together if that's easier.
+
+---
+
+*(There is a detailed technical version of this list for our engineering team at `TRAVEL_CRM_CLIENT_REQUIREMENTS.md` — this document is the plain-language summary.)*

--- a/e2e/tests/travel-flight-plugin-api.spec.js
+++ b/e2e/tests/travel-flight-plugin-api.spec.js
@@ -1,0 +1,38 @@
+// @ts-check
+/**
+ * Gate spec — Flight Quotation plugin endpoint (#908 FR-5).
+ *
+ *   POST /api/v1/flight-plugin/quotes   — X-API-Key auth (externalAuth)
+ *
+ * Pins the auth-gate contract. The keyed happy-path is intentionally NOT
+ * exercised with a hardcoded demo key — a real per-advisor key is generated
+ * in production (no fake credential is seeded into the repo) — so this spec
+ * asserts the unauthenticated + malformed-key behaviour only.
+ */
+const { test, expect } = require("@playwright/test");
+
+const BASE_URL = process.env.BASE_URL || "https://crm.globusdemos.com";
+const REQUEST_TIMEOUT = 60000;
+const QUOTES = "/api/v1/flight-plugin/quotes";
+
+function postQuote(request, key, body) {
+  return request.post(`${BASE_URL}${QUOTES}`, {
+    headers: key
+      ? { "X-API-Key": key, "Content-Type": "application/json" }
+      : { "Content-Type": "application/json" },
+    data: body ?? {},
+    timeout: REQUEST_TIMEOUT,
+  });
+}
+
+test.describe("Flight plugin quotes API — auth gate", () => {
+  test("rejects a request with no API key (401)", async ({ request }) => {
+    const r = await postQuote(request, null, { airline: "AI" });
+    expect(r.status()).toBe(401);
+  });
+
+  test("rejects a malformed API key (401)", async ({ request }) => {
+    const r = await postQuote(request, "not-a-key", { airline: "AI" });
+    expect(r.status()).toBe(401);
+  });
+});

--- a/e2e/tests/travel-itineraries-api.spec.js
+++ b/e2e/tests/travel-itineraries-api.spec.js
@@ -478,11 +478,15 @@ test.describe("Travel itineraries API — items", () => {
     if (!token || created.itemIds.length === 0) test.skip(true, "no items");
     const itinId = created.itineraryIds[0];
     const itemId = created.itemIds[0];
+    // The route never trusts a client-supplied totalPrice — it recomputes the
+    // line total from price-affecting fields (computeItemLineTotal:
+    // unitCost*quantity + markup + gstAmount). So drive the total via those
+    // fields: 2000*1 + 0 + 0 = 2000.
     const res = await patch(
       request,
       token,
       `/api/travel/itineraries/${itinId}/items/${itemId}`,
-      { description: `${RUN_TAG} amended desc`, totalPrice: 2000 },
+      { description: `${RUN_TAG} amended desc`, unitCost: 2000, quantity: 1, markup: 0, gstAmount: 0 },
     );
     expect(res.status()).toBe(200);
     const body = await res.json();

--- a/e2e/tests/travel-itinerary-suggest-api.spec.js
+++ b/e2e/tests/travel-itinerary-suggest-api.spec.js
@@ -1,0 +1,164 @@
+// @ts-check
+/**
+ * Gate spec — travel-vertical itinerary AI "Suggest" endpoint.
+ *
+ * Covers PRD_TRAVEL_ITINERARY_UPGRADES FR-3.4:
+ *   POST /api/travel/itineraries/suggest
+ *
+ * The endpoint returns a STRUCTURED day-by-day draft for operator review
+ * (no DB write per FR-3.4(e)). Until Q11 LLM keys land it runs in stub
+ * mode (model gemini-flash, stub:true) and assembles a deterministic
+ * skeleton — so this spec pins the stub contract.
+ *
+ * Verifies:
+ *   - happy path returns { suggestion:{ summary, days[] }, model, stub }
+ *   - days array length === requested days; each day has a valid item set
+ *   - budget split lands on the per-night hotel estimatedCost
+ *   - validation (missing destination, out-of-range days, bad sub-brand)
+ *   - auth gate (no token → 401)
+ *   - cross-vertical guard (generic tenant → 403 WRONG_VERTICAL)
+ *
+ * Auth deps: yasin@travelstall.in (travel ADMIN, seed-travel.js) +
+ * admin@globussoft.com (generic ADMIN, seed.js). No persisted rows → no
+ * cleanup needed (the only side-effect is a tenant-scoped LlmCallLog row).
+ */
+
+const { test, expect } = require("@playwright/test");
+
+test.describe.configure({ mode: "serial" });
+
+const BASE_URL = process.env.BASE_URL || "https://crm.globusdemos.com";
+const REQUEST_TIMEOUT = 60000;
+
+let travelAdminToken = null;
+let genericAdminToken = null;
+
+async function loginAs(request, email, password) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const r = await request.post(`${BASE_URL}/api/auth/login`, {
+        data: { email, password },
+        headers: { "Content-Type": "application/json" },
+        timeout: REQUEST_TIMEOUT,
+      });
+      if (r.ok()) return (await r.json()).token;
+    } catch (_e) {
+      if (attempt === 0) continue;
+    }
+  }
+  return null;
+}
+
+async function getTravelAdmin(request) {
+  if (!travelAdminToken) travelAdminToken = await loginAs(request, "yasin@travelstall.in", "password123");
+  return travelAdminToken;
+}
+async function getGenericAdmin(request) {
+  if (!genericAdminToken) genericAdminToken = await loginAs(request, "admin@globussoft.com", "password123");
+  return genericAdminToken;
+}
+
+const headers = (token) => ({ Authorization: `Bearer ${token}`, "Content-Type": "application/json" });
+
+async function retryOn5xx(fn) {
+  let r;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    r = await fn();
+    if (r.status() < 500) return r;
+    await new Promise((res) => setTimeout(res, 500 * (attempt + 1)));
+  }
+  return r;
+}
+
+async function post(request, token, path, body) {
+  return retryOn5xx(() =>
+    request.post(`${BASE_URL}${path}`, {
+      headers: token ? headers(token) : { "Content-Type": "application/json" },
+      data: body ?? {},
+      timeout: REQUEST_TIMEOUT,
+    }),
+  );
+}
+
+const SUGGEST = "/api/travel/itineraries/suggest";
+
+test.describe("Travel itinerary suggest — POST /api/travel/itineraries/suggest", () => {
+  test("happy path returns a structured day-by-day stub suggestion", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    test.skip(!token, "travel admin login unavailable");
+
+    const r = await post(request, token, SUGGEST, { destination: "Dubai", days: 3, subBrand: "rfu" });
+    expect(r.status()).toBe(200);
+    const body = await r.json();
+
+    expect(body).toMatchObject({ model: "gemini-flash", stub: true });
+    expect(body.suggestion).toBeTruthy();
+    expect(typeof body.suggestion.summary).toBe("string");
+    expect(Array.isArray(body.suggestion.days)).toBe(true);
+    expect(body.suggestion.days).toHaveLength(3);
+
+    // Day numbering is 1..N and each day carries at least a hotel + activity.
+    body.suggestion.days.forEach((day, idx) => {
+      expect(day.dayNumber).toBe(idx + 1);
+      expect(Array.isArray(day.items)).toBe(true);
+      const types = day.items.map((it) => it.itemType);
+      expect(types).toContain("hotel");
+      expect(types).toContain("activity");
+    });
+    // Day 1 has an arrival flight; last day has a departure flight.
+    expect(body.suggestion.days[0].items.some((it) => it.itemType === "flight")).toBe(true);
+    expect(body.suggestion.days[2].items.some((it) => it.itemType === "flight")).toBe(true);
+  });
+
+  test("budget-per-pax splits onto the per-night hotel estimatedCost", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    test.skip(!token, "travel admin login unavailable");
+
+    const r = await post(request, token, SUGGEST, { destination: "Bali", days: 4, budgetPerPax: 40000 });
+    expect(r.status()).toBe(200);
+    const body = await r.json();
+    const hotelDay1 = body.suggestion.days[0].items.find((it) => it.itemType === "hotel");
+    // 40000 / 4 = 10000 per night.
+    expect(hotelDay1.estimatedCost).toBe(10000);
+  });
+
+  test("rejects a missing destination with 400", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    test.skip(!token, "travel admin login unavailable");
+    const r = await post(request, token, SUGGEST, { days: 3 });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe("MISSING_DESTINATION");
+  });
+
+  test("rejects out-of-range days with 400", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    test.skip(!token, "travel admin login unavailable");
+    const zero = await post(request, token, SUGGEST, { destination: "Goa", days: 0 });
+    expect(zero.status()).toBe(400);
+    expect((await zero.json()).code).toBe("INVALID_DAYS");
+    const tooMany = await post(request, token, SUGGEST, { destination: "Goa", days: 99 });
+    expect(tooMany.status()).toBe(400);
+    expect((await tooMany.json()).code).toBe("INVALID_DAYS");
+  });
+
+  test("rejects an invalid sub-brand with 400", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    test.skip(!token, "travel admin login unavailable");
+    const r = await post(request, token, SUGGEST, { destination: "Dubai", days: 2, subBrand: "not-a-brand" });
+    expect(r.status()).toBe(400);
+    expect((await r.json()).code).toBe("INVALID_SUB_BRAND");
+  });
+
+  test("requires authentication (401 without token)", async ({ request }) => {
+    const r = await post(request, null, SUGGEST, { destination: "Dubai", days: 2 });
+    expect(r.status()).toBe(401);
+  });
+
+  test("rejects a generic (non-travel) tenant with 403 WRONG_VERTICAL", async ({ request }) => {
+    const token = await getGenericAdmin(request);
+    test.skip(!token, "generic admin login unavailable");
+    const r = await post(request, token, SUGGEST, { destination: "Dubai", days: 2 });
+    expect(r.status()).toBe(403);
+    expect((await r.json()).code).toBe("WRONG_VERTICAL");
+  });
+});

--- a/e2e/tests/travel-rfu-profiles-api.spec.js
+++ b/e2e/tests/travel-rfu-profiles-api.spec.js
@@ -186,6 +186,17 @@ test.describe("Travel RFU profiles API — CRUD", () => {
     expect((await res.json()).code).toBe("INVALID_TIER");
   });
 
+  test("GET /rfu-profiles?fields=summary omits sensitive PII columns", async ({ request }) => {
+    const token = await getTravelAdmin(request);
+    if (!token || created.profileIds.length === 0) test.skip(true, "no profiles");
+    const res = await get(request, token, "/api/travel/rfu-profiles?fields=summary");
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const seeded = body.profiles.find((p) => p.id === created.profileIds[0]);
+    expect(seeded.passportNumber).toBeUndefined();
+    expect(seeded.contactId).toBeDefined();
+  });
+
   test("GET /rfu-profiles/by-contact/:contactId returns the profile", async ({ request }) => {
     const token = await getTravelAdmin(request);
     if (!token || !contactId) test.skip(true, "no contact");

--- a/e2e/tests/webhook-credential-api.spec.js
+++ b/e2e/tests/webhook-credential-api.spec.js
@@ -1,0 +1,187 @@
+// @ts-check
+/**
+ * Webhook Signing Credential — API coverage.
+ *
+ * routes/settings.js — the per-tenant HMAC signing credential that replaces
+ * the single global WEBHOOK_HMAC_SECRET. Surfaced in the Settings page. Covers:
+ *   GET    /api/settings/webhook-credential          — ADMIN, status + entitlement, NEVER leaks secret
+ *   POST   /api/settings/webhook-credential          — ADMIN, entitlement-gated, show-once raw secret, 409 if active
+ *   POST   /api/settings/webhook-credential/rotate   — ADMIN, show-once new secret, differs from first
+ *   DELETE /api/settings/webhook-credential          — ADMIN, revoke (status REVOKED)
+ *
+ * Auth: admin@globussoft.com (generic tenant, seeded TRIAL with a 15-day
+ * trial → entitled, so generation/rotation return 201/200 deterministically).
+ * Role gate uses manager@crm.com (MANAGER → 403).
+ *
+ * Show-once contract pinned here: POST/rotate responses INCLUDE `secret`
+ * (the raw value); GET responses NEVER do. There is no reveal endpoint.
+ *
+ * State note: tenantId is @unique so there is ONE credential row per tenant,
+ * shared across these tests — hence `mode: 'serial'` for the lifecycle block.
+ * Re-runs are safe: generate reactivates a previously-REVOKED row (no 409),
+ * and afterAll revokes so the tenant is left in a known state.
+ *
+ * The 402-not-entitled gate is covered at the unit layer
+ * (backend/test/lib/webhookEntitlement.test.js) — every seeded tenant here is
+ * trial-entitled, so it can't be exercised deterministically from e2e.
+ */
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BASE_URL || 'https://crm.globusdemos.com';
+const REQUEST_TIMEOUT = 60000;
+
+let adminToken = null;
+let managerToken = null;
+
+async function loginAs(request, email, password) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const r = await request.post(`${BASE_URL}/api/auth/login`, {
+        data: { email, password },
+        headers: { 'Content-Type': 'application/json' },
+        timeout: REQUEST_TIMEOUT,
+      });
+      if (r.ok()) return (await r.json()).token;
+    } catch (_e) {
+      if (attempt === 0) continue;
+    }
+  }
+  return null;
+}
+
+async function getAdmin(request) {
+  if (!adminToken) adminToken = await loginAs(request, 'admin@globussoft.com', 'password123');
+  return adminToken;
+}
+async function getManager(request) {
+  if (!managerToken) managerToken = await loginAs(request, 'manager@crm.com', 'password123');
+  return managerToken;
+}
+
+const headers = (token) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' });
+const get = (request, token) => request.get(`${BASE_URL}/api/settings/webhook-credential`, { headers: headers(token), timeout: REQUEST_TIMEOUT });
+const gen = (request, token) => request.post(`${BASE_URL}/api/settings/webhook-credential`, { headers: headers(token), data: {}, timeout: REQUEST_TIMEOUT });
+const rotate = (request, token) => request.post(`${BASE_URL}/api/settings/webhook-credential/rotate`, { headers: headers(token), data: {}, timeout: REQUEST_TIMEOUT });
+const revoke = (request, token) => request.delete(`${BASE_URL}/api/settings/webhook-credential`, { headers: headers(token), timeout: REQUEST_TIMEOUT });
+
+test.afterAll(async ({ request }) => {
+  const token = await getAdmin(request);
+  if (token) await revoke(request, token).catch(() => {});
+});
+
+// ── Auth + role gates ───────────────────────────────────────────────
+
+test.describe('Webhook Credential API — auth + role gates', () => {
+  test('GET without token → 401', async ({ request }) => {
+    const r = await request.get(`${BASE_URL}/api/settings/webhook-credential`, { timeout: REQUEST_TIMEOUT });
+    expect(r.status()).toBe(401);
+  });
+
+  test('POST without token → 401', async ({ request }) => {
+    const r = await request.post(`${BASE_URL}/api/settings/webhook-credential`, { data: {}, headers: { 'Content-Type': 'application/json' }, timeout: REQUEST_TIMEOUT });
+    expect(r.status()).toBe(401);
+  });
+
+  test('GET as MANAGER (non-admin) → 403', async ({ request }) => {
+    const token = await getManager(request);
+    test.skip(!token, 'manager login unavailable');
+    const r = await get(request, token);
+    expect(r.status()).toBe(403);
+  });
+
+  test('POST as MANAGER (non-admin) → 403', async ({ request }) => {
+    const token = await getManager(request);
+    test.skip(!token, 'manager login unavailable');
+    const r = await gen(request, token);
+    expect(r.status()).toBe(403);
+  });
+});
+
+// ── Lifecycle (serial — shares the single per-tenant credential row) ──
+
+test.describe('Webhook Credential API — lifecycle', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let firstSecret = null;
+
+  test('GET returns entitlement + signing block, never a raw secret', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    const r = await get(request, token);
+    expect(r.status(), await r.text()).toBe(200);
+    const body = await r.json();
+    expect(body).toHaveProperty('exists');
+    expect(body).toHaveProperty('entitled');
+    expect(body.entitled).toBe(true); // seeded admin is trial-entitled
+    expect(body).not.toHaveProperty('secret'); // never leaks the raw secret
+    expect(body.signing).toMatchObject({
+      header: 'X-Globussoft-Signature',
+      algorithm: 'HMAC-SHA256',
+    });
+  });
+
+  test('POST generates a credential and returns the raw secret ONCE', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    // Clean slate: if an ACTIVE credential lingers from a prior run, revoke so
+    // generate doesn't 409. (A revoked row is reactivated by generate.)
+    const pre = await get(request, token);
+    if ((await pre.json()).status === 'ACTIVE') await revoke(request, token);
+
+    const r = await gen(request, token);
+    expect(r.status(), await r.text()).toBe(201);
+    const body = await r.json();
+    expect(body.exists).toBe(true);
+    expect(body.status).toBe('ACTIVE');
+    expect(typeof body.secret).toBe('string');
+    expect(body.secret).toMatch(/^[a-f0-9]{64}$/); // 32-byte hex
+    expect(body.signingId).toMatch(/^whid_[a-f0-9]+$/);
+    firstSecret = body.secret;
+  });
+
+  test('GET after generate exposes status/metadata but NOT the secret', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    const r = await get(request, token);
+    expect(r.status()).toBe(200);
+    const body = await r.json();
+    expect(body.exists).toBe(true);
+    expect(body.status).toBe('ACTIVE');
+    expect(body.signingId).toMatch(/^whid_[a-f0-9]+$/);
+    expect(body).not.toHaveProperty('secret'); // show-once: not retrievable
+    expect(body.secretMasked).not.toContain(firstSecret); // hint isn't the secret
+  });
+
+  test('POST again while ACTIVE → 409 (must rotate)', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    const r = await gen(request, token);
+    expect(r.status(), await r.text()).toBe(409);
+    expect((await r.json()).code).toBe('CREDENTIAL_EXISTS');
+  });
+
+  test('rotate returns a NEW raw secret different from the first', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    const r = await rotate(request, token);
+    expect(r.status(), await r.text()).toBe(200);
+    const body = await r.json();
+    expect(typeof body.secret).toBe('string');
+    expect(body.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(body.secret).not.toBe(firstSecret); // rotation actually changed it
+    expect(body.lastRotatedAt).toBeTruthy();
+  });
+
+  test('revoke sets status REVOKED', async ({ request }) => {
+    const token = await getAdmin(request);
+    test.skip(!token, 'admin login unavailable');
+    const r = await revoke(request, token);
+    expect(r.status(), await r.text()).toBe(200);
+    const body = await r.json();
+    expect(body.success).toBe(true);
+    expect(body.status).toBe('REVOKED');
+
+    const after = await get(request, token);
+    expect((await after.json()).status).toBe('REVOKED');
+  });
+});

--- a/e2e/tests/wellness-portal-notifications-api.spec.js
+++ b/e2e/tests/wellness-portal-notifications-api.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+/**
+ * Wellness patient-portal notification inbox — Option A REST endpoints.
+ *
+ * routes/wellness.js (behind verifyPatientToken, scoped to req.patient.id):
+ *   GET  /api/wellness/portal/me/notifications            → { notifications[], unreadCount, count }
+ *   PUT  /api/wellness/portal/me/notifications/:id/read    → updated row (isRead:true)
+ *   POST /api/wellness/portal/me/notifications/mark-all-read → { success, marked }
+ *
+ * These serve the patient Android app / web portal inbox. They are SEPARATE
+ * from the staff /api/notifications bell (which rejects portal tokens by
+ * design) — backed by the additive PatientNotification table, patient-scoped.
+ *
+ * Auth model pinned:
+ *   - no token            → 401
+ *   - staff JWT (no patientId / no linked Patient) → rejected (401/403), never 200
+ *   - valid portal token  → 200, sees ONLY this patient's rows
+ *
+ * Token mint: demo-OTP bypass (#238/#292) for the seeded "Demo Portal Patient"
+ * at +919876500001 — request-otp + verify-otp with WELLNESS_DEMO_OTP (1234).
+ * seed-wellness.js seeds 3 notifications for this patient (2 unread, 1 read).
+ *
+ * Re-run safe: the only mutation is marking rows read; after mark-all-read the
+ * unread invariant (=0) holds regardless of prior runs. The 3 seeded rows are
+ * never deleted/duplicated (seed is count-guarded). Acceptable demo pollution:
+ * after this spec the demo patient's notifications are all read.
+ */
+const { test, expect } = require('@playwright/test');
+
+test.describe.configure({ mode: 'serial' });
+
+const BASE_URL = process.env.BASE_URL || 'https://crm.globusdemos.com';
+const API = `${BASE_URL}/api`;
+const REQUEST_TIMEOUT = 60000;
+
+const DEMO_PORTAL_PHONE = '+919876500001';
+const DEMO_OTP = process.env.WELLNESS_DEMO_OTP || '1234';
+const RISHU = { email: 'rishu@enhancedwellness.in', password: 'password123' };
+
+let portalToken = '';
+let staffToken = '';
+const portalAuth = () => ({ Authorization: `Bearer ${portalToken}` });
+async function safeJson(res) { try { return await res.json(); } catch (_e) { return null; } }
+
+test.beforeAll(async ({ request }) => {
+  // Mint a portal token via demo-OTP bypass.
+  await request.post(`${API}/wellness/portal/login/request-otp`, { data: { phone: DEMO_PORTAL_PHONE }, timeout: REQUEST_TIMEOUT });
+  const verify = await request.post(`${API}/wellness/portal/login/verify-otp`, {
+    data: { phone: DEMO_PORTAL_PHONE, otp: DEMO_OTP }, timeout: REQUEST_TIMEOUT,
+  });
+  if (verify.ok()) portalToken = (await verify.json()).token || '';
+
+  const login = await request.post(`${API}/auth/login`, { data: RISHU, timeout: REQUEST_TIMEOUT });
+  if (login.ok()) staffToken = (await login.json()).token || '';
+});
+
+// ── Auth gates ──────────────────────────────────────────────────────
+
+test('GET notifications without token → 401', async ({ request }) => {
+  const r = await request.get(`${API}/wellness/portal/me/notifications`, { timeout: REQUEST_TIMEOUT });
+  expect(r.status()).toBe(401);
+});
+
+test('GET notifications with a STAFF token → rejected (never 200, no leak)', async ({ request }) => {
+  test.skip(!staffToken, 'staff login unavailable');
+  const r = await request.get(`${API}/wellness/portal/me/notifications`, {
+    headers: { Authorization: `Bearer ${staffToken}` }, timeout: REQUEST_TIMEOUT,
+  });
+  // Staff JWT carries userId (no patientId) + has no linked Patient → 401/403.
+  expect([401, 403]).toContain(r.status());
+  expect(r.status()).not.toBe(200);
+});
+
+// ── Inbox lifecycle (serial — shares the demo patient's rows) ────────
+
+test('GET returns the patient inbox shape (notifications[] + unreadCount + count)', async ({ request }) => {
+  test.skip(!portalToken, 'portal token unavailable (WELLNESS_DEMO_OTP not set?)');
+  const r = await request.get(`${API}/wellness/portal/me/notifications`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT });
+  expect(r.status(), await r.text()).toBe(200);
+  const body = await r.json();
+  expect(Array.isArray(body.notifications)).toBe(true);
+  expect(typeof body.unreadCount).toBe('number');
+  expect(typeof body.count).toBe('number');
+  expect(body.notifications.length).toBeGreaterThanOrEqual(1); // 3 seeded
+  // Public shape: rows must NOT leak tenantId.
+  for (const n of body.notifications) {
+    expect(n).not.toHaveProperty('tenantId');
+    expect(n).toHaveProperty('id');
+    expect(n).toHaveProperty('title');
+    expect(n).toHaveProperty('isRead');
+  }
+});
+
+test('PUT :id/read marks a single notification read', async ({ request }) => {
+  test.skip(!portalToken, 'portal token unavailable');
+  const list = await (await request.get(`${API}/wellness/portal/me/notifications`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT })).json();
+  const target = list.notifications[0];
+  const r = await request.put(`${API}/wellness/portal/me/notifications/${target.id}/read`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT });
+  expect(r.status(), await r.text()).toBe(200);
+  const body = await r.json();
+  expect(body.id).toBe(target.id);
+  expect(body.isRead).toBe(true);
+  expect(body).not.toHaveProperty('tenantId');
+});
+
+test('PUT :id/read on a non-existent id → 404', async ({ request }) => {
+  test.skip(!portalToken, 'portal token unavailable');
+  const r = await request.put(`${API}/wellness/portal/me/notifications/99999999/read`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT });
+  expect(r.status()).toBe(404);
+  expect((await safeJson(r))?.code).toBe('NOTIFICATION_NOT_FOUND');
+});
+
+test('POST mark-all-read clears unread; subsequent GET has unreadCount 0', async ({ request }) => {
+  test.skip(!portalToken, 'portal token unavailable');
+  const r = await request.post(`${API}/wellness/portal/me/notifications/mark-all-read`, { headers: portalAuth(), data: {}, timeout: REQUEST_TIMEOUT });
+  expect(r.status(), await r.text()).toBe(200);
+  const body = await r.json();
+  expect(body.success).toBe(true);
+  expect(typeof body.marked).toBe('number');
+
+  const after = await (await request.get(`${API}/wellness/portal/me/notifications`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT })).json();
+  expect(after.unreadCount).toBe(0);
+  expect(after.notifications.every((n) => n.isRead === true)).toBe(true);
+});
+
+test('?unreadOnly=true returns only unread (empty after mark-all-read)', async ({ request }) => {
+  test.skip(!portalToken, 'portal token unavailable');
+  const r = await request.get(`${API}/wellness/portal/me/notifications?unreadOnly=true`, { headers: portalAuth(), timeout: REQUEST_TIMEOUT });
+  expect(r.status()).toBe(200);
+  const body = await r.json();
+  expect(body.notifications.every((n) => n.isRead === false)).toBe(true);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,12 @@
       "version": "3.3.0",
       "dependencies": {
         "leaflet": "^1.9.4",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.499.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-grid-layout": "^2.2.3",
+        "react-leaflet": "^4.2.1",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^7.13.2",
         "reactflow": "^11.11.4",
@@ -1351,6 +1353,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
       "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
       "peerDependencies": {
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
@@ -5329,7 +5332,8 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6271,6 +6275,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
       "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
       "dependencies": {
         "@react-leaflet/core": "^2.1.0"
       },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -250,6 +250,7 @@ const TravelFlyerTemplates = lazy(() => import("./pages/travel/FlyerTemplates"))
 const TravelReligiousPackets = lazy(() => import("./pages/travel/ReligiousPackets"));
 const TravelTmcMicrositePreview = lazy(() => import("./pages/travel/TmcMicrositePreview"));
 const TravelItineraryDetail = lazy(() => import("./pages/travel/ItineraryDetail"));
+const TravelItineraryEditor = lazy(() => import("./pages/travel/ItineraryEditor"));
 const TravelLeadDetail = lazy(() => import("./pages/travel/LeadDetail"));
 // Arc 2 #904 slice — InboundLeads admin page (STUB consumer). Operator-facing
 // list of inbound leads ingested via POST /api/travel/inbound/leads/:channel
@@ -1420,6 +1421,7 @@ export default function App() {
                   inside DiagnosticBuilder's EngineWeights tab for now. */}
               <Route path="travel/tmc/catalogue" element={<TravelOnly><TravelTmcCatalogueAdmin /></TravelOnly>} />
               <Route path="travel/itineraries/:id" element={<TravelOnly><TravelItineraryDetail /></TravelOnly>} />
+              <Route path="travel/itineraries/:id/edit" element={<TravelOnly><TravelItineraryEditor /></TravelOnly>} />
               <Route path="travel/leads/:contactId" element={<TravelOnly><TravelLeadDetail /></TravelOnly>} />
               {/* Arc 2 #904 slice — InboundLeads admin (STUB client-side
                   filter pending dedicated GET endpoint). Operator surface

--- a/frontend/src/__tests__/MarketingFlyerStudio.test.jsx
+++ b/frontend/src/__tests__/MarketingFlyerStudio.test.jsx
@@ -68,7 +68,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 // Stable mock impl for useActiveSubBrand — per-test setup uses
@@ -98,6 +98,7 @@ vi.mock('../utils/notify', () => ({
 const fetchApiMock = vi.fn();
 vi.mock('../utils/api', () => ({
   fetchApi: (...args) => fetchApiMock(...args),
+  getAuthToken: () => 'tk',
 }));
 
 // useSearchParams + useNavigate mocked — STABLE references for both the
@@ -163,45 +164,54 @@ describe('MarketingFlyerStudio — SHELL surface', () => {
     expect(screen.getByText(/TMC \/ RFU \/ Travel Stall \/ Visa Sure/i)).toBeTruthy();
   });
 
-  it('renders 4 sub-brand placeholder cards (tmc / rfu / travelstall / visasure)', () => {
+  it('renders the editor toolbar (+ Text / + Image) and canvas with the seeded block', () => {
     renderStudio();
-    const ids = ['tmc', 'rfu', 'travelstall', 'visasure'];
-    for (const id of ids) {
-      const card = screen.getByTestId(`flyer-card-${id}`);
-      expect(card).toBeTruthy();
-      expect(card.getAttribute('data-sub-brand')).toBe(id);
-    }
-    // Container has exactly 4 cards — exact count guards against
-    // accidental drift if a 5th sub-brand is added without updating the
-    // canonical VALID_SUB_BRANDS set.
-    const cards = screen.getByTestId('marketing-flyer-studio-cards').querySelectorAll('[data-sub-brand]');
-    expect(cards.length).toBe(4);
+    expect(screen.getByTestId('flyer-editor')).toBeTruthy();
+    expect(screen.getByTestId('flyer-canvas')).toBeTruthy();
+    expect(screen.getByTestId('flyer-add-text')).toBeTruthy();
+    expect(screen.getByTestId('flyer-add-image')).toBeTruthy();
+    // The default layout seeds one text block on the canvas.
+    expect(screen.getByTestId('flyer-block-0')).toBeTruthy();
   });
 
-  it('shows a "Coming soon" overlay affordance on every sub-brand card', () => {
+  it('"+ Text" appends a text block to the canvas', () => {
     renderStudio();
-    const ids = ['tmc', 'rfu', 'travelstall', 'visasure'];
-    for (const id of ids) {
-      const overlay = screen.getByTestId(`flyer-card-${id}-coming-soon`);
-      expect(overlay).toBeTruthy();
-      // Overlay carries the literal "Coming soon" copy.
-      expect(overlay.textContent || '').toMatch(/coming soon/i);
+    expect(screen.queryByTestId('flyer-block-1')).toBeNull();
+    fireEvent.click(screen.getByTestId('flyer-add-text'));
+    expect(screen.getByTestId('flyer-block-1')).toBeTruthy();
+  });
+
+  it('"+ Image" appends an image block (shows the set-URL placeholder)', () => {
+    renderStudio();
+    fireEvent.click(screen.getByTestId('flyer-add-image'));
+    const block = screen.getByTestId('flyer-block-1');
+    expect(block).toBeTruthy();
+    expect(block.textContent || '').toMatch(/set url/i);
+  });
+
+  it('clicking a block selects it and the properties panel edits its text live', () => {
+    renderStudio();
+    fireEvent.click(screen.getByTestId('flyer-block-0'));
+    const textArea = screen.getByLabelText('Block text');
+    expect(textArea).toBeTruthy();
+    fireEvent.change(textArea, { target: { value: 'Ramadan Umrah 2026' } });
+    expect(screen.getByTestId('flyer-block-0').textContent || '').toMatch(/Ramadan Umrah 2026/);
+  });
+
+  it('renders a colour swatch for each of the 5 palette keys', () => {
+    renderStudio();
+    for (const k of ['primaryHex', 'secondaryHex', 'accentHex', 'textHex', 'bgHex']) {
+      expect(screen.getByTestId(`palette-${k}`)).toBeTruthy();
     }
   });
 
-  it('visually highlights the active sub-brand card (data-active + aria-current)', () => {
-    activeSubBrandMockImpl.mockReturnValue({ activeSubBrand: 'rfu', setActiveSubBrand: () => {} });
+  it('an image block exposes the URL field + an "Upload image" control', () => {
     renderStudio();
-    const rfuCard = screen.getByTestId('flyer-card-rfu');
-    expect(rfuCard.getAttribute('data-active')).toBe('true');
-    expect(rfuCard.getAttribute('aria-current')).toBe('true');
-
-    // Non-active cards remain data-active='false' with no aria-current.
-    for (const id of ['tmc', 'travelstall', 'visasure']) {
-      const card = screen.getByTestId(`flyer-card-${id}`);
-      expect(card.getAttribute('data-active')).toBe('false');
-      expect(card.getAttribute('aria-current')).toBeNull();
-    }
+    fireEvent.click(screen.getByTestId('flyer-add-image'));
+    fireEvent.click(screen.getByTestId('flyer-block-1'));
+    expect(screen.getByLabelText('Image URL')).toBeTruthy();
+    expect(screen.getByTestId('flyer-image-upload')).toBeTruthy();
+    expect(screen.getByTestId('flyer-image-file')).toBeTruthy();
   });
 
   it('RoleGuard gate — USER role blocks the studio; ADMIN/MANAGER render the studio', async () => {
@@ -233,21 +243,11 @@ describe('MarketingFlyerStudio — SHELL surface', () => {
     });
   });
 
-  it('renders without throwing when activeSubBrand is null (no card highlighted)', () => {
+  it('renders without throwing when activeSubBrand is null', () => {
     activeSubBrandMockImpl.mockReturnValue({ activeSubBrand: null, setActiveSubBrand: () => {} });
     expect(() => renderStudio()).not.toThrow();
-    // Heading mounts.
     expect(screen.getByRole('heading', { level: 1, name: /marketing flyer studio/i })).toBeTruthy();
-    // All 4 cards mount with data-active='false' (no highlight).
-    for (const id of ['tmc', 'rfu', 'travelstall', 'visasure']) {
-      const card = screen.getByTestId(`flyer-card-${id}`);
-      expect(card.getAttribute('data-active')).toBe('false');
-      expect(card.getAttribute('aria-current')).toBeNull();
-    }
-    // Defensive — within() resolves the cards container so the test
-    // double-checks the scope is what we expect.
-    const container = screen.getByTestId('marketing-flyer-studio-cards');
-    expect(within(container).getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(4);
+    expect(screen.getByTestId('flyer-editor')).toBeTruthy();
   });
 });
 

--- a/frontend/src/__tests__/PatientPortal.test.jsx
+++ b/frontend/src/__tests__/PatientPortal.test.jsx
@@ -189,9 +189,25 @@ function installFetchMock({
   prescriptions = PRESCRIPTIONS_PAYLOAD,
   permissions = PORTAL_PERMISSIONS,
   appointmentsByBucket = APPOINTMENTS_BY_BUCKET,
+  // Default empty so existing tests see NO notifications tab change; the
+  // notification-specific tests below pass a populated payload.
+  notificationsPayload = { notifications: [], unreadCount: 0, count: 0 },
 } = {}) {
+  const jsonRes = (body) => Promise.resolve({
+    ok: true, status: 200, headers: new Map([['content-type', 'application/json']]), json: () => Promise.resolve(body),
+  });
   const fetchStub = vi.fn((url, opts = {}) => {
     const method = opts.method || 'GET';
+    // Patient notification inbox (Option A) — GET list / PUT read / POST mark-all.
+    if (url === '/api/wellness/portal/me/notifications' && method === 'GET') {
+      return jsonRes(notificationsPayload);
+    }
+    if (typeof url === 'string' && /\/api\/wellness\/portal\/me\/notifications\/\d+\/read$/.test(url) && method === 'PUT') {
+      return jsonRes({ id: Number(url.match(/\/(\d+)\/read$/)[1]), isRead: true });
+    }
+    if (url === '/api/wellness/portal/me/notifications/mark-all-read' && method === 'POST') {
+      return jsonRes({ success: true, marked: notificationsPayload.unreadCount || 0 });
+    }
     if (url === '/api/wellness/portal/health') {
       return Promise.resolve({
         ok: true,
@@ -822,5 +838,94 @@ describe('<PatientPortal /> — PDF download', () => {
       expect(notifyError).toHaveBeenCalled();
     });
     expect(notifyError.mock.calls[0][0]).toMatch(/Could not download/i);
+  });
+});
+
+/**
+ * Notification inbox (Option A — patient-portal REST inbox). Pins:
+ *   - GET /portal/me/notifications loads on mount; unread badge shows count.
+ *   - Notifications tab renders the rows (title + message).
+ *   - Mark-all-read fires POST /mark-all-read + clears the unread badge.
+ *   - Single "Mark read" fires PUT /:id/read.
+ *   - Empty inbox → "No notifications yet." + no badge.
+ * The notification endpoints are ungated (any logged-in patient), separate
+ * from the staff bell. Existing tests pass the default empty payload, so this
+ * feature is invisible to them — additive, nothing breaks.
+ */
+describe('<PatientPortal /> — notification inbox', () => {
+  beforeEach(() => {
+    localStorage.setItem(PORTAL_TOKEN_KEY, 'seeded-token');
+    localStorage.setItem(PORTAL_NAME_KEY, 'Priya Sharma');
+  });
+
+  const NOTIFS = {
+    notifications: [
+      { id: 9001, title: 'Appointment confirmed', message: 'Your visit is confirmed for tomorrow 11 AM.', type: 'appointment', isRead: false, createdAt: '2026-06-08T10:00:00.000Z' },
+      { id: 9002, title: 'Payment receipt', message: 'We received ₹1,500. Thank you!', type: 'payment', isRead: true, createdAt: '2026-06-07T09:00:00.000Z' },
+    ],
+    unreadCount: 1,
+    count: 2,
+  };
+
+  it('loads notifications on mount; unread badge shows the count', async () => {
+    const fetchStub = installFetchMock({ notificationsPayload: NOTIFS });
+    render(<PatientPortal />);
+    await waitFor(() => {
+      const call = fetchStub.mock.calls.find(([u]) => u === '/api/wellness/portal/me/notifications');
+      expect(call).toBeTruthy();
+      expect(call[1].headers.Authorization).toBe('Bearer seeded-token');
+    });
+    // Unread badge renders with "1".
+    expect(await screen.findByTestId('portal-notif-badge')).toHaveTextContent('1');
+  });
+
+  it('Notifications tab renders rows (title + message)', async () => {
+    installFetchMock({ notificationsPayload: NOTIFS });
+    render(<PatientPortal />);
+    await screen.findByTestId('portal-notif-badge');
+    fireEvent.click(screen.getByRole('button', { name: /Notifications/i }));
+    expect(await screen.findByText('Appointment confirmed')).toBeInTheDocument();
+    expect(screen.getByText(/Your visit is confirmed/i)).toBeInTheDocument();
+    expect(screen.getByText('Payment receipt')).toBeInTheDocument();
+  });
+
+  it('Mark all read → POST /mark-all-read fires + badge clears', async () => {
+    const fetchStub = installFetchMock({ notificationsPayload: NOTIFS });
+    render(<PatientPortal />);
+    await screen.findByTestId('portal-notif-badge');
+    fireEvent.click(screen.getByRole('button', { name: /Notifications/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Mark all read/i }));
+    await waitFor(() => {
+      const call = fetchStub.mock.calls.find(
+        ([u, o]) => u === '/api/wellness/portal/me/notifications/mark-all-read' && o?.method === 'POST',
+      );
+      expect(call).toBeTruthy();
+    });
+    // Optimistic clear — badge disappears.
+    await waitFor(() => expect(screen.queryByTestId('portal-notif-badge')).toBeNull());
+  });
+
+  it('single "Mark read" → PUT /:id/read fires for the unread row', async () => {
+    const fetchStub = installFetchMock({ notificationsPayload: NOTIFS });
+    render(<PatientPortal />);
+    await screen.findByTestId('portal-notif-badge');
+    fireEvent.click(screen.getByRole('button', { name: /Notifications/i }));
+    // Only the unread row (9001) shows a "Mark read" button.
+    fireEvent.click(await screen.findByRole('button', { name: /^Mark read$/i }));
+    await waitFor(() => {
+      const call = fetchStub.mock.calls.find(
+        ([u, o]) => u === '/api/wellness/portal/me/notifications/9001/read' && o?.method === 'PUT',
+      );
+      expect(call).toBeTruthy();
+    });
+  });
+
+  it('empty inbox → "No notifications yet." + no unread badge', async () => {
+    installFetchMock(); // default empty notificationsPayload
+    render(<PatientPortal />);
+    await screen.findByText('Hair PRP'); // dashboard loaded
+    expect(screen.queryByTestId('portal-notif-badge')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Notifications/i }));
+    expect(await screen.findByText(/No notifications yet\./i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/WebhookSigningCredential.test.jsx
+++ b/frontend/src/__tests__/WebhookSigningCredential.test.jsx
@@ -1,0 +1,199 @@
+/**
+ * WebhookSigningCredential.test.jsx — vitest + RTL coverage for the reusable
+ * per-tenant HMAC signing-credential component (frontend/src/components/
+ * WebhookSigningCredential.jsx). Rendered inside the Settings page.
+ *
+ * Backend contract pinned (all under /api/settings/webhook-credential):
+ *   GET    → { exists, status, signingId, secretMasked, entitled, signing, ... }  (never `secret`)
+ *   POST   → { ...status, secret, signing, warning }                              (show-once raw secret)
+ *   POST /rotate → { ...status, secret, lastRotatedAt }                           (new show-once secret)
+ *   DELETE → { success, status: 'REVOKED' }
+ *
+ * Contracts pinned here:
+ *   1. entitled + no credential → "Generate signing secret" button enabled.
+ *   2. NOT entitled + no credential → button disabled + "Upgrade to enable" link.
+ *   3. active credential → signingId + status + receiver-config block render;
+ *      the raw 64-hex secret NEVER renders (show-once model).
+ *   4. generate → POSTs /api/settings/webhook-credential + reveals the
+ *      show-once secret in a centered modal dialog (full key + Copy + Done).
+ *   5. modal Done button closes the reveal.
+ *   6. rotate → notify.confirm + POST /rotate + reveals the new secret in a modal.
+ *   7. rotate cancelled → confirm:false means NO rotate POST.
+ *   8. revoke → notify.confirm + DELETE.
+ *   9. non-admin (GET 403 → component returns null) renders nothing.
+ *
+ * Stable mock pattern (2026-05-12 standing rule): notify is ONE object
+ * reference for the whole module so hooks reading it in useCallback deps
+ * don't trigger re-render loops.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+
+const fetchApiMock = vi.fn();
+vi.mock('../utils/api', () => ({
+  fetchApi: (...args) => fetchApiMock(...args),
+}));
+
+const notifyError = vi.fn();
+const notifySuccess = vi.fn();
+const notifyConfirm = vi.fn();
+const notifyObj = {
+  error: notifyError,
+  info: vi.fn(),
+  success: notifySuccess,
+  confirm: (...args) => notifyConfirm(...args),
+};
+vi.mock('../utils/notify', () => ({
+  useNotify: () => notifyObj,
+}));
+
+import WebhookSigningCredential from '../components/WebhookSigningCredential';
+
+const API = '/api/settings/webhook-credential';
+const SIGNING = {
+  header: 'X-Globussoft-Signature',
+  algorithm: 'HMAC-SHA256',
+  signedPayload: '<t>.<rawBody>',
+  receiverEnvVar: 'WEBHOOK_HMAC_SECRET_CRM',
+};
+const credNone = (entitled) => ({
+  exists: false, status: null, signingId: null, lastRotatedAt: null,
+  createdAt: null, secretMasked: null, entitled,
+  entitlementReason: entitled ? 'active_trial' : 'no_active_subscription',
+  signing: SIGNING,
+});
+const credActive = {
+  exists: true, status: 'ACTIVE', signingId: 'whid_abcd1234', lastRotatedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z', secretMasked: 'whsec_••••••1234',
+  entitled: true, entitlementReason: 'active_subscription', signing: SIGNING,
+};
+const RAW_SECRET = 'a'.repeat(64);
+
+// Build a fetch mock returning `cred` for the credential GET; POST/rotate/DELETE
+// return show-once / status payloads.
+const withCred = (cred, overrides = {}) => (url, opts) => {
+  if (url === API && (!opts || !opts.method || opts.method === 'GET')) {
+    return Promise.resolve(cred);
+  }
+  if (url === API && opts?.method === 'POST') {
+    return Promise.resolve(overrides.post ?? { ...credActive, secret: RAW_SECRET });
+  }
+  if (url === `${API}/rotate` && opts?.method === 'POST') {
+    return Promise.resolve(overrides.rotate ?? { ...credActive, lastRotatedAt: '2026-02-02T00:00:00.000Z', secret: 'b'.repeat(64) });
+  }
+  if (url === API && opts?.method === 'DELETE') {
+    return Promise.resolve({ success: true, ...credActive, status: 'REVOKED' });
+  }
+  return Promise.resolve(null);
+};
+
+describe('<WebhookSigningCredential />', () => {
+  beforeEach(() => {
+    fetchApiMock.mockReset();
+    notifyError.mockReset();
+    notifySuccess.mockReset();
+    notifyConfirm.mockReset();
+    notifyConfirm.mockResolvedValue(true);
+  });
+
+  it('entitled + no credential: Generate signing secret button is ENABLED', async () => {
+    fetchApiMock.mockImplementation(withCred(credNone(true)));
+    render(<WebhookSigningCredential />);
+    const btn = await screen.findByRole('button', { name: /Generate signing secret/i });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('NOT entitled + no credential: generate disabled + Upgrade link shown', async () => {
+    fetchApiMock.mockImplementation(withCred(credNone(false)));
+    render(<WebhookSigningCredential />);
+    const btn = await screen.findByRole('button', { name: /Generate signing secret/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/Upgrade to enable/i)).toBeInTheDocument();
+  });
+
+  it('active credential: shows signingId + status + receiver config, never the raw secret', async () => {
+    fetchApiMock.mockImplementation(withCred(credActive));
+    render(<WebhookSigningCredential />);
+    expect(await screen.findByText('whid_abcd1234')).toBeInTheDocument();
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rotate/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Revoke/i })).toBeInTheDocument();
+    expect(screen.getByText(/X-Globussoft-Signature/)).toBeInTheDocument();
+    expect(screen.getByText(/HMAC-SHA256/)).toBeInTheDocument();
+    expect(screen.getByText(/WEBHOOK_HMAC_SECRET_CRM/)).toBeInTheDocument();
+    expect(screen.getByText(/whsec_••••••1234/)).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp(RAW_SECRET))).not.toBeInTheDocument();
+  });
+
+  it('generate: POSTs the credential + reveals the show-once secret in a centered modal', async () => {
+    fetchApiMock.mockImplementation(withCred(credNone(true)));
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Generate signing secret/i }));
+
+    await waitFor(() => {
+      const post = fetchApiMock.mock.calls.find(([u, o]) => u === API && o?.method === 'POST');
+      expect(post).toBeTruthy();
+    });
+    // The full secret is revealed once, in a modal dialog (not a clipped toast).
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(RAW_SECRET)).toBeInTheDocument();
+    expect(within(dialog).getByText(/only time/i)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /Copy secret/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /Done/i })).toBeInTheDocument();
+  });
+
+  it('reveal modal: Done closes it', async () => {
+    fetchApiMock.mockImplementation(withCred(credNone(true)));
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Generate signing secret/i }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: /Done/i }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('rotate: confirm + POST /rotate + reveals the new secret in a modal', async () => {
+    fetchApiMock.mockImplementation(withCred(credActive));
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Rotate/i }));
+
+    await waitFor(() => expect(notifyConfirm).toHaveBeenCalledWith(expect.stringMatching(/Rotate the webhook signing secret/i)));
+    await waitFor(() => {
+      const rot = fetchApiMock.mock.calls.find(([u, o]) => u === `${API}/rotate` && o?.method === 'POST');
+      expect(rot).toBeTruthy();
+    });
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('b'.repeat(64))).toBeInTheDocument();
+  });
+
+  it('rotate cancelled: confirm → false means NO rotate POST fires', async () => {
+    fetchApiMock.mockImplementation(withCred(credActive));
+    notifyConfirm.mockResolvedValue(false);
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Rotate/i }));
+    await waitFor(() => expect(notifyConfirm).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+    const rot = fetchApiMock.mock.calls.find(([u, o]) => u === `${API}/rotate` && o?.method === 'POST');
+    expect(rot).toBeUndefined();
+  });
+
+  it('revoke: confirm + DELETE', async () => {
+    fetchApiMock.mockImplementation(withCred(credActive));
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Revoke/i }));
+
+    await waitFor(() => expect(notifyConfirm).toHaveBeenCalledWith(expect.stringMatching(/Revoke the webhook signing secret/i)));
+    await waitFor(() => {
+      const del = fetchApiMock.mock.calls.find(([u, o]) => u === API && o?.method === 'DELETE');
+      expect(del).toBeTruthy();
+    });
+  });
+
+  it('non-admin (GET rejects with 403) renders nothing', async () => {
+    fetchApiMock.mockImplementation(() => Promise.reject(Object.assign(new Error('forbidden'), { status: 403 })));
+    const { container } = render(<WebhookSigningCredential />);
+    // Give the load() effect a tick to settle into the null-cred state.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1639,6 +1639,16 @@ function renderTravelNav({
           label="School Term Calendar"
         />
       )}
+      {/* T26 (PRD_TMC_DIAGNOSTIC_SALES_ROUTING_ENGINE §10) — TMC trip-catalogue
+          admin (route /travel/tmc/catalogue → TmcCatalogueAdmin). ADMIN+MANAGER
+          visible, mirroring the page's verifyRole posture; TMC-brand scoped. */}
+      {isManager && inBrand("tmc") && (
+        <Link
+          to="/travel/tmc/catalogue"
+          icon={BookOpen}
+          label="TMC Catalogue"
+        />
+      )}
       {/* tick #186 — Marketing Flyer Studio Phase 2 SHELL (#908).
           MANAGER+ operator-facing surface; real impl per PRD §8 build
           order in docs/PRD_TRAVEL_MARKETING_FLYER.md. */}

--- a/frontend/src/components/WebhookSigningCredential.jsx
+++ b/frontend/src/components/WebhookSigningCredential.jsx
@@ -1,0 +1,257 @@
+import { useState, useEffect } from 'react';
+import { ShieldCheck, RotateCw, Plus, Trash2, Copy, Check, X, AlertTriangle } from 'lucide-react';
+import { fetchApi } from '../utils/api';
+import { useNotify } from '../utils/notify';
+
+// Per-tenant HMAC signing credential management — generate / rotate / revoke
+// the secret used to sign every outbound webhook (the lead-sync stream
+// GlobusPhone consumes). Replaces the old single global WEBHOOK_HMAC_SECRET.
+//
+// Self-contained: loads its own credential state and renders nothing when the
+// API 403s (non-admins) so it can be dropped into any admin surface. Lives in
+// the Settings page; the secret is shown ONCE on generate/rotate (Stripe/
+// GitHub/AWS show-once model — no reveal). The one-time secret is presented in
+// a centered modal (NOT a toast) so the full 64-char value is fully visible +
+// copyable. Generation/rotation are gated on an active subscription/trial
+// server-side (402 → surfaced as a toast).
+const API = '/api/settings/webhook-credential';
+
+export default function WebhookSigningCredential() {
+  const notify = useNotify();
+  // GET /api/settings/webhook-credential response. null until loaded / when the
+  // endpoint 403s (non-admin) — the panel then renders nothing.
+  const [cred, setCred] = useState(null);
+  // The one-time secret reveal modal: { secret, verb } | null.
+  const [revealed, setRevealed] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = async () => {
+    try {
+      const c = await fetchApi(API, { silent: true });
+      setCred(c);
+    } catch (_err) {
+      setCred(null);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  // Open the one-time reveal modal (best-effort clipboard copy too). This is
+  // the ONLY place the raw secret is ever surfaced.
+  const announceSecret = (secret, verb) => {
+    try { navigator.clipboard.writeText(secret); } catch { /* clipboard may be blocked */ }
+    setCopied(false);
+    setRevealed({ secret, verb });
+  };
+
+  const copySecret = () => {
+    if (!revealed) return;
+    try { navigator.clipboard.writeText(revealed.secret); } catch { /* ignore */ }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const generate = async () => {
+    try {
+      const r = await fetchApi(API, { method: 'POST' });
+      if (r?.secret) announceSecret(r.secret, 'generated');
+      load();
+    } catch (_err) {
+      /* fetchApi already toasted the 402 / 409 / 500 message */
+    }
+  };
+
+  const rotate = async () => {
+    if (!(await notify.confirm('Rotate the webhook signing secret? The current secret stops working immediately — you must update GlobusPhone (or any receiver) with the new value.'))) return;
+    try {
+      const r = await fetchApi(`${API}/rotate`, { method: 'POST' });
+      if (r?.secret) announceSecret(r.secret, 'rotated');
+      load();
+    } catch (_err) {
+      /* fetchApi already toasted */
+    }
+  };
+
+  const revoke = async () => {
+    if (!(await notify.confirm('Revoke the webhook signing secret? All outbound webhook delivery for this account stops until you generate a new secret.'))) return;
+    try {
+      await fetchApi(API, { method: 'DELETE' });
+      load();
+    } catch (_err) {
+      /* fetchApi already toasted */
+    }
+  };
+
+  if (!cred) return null;
+
+  return (
+    <>
+      <div className="card" style={{ padding: 'clamp(1.25rem, 3vw, 2rem)' }}>
+        <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <ShieldCheck size={20} color="var(--primary-color, var(--accent-color))" /> Webhook Signing Credential
+        </h3>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
+          One HMAC secret signs every outbound webhook for your account. Configure it in GlobusPhone (or any receiver)
+          so it can verify each delivery. The secret is shown only once — rotate if you lose it.
+        </p>
+
+        {/* Not entitled → disable generation, point to /pricing. */}
+        {!cred.entitled && !cred.exists && (
+          <div style={{ padding: '1rem 1.25rem', background: 'var(--subtle-bg)', border: '1px solid var(--border-color)', borderRadius: '8px', marginBottom: '1.5rem' }}>
+            <p style={{ fontSize: '0.9rem', margin: 0 }}>
+              Webhook signing is available on an active subscription.{' '}
+              <a href="/pricing" style={{ color: 'var(--primary-color, var(--accent-color))', fontWeight: 600 }}>Upgrade to enable →</a>
+            </p>
+          </div>
+        )}
+
+        {/* No credential yet → generate (disabled when not entitled). */}
+        {!cred.exists && (
+          <button
+            className="btn-primary"
+            onClick={generate}
+            disabled={!cred.entitled}
+            title={cred.entitled ? 'Generate a signing secret' : 'Requires an active subscription'}
+            style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', opacity: cred.entitled ? 1 : 0.5, cursor: cred.entitled ? 'pointer' : 'not-allowed' }}
+          >
+            <Plus size={18} /> Generate signing secret
+          </button>
+        )}
+
+        {/* Credential exists → status, metadata, GlobusPhone config, actions. */}
+        {cred.exists && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem', padding: '1.25rem', background: 'var(--subtle-bg)', border: '1px solid var(--border-color)', borderLeft: '3px solid var(--primary-color, var(--accent-color))', borderRadius: '10px' }}>
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap' }}>
+                  <span style={{ fontFamily: 'monospace', fontWeight: 700, fontSize: '1rem', color: 'var(--text-primary)' }}>{cred.signingId}</span>
+                  <span style={{
+                    fontSize: '0.7rem', padding: '0.2rem 0.65rem', borderRadius: 20, fontWeight: 700, letterSpacing: '0.03em',
+                    border: `1px solid ${cred.status === 'ACTIVE' ? 'var(--success-color, #10b981)' : 'var(--danger-color, #ef4444)'}`,
+                    background: cred.status === 'ACTIVE' ? 'rgba(16,185,129,0.18)' : 'rgba(239,68,68,0.18)',
+                    color: cred.status === 'ACTIVE' ? 'var(--success-color, #10b981)' : 'var(--danger-color, #ef4444)',
+                  }}>{cred.status}</span>
+                </div>
+                <p style={{ fontSize: '0.82rem', color: 'var(--text-secondary)', marginTop: '0.5rem', fontFamily: 'monospace' }}>
+                  {cred.secretMasked} <span style={{ opacity: 0.8 }}>· secret hidden — shown once at creation</span>
+                </p>
+                {cred.lastRotatedAt && (
+                  <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '0.3rem' }}>
+                    Last rotated {new Date(cred.lastRotatedAt).toLocaleString()}
+                  </p>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: '0.6rem', alignItems: 'center' }}>
+                <button
+                  className="btn-secondary"
+                  onClick={rotate}
+                  disabled={!cred.entitled}
+                  title={cred.entitled ? 'Rotate (replace) the secret' : 'Requires an active subscription'}
+                  style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.5rem 0.9rem', fontWeight: 600, opacity: cred.entitled ? 1 : 0.5, cursor: cred.entitled ? 'pointer' : 'not-allowed' }}
+                >
+                  <RotateCw size={16} /> Rotate
+                </button>
+                <button onClick={revoke} title="Revoke (stops all webhook delivery)" style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid var(--danger-color, #ef4444)', color: 'var(--danger-color, #ef4444)', cursor: 'pointer', borderRadius: 8, padding: '0.5rem 0.9rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                  <Trash2 size={16} /> Revoke
+                </button>
+              </div>
+            </div>
+
+            {!cred.entitled && (
+              <div style={{ padding: '0.75rem 1rem', background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: '8px', fontSize: '0.85rem', color: 'var(--text-primary)' }}>
+                Subscription inactive — outbound webhook delivery is paused until the subscription is renewed.{' '}
+                <a href="/pricing" style={{ color: 'var(--primary-color, var(--accent-color))', fontWeight: 600 }}>Renew →</a>
+              </div>
+            )}
+
+            {/* Receiver-side config block (e.g. GlobusPhone). */}
+            {cred.signing && (
+              <div style={{ background: 'var(--subtle-bg)', border: '1px solid var(--border-color)', borderRadius: '10px', padding: '1.1rem 1.25rem' }}>
+                <p style={{ fontWeight: 600, color: 'var(--text-primary)', marginBottom: '0.75rem', fontSize: '0.9rem' }}>Receiver configuration (e.g. GlobusPhone)</p>
+                <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '0.4rem 1rem', fontSize: '0.82rem', alignItems: 'baseline' }}>
+                  <span style={{ color: 'var(--text-secondary)' }}>Signature header</span>
+                  <code style={{ color: 'var(--text-primary)', fontFamily: 'monospace', wordBreak: 'break-all' }}>{cred.signing.header}</code>
+                  <span style={{ color: 'var(--text-secondary)' }}>Algorithm</span>
+                  <code style={{ color: 'var(--text-primary)', fontFamily: 'monospace' }}>{cred.signing.algorithm}</code>
+                  <span style={{ color: 'var(--text-secondary)' }}>Signed payload</span>
+                  <code style={{ color: 'var(--text-primary)', fontFamily: 'monospace' }}>{cred.signing.signedPayload}</code>
+                  <span style={{ color: 'var(--text-secondary)' }}>Receiver secret env</span>
+                  <code style={{ color: 'var(--text-primary)', fontFamily: 'monospace', wordBreak: 'break-all' }}>{cred.signing.receiverEnvVar}</code>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* One-time secret reveal — centered modal so the full 64-char key is
+          visible + copyable (replaces the old clipped corner toast). */}
+      {revealed && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Webhook signing secret"
+          onClick={() => setRevealed(null)}
+          style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)', zIndex: 10000, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1.5rem', animation: 'fadeIn 0.2s ease-out' }}
+        >
+          <div
+            className="card"
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: '100%', maxWidth: 560, padding: '2rem', boxShadow: '0 25px 50px -12px rgba(0,0,0,0.6)', border: '1px solid var(--border-color)' }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', marginBottom: '0.5rem' }}>
+              <ShieldCheck size={22} color="var(--primary-color, var(--accent-color))" />
+              <h3 style={{ fontSize: '1.2rem', fontWeight: 700, margin: 0 }}>
+                Webhook signing secret {revealed.verb}
+              </h3>
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.6rem', alignItems: 'flex-start', padding: '0.75rem 1rem', background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.4)', borderRadius: '8px', margin: '0.75rem 0 1.25rem' }}>
+              <AlertTriangle size={18} color="#f59e0b" style={{ flexShrink: 0, marginTop: 2 }} />
+              <p style={{ margin: 0, fontSize: '0.85rem', color: 'var(--text-primary)' }}>
+                This is the <strong>only time</strong> this secret will be shown. Copy it now and store it securely — if you lose it, rotate the credential and it will not be shown again.
+              </p>
+            </div>
+
+            <label style={{ display: 'block', fontSize: '0.8rem', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '0.4rem' }}>
+              Signing secret
+            </label>
+            <div style={{ position: 'relative', marginBottom: '1.25rem' }}>
+              <code
+                style={{
+                  display: 'block', userSelect: 'all', wordBreak: 'break-all', fontFamily: 'monospace',
+                  fontSize: '0.9rem', lineHeight: 1.5, color: 'var(--text-primary)',
+                  background: 'var(--subtle-bg)', border: '1px solid var(--border-color)', borderRadius: '8px',
+                  padding: '0.85rem 1rem',
+                }}
+              >
+                {revealed.secret}
+              </code>
+            </div>
+
+            <p style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', margin: '0 0 1.25rem' }}>
+              Paste this into GlobusPhone (or any receiver) as <code style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>WEBHOOK_HMAC_SECRET_CRM</code>.
+            </p>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem' }}>
+              <button
+                className="btn-secondary"
+                onClick={copySecret}
+                style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.55rem 1rem', fontWeight: 600 }}
+              >
+                {copied ? <Check size={16} /> : <Copy size={16} />} {copied ? 'Copied!' : 'Copy secret'}
+              </button>
+              <button
+                className="btn-primary"
+                onClick={() => setRevealed(null)}
+                style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.55rem 1.1rem', fontWeight: 600 }}
+              >
+                <X size={16} /> Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Developer.jsx
+++ b/frontend/src/pages/Developer.jsx
@@ -73,7 +73,7 @@ export default function Developer() {
     try {
       const k = await fetchApi('/api/developer/apikeys');
       setKeys(Array.isArray(k) ? k : []);
-      
+
       const h = await fetchApi('/api/developer/webhooks');
       setHooks(Array.isArray(h) ? h : []);
     } catch (err) {
@@ -217,7 +217,7 @@ export default function Developer() {
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2rem' }}>
-        
+
         {/* API Keys */}
         <div className="card" style={{ padding: '2rem' }}>
           <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -32,6 +32,7 @@ import { useNotify } from "../utils/notify";
 import { usePermissions } from "../hooks/usePermissions";
 import { ThemeContext, AuthContext } from "../App";
 import PasswordInput from "../components/PasswordInput";
+import WebhookSigningCredential from "../components/WebhookSigningCredential";
 
 // #391: single source of truth for the default brand color so the color
 // picker swatch, the placeholder hint, and the color actually applied
@@ -1474,6 +1475,11 @@ export default function Settings() {
               </p>
             )}
           </div>
+
+          {/* Webhook Signing Credential — per-tenant HMAC secret for outbound
+              webhooks (GlobusPhone lead-sync). Self-contained admin component;
+              ADMIN-only + subscription-gated server-side. */}
+          <WebhookSigningCredential />
 
           {/* Notification Preferences Card */}
           <NotificationPreferencesCard notify={notify} />

--- a/frontend/src/pages/travel/ItineraryDetail.jsx
+++ b/frontend/src/pages/travel/ItineraryDetail.jsx
@@ -24,7 +24,7 @@
 //      PRD §3.6(d) pricing transparency.
 
 import { useEffect, useState, useContext } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import {
   Map as MapIcon, Plane, Hotel, MapPin, Briefcase, FileText, Shield,
   Plus, Pencil, Trash2, X, Sparkles, Share2, Download, Check, XCircle, Copy,
@@ -478,6 +478,10 @@ export default function ItineraryDetail() {
             <a href={pdfHref} target="_blank" rel="noreferrer" style={{ ...secondaryBtn, textDecoration: "none" }}>
               <Download size={14} /> PDF
             </a>
+            {/* FR-3.3/3.4 — open the visual day-by-day planner + map editor. */}
+            <Link to={`/travel/itineraries/${id}/edit`} style={{ ...secondaryBtn, textDecoration: "none" }} aria-label="Open the day-by-day planner and map">
+              <MapIcon size={14} /> Day planner
+            </Link>
           </div>
         </div>
         {shareUrl && (

--- a/frontend/src/pages/travel/ItineraryEditor.jsx
+++ b/frontend/src/pages/travel/ItineraryEditor.jsx
@@ -1,0 +1,334 @@
+// Travel CRM — Itinerary visual day-by-day editor + map.
+//
+// PRD_TRAVEL_ITINERARY_UPGRADES FR-3.3 (day-by-day visual editor) +
+// FR-3.4 (map preview). Mounts at /travel/itineraries/:id/edit — the read
+// view at /travel/itineraries/:id is unchanged. Travel-vertical only
+// (wrapped in <TravelOnly> in App.jsx), so wellness/generic never reach it.
+//
+// What it does:
+//   - Loads the itinerary + items (GET /api/travel/itineraries/:id).
+//   - Groups items into Day cards by ItineraryItem.dayNumber (S8 column).
+//     Items without a dayNumber land in an "Unscheduled" bucket.
+//   - Drag an item onto another Day (native HTML5 DnD) → PATCH
+//     /items/:itemId { dayNumber } (optimistic; refetches on failure).
+//   - Right pane: Leaflet + OpenStreetMap map plotting every item that has
+//     latitude + longitude, with day-numbered pins + a day-ordered route
+//     polyline. Free OSM tiles — no Mapbox key required.
+//
+// No schema change — dayNumber/latitude/longitude already exist on
+// ItineraryItem. Adding NEW items / editing prices stays on the detail page;
+// this editor is about day organisation + the map.
+//
+// Pins use L.divIcon (a numbered circle) rather than the default Leaflet
+// marker image, which sidesteps the well-known marker-asset 404 under
+// bundlers — no icon-image import/patch needed.
+
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { MapContainer, TileLayer, Marker, Popup, Polyline, useMap, useMapEvents } from "react-leaflet";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import {
+  ArrowLeft, Plane, Hotel, MapPin, Briefcase, FileText, Shield,
+  Train, Bus, Car, Camera, Utensils, Package, GripVertical, MapPinned,
+} from "lucide-react";
+import { fetchApi } from "../../utils/api";
+import { useNotify } from "../../utils/notify";
+
+const ITEM_ICONS = {
+  flight: Plane, train: Train, bus: Bus, cab: Car, transfer: MapPin,
+  hotel: Hotel, sightseeing: Camera, activity: Briefcase, meals: Utensils,
+  visa: FileText, insurance: Shield, other: Package,
+};
+
+function dayPin(dayNumber) {
+  const label = dayNumber ? `D${dayNumber}` : "•";
+  return L.divIcon({
+    className: "itin-day-pin",
+    html: `<div style="background:#122647;color:#fff;border:2px solid #fff;border-radius:50%;width:30px;height:30px;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;box-shadow:0 1px 4px rgba(0,0,0,0.35)">${label}</div>`,
+    iconSize: [30, 30],
+    iconAnchor: [15, 15],
+  });
+}
+
+// Pans/zooms the map to fit all plotted points whenever they change.
+function FitBounds({ points }) {
+  const map = useMap();
+  useEffect(() => {
+    if (points && points.length > 0) {
+      try {
+        map.fitBounds(L.latLngBounds(points), { padding: [40, 40], maxZoom: 12 });
+      } catch (_e) {
+        /* ignore degenerate bounds */
+      }
+    }
+  }, [points, map]);
+  return null;
+}
+
+// Captures map clicks so a selected item can be placed at the clicked point.
+function MapClicks({ onPick }) {
+  useMapEvents({
+    click(e) {
+      onPick(e.latlng.lat, e.latlng.lng);
+    },
+  });
+  return null;
+}
+
+export default function ItineraryEditor() {
+  const { id } = useParams();
+  const notify = useNotify();
+  const [itin, setItin] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [extraDays, setExtraDays] = useState(0); // local "+ Add day" beyond derived count
+  const [dragId, setDragId] = useState(null);
+  const [selectedId, setSelectedId] = useState(null); // item selected for "click map to place"
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchApi(`/api/travel/itineraries/${id}`);
+      setItin(data);
+    } catch (e) {
+      setError(e?.message || "Failed to load itinerary");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const items = useMemo(() => (itin?.items ? [...itin.items] : []), [itin]);
+
+  // Day count = max(date-range span, highest dayNumber present, 1) + locally-added days.
+  const derivedDayCount = useMemo(() => {
+    let n = 1;
+    if (itin?.startDate && itin?.endDate) {
+      const ms = new Date(itin.endDate) - new Date(itin.startDate);
+      if (Number.isFinite(ms) && ms >= 0) n = Math.max(n, Math.floor(ms / 86400000) + 1);
+    }
+    for (const it of items) if (it.dayNumber && it.dayNumber > n) n = it.dayNumber;
+    return n;
+  }, [itin, items]);
+
+  const dayCount = derivedDayCount + extraDays;
+
+  const itemsForDay = useCallback(
+    (day) =>
+      items
+        .filter((it) => (day === null ? !it.dayNumber : it.dayNumber === day))
+        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0)),
+    [items],
+  );
+
+  // Map points in day order (then position) — only items with numeric coords.
+  const mapItems = useMemo(
+    () =>
+      items
+        .filter((it) => typeof it.latitude === "number" && typeof it.longitude === "number")
+        .sort(
+          (a, b) =>
+            (a.dayNumber ?? 999) - (b.dayNumber ?? 999) ||
+            (a.position ?? 0) - (b.position ?? 0),
+        ),
+    [items],
+  );
+  const routeLine = useMemo(() => mapItems.map((it) => [it.latitude, it.longitude]), [mapItems]);
+
+  const moveToDay = useCallback(
+    async (itemId, day) => {
+      const target = items.find((it) => it.id === itemId);
+      if (!target || target.dayNumber === day) return;
+      // Optimistic local update; PATCH persists. Refetch on failure to restore truth.
+      setItin((prev) =>
+        prev && {
+          ...prev,
+          items: prev.items.map((it) => (it.id === itemId ? { ...it, dayNumber: day } : it)),
+        });
+      try {
+        await fetchApi(`/api/travel/itineraries/${id}/items/${itemId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ dayNumber: day }),
+          silent: true,
+        });
+      } catch (_e) {
+        notify?.error?.("Couldn't move item — reverting.");
+        load();
+      }
+    },
+    [items, id, notify, load],
+  );
+
+  // Place the selected item at a clicked map coordinate (FR-3.4). Optimistic
+  // local update + PATCH { latitude, longitude }; refetch on failure.
+  const setItemLatLng = useCallback(
+    async (itemId, lat, lng) => {
+      const latitude = Math.round(lat * 1e6) / 1e6;
+      const longitude = Math.round(lng * 1e6) / 1e6;
+      setItin((prev) =>
+        prev && {
+          ...prev,
+          items: prev.items.map((it) => (it.id === itemId ? { ...it, latitude, longitude } : it)),
+        });
+      try {
+        await fetchApi(`/api/travel/itineraries/${id}/items/${itemId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ latitude, longitude }),
+          silent: true,
+        });
+      } catch (_e) {
+        notify?.error?.("Couldn't set location — reverting.");
+        load();
+      }
+    },
+    [id, notify, load],
+  );
+
+  if (loading) return <div style={{ padding: "2rem" }}>Loading&hellip;</div>;
+  if (error) {
+    return (
+      <div style={{ padding: "2rem", color: "#A8323F" }}>
+        {error} — <Link to={`/travel/itineraries/${id}`}>back to itinerary</Link>
+      </div>
+    );
+  }
+  if (!itin) return null;
+
+  const dayBuckets = [null, ...Array.from({ length: dayCount }, (_, i) => i + 1)];
+  // Default centre when nothing is placed yet = India (broad view); once any
+  // pin exists, FitBounds zooms to the actual points.
+  const mapCenter = mapItems.length ? [mapItems[0].latitude, mapItems[0].longitude] : [22.5, 79];
+
+  return (
+    <div data-vertical="travel" style={{ padding: "1.25rem", height: "100%", display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+        <Link
+          to={`/travel/itineraries/${id}`}
+          style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", color: "var(--text-secondary)", textDecoration: "none", fontSize: "0.85rem" }}
+        >
+          <ArrowLeft size={16} /> Back to itinerary
+        </Link>
+        <h1 style={{ margin: 0, fontSize: "1.15rem", color: "var(--text-primary)" }}>
+          {itin.destination || "Itinerary"} — day planner
+        </h1>
+        <span style={{ fontSize: "0.78rem", color: "var(--text-secondary)" }}>
+          Drag items between days · {mapItems.length}/{items.length} plotted on map
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: "1rem", flex: 1, minHeight: 0, flexWrap: "wrap" }}>
+        {/* Day cards */}
+        <div style={{ flex: "1 1 420px", minWidth: 320, overflowY: "auto", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          {dayBuckets.map((day) => {
+            const dayItems = itemsForDay(day);
+            return (
+              <div
+                key={day === null ? "unscheduled" : day}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  if (dragId != null) moveToDay(dragId, day);
+                  setDragId(null);
+                }}
+                style={{ border: "1px solid var(--border-color)", borderRadius: 10, background: "var(--surface-color)", padding: "0.75rem" }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.5rem" }}>
+                  <strong style={{ fontSize: "0.85rem", color: "var(--text-primary)" }}>
+                    {day === null ? "Unscheduled" : `Day ${day}`}
+                  </strong>
+                  <span style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+                    {dayItems.length} item{dayItems.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                {dayItems.length === 0 && (
+                  <div style={{ fontSize: "0.75rem", color: "var(--text-secondary)", padding: "0.5rem", border: "1px dashed var(--border-color)", borderRadius: 6, textAlign: "center" }}>
+                    Drop items here
+                  </div>
+                )}
+                {dayItems.map((it) => {
+                  const Icon = ITEM_ICONS[it.itemType] || Package;
+                  const hasGeo = typeof it.latitude === "number" && typeof it.longitude === "number";
+                  return (
+                    <div
+                      key={it.id}
+                      draggable
+                      onDragStart={() => setDragId(it.id)}
+                      onDragEnd={() => setDragId(null)}
+                      onClick={() => setSelectedId((cur) => (cur === it.id ? null : it.id))}
+                      title="Click to select, then click the map to place this item"
+                      style={{
+                        display: "flex", alignItems: "center", gap: "0.5rem",
+                        padding: "0.5rem", marginTop: "0.4rem",
+                        border: selectedId === it.id ? "2px solid var(--primary-color, var(--accent-color))" : "1px solid var(--border-color)",
+                        borderRadius: 6,
+                        background: selectedId === it.id ? "rgba(18,38,71,0.06)" : "var(--subtle-bg, rgba(0,0,0,0.02))",
+                        cursor: "grab", opacity: dragId === it.id ? 0.5 : 1,
+                      }}
+                    >
+                      <GripVertical size={14} style={{ color: "var(--text-secondary)", flexShrink: 0 }} />
+                      <Icon size={15} style={{ color: "var(--primary-color, var(--accent-color))", flexShrink: 0 }} />
+                      <span style={{ fontSize: "0.8rem", color: "var(--text-primary)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {it.description}
+                      </span>
+                      {hasGeo ? (
+                        <MapPinned size={13} style={{ color: "#2F7A4D", flexShrink: 0 }} aria-label="On map" />
+                      ) : (
+                        <MapPin size={13} style={{ color: "var(--border-color)", flexShrink: 0 }} aria-label="No coordinates" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => setExtraDays((n) => n + 1)}
+            style={{ alignSelf: "flex-start", padding: "0.4rem 0.8rem", border: "1px dashed var(--border-color)", borderRadius: 6, background: "transparent", color: "var(--text-secondary)", cursor: "pointer", fontSize: "0.8rem" }}
+          >
+            + Add day
+          </button>
+        </div>
+
+        {/* Map — always rendered so you can click to place pins. */}
+        <div style={{ flex: "1 1 380px", minWidth: 300, minHeight: 360, borderRadius: 10, overflow: "hidden", border: "1px solid var(--border-color)", position: "relative" }}>
+          <div style={{ position: "absolute", zIndex: 1000, top: 8, left: 8, right: 8, padding: "0.45rem 0.65rem", borderRadius: 6, background: "rgba(18,38,71,0.88)", color: "#fff", fontSize: "0.72rem", pointerEvents: "none", lineHeight: 1.3 }}>
+            {selectedId
+              ? `Click the map to place “${items.find((i) => i.id === selectedId)?.description || "item"}”.`
+              : mapItems.length === 0
+                ? "No pins yet — select an item on the left, then click the map to drop its location."
+                : "Select an item on the left, then click the map to set/move its pin."}
+          </div>
+          <MapContainer
+            center={mapCenter}
+            zoom={mapItems.length ? 6 : 4}
+            style={{ height: "100%", width: "100%", minHeight: 360, cursor: selectedId ? "crosshair" : "grab" }}
+            scrollWheelZoom
+          >
+            <TileLayer
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            />
+            {routeLine.length >= 2 && (
+              <Polyline positions={routeLine} pathOptions={{ color: "#122647", weight: 3, opacity: 0.6, dashArray: "6 6" }} />
+            )}
+            {mapItems.map((it) => (
+              <Marker key={it.id} position={[it.latitude, it.longitude]} icon={dayPin(it.dayNumber)}>
+                <Popup>
+                  <strong>{it.dayNumber ? `Day ${it.dayNumber}` : "Unscheduled"}</strong>
+                  <br />
+                  {it.description}
+                </Popup>
+              </Marker>
+            ))}
+            <FitBounds points={routeLine} />
+            <MapClicks onPick={(lat, lng) => { if (selectedId != null) setItemLatLng(selectedId, lat, lng); }} />
+          </MapContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/travel/MarketingFlyerStudio.jsx
+++ b/frontend/src/pages/travel/MarketingFlyerStudio.jsx
@@ -1,90 +1,32 @@
 /**
- * MarketingFlyerStudio.jsx — Phase 2 composer surface for the Travel
- * vertical Marketing Flyer Studio (GH #908). Slice 5 wires the SHELL
- * page to the /api/travel/flyer-templates CRUD endpoints shipped by
- * slice 3 (commit 5c2dd474):
+ * MarketingFlyerStudio.jsx — dedicated Marketing Flyer editor (GH #908;
+ * PRD docs/PRD_TRAVEL_MARKETING_FLYER.md). Client decision: build an in-house
+ * dedicated editor (not the landing-page-builder reuse, not Polotno).
  *
- *   - On mount: parse ?template=<id> from the URL. If present, GET
- *     /api/travel/flyer-templates/:id and seed the composer's local
- *     palette/layout/assets state from the parsed JSON columns.
- *   - "Save as Template" button → modal with name + sub-brand → POSTs
- *     to /api/travel/flyer-templates with palette/layout/assets
- *     serialized as JSON-string @db.Text payloads (matching the
- *     route's parseJsonColumn shape).
+ * Slice 1 (this file): a canvas editor that mutates the `layout` array —
+ *   - Add Text / Add Image blocks (absolute x/y/width/height in CANVAS space).
+ *   - Click to select; drag to move; numeric X/Y/W/H inputs for precision.
+ *   - Edit text content / colour / font-size; edit image URL; delete block.
+ *   - Edit the 5 palette colours via toolbar swatches (canvas bg = bgHex).
+ * The editor mutates the SAME palette/layout/assets state the existing
+ * load + Save-as-Template lifecycle serialises (slice 5, /api/travel/
+ * flyer-templates), so that flow is unchanged.
  *
- * The four sub-brand placeholder cards from the prior SHELL are kept
- * (Phase 2 follow-up ticks layer the canvas editor / asset library /
- * AI copy / PDF export onto this same page). The slice-5 surface is
- * additive: load + save template lifecycle without disturbing the
- * existing SHELL affordances.
+ * Follow-up slices: image upload (Multer), resize handles + more block types,
+ * PNG/PDF export, brand-lock to the sub-brand kit, WhatsApp/email share.
  *
- * PRD reference: docs/PRD_TRAVEL_MARKETING_FLYER.md §3.1 (template
- * editor) + §3.7 (templates marketplace). Companion: FlyerTemplates
- * .jsx (commit a64c1058) is the saved-templates LIST page; the
- * composer here is the load + save surface.
- *
- * Mount: /travel/marketing/flyer-studio — wrapped in <TravelOnly> +
- * <RoleGuard allow={['ADMIN','MANAGER']}/> per the PRD's NFR-4.8 RBAC
- * surface.
- *
- * Sub-brand pre-highlight: consumes useActiveSubBrand() so the
- * operator's session-scoped "I'm working on TMC today" preference
- * pre-highlights the matching sub-brand card AND pre-fills the "Save
- * as Template" modal's sub-brand dropdown.
- *
- * Save-template URL-update decision: on successful POST, the URL is
- * updated to ?template=<newId> via setSearchParams({ template: id })
- * so a subsequent page refresh re-loads the just-saved template
- * (otherwise the operator loses their work on refresh). This is
- * non-blocking — if setSearchParams isn't available (e.g. tests
- * without Router mounted), the save still succeeds; the URL just
- * stays as-is.
- *
- * Path: frontend/src/pages/travel/MarketingFlyerStudio.jsx — sibling
- * to FlyerTemplates.jsx (the list page) + the Phase 2 Travel scaffold
- * cohort.
+ * Mount: /travel/marketing/flyer-studio — <TravelOnly> + <RoleGuard
+ * allow={['ADMIN','MANAGER']}/> per the PRD NFR-4.8 RBAC surface.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Sparkles, FileImage, Lock, Save, Loader } from 'lucide-react';
+import { FileImage, Save, Loader } from 'lucide-react';
 import { useActiveSubBrand } from '../../utils/subBrand';
 import { useNotify } from '../../utils/notify';
-import { fetchApi } from '../../utils/api';
+import { fetchApi, getAuthToken } from '../../utils/api';
 
-// Canonical 4-sub-brand catalogue. Kept inline (rather than imported
-// from utils/travelSubBrand.js) so the SHELL is self-contained for
-// reviewers + grep — the canonical id set is asserted by
-// subBrand.test.jsx's cross-file invariant, so drift here would
-// surface upstream.
-const SUB_BRAND_CARDS = [
-  {
-    id: 'tmc',
-    label: 'TMC',
-    tagline: 'School trips — Bronze / Silver / Gold tiered packages',
-    sample: 'Summer Europe — Class IX-X — 12 nights',
-  },
-  {
-    id: 'rfu',
-    label: 'RFU',
-    tagline: 'Umrah & religious-tourism packages',
-    sample: 'Ramadan Umrah — Departures Mar / Apr / May',
-  },
-  {
-    id: 'travelstall',
-    label: 'Travel Stall',
-    tagline: 'Family weekend offers + seasonal getaways',
-    sample: 'Goa weekend — ₹14,999/pax — limited time',
-  },
-  {
-    id: 'visasure',
-    label: 'Visa Sure',
-    tagline: 'Visa-service flyers — KPI tiles + testimonials',
-    sample: 'UK Visa in 5 days — 97% approval rate',
-  },
-];
-
-// Sub-brand options for the "Save as Template" modal — the canonical
-// 4 ids plus "no sub-brand" (tenant-wide template).
+// Sub-brand options for the "Save as Template" modal — the canonical 4 ids
+// plus "no sub-brand" (tenant-wide template).
 const SAVE_SUB_BRAND_OPTIONS = [
   { value: '', label: 'Tenant-wide (no sub-brand)' },
   { value: 'tmc', label: 'TMC (schools)' },
@@ -93,11 +35,7 @@ const SAVE_SUB_BRAND_OPTIONS = [
   { value: 'visasure', label: 'Visa Sure' },
 ];
 
-// Default composer state. Matches the slice-1 validator's minimum-
-// valid shape: 4 required hex colors + 1 placeholder text block. The
-// renderer requires at least one block, so the default is a single
-// "Tap to edit" text block; operators replace it via the (future)
-// canvas editor.
+// Default composer state — minimum-valid shape: 4+ hex colours + 1 text block.
 const DEFAULT_PALETTE = {
   primaryHex: '#122647',
   secondaryHex: '#265855',
@@ -105,34 +43,28 @@ const DEFAULT_PALETTE = {
   textHex: '#222222',
   bgHex: '#FFFDF7',
 };
-
 const DEFAULT_LAYOUT = [
-  {
-    type: 'text',
-    x: 24,
-    y: 24,
-    width: 480,
-    height: 80,
-    content: 'Tap to edit headline',
-  },
+  { type: 'text', x: 24, y: 24, width: 480, height: 80, content: 'Tap to edit headline' },
 ];
-
 const DEFAULT_ASSETS = {};
+
+// Slice-1 editor: the 5 palette colours editable via the toolbar swatches.
+const PALETTE_KEYS = ['primaryHex', 'secondaryHex', 'accentHex', 'textHex', 'bgHex'];
+// Editor canvas dimensions (portrait flyer). Blocks are positioned in this
+// coordinate space; export-to-PNG/PDF lands in a later slice.
+const CANVAS_W = 540;
+const CANVAS_H = 720;
 
 export default function MarketingFlyerStudio() {
   const { activeSubBrand } = useActiveSubBrand() || { activeSubBrand: null };
   const notify = useNotify();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Composer state — palette / layout / assets. Seeded from the
-  // template-load GET when ?template=<id> is present; otherwise
-  // initialised to the placeholder defaults above.
+  // Composer state — palette / layout / assets.
   const [palette, setPalette] = useState(DEFAULT_PALETTE);
   const [layout, setLayout] = useState(DEFAULT_LAYOUT);
   const [assets, setAssets] = useState(DEFAULT_ASSETS);
 
-  // Loaded-template metadata (display only — the canvas editor reads
-  // palette/layout/assets directly).
   const [loadedTemplate, setLoadedTemplate] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -142,10 +74,76 @@ export default function MarketingFlyerStudio() {
   const [saveSubBrand, setSaveSubBrand] = useState(activeSubBrand || '');
   const [saving, setSaving] = useState(false);
 
-  // Parse @db.Text JSON columns from the load-template response.
-  // Each column may arrive as either a JSON string (the canonical
-  // storage shape) or — defensively — an already-parsed object if
-  // the backend ever changes its mind. Helper handles both.
+  // ── Slice-1 editor state + handlers ─────────────────────────────────
+  const [selectedIdx, setSelectedIdx] = useState(null);
+  const dragRef = useRef(null);
+  const fileInputRef = useRef(null);
+  const [uploading, setUploading] = useState(false);
+
+  const addBlock = useCallback((type) => {
+    setLayout((prev) => {
+      const offset = prev.length * 12;
+      const block = type === 'image'
+        ? { type: 'image', x: 24, y: 24 + offset, width: 180, height: 120, src: '' }
+        : { type: 'text', x: 24, y: 24 + offset, width: 240, height: 48, content: 'New text', color: palette.textHex || '#222222', fontSize: 18 };
+      return [...prev, block];
+    });
+  }, [palette]);
+
+  const updateBlock = useCallback((idx, patch) => {
+    setLayout((prev) => prev.map((b, i) => (i === idx ? { ...b, ...patch } : b)));
+  }, []);
+
+  const removeBlock = useCallback((idx) => {
+    setLayout((prev) => prev.filter((_, i) => i !== idx));
+    setSelectedIdx(null);
+  }, []);
+
+  // Pointer-drag to reposition a block; numeric X/Y inputs are the precise fallback.
+  const onBlockMouseDown = useCallback((e, idx) => {
+    e.preventDefault();
+    setSelectedIdx(idx);
+    const b = layout[idx] || {};
+    dragRef.current = { idx, startX: e.clientX, startY: e.clientY, origX: b.x || 0, origY: b.y || 0 };
+  }, [layout]);
+  const onCanvasMouseMove = useCallback((e) => {
+    const d = dragRef.current;
+    if (!d) return;
+    const nx = Math.max(0, Math.round(d.origX + (e.clientX - d.startX)));
+    const ny = Math.max(0, Math.round(d.origY + (e.clientY - d.startY)));
+    setLayout((prev) => prev.map((b, i) => (i === d.idx ? { ...b, x: nx, y: ny } : b)));
+  }, []);
+  const onCanvasMouseUp = useCallback(() => { dragRef.current = null; }, []);
+
+  // FR-3.2.2 — upload an image for the selected image block. Raw fetch + FormData
+  // (fetchApi forces JSON content-type, so we bypass it — same as the landing-page
+  // image upload). Server returns { url } (S3 when configured, else local).
+  const handleUploadImage = useCallback(async (file, idx) => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append('image', file);
+      const token = getAuthToken();
+      const res = await fetch('/api/travel/flyer-templates/upload', {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: fd,
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        notify?.error?.(data?.error || 'Image upload failed');
+        return;
+      }
+      updateBlock(idx, { src: data.url });
+    } catch (e) {
+      notify?.error?.(e?.message || 'Image upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }, [notify, updateBlock]);
+
+  // Parse @db.Text JSON columns — tolerates JSON string OR already-parsed object.
   const parseJsonField = useCallback((field, fallback) => {
     if (field == null) return fallback;
     if (typeof field === 'object') return field;
@@ -170,25 +168,18 @@ export default function MarketingFlyerStudio() {
         setPalette(parsedPalette || DEFAULT_PALETTE);
         setLayout(Array.isArray(parsedLayout) ? parsedLayout : DEFAULT_LAYOUT);
         setAssets(parsedAssets && typeof parsedAssets === 'object' ? parsedAssets : DEFAULT_ASSETS);
+        setSelectedIdx(null);
         setLoadedTemplate({
           id: data?.id ?? templateId,
           name: data?.name || `Template #${templateId}`,
           subBrand: data?.subBrand || null,
         });
-        // Pre-fill the save modal with the loaded template's metadata
-        // so "Save as Template" without rename overwrites cleanly
-        // (well — POST creates a new row; this is the suggested name).
         setSaveName(data?.name ? `${data.name} (copy)` : '');
         setSaveSubBrand(data?.subBrand || activeSubBrand || '');
         notify?.info?.(`Loaded template: ${data?.name || `#${templateId}`}`);
       } catch (err) {
-        // fetchApi already toasted via global notify on the 4xx/5xx
-        // path; the route-level handler here only needs to clear the
-        // loaded-template indicator and reset to defaults so the
-        // composer stays usable.
         setLoadedTemplate(null);
         if (!err?.status) {
-          // Non-HTTP error (parse / network race not handled by fetchApi).
           notify?.error?.(err?.message || 'Failed to load template');
         }
       } finally {
@@ -198,19 +189,12 @@ export default function MarketingFlyerStudio() {
     [activeSubBrand, notify, parseJsonField],
   );
 
-  // Mount effect: if ?template=<id> is in the URL, fire the load GET.
-  // Depends on the param VALUE (string), not the URLSearchParams
-  // object — useSearchParams returns a fresh object reference on
-  // every render, so depending on the object would re-fire the GET
-  // every render (thrashes the backend; also confuses tests).
+  // Mount effect: ?template=<id> → load. Depend on the param VALUE only.
   const templateIdParam = searchParams?.get?.('template') || null;
   useEffect(() => {
     if (templateIdParam && /^\d+$/.test(templateIdParam)) {
       loadTemplate(parseInt(templateIdParam, 10));
     }
-    // Intentionally only depend on the param string. loadTemplate
-    // captures the latest notify + activeSubBrand via useCallback,
-    // but we don't want the effect re-firing when those change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [templateIdParam]);
 
@@ -235,8 +219,6 @@ export default function MarketingFlyerStudio() {
     try {
       const body = {
         name: trimmedName,
-        // Empty-string sub-brand sends as omitted — the backend
-        // treats absent subBrand as "tenant-wide" (NULL column).
         paletteJson: JSON.stringify(palette),
         layoutJson: JSON.stringify(layout),
         assetsJson: JSON.stringify(assets),
@@ -248,10 +230,6 @@ export default function MarketingFlyerStudio() {
       });
       notify?.success?.(`Template "${trimmedName}" saved`);
       setShowSaveModal(false);
-      // Update the URL so a refresh re-loads what was just saved
-      // (otherwise the operator loses their work on refresh). The
-      // try/catch guards against test environments without a router
-      // (setSearchParams may throw).
       try {
         if (created?.id && setSearchParams) {
           setSearchParams({ template: String(created.id) });
@@ -259,8 +237,6 @@ export default function MarketingFlyerStudio() {
       } catch (_e) {
         /* no-op — URL update is best-effort */
       }
-      // Reflect the freshly-saved template as the active one so the
-      // next "Save as Template" pre-fills with the new name.
       if (created?.id) {
         setLoadedTemplate({
           id: created.id,
@@ -269,10 +245,6 @@ export default function MarketingFlyerStudio() {
         });
       }
     } catch (err) {
-      // fetchApi auto-toasted any 4xx/5xx via global notify. Only
-      // re-surface here for non-HTTP errors (validator parse failures
-      // bubble through fetchApi's err.data.errors path; for the
-      // first-cut wire-in we surface the generic message).
       if (!err?.status) {
         notify?.error?.(err?.message || 'Failed to save template');
       }
@@ -280,6 +252,8 @@ export default function MarketingFlyerStudio() {
       setSaving(false);
     }
   };
+
+  const selected = selectedIdx != null ? layout[selectedIdx] : null;
 
   return (
     <div style={pageWrap} data-testid="marketing-flyer-studio">
@@ -290,8 +264,8 @@ export default function MarketingFlyerStudio() {
           </h1>
           <p style={subtitleStyle}>
             Build branded flyers for TMC / RFU / Travel Stall / Visa Sure.
-            Pick a sub-brand template to get started — your sub-brand kit
-            (logo, palette, fonts) auto-loads from the tenant config.
+            Add blocks to the canvas, set the palette, then save as a reusable
+            template.
           </p>
         </div>
         <div style={headerActions}>
@@ -304,83 +278,189 @@ export default function MarketingFlyerStudio() {
           >
             <Save size={14} aria-hidden /> Save as Template
           </button>
-          <div style={comingSoonPill} aria-label="Feature status: coming soon">
-            <Sparkles size={14} aria-hidden /> Coming soon
-          </div>
         </div>
       </header>
 
-      {/* Loaded-template indicator — visible affordance that the
-          composer state reflects a stored row, not the placeholder
-          defaults. */}
       {loading && (
         <div role="status" style={statusBanner} data-testid="loading-template">
           <Loader size={14} aria-hidden /> Loading template&hellip;
         </div>
       )}
       {!loading && loadedTemplate && (
-        <div
-          role="status"
-          style={statusBanner}
-          data-testid="loaded-template-banner"
-        >
+        <div role="status" style={statusBanner} data-testid="loaded-template-banner">
           <strong>Editing:</strong> {loadedTemplate.name}
           {loadedTemplate.subBrand ? ` — ${loadedTemplate.subBrand.toUpperCase()}` : ''}
         </div>
       )}
-      {!loading && !loadedTemplate && (
-        <div role="status" style={statusBanner}>
-          <strong>Phase 2 scaffold.</strong> The Marketing Flyer Studio is
-          designed in <code>docs/PRD_TRAVEL_MARKETING_FLYER.md</code>;
-          implementation lands in follow-up ticks (canvas editor, asset
-          library, AI copy/image generation, PDF/PNG export, WhatsApp
-          share). This page previews the surface only.
+
+      {/* ── Editor: toolbar | canvas | properties (Slice 1) ───────────── */}
+      <div data-testid="flyer-editor" style={editorWrap}>
+        <div style={toolbarStyle}>
+          <button type="button" onClick={() => addBlock('text')} style={toolBtn} data-testid="flyer-add-text">
+            + Text
+          </button>
+          <button type="button" onClick={() => addBlock('image')} style={toolBtn} data-testid="flyer-add-image">
+            + Image
+          </button>
+          <span style={{ marginLeft: 'auto', display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+            <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>Palette</span>
+            {PALETTE_KEYS.map((k) => (
+              <input
+                key={k}
+                type="color"
+                aria-label={k}
+                title={k}
+                data-testid={`palette-${k}`}
+                value={palette[k] || '#000000'}
+                onChange={(e) => setPalette({ ...palette, [k]: e.target.value })}
+                style={swatchStyle}
+              />
+            ))}
+          </span>
         </div>
-      )}
 
-      <section
-        aria-label="Sub-brand template cards"
-        style={cardsGrid}
-        data-testid="marketing-flyer-studio-cards"
-      >
-        {SUB_BRAND_CARDS.map((card) => {
-          const isActive = card.id === activeSubBrand;
-          return (
-            <article
-              key={card.id}
-              data-testid={`flyer-card-${card.id}`}
-              data-sub-brand={card.id}
-              data-active={isActive ? 'true' : 'false'}
-              aria-current={isActive ? 'true' : undefined}
-              style={isActive ? { ...cardStyle, ...cardActiveStyle } : cardStyle}
-            >
-              <div style={cardHeader}>
-                <FileImage size={22} aria-hidden />
-                <div>
-                  <h2 style={cardTitle}>{card.label}</h2>
-                  <p style={cardTagline}>{card.tagline}</p>
-                </div>
-              </div>
-              <div style={cardSample}>
-                <span style={cardSampleLabel}>Sample headline</span>
-                <span style={cardSampleText}>{card.sample}</span>
-              </div>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+          {/* Canvas */}
+          <div
+            data-testid="flyer-canvas"
+            onMouseMove={onCanvasMouseMove}
+            onMouseUp={onCanvasMouseUp}
+            onMouseLeave={onCanvasMouseUp}
+            onClick={(e) => { if (e.target === e.currentTarget) setSelectedIdx(null); }}
+            style={{ ...canvasStyle, background: palette.bgHex || '#FFFFFF' }}
+          >
+            {layout.map((b, idx) => (
               <div
-                style={comingSoonOverlay}
-                data-testid={`flyer-card-${card.id}-coming-soon`}
-                role="note"
-                aria-label={`${card.label} flyer templates coming soon`}
+                key={idx}
+                data-testid={`flyer-block-${idx}`}
+                onMouseDown={(e) => onBlockMouseDown(e, idx)}
+                onClick={(e) => { e.stopPropagation(); setSelectedIdx(idx); }}
+                style={{
+                  position: 'absolute',
+                  left: b.x || 0,
+                  top: b.y || 0,
+                  width: b.width || 100,
+                  height: b.height || 40,
+                  boxSizing: 'border-box',
+                  padding: 4,
+                  overflow: 'hidden',
+                  cursor: 'move',
+                  border: selectedIdx === idx
+                    ? '2px solid var(--primary-color, var(--accent-color))'
+                    : '1px dashed rgba(0,0,0,0.25)',
+                  color: b.color || palette.textHex || '#222222',
+                  fontSize: b.fontSize || 16,
+                }}
               >
-                <Lock size={14} aria-hidden /> Coming soon
+                {b.type === 'image'
+                  ? (b.src
+                    ? <img src={b.src} alt="" style={{ maxWidth: '100%', maxHeight: '100%' }} />
+                    : <span style={{ fontSize: 11, opacity: 0.5 }}>Image — set URL →</span>)
+                  : (b.content || '')}
               </div>
-            </article>
-          );
-        })}
-      </section>
+            ))}
+          </div>
 
-      {/* "Save as Template" modal — minimal form with name + sub-brand.
-          Palette / layout / assets serialize from current composer
-          state. Full canvas editing lives in follow-up ticks. */}
+          {/* Properties */}
+          <div style={propsPanel} data-testid="flyer-properties">
+            {!selected ? (
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: 0 }}>
+                Select a block to edit it — or use <strong>+ Text</strong> / <strong>+ Image</strong> to add one.
+              </p>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <strong style={{ fontSize: 12 }}>
+                  {selected.type === 'image' ? 'Image block' : 'Text block'}
+                </strong>
+                {selected.type === 'image' ? (
+                  <>
+                    <label style={propLabel}>
+                      Image URL
+                      <input
+                        type="text"
+                        aria-label="Image URL"
+                        value={selected.src || ''}
+                        onChange={(e) => updateBlock(selectedIdx, { src: e.target.value })}
+                        style={propInput}
+                        placeholder="https://… or /uploads/…"
+                      />
+                    </label>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      data-testid="flyer-image-file"
+                      style={{ display: 'none' }}
+                      onChange={(e) => handleUploadImage(e.target.files && e.target.files[0], selectedIdx)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current && fileInputRef.current.click()}
+                      disabled={uploading}
+                      data-testid="flyer-image-upload"
+                      style={toolBtn}
+                    >
+                      {uploading ? 'Uploading…' : 'Upload image'}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <label style={propLabel}>
+                      Text
+                      <textarea
+                        aria-label="Block text"
+                        value={selected.content || ''}
+                        onChange={(e) => updateBlock(selectedIdx, { content: e.target.value })}
+                        rows={3}
+                        style={propInput}
+                      />
+                    </label>
+                    <label style={propLabel}>
+                      Colour
+                      <input
+                        type="color"
+                        aria-label="Text colour"
+                        value={selected.color || '#222222'}
+                        onChange={(e) => updateBlock(selectedIdx, { color: e.target.value })}
+                        style={{ ...propInput, padding: 2, height: 30 }}
+                      />
+                    </label>
+                    <label style={propLabel}>
+                      Font size
+                      <input
+                        type="number"
+                        aria-label="Font size"
+                        value={selected.fontSize || 16}
+                        onChange={(e) => updateBlock(selectedIdx, { fontSize: Number(e.target.value) || 16 })}
+                        style={propInput}
+                      />
+                    </label>
+                  </>
+                )}
+                <div style={{ display: 'flex', gap: 8 }}>
+                  {['x', 'y', 'width', 'height'].map((dim) => (
+                    <label key={dim} style={{ ...propLabel, flex: 1 }}>
+                      {dim}
+                      <input
+                        type="number"
+                        aria-label={dim}
+                        value={selected[dim] || 0}
+                        onChange={(e) => updateBlock(selectedIdx, { [dim]: Math.max(0, Number(e.target.value) || 0) })}
+                        style={propInput}
+                      />
+                    </label>
+                  ))}
+                </div>
+                <button type="button" onClick={() => removeBlock(selectedIdx)} style={deleteBtn} data-testid="flyer-delete-block">
+                  Delete block
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* "Save as Template" modal — name + sub-brand; serialises palette/layout/assets. */}
       {showSaveModal && (
         <div
           role="dialog"
@@ -389,18 +469,13 @@ export default function MarketingFlyerStudio() {
           style={modalOverlay}
           data-testid="save-template-modal"
         >
-          <form
-            onSubmit={handleSaveTemplate}
-            style={modalDialog}
-            data-testid="save-template-form"
-          >
+          <form onSubmit={handleSaveTemplate} style={modalDialog} data-testid="save-template-form">
             <h2 id="save-template-heading" style={modalHeading}>
               Save as Template
             </h2>
             <p style={modalHint}>
               Capture the current palette + layout + assets as a reusable
-              template. You can find it later on the Flyer Templates list
-              page.
+              template. You can find it later on the Flyer Templates list page.
             </p>
             <label style={modalLabel}>
               Template name *
@@ -453,323 +528,33 @@ export default function MarketingFlyerStudio() {
           </form>
         </div>
       )}
-
-      {/* TODO chunks — each maps to a PRD §3 group. Follow-up ticks
-          should pick these in §8 dependency order. Grep markers
-          intentionally include the PRD-section anchor so a future
-          implementer's `grep -rn 'PRD §3.1'` finds the wire-in site. */}
-
-      {/* TODO(PRD §3.1 — flyer template editor):
-          Build the drag-drop block builder. Mirror the substrate from
-          frontend/src/pages/LandingPageBuilder.jsx — extract into a
-          shared <VisualBuilder/> first (PRD §8 dep #1). Block-type
-          registry per FR-3.1.2: header / image / text / button /
-          pricing-tile / testimonial / destination-grid / footer /
-          kpi-tile / badge / divider. Per-block style props per
-          FR-3.1.3; snap-to-grid + spacing visualizer FR-3.1.4; undo/
-          redo stack FR-3.1.5; responsive preview toggle FR-3.1.6;
-          concurrent-edit lock (60min TTL) FR-3.1.7. */}
-
-      {/* TODO(PRD §3.2 — asset library):
-          Per-tenant image library — new Asset model rows scoped by
-          tenantId + subBrandKey + kind (LOGO/PHOTO/ICON/ILLUSTRATION).
-          Multer pipeline upload FR-3.2.2; full-text tag search
-          FR-3.2.3; AI image generation STUB mode FR-3.2.4 (cred-
-          blocked Q-MF-2 — placeholder + ops-fulfillment queue until
-          DALL-E / Replicate / Midjourney key lands per DD-5.3).
-          Usage count + stale-flagging FR-3.2.5; ZIP bulk import
-          FR-3.2.6. */}
-
-      {/* TODO(PRD §3.3 — brand consistency):
-          Per-sub-brand brand kit reader. Pull from
-          Tenant.subBrandConfigJson.<subBrandKey> (commit 621aab7 wired
-          the consumer; this page consumes per FR-3.3.1). Brand-kit-
-          aware block defaults FR-3.3.2; lock-to-brand mode default
-          ON per DD-5.5 (operator with MANAGER+ can toggle FR-3.3.3);
-          "Apply latest brand kit" diff button FR-3.3.4. */}
-
-      {/* TODO(PRD §3.4 — output formats):
-          PDF export — extend backend/services/pdfRenderer.js with
-          renderFlyer(flyerId, format) for A4 / US-letter print-quality
-          (FR-3.4.1). PNG export — new backend service imageRenderer.js
-          using Puppeteer for square (1080×1080) / portrait (1080×1920)
-          / landscape (1920×1080) / email-banner (1200×628) aspects
-          (FR-3.4.2). WhatsApp-share-ready compression to ≤5MB
-          FR-3.4.3; draft-status diagonal watermark FR-3.4.4; output-
-          URL caching keyed by template-hash FR-3.4.5. */}
-
-      {/* TODO(PRD §3.5 — distribution flow):
-          Direct WhatsApp share FR-3.5.1 — consumes
-          whatsappProvider.sendMedia() + logs Touchpoint with flyerId.
-          Cred-blocked Q-MF-3 (overlaps with WHATSAPP_INTEGRATION_PRD
-          Q9 + PRD_TRAVEL_B2B_AGENT_PORTAL Q-B2B-3). Email-attach
-          single + bulk FR-3.5.2; public signed-URL share FR-3.5.3;
-          iframe embed-code snippet FR-3.5.4. */}
-
-      {/* TODO(PRD §3.6 — AI assistance):
-          Extend backend/lib/llmRouter.js with two task classes —
-          'marketing-flyer-copy' (headline / CTA / body variants
-          FR-3.6.1) and 'marketing-flyer-image' (DALL-E / Stable
-          Diffusion / Midjourney per DD-5.3; STUB until Q-MF-2 lands
-          FR-3.6.3). AI-suggested layouts FR-3.6.2 (rule-based Phase
-          1, ML-driven Phase 2). Performance-hint engine FR-3.6.4
-          deferred to Phase 2 (needs impression / conversion tracking
-          plumbing). */}
-
-      {/* TODO(PRD §3.7 — templates marketplace):
-          Curated templates per sub-brand FR-3.7.1 — TMC schools
-          (8-12) / RFU Umrah (6-10) / Travel Stall family (10-15) /
-          Visa Sure (5-8). Per-template metadata FR-3.7.2. Operator-
-          submitted templates with admin-moderated queue per DD-5.4
-          (FR-3.7.3). Marketplace search + filter FR-3.7.4. */}
-
-      {/* TODO(PRD §8 — dependency build order):
-          Phase 1 ships AC-6.1 through AC-6.10 except AC-6.9 (Q-MF-3
-          cred-blocked, stub mode acceptable). Phase 2 layers
-          analytics, A/B testing, animated MP4/GIF output. Phase 3
-          adds print-on-demand fulfillment via Printful / Vistaprint.
-          Do NOT start in-house editor build until DD-5.1 is resolved
-          (sunk cost: 4-6 weeks if Polotno would have worked). */}
     </div>
   );
 }
 
-const pageWrap = {
-  padding: 24,
-  maxWidth: 1200,
-  margin: '0 auto',
-};
+const pageWrap = { padding: 24, maxWidth: 1200, margin: '0 auto' };
+const headerWrap = { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 12, marginBottom: 16 };
+const headerActions = { display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' };
+const headingStyle = { display: 'flex', alignItems: 'center', gap: 10, margin: 0, marginBottom: 4, color: 'var(--text-primary)' };
+const subtitleStyle = { color: 'var(--text-secondary)', margin: 0, maxWidth: 720, lineHeight: 1.5 };
+const statusBanner = { padding: '12px 16px', borderRadius: 8, background: 'var(--surface-color)', border: '1px solid var(--border-color)', color: 'var(--text-primary)', fontSize: 13, lineHeight: 1.5, marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' };
 
-const headerWrap = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'flex-start',
-  flexWrap: 'wrap',
-  gap: 12,
-  marginBottom: 16,
-};
+const editorWrap = { display: 'flex', flexDirection: 'column', gap: 12 };
+const toolbarStyle = { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', padding: '8px 10px', borderRadius: 8, background: 'var(--surface-color)', border: '1px solid var(--border-color)' };
+const toolBtn = { display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 12px', borderRadius: 6, fontSize: 13, fontWeight: 600, background: 'var(--primary-color, var(--accent-color))', color: 'var(--accent-text, #fff)', border: 'none', cursor: 'pointer' };
+const swatchStyle = { width: 26, height: 26, padding: 0, border: '1px solid var(--border-color)', borderRadius: 4, cursor: 'pointer', background: 'transparent' };
+const canvasStyle = { position: 'relative', width: CANVAS_W, height: CANVAS_H, flexShrink: 0, borderRadius: 8, border: '1px solid var(--border-color)', boxShadow: 'var(--glass-shadow)', overflow: 'hidden' };
+const propsPanel = { flex: '1 1 240px', minWidth: 220, padding: 12, borderRadius: 8, background: 'var(--surface-color)', border: '1px solid var(--border-color)' };
+const propLabel = { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: 'var(--text-secondary)' };
+const propInput = { padding: '6px 8px', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--bg-color, rgba(255,255,255,0.05))', color: 'var(--text-primary)', fontSize: 13, outline: 'none', width: '100%', boxSizing: 'border-box' };
+const deleteBtn = { padding: '6px 12px', borderRadius: 6, fontSize: 12, fontWeight: 600, background: 'transparent', color: '#A8323F', border: '1px solid #A8323F', cursor: 'pointer' };
 
-const headerActions = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 10,
-  flexWrap: 'wrap',
-};
-
-const headingStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 10,
-  margin: 0,
-  marginBottom: 4,
-  color: 'var(--text-primary)',
-};
-
-const subtitleStyle = {
-  color: 'var(--text-secondary)',
-  margin: 0,
-  maxWidth: 720,
-  lineHeight: 1.5,
-};
-
-const comingSoonPill = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  padding: '6px 12px',
-  borderRadius: 999,
-  background: 'var(--primary-color, var(--accent-color))',
-  color: 'var(--accent-text, #fff)',
-  fontSize: 12,
-  fontWeight: 600,
-  letterSpacing: 0.3,
-};
-
-const statusBanner = {
-  padding: '12px 16px',
-  borderRadius: 8,
-  background: 'var(--surface-color)',
-  border: '1px solid var(--border-color)',
-  color: 'var(--text-primary)',
-  fontSize: 13,
-  lineHeight: 1.5,
-  marginBottom: 20,
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  flexWrap: 'wrap',
-};
-
-const cardsGrid = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))',
-  gap: 16,
-  marginBottom: 24,
-};
-
-const cardStyle = {
-  position: 'relative',
-  background: 'var(--surface-color)',
-  border: '1px solid var(--border-color)',
-  borderRadius: 10,
-  padding: 16,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-  minHeight: 180,
-  transition: 'border-color 120ms ease, box-shadow 120ms ease',
-};
-
-const cardActiveStyle = {
-  borderColor: 'var(--primary-color, var(--accent-color))',
-  boxShadow: '0 0 0 2px rgba(38, 88, 85, 0.18)',
-};
-
-const cardHeader = {
-  display: 'flex',
-  alignItems: 'flex-start',
-  gap: 10,
-  color: 'var(--primary-color, var(--accent-color))',
-};
-
-const cardTitle = {
-  margin: 0,
-  fontSize: 16,
-  fontWeight: 600,
-  color: 'var(--text-primary)',
-};
-
-const cardTagline = {
-  margin: '2px 0 0',
-  fontSize: 12,
-  color: 'var(--text-secondary)',
-  lineHeight: 1.4,
-};
-
-const cardSample = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-  padding: '10px 12px',
-  borderRadius: 6,
-  background: 'var(--subtle-bg, rgba(0,0,0,0.03))',
-  border: '1px dashed var(--border-color)',
-};
-
-const cardSampleLabel = {
-  fontSize: 10,
-  textTransform: 'uppercase',
-  letterSpacing: 0.5,
-  color: 'var(--text-secondary)',
-};
-
-const cardSampleText = {
-  fontSize: 13,
-  color: 'var(--text-primary)',
-  fontStyle: 'italic',
-};
-
-const comingSoonOverlay = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  alignSelf: 'flex-start',
-  padding: '4px 10px',
-  borderRadius: 999,
-  background: 'rgba(0, 0, 0, 0.08)',
-  color: 'var(--text-secondary)',
-  fontSize: 11,
-  fontWeight: 600,
-  letterSpacing: 0.3,
-  textTransform: 'uppercase',
-};
-
-const savePrimaryBtn = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  padding: '8px 14px',
-  borderRadius: 6,
-  fontWeight: 600,
-  fontSize: 13,
-  background: 'var(--primary-color, var(--accent-color))',
-  color: 'var(--accent-text, #fff)',
-  border: 'none',
-  cursor: 'pointer',
-};
-
-const secondaryBtn = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  padding: '8px 14px',
-  borderRadius: 6,
-  fontWeight: 600,
-  fontSize: 13,
-  background: 'var(--surface-color)',
-  color: 'var(--text-primary)',
-  border: '1px solid var(--border-color)',
-  cursor: 'pointer',
-};
-
-const modalOverlay = {
-  position: 'fixed',
-  inset: 0,
-  background: 'rgba(0, 0, 0, 0.5)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  zIndex: 1000,
-  padding: 16,
-};
-
-const modalDialog = {
-  background: 'var(--surface-color)',
-  border: '1px solid var(--border-color)',
-  borderRadius: 10,
-  padding: 20,
-  width: '100%',
-  maxWidth: 480,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-};
-
-const modalHeading = {
-  margin: 0,
-  fontSize: 18,
-  fontWeight: 600,
-  color: 'var(--text-primary)',
-};
-
-const modalHint = {
-  margin: 0,
-  fontSize: 12,
-  color: 'var(--text-secondary)',
-  lineHeight: 1.4,
-};
-
-const modalLabel = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-  fontSize: 12,
-  color: 'var(--text-secondary)',
-};
-
-const modalInput = {
-  padding: '8px 10px',
-  borderRadius: 6,
-  border: '1px solid var(--border-color)',
-  background: 'var(--bg-color, rgba(255,255,255,0.05))',
-  color: 'var(--text-primary)',
-  fontSize: 13,
-  outline: 'none',
-};
-
-const modalActions = {
-  display: 'flex',
-  justifyContent: 'flex-end',
-  gap: 8,
-  marginTop: 8,
-};
+const savePrimaryBtn = { display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 6, fontWeight: 600, fontSize: 13, background: 'var(--primary-color, var(--accent-color))', color: 'var(--accent-text, #fff)', border: 'none', cursor: 'pointer' };
+const secondaryBtn = { display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 6, fontWeight: 600, fontSize: 13, background: 'var(--surface-color)', color: 'var(--text-primary)', border: '1px solid var(--border-color)', cursor: 'pointer' };
+const modalOverlay = { position: 'fixed', inset: 0, background: 'rgba(0, 0, 0, 0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: 16 };
+const modalDialog = { background: 'var(--surface-color)', border: '1px solid var(--border-color)', borderRadius: 10, padding: 20, width: '100%', maxWidth: 480, display: 'flex', flexDirection: 'column', gap: 12 };
+const modalHeading = { margin: 0, fontSize: 18, fontWeight: 600, color: 'var(--text-primary)' };
+const modalHint = { margin: 0, fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.4 };
+const modalLabel = { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'var(--text-secondary)' };
+const modalInput = { padding: '8px 10px', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--bg-color, rgba(255,255,255,0.05))', color: 'var(--text-primary)', fontSize: 13, outline: 'none' };
+const modalActions = { display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8 };

--- a/frontend/src/pages/wellness/PatientPortal.jsx
+++ b/frontend/src/pages/wellness/PatientPortal.jsx
@@ -10,6 +10,8 @@ import {
   Download,
   Calendar as CalendarIcon,
   ShoppingBag,
+  Bell,
+  CheckCheck,
 } from 'lucide-react';
 import { useNotify } from '../../utils/notify';
 import { formatDate } from '../../utils/date';
@@ -288,6 +290,10 @@ function Dashboard({ token, onLogout }) {
   // sidebar/tab visibility.
   const [permissions, setPermissions] = useState(null);
   const [loading, setLoading] = useState(true);
+  // Patient notification inbox (Option A). Always available to a logged-in
+  // patient — no permission gate — so no hasPerm dependency here.
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
 
   const hasPerm = useCallback(
     (key) => Array.isArray(permissions) && permissions.includes(key),
@@ -308,6 +314,21 @@ function Dashboard({ token, onLogout }) {
       const permList = Array.isArray(perms?.permissions) ? perms.permissions : [];
       setMe(m);
       setPermissions(permList);
+
+      // Notification inbox — ungated (any logged-in patient). Non-fatal: a
+      // failure leaves the inbox empty without breaking the rest of the portal.
+      try {
+        const n = await portalFetch('/api/wellness/portal/me/notifications', token);
+        if (!signal?.aborted) {
+          setNotifications(Array.isArray(n?.notifications) ? n.notifications : []);
+          setUnreadCount(typeof n?.unreadCount === 'number' ? n.unreadCount : 0);
+        }
+      } catch (_nEx) {
+        if (!signal?.aborted) {
+          setNotifications([]);
+          setUnreadCount(0);
+        }
+      }
 
       // Visits/appointments fetching moved into the embedded
       // <MyBookings /> component which hits the new
@@ -364,6 +385,32 @@ function Dashboard({ token, onLogout }) {
     return () => ctrl.abort();
   }, [loadAll]);
 
+  // Mark ONE notification read (optimistic; backend is the source of truth).
+  // No-op if already read so the unread count never drifts negative.
+  const markNotificationRead = useCallback(async (id) => {
+    setNotifications((prev) => {
+      const item = prev.find((n) => n.id === id);
+      if (!item || item.isRead) return prev;
+      setUnreadCount((c) => Math.max(0, c - 1));
+      return prev.map((n) => (n.id === id ? { ...n, isRead: true } : n));
+    });
+    try {
+      await portalFetch(`/api/wellness/portal/me/notifications/${id}/read`, token, { method: 'PUT' });
+    } catch (_e) {
+      /* optimistic UI already applied; a transient failure self-heals on next load */
+    }
+  }, [token]);
+
+  const markAllNotificationsRead = useCallback(async () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+    setUnreadCount(0);
+    try {
+      await portalFetch('/api/wellness/portal/me/notifications/mark-all-read', token, { method: 'POST' });
+    } catch (_e) {
+      /* optimistic; self-heals on next load */
+    }
+  }, [token]);
+
   const downloadRx = async (rxId) => {
     try {
       // Patient-portal tokens carry { patientId } not { userId }, so the
@@ -399,6 +446,7 @@ function Dashboard({ token, onLogout }) {
   const tabs = useMemo(() => {
     const allTabs = [
       { key: 'visits', label: 'My Visits', icon: CalendarIcon },
+      { key: 'notifications', label: 'Notifications', icon: Bell },
       {
         key: 'prescriptions',
         label: 'Prescriptions',
@@ -515,6 +563,25 @@ function Dashboard({ token, onLogout }) {
               }}
             >
               <Icon size={15} /> {t.label}
+              {t.key === 'notifications' && unreadCount > 0 && (
+                <span
+                  data-testid="portal-notif-badge"
+                  style={{
+                    marginLeft: 2,
+                    minWidth: 18,
+                    textAlign: 'center',
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    background: '#ef4444',
+                    color: '#fff',
+                    borderRadius: 10,
+                    padding: '0 0.35rem',
+                    lineHeight: '1.5',
+                  }}
+                >
+                  {unreadCount}
+                </span>
+              )}
             </button>
           );
         })}
@@ -534,6 +601,100 @@ function Dashboard({ token, onLogout }) {
             fetcher={(url, options = {}) => portalFetch(url, token, options)}
             hideBookCta={true}
           />
+        )}
+
+        {!loading && tab === 'notifications' && (
+          <div style={{ display: 'grid', gap: '0.75rem' }}>
+            {unreadCount > 0 && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <button
+                  onClick={markAllNotificationsRead}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.3rem',
+                    padding: '0.4rem 0.8rem',
+                    background: 'rgba(255,255,255,0.05)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    borderRadius: 6,
+                    color: 'var(--text-primary)',
+                    cursor: 'pointer',
+                    fontSize: '0.8rem',
+                  }}
+                >
+                  <CheckCheck size={14} /> Mark all read
+                </button>
+              </div>
+            )}
+
+            {notifications.length === 0 && (
+              <div
+                className="glass"
+                style={{ padding: '1.5rem', textAlign: 'center', color: 'var(--text-secondary)' }}
+              >
+                No notifications yet.
+              </div>
+            )}
+
+            {notifications.map((n) => (
+              <div
+                key={n.id}
+                className="glass"
+                style={{
+                  padding: '1rem',
+                  display: 'flex',
+                  gap: '0.75rem',
+                  alignItems: 'flex-start',
+                  // Unread rows get an accent left-stripe + slightly stronger tint.
+                  borderLeft: n.isRead ? '3px solid transparent' : '3px solid var(--accent-color)',
+                  opacity: n.isRead ? 0.8 : 1,
+                }}
+              >
+                {/* Unread dot */}
+                <span
+                  style={{
+                    marginTop: 6,
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    flexShrink: 0,
+                    background: n.isRead ? 'transparent' : 'var(--accent-color)',
+                    border: n.isRead ? '1px solid rgba(255,255,255,0.2)' : 'none',
+                  }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+                    <div style={{ fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                      <Bell size={14} /> {n.title}
+                    </div>
+                    <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>
+                      {formatDate(n.createdAt)}
+                    </span>
+                  </div>
+                  <p style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', marginTop: '0.35rem', lineHeight: 1.5 }}>
+                    {n.message}
+                  </p>
+                  {!n.isRead && (
+                    <button
+                      onClick={() => markNotificationRead(n.id)}
+                      style={{
+                        marginTop: '0.5rem',
+                        padding: '0.25rem 0.6rem',
+                        background: 'transparent',
+                        border: '1px solid rgba(255,255,255,0.12)',
+                        borderRadius: 6,
+                        color: 'var(--text-secondary)',
+                        cursor: 'pointer',
+                        fontSize: '0.75rem',
+                      }}
+                    >
+                      Mark read
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
         )}
 
         {!loading && tab === 'prescriptions' && (


### PR DESCRIPTION
[X] Itinerary "Suggest" (AI day-by-day) — Tier-1 #7:
[X]   - Added the itinerary-suggest task class to lib/llmRouter.js and a new
[X]     POST /api/travel/itineraries/suggest endpoint (travel-gated). Operator
[X]     sends destination + days + budget-per-pax + traveller profile → returns a
[X]     structured { summary, days[] } draft for review (no DB write). Stub-mode
[X]     today; real output when LLM keys land.
[X]   - Extended the item PATCH to accept dayNumber / latitude / longitude
[X]     (columns already existed from S8) — no schema migration.

[X] LLM router real-mode — closed the "stub even with a key" landmine:
[X]   - lib/llmRouter.js now calls the REAL provider (Anthropic / OpenAI / Gemini /
[X]     Perplexity) when the task's key is present AND NODE_ENV !== 'test'; falls
[X]     back to the deterministic stub otherwise (so CI + dev stay offline). Model
[X]     IDs are env-overridable (LLM_MODEL_*) so a model rename is config, not code.
[X]   - Result: every AI feature (suggest, talking-points, form-vs-call, draft)
[X]     auto-upgrades to real output the moment a key is set — zero code change.

[X] Itinerary visual day-by-day editor + map — Tier-1 #1:
[X]   - New pages/travel/ItineraryEditor.jsx at /travel/itineraries/:id/edit:
[X]     Day cards with drag-between-days (native DnD, saves dayNumber), a Leaflet +
[X]     OpenStreetMap map (free, no key) with day-numbered pins + route polyline,
[X]     and click-to-place (select an item → click the map to set/move its pin).
[X]   - "Day planner" entry button on ItineraryDetail.jsx; lazy route in App.jsx;
[X]     added leaflet + react-leaflet (React-18 v4) to frontend deps.

[X] Dedicated Marketing Flyer editor 
[X]   - Rewrote pages/travel/MarketingFlyerStudio.jsx from the "coming soon"
[X]     scaffold into a real canvas editor: + Text / + Image blocks, click-to-select,
[X]     pointer-drag to move, properties panel (content / colour / font-size /
[X]     X-Y-W-H / delete), and 5 editable palette swatches. Wired to the existing
[X]     Save-as-Template + load lifecycle (unchanged).
[X]   - Image upload: POST /api/travel/flyer-templates/upload (Multer) → uses
[X]     services/s3Service when AWS_S3_BUCKET_NAME is set, else local-disk fallback;
[X]     frontend "Upload image" button on the image block.