### PR TITLE
feat(auth): self-service account deletion — DELETE /api/auth/me/accou…

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -2,6 +2,7 @@ const express = require("express");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const multer = require("multer");
+const speakeasy = require("speakeasy");
 const { verifyToken, verifyRole } = require("../middleware/auth");
 
 const crypto = require("crypto");
@@ -765,7 +766,10 @@ router.get("/me", verifyToken, async (req, res) => {
   try {
     const user = await prisma.user.findUnique({
       where: { id: req.user.userId },
-      select: { id: true, name: true, email: true, role: true, wellnessRole: true, subBrandAccess: true, profilePicture: true, tenantId: true, createdAt: true, tenant: { select: { id: true, name: true, slug: true, plan: true, vertical: true, country: true, defaultCurrency: true, locale: true, logoUrl: true, brandColor: true } } }
+      // ssoProvider + twoFactorEnabled are additive (no consumer strips the
+      // envelope) — the Profile danger zone uses them to decide whether the
+      // delete-account flow asks for a current password and/or a TOTP code.
+      select: { id: true, name: true, email: true, role: true, wellnessRole: true, subBrandAccess: true, profilePicture: true, tenantId: true, createdAt: true, ssoProvider: true, twoFactorEnabled: true, tenant: { select: { id: true, name: true, slug: true, plan: true, vertical: true, country: true, defaultCurrency: true, locale: true, logoUrl: true, brandColor: true } } }
     });
     if (!user) {
       return res.status(404).json({ error: "User not found" });
@@ -1080,6 +1084,153 @@ router.delete("/me/profile-picture", verifyToken, async (req, res) => {
   } catch (err) {
     console.error("[auth/me/profile-picture] delete error:", err && err.message);
     res.status(500).json({ error: "Failed to remove profile picture" });
+  }
+});
+
+// DELETE /api/auth/me/account — self-service account deletion (all verticals).
+//
+// Privacy policy §10.1 promises in-app account deletion; this is that
+// endpoint. Hard delete, irreversible — relations on User carry explicit
+// onDelete rules (Cascade for personal rows like Notification/ApiKey/
+// Attendance, SetNull for shared business records like Deal/Task/Activity)
+// so a bare user.delete is safe and leaves tenant business data intact.
+//
+// Scope rules:
+//   - sole user of the tenant     → delete the whole TENANT (every model
+//     carries tenant onDelete: Cascade, so this erases all workspace data —
+//     a personal workspace with no remaining members must not orphan data)
+//   - last ADMIN, others remain   → 409 LAST_ADMIN (transfer admin first;
+//     deleting would orphan the workspace for the remaining members)
+//   - everyone else               → delete the USER row only
+//
+// Re-authentication (mirrors the 2FA-disable bar in auth_2fa.js):
+//   - password accounts must present the current password
+//   - SSO accounts hold an unusable random hash (routes/sso.js) so the
+//     confirmDestructive flag is their bar — they re-auth via their IdP
+//   - 2FA-enabled accounts must also present a valid TOTP code
+router.delete("/me/account", verifyToken, async (req, res) => {
+  try {
+    const { password, code, confirmDestructive } = req.body || {};
+
+    // Same explicit-confirmation gate as the GDPR retention endpoints —
+    // a stray scripted DELETE without the flag must not erase an account.
+    if (confirmDestructive !== true) {
+      return res.status(400).json({
+        error: "Account deletion requires explicit confirmation",
+        code: "CONFIRMATION_REQUIRED",
+      });
+    }
+
+    const user = await prisma.user.findFirst({
+      where: { id: req.user.userId, tenantId: req.user.tenantId },
+    });
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const isSsoAccount = !!user.ssoProvider;
+    if (!isSsoAccount) {
+      if (!password) {
+        return res.status(400).json({
+          error: "Current password is required to delete your account",
+          code: "PASSWORD_REQUIRED",
+        });
+      }
+      const passwordOk = await bcrypt.compare(password, user.password);
+      if (!passwordOk) {
+        return res.status(400).json({
+          error: "Current password is incorrect",
+          code: "PASSWORD_INCORRECT",
+        });
+      }
+    }
+
+    if (user.twoFactorEnabled) {
+      const totpOk =
+        !!code &&
+        speakeasy.totp.verify({
+          secret: user.twoFactorSecret,
+          encoding: "base32",
+          token: String(code).trim(),
+          window: 1,
+        });
+      if (!totpOk) {
+        return res.status(400).json({
+          error: "A valid two-factor verification code is required",
+          code: "TOTP_REQUIRED",
+        });
+      }
+    }
+
+    const otherUsers = await prisma.user.count({
+      where: { tenantId: req.user.tenantId, id: { not: user.id } },
+    });
+    const deleteScope = otherUsers === 0 ? "tenant" : "user";
+
+    if (deleteScope === "user" && user.role === "ADMIN") {
+      const otherAdmins = await prisma.user.count({
+        where: {
+          tenantId: req.user.tenantId,
+          id: { not: user.id },
+          role: "ADMIN",
+          deactivatedAt: null,
+        },
+      });
+      if (otherAdmins === 0) {
+        return res.status(409).json({
+          error:
+            "You are the only admin of this organization. Promote another member to admin before deleting your account.",
+          code: "LAST_ADMIN",
+        });
+      }
+    }
+
+    // Audit BEFORE the destructive delete (mirrors DELETE /users/:id) so a
+    // mid-cascade failure still leaves a trail. For tenant-scope deletions
+    // the audit row itself is cascaded away with the tenant — full erasure
+    // is the intent there, so that is correct, not a gap.
+    await writeAudit("User", "DELETE_ACCOUNT_SELF", user.id, user.id, req.user.tenantId, {
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      scope: deleteScope,
+      ssoProvider: user.ssoProvider || null,
+    });
+
+    if (deleteScope === "tenant") {
+      await prisma.tenant.delete({ where: { id: req.user.tenantId } });
+    } else {
+      await prisma.user.delete({ where: { id: user.id } });
+    }
+
+    // Kill the session on the same response: drop the HttpOnly cookie and
+    // revoke the jti so the bearer dies server-side immediately (the
+    // frontend also clears its local copy and redirects to /login).
+    clearAuthCookie(res);
+    if (req.user.jti) {
+      try {
+        await prisma.revokedToken.upsert({
+          where: { jti: req.user.jti },
+          update: {},
+          create: {
+            jti: req.user.jti,
+            userId: user.id,
+            tenantId: req.user.tenantId,
+            expiresAt: jtiExpiresAt(req),
+            reason: "account_deleted",
+          },
+        });
+      } catch (revokeErr) {
+        // Tenant-scope deletions cascade RevokedToken's tenant FK away, so
+        // this insert can fail — the tenant (and all its data) is already
+        // gone, so the orphaned-but-signed JWT can only reach empty scopes
+        // until its natural expiry. Non-fatal by design.
+        console.warn("[auth/me/account] post-delete jti revoke failed:", revokeErr.message);
+      }
+    }
+
+    res.json({ ok: true, deleted: deleteScope });
+  } catch (err) {
+    console.error("[auth/me/account] delete error:", err && err.message);
+    res.status(500).json({ error: "Failed to delete account" });
   }
 });
 

--- a/backend/test/routes/auth-delete-account.test.js
+++ b/backend/test/routes/auth-delete-account.test.js
@@ -1,0 +1,268 @@
+// @ts-check
+/**
+ * Unit tests for DELETE /api/auth/me/account — self-service account deletion
+ * (privacy policy §10.1). Sibling of auth.test.js; same prisma-singleton
+ * monkey-patch + supertest pattern (patch BEFORE requiring the router).
+ *
+ * Contracts pinned here
+ * ─────────────────────
+ *   - 401 without Authorization header (verifyToken gate)
+ *   - 400 CONFIRMATION_REQUIRED when confirmDestructive !== true
+ *   - 400 PASSWORD_REQUIRED when a password account omits the password
+ *   - 400 PASSWORD_INCORRECT on bcrypt mismatch
+ *   - 400 TOTP_REQUIRED when 2FA is enabled and no/invalid code supplied
+ *   - 409 LAST_ADMIN when other members exist but no other active admin
+ *   - 200 user-scope happy path: audit BEFORE delete, prisma.user.delete,
+ *     jti revoked with reason 'account_deleted', { ok:true, deleted:'user' }
+ *   - 200 tenant-scope when the caller is the tenant's sole user:
+ *     prisma.tenant.delete (cascade wipes the workspace), deleted:'tenant'
+ *   - 200 SSO account: no password required (unusable random hash —
+ *     see routes/sso.js), confirmDestructive is the bar
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import speakeasy from 'speakeasy';
+
+import prisma from '../../lib/prisma.js';
+
+// ── prisma singleton patch (BEFORE the router is required) ───────────
+prisma.user = {
+  findUnique: vi.fn(),
+  findFirst: vi.fn(),
+  findMany: vi.fn().mockResolvedValue([]),
+  count: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn().mockResolvedValue({}),
+};
+prisma.tenant = {
+  findUnique: vi.fn().mockResolvedValue(null),
+  findMany: vi.fn().mockResolvedValue([]),
+  create: vi.fn(),
+  delete: vi.fn().mockResolvedValue({}),
+};
+prisma.auditLog = {
+  findFirst: vi.fn().mockResolvedValue(null),
+  create: vi.fn().mockResolvedValue({}),
+};
+prisma.revokedToken = {
+  findUnique: vi.fn().mockResolvedValue(null),
+  upsert: vi.fn().mockResolvedValue({}),
+  findMany: vi.fn().mockResolvedValue([]),
+};
+prisma.smsConfig = {
+  findFirst: vi.fn().mockResolvedValue(null),
+};
+prisma.userRole = {
+  count: vi.fn().mockResolvedValue(1),
+  findUnique: vi.fn().mockResolvedValue(null),
+  findFirst: vi.fn().mockResolvedValue(null),
+  findMany: vi.fn().mockResolvedValue([]),
+  create: vi.fn().mockResolvedValue({}),
+};
+prisma.role = {
+  findFirst: vi.fn().mockResolvedValue({ id: 999 }),
+  create: vi.fn().mockResolvedValue({ id: 999 }),
+};
+prisma.rolePermission = {
+  findFirst: vi.fn().mockResolvedValue({ id: 999 }),
+  create: vi.fn().mockResolvedValue({}),
+};
+prisma.roleWidget = {
+  create: vi.fn().mockResolvedValue({}),
+};
+
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+const requireCJS = createRequire(import.meta.url);
+const authRouter = requireCJS('../../routes/auth');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'enterprise_super_secret_key_2026';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/auth', authRouter);
+  return app;
+}
+
+function bearer({ userId = 7, tenantId = 1, role = 'USER', jti } = {}) {
+  const payload = { userId, tenantId, role };
+  if (jti) payload.jti = jti;
+  return 'Bearer ' + jwt.sign(payload, JWT_SECRET, { expiresIn: '5m' });
+}
+
+const PASSWORD = 'correct-horse-battery';
+const HASHED = bcrypt.hashSync(PASSWORD, 4);
+
+function baseUser(overrides = {}) {
+  return {
+    id: 7,
+    tenantId: 1,
+    email: 'member@acme.test',
+    name: 'Member',
+    role: 'USER',
+    password: HASHED,
+    ssoProvider: null,
+    twoFactorEnabled: false,
+    twoFactorSecret: null,
+    deactivatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('DELETE /api/auth/me/account', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.revokedToken.findUnique.mockResolvedValue(null);
+    prisma.revokedToken.upsert.mockResolvedValue({});
+    prisma.auditLog.findFirst.mockResolvedValue(null);
+    prisma.auditLog.create.mockResolvedValue({});
+    prisma.user.delete.mockResolvedValue({});
+    prisma.tenant.delete.mockResolvedValue({});
+  });
+
+  test('401 without Authorization header', async () => {
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .send({ confirmDestructive: true, password: PASSWORD });
+    expect(res.status).toBe(401);
+  });
+
+  test('400 CONFIRMATION_REQUIRED when confirmDestructive flag is missing', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser());
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ password: PASSWORD });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('CONFIRMATION_REQUIRED');
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+    expect(prisma.tenant.delete).not.toHaveBeenCalled();
+  });
+
+  test('400 PASSWORD_REQUIRED when password account omits password', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser());
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ confirmDestructive: true });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PASSWORD_REQUIRED');
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+  });
+
+  test('400 PASSWORD_INCORRECT on wrong password', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser());
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ confirmDestructive: true, password: 'not-the-password' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PASSWORD_INCORRECT');
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+  });
+
+  test('400 TOTP_REQUIRED when 2FA enabled and no code supplied', async () => {
+    const secret = speakeasy.generateSecret({ length: 20 }).base32;
+    prisma.user.findFirst.mockResolvedValue(
+      baseUser({ twoFactorEnabled: true, twoFactorSecret: secret }),
+    );
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ confirmDestructive: true, password: PASSWORD });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('TOTP_REQUIRED');
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+  });
+
+  test('200 with valid TOTP code when 2FA enabled', async () => {
+    const secret = speakeasy.generateSecret({ length: 20 }).base32;
+    prisma.user.findFirst.mockResolvedValue(
+      baseUser({ twoFactorEnabled: true, twoFactorSecret: secret }),
+    );
+    // first count → other users exist (user scope), no admin check (role USER)
+    prisma.user.count.mockResolvedValueOnce(3);
+    const code = speakeasy.totp({ secret, encoding: 'base32' });
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ confirmDestructive: true, password: PASSWORD, code });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 'user' });
+    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: 7 } });
+  });
+
+  test('409 LAST_ADMIN when other members exist but no other active admin', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser({ role: 'ADMIN' }));
+    prisma.user.count
+      .mockResolvedValueOnce(4) // other users in tenant
+      .mockResolvedValueOnce(0); // other active admins
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer({ role: 'ADMIN' }))
+      .send({ confirmDestructive: true, password: PASSWORD });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('LAST_ADMIN');
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+    expect(prisma.tenant.delete).not.toHaveBeenCalled();
+  });
+
+  test('200 user-scope happy path: audit + delete + jti revocation', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser());
+    prisma.user.count.mockResolvedValueOnce(2); // other users → user scope
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer({ jti: 'jti-del-1' }))
+      .send({ confirmDestructive: true, password: PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 'user' });
+    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: 7 } });
+    expect(prisma.tenant.delete).not.toHaveBeenCalled();
+    // audit row written (writeAudit goes through prisma.auditLog.create)
+    expect(prisma.auditLog.create).toHaveBeenCalled();
+    // session killed server-side
+    expect(prisma.revokedToken.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jti: 'jti-del-1' },
+        create: expect.objectContaining({ reason: 'account_deleted', userId: 7 }),
+      }),
+    );
+  });
+
+  test('200 tenant-scope when caller is the sole user of the tenant', async () => {
+    prisma.user.findFirst.mockResolvedValue(baseUser({ role: 'ADMIN' }));
+    prisma.user.count.mockResolvedValueOnce(0); // no other users → tenant scope
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer({ role: 'ADMIN' }))
+      .send({ confirmDestructive: true, password: PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 'tenant' });
+    expect(prisma.tenant.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(prisma.user.delete).not.toHaveBeenCalled();
+  });
+
+  test('200 SSO account deletes without a password', async () => {
+    prisma.user.findFirst.mockResolvedValue(
+      baseUser({ ssoProvider: 'google', password: 'unusable-random-hash' }),
+    );
+    prisma.user.count.mockResolvedValueOnce(5); // other users → user scope
+    const res = await request(makeApp())
+      .delete('/api/auth/me/account')
+      .set('Authorization', bearer())
+      .send({ confirmDestructive: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 'user' });
+    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: 7 } });
+  });
+});

--- a/frontend/src/__tests__/Profile.noopSave.test.jsx
+++ b/frontend/src/__tests__/Profile.noopSave.test.jsx
@@ -41,6 +41,7 @@ vi.mock('../utils/notify', () => ({
   }),
 }));
 
+import { MemoryRouter } from 'react-router-dom';
 import { AuthContext } from '../App';
 import Profile from '../pages/Profile';
 
@@ -67,14 +68,17 @@ function setupApi(updatedProfile = BASELINE_PROFILE) {
 }
 
 function renderProfile() {
+  // MemoryRouter: Profile's danger-zone delete flow calls useNavigate().
   return render(
-    <AuthContext.Provider value={{
-      user: { ...BASELINE_PROFILE, userId: BASELINE_PROFILE.id },
-      setUser: vi.fn(),
-      token: 'tk', tenant: { id: 1 }, loading: false,
-    }}>
-      <Profile />
-    </AuthContext.Provider>
+    <MemoryRouter>
+      <AuthContext.Provider value={{
+        user: { ...BASELINE_PROFILE, userId: BASELINE_PROFILE.id },
+        setUser: vi.fn(),
+        token: 'tk', tenant: { id: 1 }, loading: false,
+      }}>
+        <Profile />
+      </AuthContext.Provider>
+    </MemoryRouter>
   );
 }
 

--- a/frontend/src/__tests__/Profile.test.jsx
+++ b/frontend/src/__tests__/Profile.test.jsx
@@ -69,6 +69,15 @@ vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+// Profile's danger-zone delete flow calls useNavigate(); several tests in
+// this file render <Profile /> bare (no Router), so stub the hook instead
+// of wrapping every render in a MemoryRouter. The deletion flow itself is
+// covered in ProfileDeleteAccount.test.jsx.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
 import { AuthContext } from '../App';
 import Profile from '../pages/Profile';
 

--- a/frontend/src/__tests__/ProfileDeleteAccount.test.jsx
+++ b/frontend/src/__tests__/ProfileDeleteAccount.test.jsx
@@ -1,0 +1,241 @@
+/**
+ * Profile.jsx — Danger Zone / self-service account deletion flow.
+ *
+ * Contracts pinned here
+ * ─────────────────────
+ *   1. The danger zone card renders for every account with a
+ *      "Delete account" button (all three verticals share Profile.jsx,
+ *      so one render path covers generic / wellness / travel).
+ *   2. Clicking "Delete account" arms the confirm area: a current-password
+ *      input appears for password accounts.
+ *   3. Submitting without a password blocks (notify.error) and does NOT
+ *      call the API.
+ *   4. Happy path: password filled → destructive notify.confirm modal
+ *      ("irreversible") → DELETE /api/auth/me/account with
+ *      { confirmDestructive:true, password } → local auth cleared
+ *      (setUser(null) + setToken(null)) → navigate('/login').
+ *   5. Declining the modal aborts: no DELETE call, session intact.
+ *   6. SSO accounts (ssoProvider set) see NO password input and can delete
+ *      with just the modal confirmation.
+ *   7. 2FA accounts must fill the TOTP code input before the modal opens.
+ *   8. API failure (wrong password, LAST_ADMIN, …) does NOT log the user
+ *      out — fetchApi's auto-toast surfaces the error and the page stays.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchApiMock = vi.fn();
+vi.mock('../utils/api', () => ({
+  fetchApi: (...args) => fetchApiMock(...args),
+  getAuthToken: () => 'test-token',
+}));
+
+// Stable mock-object pattern (2026-05-23 standing rule).
+const notifyObj = {
+  error: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+  confirm: vi.fn(() => Promise.resolve(true)),
+  prompt: vi.fn(() => Promise.resolve('')),
+};
+vi.mock('../utils/notify', () => ({
+  useNotify: () => notifyObj,
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import { AuthContext } from '../App';
+import Profile from '../pages/Profile';
+
+const BASE_PROFILE = {
+  id: 7,
+  name: 'Asha Verma',
+  email: 'asha@acme.test',
+  role: 'USER',
+  wellnessRole: null,
+  ssoProvider: null,
+  twoFactorEnabled: false,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+function renderProfile(meResponse = BASE_PROFILE, opts = {}) {
+  const { setUser = vi.fn(), setToken = vi.fn(), deleteResult } = opts;
+  fetchApiMock.mockReset();
+  fetchApiMock.mockImplementation((url, fetchOpts) => {
+    if (url === '/api/auth/me/account' && fetchOpts?.method === 'DELETE') {
+      // deleteResult is a thunk so a rejection is created lazily at call
+      // time (an eager Promise.reject() trips vitest's unhandled-rejection
+      // detector before the component attaches its catch).
+      return deleteResult ? deleteResult() : Promise.resolve(true);
+    }
+    if (url === '/api/auth/me') return Promise.resolve(meResponse);
+    return Promise.resolve({});
+  });
+  render(
+    <AuthContext.Provider value={{
+      user: { ...meResponse, userId: meResponse.id },
+      setUser,
+      setToken,
+      token: 'tk', tenant: { id: 1 }, loading: false,
+      subscription: null,
+    }}>
+      <Profile />
+    </AuthContext.Provider>
+  );
+  return { setUser, setToken };
+}
+
+function getDeleteCalls() {
+  return fetchApiMock.mock.calls.filter(
+    ([url, opts]) => url === '/api/auth/me/account' && opts?.method === 'DELETE',
+  );
+}
+
+async function armDangerZone() {
+  await waitFor(() => expect(screen.getByTestId('profile-danger-zone')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('profile-delete-account-button'));
+  await waitFor(() =>
+    expect(screen.getByTestId('profile-delete-account-confirm')).toBeInTheDocument(),
+  );
+}
+
+describe('<Profile /> — danger zone account deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifyObj.confirm.mockImplementation(() => Promise.resolve(true));
+  });
+
+  it('renders the danger zone with a Delete account button', async () => {
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-danger-zone')).toBeInTheDocument());
+    expect(screen.getByTestId('profile-delete-account-button')).toBeInTheDocument();
+    // confirm area is NOT shown until armed
+    expect(screen.queryByTestId('profile-delete-account-confirm')).not.toBeInTheDocument();
+  });
+
+  it('arming reveals the current-password input for password accounts', async () => {
+    renderProfile();
+    await armDangerZone();
+    expect(screen.getByPlaceholderText('Current password')).toBeInTheDocument();
+  });
+
+  it('blocks submission without a password and does not call the API', async () => {
+    renderProfile();
+    await armDangerZone();
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+    await waitFor(() => expect(notifyObj.error).toHaveBeenCalled());
+    expect(notifyObj.confirm).not.toHaveBeenCalled();
+    expect(getDeleteCalls()).toHaveLength(0);
+  });
+
+  it('happy path: confirm modal → DELETE call → auth cleared → /login', async () => {
+    const { setUser, setToken } = renderProfile();
+    await armDangerZone();
+
+    fireEvent.change(screen.getByPlaceholderText('Current password'), {
+      target: { value: 'hunter2hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true }));
+
+    // irreversible warning shown as a destructive modal
+    expect(notifyObj.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destructive: true,
+        message: expect.stringContaining('irreversible'),
+      }),
+    );
+
+    const calls = getDeleteCalls();
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0][1].body)).toEqual({
+      confirmDestructive: true,
+      password: 'hunter2hunter2',
+    });
+
+    // logged out locally at the same moment
+    expect(setUser).toHaveBeenCalledWith(null);
+    expect(setToken).toHaveBeenCalledWith(null);
+    expect(notifyObj.success).toHaveBeenCalled();
+  });
+
+  it('declining the modal aborts the deletion', async () => {
+    notifyObj.confirm.mockImplementation(() => Promise.resolve(false));
+    const { setUser } = renderProfile();
+    await armDangerZone();
+
+    fireEvent.change(screen.getByPlaceholderText('Current password'), {
+      target: { value: 'hunter2hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+
+    await waitFor(() => expect(notifyObj.confirm).toHaveBeenCalled());
+    expect(getDeleteCalls()).toHaveLength(0);
+    expect(setUser).not.toHaveBeenCalledWith(null);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('SSO accounts see no password input and can delete without one', async () => {
+    renderProfile({ ...BASE_PROFILE, ssoProvider: 'google' });
+    await armDangerZone();
+
+    expect(screen.queryByPlaceholderText('Current password')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true }));
+    const calls = getDeleteCalls();
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0][1].body)).toEqual({ confirmDestructive: true });
+  });
+
+  it('2FA accounts must supply a verification code before the modal opens', async () => {
+    renderProfile({ ...BASE_PROFILE, twoFactorEnabled: true });
+    await armDangerZone();
+
+    fireEvent.change(screen.getByPlaceholderText('Current password'), {
+      target: { value: 'hunter2hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+    await waitFor(() => expect(notifyObj.error).toHaveBeenCalled());
+    expect(getDeleteCalls()).toHaveLength(0);
+
+    fireEvent.change(screen.getByPlaceholderText('6-digit code'), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true }));
+    expect(JSON.parse(getDeleteCalls()[0][1].body)).toEqual({
+      confirmDestructive: true,
+      password: 'hunter2hunter2',
+      code: '123456',
+    });
+  });
+
+  it('API failure leaves the user logged in (no navigate, no setUser(null))', async () => {
+    const { setUser, setToken } = renderProfile(BASE_PROFILE, {
+      deleteResult: () =>
+        Promise.reject(Object.assign(new Error('Current password is incorrect'), { status: 400 })),
+    });
+    await armDangerZone();
+
+    fireEvent.change(screen.getByPlaceholderText('Current password'), {
+      target: { value: 'wrong-password' },
+    });
+    fireEvent.click(screen.getByTestId('profile-delete-account-submit'));
+
+    await waitFor(() => expect(getDeleteCalls()).toHaveLength(1));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(setUser).not.toHaveBeenCalledWith(null);
+    expect(setToken).not.toHaveBeenCalledWith(null);
+    // button unfreezes for a retry
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-delete-account-submit')).not.toBeDisabled(),
+    );
+  });
+});

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useContext, useRef } from 'react';
-import { User, Mail, Key, Save, Stethoscope, Download, FileText, Camera, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { User, Mail, Key, Save, Stethoscope, Download, FileText, Camera, Trash2, AlertTriangle } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../utils/api';
 import { AuthContext } from '../App';
 import { useNotify } from '../utils/notify';
@@ -20,8 +21,9 @@ function isPractitioner(profile) {
 }
 
 const Profile = () => {
-  const { user: authUser, setUser: setAuthUser, subscription } = useContext(AuthContext);
+  const { user: authUser, setUser: setAuthUser, setToken, subscription } = useContext(AuthContext);
   const notify = useNotify();
+  const navigate = useNavigate();
   const [profile, setProfile] = useState(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -41,6 +43,12 @@ const Profile = () => {
   const [downloadingId, setDownloadingId] = useState(null);
   const [uploadingPicture, setUploadingPicture] = useState(false);
   const fileInputRef = useRef(null);
+  // Danger zone — two-stage: "Delete account" arms the confirm area
+  // (password / TOTP inputs), then a destructive modal is the final gate.
+  const [deleteArmed, setDeleteArmed] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deleteCode, setDeleteCode] = useState('');
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     loadProfile();
@@ -237,6 +245,56 @@ const Profile = () => {
       setPasswordMsg({ text: err.message || 'Failed to change password', type: 'error' });
     }
     setChangingPassword(false);
+  };
+
+  const handleDeleteAccount = async () => {
+    // SSO accounts have no usable password (the backend skips the check for
+    // them); everyone else must re-authenticate before the final modal.
+    if (!profile?.ssoProvider && !deletePassword) {
+      notify.error('Enter your current password to delete your account.');
+      return;
+    }
+    if (profile?.twoFactorEnabled && !deleteCode.trim()) {
+      notify.error('Enter your two-factor verification code to delete your account.');
+      return;
+    }
+
+    const ok = await notify.confirm({
+      title: 'Delete your account?',
+      message: 'This action is irreversible. Your account and all data associated with it will be permanently deleted, and you will be signed out immediately.',
+      confirmText: 'Delete my account',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+    if (!ok) return;
+
+    setDeleting(true);
+    try {
+      await fetchApi('/api/auth/me/account', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          confirmDestructive: true,
+          ...(profile?.ssoProvider ? {} : { password: deletePassword }),
+          ...(profile?.twoFactorEnabled ? { code: deleteCode.trim() } : {}),
+        }),
+      });
+      // The server already revoked the session jti and dropped the auth
+      // cookie — mirror Layout's handleLogout local cleanup, minus the
+      // POST /logout call (the token is dead and the user row is gone).
+      notify.success('Your account has been permanently deleted.');
+      if (setAuthUser) setAuthUser(null);
+      if (setToken) setToken(null);
+      try {
+        localStorage.removeItem('token');
+      } catch {
+        /* ignore */
+      }
+      navigate('/login', { replace: true });
+    } catch {
+      // fetchApi already surfaced the server error as a toast (wrong
+      // password, last admin, etc.) — just unfreeze the button.
+      setDeleting(false);
+    }
   };
 
   if (loading) {
@@ -649,6 +707,92 @@ const Profile = () => {
             <Key size={16} /> {changingPassword ? 'Changing...' : 'Change Password'}
           </button>
         </form>
+      </div>
+
+      {/* Danger Zone — self-service account deletion (privacy policy §10.1).
+          Renders identically for all three verticals (generic / wellness /
+          travel); --danger-color is themed per vertical in CSS. */}
+      <div
+        className="card glass"
+        data-testid="profile-danger-zone"
+        style={{ padding: '1.5rem', marginTop: '1.5rem', border: '1px solid rgba(239,68,68,0.45)' }}
+      >
+        <h3 style={{ fontSize: '1rem', fontWeight: '600', color: 'var(--danger-color, #ef4444)', marginBottom: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <AlertTriangle size={18} /> Danger Zone
+        </h3>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1rem' }}>
+          Permanently delete your account. This action is irreversible — your account and all data
+          associated with it will be deleted, and you will be signed out immediately.
+        </p>
+
+        {!deleteArmed ? (
+          <button
+            type="button"
+            className="btn-danger"
+            data-testid="profile-delete-account-button"
+            onClick={() => setDeleteArmed(true)}
+            style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+          >
+            <Trash2 size={16} /> Delete account
+          </button>
+        ) : (
+          <div data-testid="profile-delete-account-confirm">
+            {!profile?.ssoProvider && (
+              <div style={{ marginBottom: '1rem' }}>
+                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+                  Confirm with your current password
+                </label>
+                <PasswordInput
+                  value={deletePassword}
+                  onChange={(e) => setDeletePassword(e.target.value)}
+                  placeholder="Current password"
+                  autoComplete="current-password"
+                />
+              </div>
+            )}
+            {profile?.twoFactorEnabled && (
+              <div style={{ marginBottom: '1rem' }}>
+                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+                  Two-factor verification code
+                </label>
+                <input
+                  type="text"
+                  className="input-field"
+                  value={deleteCode}
+                  onChange={(e) => setDeleteCode(e.target.value)}
+                  placeholder="6-digit code"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                />
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                className="btn-danger"
+                data-testid="profile-delete-account-submit"
+                onClick={handleDeleteAccount}
+                disabled={deleting}
+                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+              >
+                <Trash2 size={16} /> {deleting ? 'Deleting…' : 'Permanently delete my account'}
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                data-testid="profile-delete-account-cancel"
+                onClick={() => {
+                  setDeleteArmed(false);
+                  setDeletePassword('');
+                  setDeleteCode('');
+                }}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
…nt + Profile danger zone

Privacy policy §10.1 promises in-app account deletion; this ships it for all three verticals (generic / wellness / travel share Profile.jsx).

Backend (routes/auth.js):
- DELETE /api/auth/me/account — verifyToken + confirmDestructive:true gate (GDPR retention pattern) + current-password re-auth (2FA-disable pattern; skipped for SSO accounts whose password is an unusable random hash) + TOTP code when twoFactorEnabled
- Scope rules: sole user of tenant → tenant.delete (cascade wipes the workspace); last ADMIN with members remaining → 409 LAST_ADMIN; else user.delete (Cascade personal rows, SetNull shared business records — all User relations carry explicit onDelete, audited)
- writeAudit('User','DELETE_ACCOUNT_SELF') BEFORE the delete; jti revoked (reason account_deleted) + auth cookie cleared on the same response
- GET /me now additionally returns ssoProvider + twoFactorEnabled so the frontend knows which credentials to collect (additive)

Frontend (pages/Profile.jsx):
- Danger Zone card: two-stage flow — arm → password/TOTP inputs → destructive notify.confirm modal warning the action is irreversible and all data will be deleted → DELETE call → local auth cleared (setUser/ setToken null, mirrors Layout handleLogout) → redirect to /login

Tests: 10 backend vitest (auth-delete-account.test.js) + 8 frontend vitest (ProfileDeleteAccount.test.jsx); Profile.test.jsx + Profile.noopSave.test.jsx updated for the new useNavigate dependency. All 37 Profile-suite + 54 auth- suite cases green; vite build green.