### PR TITLE
Added the notification for the users on based on trip added review cu…

### DIFF
--- a/backend/cron/paymentDeadlineEngine.js
+++ b/backend/cron/paymentDeadlineEngine.js
@@ -1,0 +1,215 @@
+// Travel CRM — pay-or-cancel deposit-deadline engine (2026-06-16 feature).
+//
+// Business rule (product call): once a customer ACCEPTS an itinerary, the
+// booking is committed but not yet paid. They must pay the 50% deposit at
+// least 7 days before departure (deadline = startDate - 7d). We:
+//
+//   T-10 → T-7  email the customer a daily, escalating "pay your deposit"
+//               reminder (deadline is T-7).
+//   T-6 (deadline missed, still unpaid)
+//               → email the customer an "at-risk" notice AND raise an advisor
+//                 notification to review for cancellation, AND stamp
+//                 Itinerary.paymentOverdueAt so the advisor list badges it.
+//
+// IMPORTANT: this engine NEVER changes the itinerary status. There is no
+// auto-cancel — an advisor manually sets status "expired" to cancel (product
+// decision: flag-and-review, not silent destruction of a real booking).
+//
+// Scope: every travel sub-brand EXCEPT Visa Sure (visa applications don't use
+// the 50%-deposit trip model). Only `accepted` itineraries with a positive
+// totalAmount and no advance recorded are chased (advance_paid / fully_paid
+// have already paid; those get the packing-countdown engine instead).
+//
+// Idempotency: one PaymentDeadlineNudge row per (itineraryId, dayTag), claimed
+// BEFORE sending so an hourly re-tick can't double-send. dayTag ∈
+// {d10,d9,d8,d7,overdue}.
+
+const cron = require("node-cron");
+const prisma = require("../lib/prisma");
+const emailSender = require("../lib/emailSender");
+const content = require("../lib/paymentDeadlineContent");
+const notificationService = require("../lib/notificationService");
+
+const { FIRE_DAYS, shouldRemind, dayTag } = content;
+const DEPOSIT_FRACTION = 0.5; // 50% deposit (PRD §4.7)
+const DEADLINE_LEAD_DAYS = 7; // deposit due 7 days before departure
+const OVERDUE_FROM_DAYS = 6; // T-6 onward (deadline missed) → flag + at-risk
+const SCAN_FLOOR_DAYS = 2; // tolerate a trip that started up to 2d ago
+const HORIZON_DAYS = Math.max(...FIRE_DAYS) + 1; // scan window upper bound (11)
+
+// Calendar-day difference (UTC) between `now` and the trip start.
+function daysToGo(now, start) {
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
+  return Math.round((b - a) / 86400000);
+}
+
+// A short, locale-stable deadline label (e.g. "14 Jun 2026").
+function formatDeadline(startDate) {
+  const d = new Date(startDate.getTime() - DEADLINE_LEAD_DAYS * 86400000);
+  return d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" });
+}
+
+// Mirror of middleware/travelGuards.getSubBrandAccessSet semantics, but applied
+// to an already-fetched user row (so we batch-fetch users once per tenant).
+function userCanAccess(user, subBrand) {
+  if (user.role === "ADMIN") return true;
+  if (!user.subBrandAccess) return true; // null/unset = full access
+  try {
+    const arr = JSON.parse(user.subBrandAccess);
+    if (!Array.isArray(arr)) return true; // malformed → full access (preserved)
+    if (arr.length === 0) return false; // explicit "[]" → deny-all
+    return arr.includes(subBrand);
+  } catch {
+    return false;
+  }
+}
+
+// One pass. `now` is injectable for tests. Returns a summary for observability.
+async function runPaymentDeadlineTick(now = new Date()) {
+  const floor = new Date(now.getTime() - SCAN_FLOOR_DAYS * 86400000);
+  const horizon = new Date(now.getTime() + HORIZON_DAYS * 86400000);
+
+  const itineraries = await prisma.itinerary.findMany({
+    where: {
+      status: "accepted", // committed but unpaid (advance_paid/fully_paid excluded)
+      subBrand: { not: "visasure" }, // everything except Visa Sure
+      startDate: { gte: floor, lte: horizon },
+    },
+    select: {
+      id: true, tenantId: true, subBrand: true, contactId: true, destination: true,
+      startDate: true, totalAmount: true, advancePaidAmount: true, currency: true, paymentOverdueAt: true,
+    },
+  });
+
+  // Batch-fetch contact email + name.
+  const contactIds = [...new Set(itineraries.map((i) => i.contactId).filter(Boolean))];
+  const contacts = contactIds.length
+    ? await prisma.contact.findMany({ where: { id: { in: contactIds } }, select: { id: true, name: true, email: true } })
+    : [];
+  const contactById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+
+  // Batch-fetch users per tenant for advisor targeting (sub-brand scoped).
+  const tenantIds = [...new Set(itineraries.map((i) => i.tenantId))];
+  const usersByTenant = {};
+  for (const tid of tenantIds) {
+    usersByTenant[tid] = await prisma.user.findMany({
+      where: { tenantId: tid },
+      select: { id: true, role: true, subBrandAccess: true },
+    });
+  }
+
+  const summary = { scanned: itineraries.length, remindersSent: 0, flagged: 0, sent: 0, skipped: 0 };
+
+  for (const itin of itineraries) {
+    if (!itin.startDate) { summary.skipped += 1; continue; }
+    const total = Number(itin.totalAmount || 0);
+    if (!(total > 0)) { summary.skipped += 1; continue; } // nothing to chase
+    const deposit = total * DEPOSIT_FRACTION;
+    // Defensive: if an advance somehow covers the deposit while status is still
+    // "accepted", treat it as paid and don't chase.
+    if (Number(itin.advancePaidAmount || 0) >= deposit) { summary.skipped += 1; continue; }
+
+    const d = daysToGo(now, new Date(itin.startDate));
+    const isReminder = shouldRemind(d);
+    const isOverdue = d <= OVERDUE_FROM_DAYS;
+    if (!isReminder && !isOverdue) { summary.skipped += 1; continue; } // before the window
+
+    const contact = itin.contactId ? contactById[itin.contactId] : null;
+    if (!contact || !contact.email) { summary.skipped += 1; continue; }
+
+    const tag = isReminder ? dayTag(d) : "overdue";
+
+    // Idempotent claim — unique([itineraryId, dayTag]) means a re-tick the
+    // same bucket collides + we skip.
+    let claim;
+    try {
+      claim = await prisma.paymentDeadlineNudge.create({
+        data: { tenantId: itin.tenantId, itineraryId: itin.id, dayTag: tag, channel: "email", status: "sending" },
+      });
+    } catch {
+      summary.skipped += 1; // P2002 — already handled this bucket
+      continue;
+    }
+
+    const common = {
+      tenantId: itin.tenantId,
+      destination: itin.destination,
+      customerName: contact.name,
+      depositAmount: deposit,
+      currency: itin.currency,
+      daysToGo: d,
+      deadlineLabel: formatDeadline(new Date(itin.startDate)),
+    };
+
+    if (isReminder) {
+      let nudge;
+      try {
+        nudge = await content.buildReminder(common);
+      } catch (e) {
+        console.error(`[PaymentDeadline] reminder build failed itin=${itin.id} ${tag}: ${e.message}`);
+        await prisma.paymentDeadlineNudge.update({ where: { id: claim.id }, data: { status: "failed" } }).catch(() => {});
+        continue;
+      }
+      const res = await emailSender.sendEmail({ to: contact.email, subject: nudge.subject, text: nudge.text, html: nudge.html });
+      const status = res.sent ? "sent" : res.reason === "no_api_key" ? "logged" : "failed";
+      if (res.sent) summary.sent += 1;
+      summary.remindersSent += 1;
+      await prisma.paymentDeadlineNudge
+        .update({ where: { id: claim.id }, data: { status, subject: nudge.subject, llmSourced: nudge.llmSourced } })
+        .catch(() => {});
+      console.log(`[PaymentDeadline] reminder itin=${itin.id} ${tag} → ${status} (llm=${nudge.llmSourced})`);
+      continue;
+    }
+
+    // ── Overdue (T-6+) — customer at-risk notice + advisor flag, no auto-cancel ──
+    const notice = content.buildOverdueNotice(common);
+    const res = await emailSender.sendEmail({ to: contact.email, subject: notice.subject, text: notice.text, html: notice.html });
+    if (res.sent) summary.sent += 1;
+    const emailStatus = res.sent ? "sent" : res.reason === "no_api_key" ? "logged" : "failed";
+
+    // Stamp the at-risk flag so the advisor list can badge it.
+    if (!itin.paymentOverdueAt) {
+      await prisma.itinerary.update({ where: { id: itin.id }, data: { paymentOverdueAt: now } }).catch(() => {});
+    }
+
+    // Raise an advisor notification (sub-brand scoped). Best-effort.
+    const flag = content.buildOverdueAdvisorFlag({
+      destination: itin.destination, customerName: contact.name, depositAmount: deposit,
+      currency: itin.currency, itineraryId: itin.id,
+    });
+    const advisors = (usersByTenant[itin.tenantId] || []).filter((u) => userCanAccess(u, itin.subBrand));
+    for (const u of advisors) {
+      await notificationService
+        .notify({
+          userId: u.id, tenantId: itin.tenantId, title: flag.title, message: flag.message,
+          type: "warning", priority: "high", entityType: "Itinerary", entityId: itin.id,
+          link: "/travel/itineraries", category: "travel-payment-overdue", dedupWindowHours: 24,
+        })
+        .catch((e) => console.error(`[PaymentDeadline] advisor notify failed itin=${itin.id} user=${u.id}: ${e.message}`));
+    }
+
+    summary.flagged += 1;
+    await prisma.paymentDeadlineNudge
+      .update({ where: { id: claim.id }, data: { status: "flagged", subject: notice.subject } })
+      .catch(() => {});
+    console.log(`[PaymentDeadline] OVERDUE itin=${itin.id} dest="${itin.destination}" → ${advisors.length} advisor(s) flagged, customer email ${emailStatus}`);
+  }
+
+  if (summary.scanned > 0) {
+    console.log(`[PaymentDeadline] tick: scanned=${summary.scanned} reminders=${summary.remindersSent} flagged=${summary.flagged} sent=${summary.sent} skipped=${summary.skipped}`);
+  }
+  return summary;
+}
+
+// Hourly tick (at :37 — offset from the trip-countdown :17 so the two don't
+// contend). Day-bucket idempotency means the first tick that sees a new bucket
+// sends; later ticks that day are no-ops.
+function initPaymentDeadlineCron() {
+  cron.schedule("37 * * * *", () => {
+    runPaymentDeadlineTick().catch((e) => console.error("[PaymentDeadline] tick error:", e.message));
+  });
+  console.log("[PaymentDeadline] cron scheduled (hourly :37)");
+}
+
+module.exports = { runPaymentDeadlineTick, initPaymentDeadlineCron, daysToGo, formatDeadline, userCanAccess };

--- a/backend/cron/travelReviewEngine.js
+++ b/backend/cron/travelReviewEngine.js
@@ -1,0 +1,112 @@
+// Travel CRM — post-trip review-request engine (2026-06-16 feature).
+//
+// After a trip completes (the itinerary's `endDate` has passed), email the
+// customer a one-minute review with a fixed set of questions
+// (lib/travelReviewQuestions.js) whose wording weaves in the destination
+// ("How was your trip to Bali?"). The email links to a public review page
+// (/p/review/:token); the customer can also submit from their logged-in
+// portal — both write the same TravelTripReview row.
+//
+// Scope: COMMITTED bookings — status ∈ {accepted, advance_paid, fully_paid}
+// (the codebase's "agreement-secured" set; a booking the customer agreed to is
+// reviewable whether or not payment was recorded). All sub-brands EXCEPT Visa
+// Sure (a visa application isn't a trip to review). Only recently-completed
+// trips (endDate within the last COMPLETION_LOOKBACK_DAYS) are picked up, so a
+// fresh deploy doesn't blast every historical booking.
+//
+// Idempotency: one TravelTripReview row per itinerary (@unique). The row is
+// claimed BEFORE the email so a re-tick can't double-request.
+//
+// Travel-only: scans the Itinerary model (travel-only) — no-ops for
+// wellness/generic.
+
+const cron = require("node-cron");
+const crypto = require("crypto");
+const prisma = require("../lib/prisma");
+const emailSender = require("../lib/emailSender");
+const content = require("../lib/travelReviewContent");
+
+// "Agreement-secured" set — any booking the customer committed to is reviewable
+// once it's over (payment state doesn't gate a review).
+const REVIEW_STATUSES = ["accepted", "advance_paid", "fully_paid"];
+const COMPLETION_LOOKBACK_DAYS = 4; // only trips completed within this window
+const PUBLIC_BASE = process.env.PUBLIC_BASE_URL || "https://crm.globusdemos.com";
+
+function reviewUrl(token) {
+  return `${PUBLIC_BASE}/p/review/${token}`;
+}
+
+// One pass. `now` is injectable for tests. Returns a summary for observability.
+async function runTravelReviewTick(now = new Date()) {
+  const floor = new Date(now.getTime() - COMPLETION_LOOKBACK_DAYS * 86400000);
+
+  const itineraries = await prisma.itinerary.findMany({
+    where: {
+      status: { in: REVIEW_STATUSES },
+      subBrand: { not: "visasure" },
+      endDate: { gte: floor, lt: now }, // completed within the lookback window
+    },
+    select: { id: true, tenantId: true, contactId: true, destination: true, endDate: true },
+  });
+
+  // Skip itineraries that already have a review row (requested or submitted).
+  const itinIds = itineraries.map((i) => i.id);
+  const existing = itinIds.length
+    ? await prisma.travelTripReview.findMany({ where: { itineraryId: { in: itinIds } }, select: { itineraryId: true } })
+    : [];
+  const haveReview = new Set(existing.map((r) => r.itineraryId));
+
+  // Batch-fetch contact email + name.
+  const contactIds = [...new Set(itineraries.map((i) => i.contactId).filter(Boolean))];
+  const contacts = contactIds.length
+    ? await prisma.contact.findMany({ where: { id: { in: contactIds } }, select: { id: true, name: true, email: true } })
+    : [];
+  const contactById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+
+  const summary = { scanned: itineraries.length, requested: 0, sent: 0, skipped: 0 };
+
+  for (const itin of itineraries) {
+    if (haveReview.has(itin.id)) { summary.skipped += 1; continue; }
+    const contact = itin.contactId ? contactById[itin.contactId] : null;
+    if (!contact || !contact.email) { summary.skipped += 1; continue; }
+
+    const token = crypto.randomBytes(24).toString("base64url");
+
+    // Idempotent claim — @unique(itineraryId) means a race/re-tick collides + we skip.
+    try {
+      await prisma.travelTripReview.create({
+        data: { tenantId: itin.tenantId, itineraryId: itin.id, contactId: contact.id, token, status: "requested" },
+      });
+    } catch {
+      summary.skipped += 1; // P2002 — already requested
+      continue;
+    }
+
+    summary.requested += 1;
+    const mail = content.buildRequestEmail({
+      destination: itin.destination,
+      customerName: contact.name,
+      reviewUrl: reviewUrl(token),
+    });
+    const res = await emailSender.sendEmail({ to: contact.email, subject: mail.subject, text: mail.text, html: mail.html });
+    if (res.sent) summary.sent += 1;
+    const status = res.sent ? "sent" : res.reason === "no_api_key" ? "logged" : "failed";
+    console.log(`[TravelReview] itin=${itin.id} dest="${itin.destination}" review requested → email ${status}`);
+  }
+
+  if (summary.scanned > 0) {
+    console.log(`[TravelReview] tick: scanned=${summary.scanned} requested=${summary.requested} sent=${summary.sent} skipped=${summary.skipped}`);
+  }
+  return summary;
+}
+
+// Daily tick at 09:07 — reviews aren't time-critical; the 4-day lookback covers
+// any missed day. Idempotency (one row per itinerary) makes re-runs safe.
+function initTravelReviewCron() {
+  cron.schedule("7 9 * * *", () => {
+    runTravelReviewTick().catch((e) => console.error("[TravelReview] tick error:", e.message));
+  });
+  console.log("[TravelReview] cron scheduled (daily 09:07)");
+}
+
+module.exports = { runTravelReviewTick, initTravelReviewCron, REVIEW_STATUSES, reviewUrl };

--- a/backend/cron/tripCountdownEngine.js
+++ b/backend/cron/tripCountdownEngine.js
@@ -1,0 +1,138 @@
+// Travel CRM — pre-trip "countdown" nudge engine (2026-06-16 feature).
+//
+// For every travel itinerary the customer has PAID for — i.e. status ∈
+// {advance_paid, fully_paid} (the 50% deposit has at least landed) — with a
+// trip start date approaching, email a short, creative reminder:
+//
+//   T-30, T-14  early check-ins
+//   T-7 … T-0   a DAILY nudge through the final week ("keep packing!")
+//
+// Why paid-only and not `accepted`: an `accepted`-but-unpaid booking is still
+// in the deposit-chase phase, handled by cron/paymentDeadlineEngine.js
+// (pay-or-cancel reminders T-10 → T-7 + an overdue advisor flag). Sending a
+// "keep packing!" email to someone who still owes a deposit is the wrong
+// message — and at T-7 both engines would otherwise fire. Once they pay
+// (status → advance_paid), they graduate from the payment track to this
+// packing track. (PRD §4.7 / 2026-06-16 product call.)
+//
+// Content: LLM-generated per email (task "trip-countdown") when Q11 keys are
+// present; otherwise the deterministic template library in
+// lib/tripCountdownContent.js (distinct copy per day). Delivery: real SendGrid
+// email (lib/emailSender.js) to Contact.email.
+//
+// Idempotency: one TripCountdownNudge row per (itineraryId, dayTag), claimed
+// BEFORE sending so an hourly re-tick on the same day can't double-email.
+//
+// Spans ALL travel sub-brands. (RFU also has the religious-milestone cron
+// travelJourneyReminders.js, which only writes Notification rows — no email —
+// so the two don't double-send.)
+
+const cron = require("node-cron");
+const prisma = require("../lib/prisma");
+const emailSender = require("../lib/emailSender");
+const content = require("../lib/tripCountdownContent");
+// Pure helpers are safe to bind directly; sendEmail + buildNudge are called
+// through their module object (emailSender.* / content.*) so a singleton
+// monkeypatch in the unit tests can intercept them (vi.mock can't reach the
+// SUT's CJS require chain under this vitest setup).
+const { FIRE_DAYS, shouldFire, dayTag } = content;
+
+// Packing nudges go only to PAID trips — `accepted`-but-unpaid is the deposit-
+// chase phase (cron/paymentDeadlineEngine.js owns it). Kept as PAID_STATUSES;
+// the old name AGREEMENT_SECURED is exported as an alias for back-compat.
+const PAID_STATUSES = ["advance_paid", "fully_paid"];
+const AGREEMENT_SECURED = PAID_STATUSES;
+const HORIZON_DAYS = Math.max(...FIRE_DAYS); // scan window upper bound (30)
+
+// Calendar-day difference (UTC) between `now` and the trip start.
+function daysToGo(now, start) {
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
+  return Math.round((b - a) / 86400000);
+}
+
+// One pass. `now` is injectable for tests. Returns a summary for observability.
+async function runTripCountdownTick(now = new Date()) {
+  const floor = new Date(now.getTime() - 86400000); // tolerate same-day/just-past
+  const horizon = new Date(now.getTime() + (HORIZON_DAYS + 1) * 86400000);
+
+  const itineraries = await prisma.itinerary.findMany({
+    where: {
+      status: { in: AGREEMENT_SECURED },
+      startDate: { gte: floor, lte: horizon },
+    },
+    select: { id: true, tenantId: true, subBrand: true, contactId: true, destination: true, startDate: true },
+  });
+
+  // Batch-fetch contact email + name.
+  const contactIds = [...new Set(itineraries.map((i) => i.contactId).filter(Boolean))];
+  const contacts = contactIds.length
+    ? await prisma.contact.findMany({ where: { id: { in: contactIds } }, select: { id: true, name: true, email: true } })
+    : [];
+  const contactById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+
+  const summary = { scanned: itineraries.length, fired: 0, sent: 0, skipped: 0 };
+
+  for (const itin of itineraries) {
+    if (!itin.startDate) { summary.skipped += 1; continue; }
+    const d = daysToGo(now, new Date(itin.startDate));
+    if (!shouldFire(d)) { summary.skipped += 1; continue; }
+
+    const contact = itin.contactId ? contactById[itin.contactId] : null;
+    if (!contact || !contact.email) { summary.skipped += 1; continue; }
+
+    const tag = dayTag(d);
+
+    // Idempotent claim — unique([itineraryId, dayTag]) means a re-tick the
+    // same day collides + we skip (at-most-once email per day-bucket).
+    let claim;
+    try {
+      claim = await prisma.tripCountdownNudge.create({
+        data: { tenantId: itin.tenantId, itineraryId: itin.id, dayTag: tag, channel: "email", status: "sending" },
+      });
+    } catch {
+      // P2002 unique violation → already handled this day-bucket.
+      summary.skipped += 1;
+      continue;
+    }
+
+    summary.fired += 1;
+    let nudge;
+    try {
+      nudge = await content.buildNudge({
+        tenantId: itin.tenantId,
+        destination: itin.destination,
+        daysToGo: d,
+        customerName: contact.name,
+      });
+    } catch (e) {
+      console.error(`[TripCountdown] content build failed for itin=${itin.id} ${tag}: ${e.message}`);
+      await prisma.tripCountdownNudge.update({ where: { id: claim.id }, data: { status: "failed" } }).catch(() => {});
+      continue;
+    }
+
+    const res = await emailSender.sendEmail({ to: contact.email, subject: nudge.subject, text: nudge.text, html: nudge.html });
+    const status = res.sent ? "sent" : res.reason === "no_api_key" ? "logged" : "failed";
+    if (res.sent) summary.sent += 1;
+    await prisma.tripCountdownNudge
+      .update({ where: { id: claim.id }, data: { status, subject: nudge.subject, llmSourced: nudge.llmSourced } })
+      .catch(() => {});
+    console.log(`[TripCountdown] itin=${itin.id} dest="${itin.destination}" ${tag} → ${status} (llm=${nudge.llmSourced})`);
+  }
+
+  if (summary.fired > 0 || summary.scanned > 0) {
+    console.log(`[TripCountdown] tick: scanned=${summary.scanned} fired=${summary.fired} sent=${summary.sent} skipped=${summary.skipped}`);
+  }
+  return summary;
+}
+
+// Hourly tick (at :17). Daily-bucket idempotency means the first tick of each
+// day that sees a new days-to-go sends; later ticks that day are no-ops.
+function initTripCountdownCron() {
+  cron.schedule("17 * * * *", () => {
+    runTripCountdownTick().catch((e) => console.error("[TripCountdown] tick error:", e.message));
+  });
+  console.log("[TripCountdown] cron scheduled (hourly :17)");
+}
+
+module.exports = { runTripCountdownTick, initTripCountdownCron, daysToGo, PAID_STATUSES, AGREEMENT_SECURED };

--- a/backend/cron/webCheckinEngine.js
+++ b/backend/cron/webCheckinEngine.js
@@ -1,0 +1,134 @@
+// Travel CRM — web check-in reminder EMAIL engine (2026-06-16 feature).
+//
+// The CUSTOMER-FACING email layer on top of the existing WebCheckin system
+// (cron/webCheckinScheduler.js owns the status lifecycle + WhatsApp nudge +
+// agent fallback; routes/travel_webcheckin.js the CRUD/queue). This engine
+// does NOT create its own rows — it reads the SAME WebCheckin rows (one per
+// flight, fanned out on itinerary accept) and emails the passenger 3 times,
+// 12h apart, before the flight's real `departureAt`:
+//
+//   T-36h  heads-up (check-in opens ~24h out)
+//   T-24h  check-in is open now
+//   T-12h  last reminder
+//
+// Each email links to the customer portal, where "Yes, I've checked in" flips
+// the WebCheckin row(s) to status `done` → this engine skips done rows AND the
+// scheduler stops escalating, so one confirm silences everything.
+//
+// Scope: only WebCheckin rows whose PARENT itinerary is PAID
+// (advance_paid/fully_paid) and non-Visa-Sure (per the 2026-06-16 product
+// call). Idempotency: WebCheckin.emailRemindersJson holds the milestone tags
+// already emailed (["h36","h24",...]).
+//
+// Travel-only: WebCheckin rows exist only in the travel vertical, so this
+// no-ops for wellness/generic tenants.
+
+const cron = require("node-cron");
+const prisma = require("../lib/prisma");
+const emailSender = require("../lib/emailSender");
+const content = require("../lib/webCheckinContent");
+
+const { MILESTONES, milestoneTag, dueMilestone } = content;
+const PAID_STATUSES = ["advance_paid", "fully_paid"];
+const ACTIVE_WC_STATUSES = ["pending", "reminded"]; // skip done/in-progress/fallback-agent/failed
+const HORIZON_HOURS = Math.max(...MILESTONES) + 1; // 37h scan window upper bound
+const PORTAL_BASE = process.env.PUBLIC_BASE_URL || "https://crm.globusdemos.com";
+const PORTAL_URL = `${PORTAL_BASE}/travel/portal`;
+
+function parseSent(json) {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+// One pass. `now` is injectable for tests. Returns a summary for observability.
+async function runWebCheckinTick(now = new Date()) {
+  const horizon = new Date(now.getTime() + HORIZON_HOURS * 3600000);
+
+  const rows = await prisma.webCheckin.findMany({
+    where: {
+      status: { in: ACTIVE_WC_STATUSES },
+      departureAt: { gte: now, lte: horizon },
+      itineraryId: { not: null },
+    },
+    select: {
+      id: true, tenantId: true, itineraryId: true, contactId: true,
+      pnr: true, airlineCode: true, flightNumber: true, passengerName: true,
+      departureAt: true, emailRemindersJson: true,
+    },
+  });
+
+  // Batch-fetch parent itineraries for the paid + non-visasure gate.
+  const itinIds = [...new Set(rows.map((r) => r.itineraryId).filter(Boolean))];
+  const itins = itinIds.length
+    ? await prisma.itinerary.findMany({ where: { id: { in: itinIds } }, select: { id: true, status: true, subBrand: true } })
+    : [];
+  const itinById = Object.fromEntries(itins.map((i) => [i.id, i]));
+
+  // Batch-fetch contact emails.
+  const contactIds = [...new Set(rows.map((r) => r.contactId).filter(Boolean))];
+  const contacts = contactIds.length
+    ? await prisma.contact.findMany({ where: { id: { in: contactIds } }, select: { id: true, name: true, email: true } })
+    : [];
+  const contactById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+
+  const summary = { scanned: rows.length, fired: 0, sent: 0, skipped: 0 };
+
+  for (const row of rows) {
+    const itin = itinById[row.itineraryId];
+    // Gate: parent itinerary must be PAID + non-Visa-Sure.
+    if (!itin || !PAID_STATUSES.includes(itin.status) || itin.subBrand === "visasure") { summary.skipped += 1; continue; }
+
+    const hoursToGo = (new Date(row.departureAt).getTime() - now.getTime()) / 3600000;
+    const milestone = dueMilestone(hoursToGo);
+    if (milestone == null) { summary.skipped += 1; continue; }
+
+    const tag = milestoneTag(milestone);
+    const already = parseSent(row.emailRemindersJson);
+    if (already.includes(tag)) { summary.skipped += 1; continue; } // idempotent
+
+    const contact = row.contactId ? contactById[row.contactId] : null;
+    const to = (contact && contact.email) || null;
+    if (!to) { summary.skipped += 1; continue; }
+
+    summary.fired += 1;
+    const mail = content.buildReminder({
+      passengerName: row.passengerName || (contact && contact.name),
+      airlineCode: row.airlineCode,
+      flightNumber: row.flightNumber,
+      pnr: row.pnr,
+      milestone,
+      portalUrl: PORTAL_URL,
+    });
+    const res = await emailSender.sendEmail({ to, subject: mail.subject, text: mail.text, html: mail.html });
+    if (res.sent) summary.sent += 1;
+    // Record the milestone as sent regardless of delivery outcome (logged/sent)
+    // so a re-tick doesn't retry a no-key send forever. A hard failure is rare
+    // and acceptable to drop — the next milestone still fires.
+    const next = [...already, tag];
+    await prisma.webCheckin.update({ where: { id: row.id }, data: { emailRemindersJson: JSON.stringify(next) } }).catch(() => {});
+    const status = res.sent ? "sent" : res.reason === "no_api_key" ? "logged" : "failed";
+    console.log(`[WebCheckinEmail] checkin=${row.id} ${row.airlineCode} ${row.flightNumber} ${tag} → ${status}`);
+  }
+
+  if (summary.scanned > 0) {
+    console.log(`[WebCheckinEmail] tick: scanned=${summary.scanned} fired=${summary.fired} sent=${summary.sent} skipped=${summary.skipped}`);
+  }
+  return summary;
+}
+
+// Hourly tick (at :47 — offset from trip-countdown :17, payment-deadline :37,
+// and the existing webCheckinScheduler's :13/:28/:43/:58). The 12h milestone
+// windows mean an hourly tick reliably fires each of T-36/24/12h once.
+function initWebCheckinCron() {
+  cron.schedule("47 * * * *", () => {
+    runWebCheckinTick().catch((e) => console.error("[WebCheckinEmail] tick error:", e.message));
+  });
+  console.log("[WebCheckinEmail] cron scheduled (hourly :47)");
+}
+
+module.exports = { runWebCheckinTick, initWebCheckinCron, PAID_STATUSES };

--- a/backend/lib/emailSender.js
+++ b/backend/lib/emailSender.js
@@ -1,0 +1,50 @@
+// Generic transactional email sender (SendGrid). Shared by any feature that
+// needs to email a customer (trip-countdown nudges, etc.). Mirrors the
+// SendGrid fetch pattern in routes/communications.js + lib/emailOtp.js.
+//
+// Returns { sent: boolean, reason?: string } and NEVER throws — callers treat
+// email as best-effort. When SENDGRID_API_KEY is unset it logs + returns
+// { sent: false, reason: "no_api_key" } so dev/CI exercise the surrounding
+// logic without real delivery.
+
+const SENDGRID_API_KEY = () => process.env.SENDGRID_API_KEY || "";
+const FROM_EMAIL = () => process.env.SENDGRID_FROM_EMAIL || "noreply@crm.globusdemos.com";
+
+async function sendEmail({ to, subject, text, html }) {
+  if (!to || !subject) {
+    return { sent: false, reason: "missing_to_or_subject" };
+  }
+  const key = SENDGRID_API_KEY();
+  if (!key) {
+    console.log(`[Email] SendGrid not configured — email to ${to} ("${subject}") logged, not sent`);
+    return { sent: false, reason: "no_api_key" };
+  }
+  const payload = {
+    personalizations: [{ to: [{ email: to }] }],
+    from: { email: FROM_EMAIL() },
+    subject,
+    content: [
+      { type: "text/plain", value: text || subject },
+      { type: "text/html", value: html || (text || subject).replace(/\n/g, "<br>") },
+    ],
+  };
+  try {
+    const resp = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (resp.ok) {
+      console.log(`[Email] Sent to ${to}: "${subject}"`);
+      return { sent: true };
+    }
+    const t = await resp.text();
+    console.error(`[Email] SendGrid error ${resp.status}: ${t}`);
+    return { sent: false, reason: `sendgrid_${resp.status}` };
+  } catch (err) {
+    console.error("[Email] send failed:", err.message);
+    return { sent: false, reason: err.message };
+  }
+}
+
+module.exports = { sendEmail };

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -78,6 +78,18 @@ const TASK_ROUTING = {
   // routing table for Travel Stall's bulk-shape Gemini calls. Real call
   // gated on Q-IT-2 / Q11 GEMINI_API_KEY (see CREDS_TRACKER).
   "itinerary-suggest": { primary: "gemini-flash", fallback: "claude-haiku" },
+  // Trip-countdown nudge (pre-trip daily reminder emails). Short, upbeat,
+  // destination-personalised copy (subject + body) keyed to days-to-go.
+  // ~0.5K in / 0.5K out — routed to gemini-flash for low-cost bulk-shape
+  // calls. Falls back to the deterministic template library in
+  // backend/lib/tripCountdownContent.js until Q11 GEMINI_API_KEY lands.
+  "trip-countdown": { primary: "gemini-flash", fallback: "claude-haiku" },
+  // Pay-or-cancel deposit-deadline reminder (2026-06-16). Short, courteous-but-
+  // urgent copy (subject + body) keyed to days-until-deadline, telling the
+  // customer to pay the 50% deposit before the cut-off. Same shape/cost profile
+  // as trip-countdown → gemini-flash; falls back to the deterministic template
+  // library in backend/lib/paymentDeadlineContent.js until Q11 keys land.
+  "payment-reminder": { primary: "gemini-flash", fallback: "claude-haiku" },
   // Marketing-flyer-copy (PRD_TRAVEL_MARKETING_FLYER FR-3.6.1 + AC-6.8).
   // 1K in / 1K out — short-form headline + body + CTA JSON. Routed to
   // gemini-flash for low-cost bulk-shape Gemini calls per PRD §9.1.
@@ -487,6 +499,8 @@ function buildPrompt(task, payload) {
     "talking-points": "You are a senior travel advisor. Given a lead's diagnostic profile, produce concise, actionable talking points for the advisor's next call. Plain text, 3-6 short bullets.",
     "form-vs-call": "You compare a customer's web-form answers against their phone-call answers, summarise the level of match, and flag any mismatches. Plain text.",
     "itinerary-suggest": "You are an expert travel planner pricing a trip for a per-person quote. Given a destination, number of days, budget tier, and traveller interests/pace, return a realistic day-by-day itinerary as STRICT JSON only — no markdown, no text outside the JSON. Shape: {\"summary\":string,\"days\":[{\"dayNumber\":number,\"items\":[{\"itemType\":string,\"description\":string,\"estimatedCost\":number}]}]}. itemType MUST be one of: flight, transfer, hotel, sightseeing, activity, meals, visa, insurance, other. estimatedCost is the typical PER-PERSON cost in INR (Indian Rupees) for that item, using your best knowledge of current average prices for that destination and budget tier — give a realistic positive number; use 0 only when the item is genuinely free. Each day should include a hotel plus at least one sightseeing, one activity, and one meals item; put an arrival flight on day 1 and a departure flight on the final day. Keep each description short and specific to the destination. Return ONLY the JSON object.",
+    "trip-countdown": "You write a short, warm, upbeat PRE-TRIP reminder email for a travel customer. Return STRICT JSON only — no markdown, no text outside the JSON. Shape: {\"subject\":string,\"body\":string}. Use AT MOST one emoji in the subject. Mention the destination and the days-to-go. Keep the body under 80 words, friendly and encouraging (e.g. packing/prep tips as the trip nears). You may use the placeholder {name} for the customer's name in the body. Return ONLY the JSON object.",
+    "payment-reminder": "You write a short, courteous but clearly URGENT deposit-reminder email for a travel customer whose booking is confirmed but whose 50% deposit is still due before a deadline. Return STRICT JSON only — no markdown, no text outside the JSON. Shape: {\"subject\":string,\"body\":string}. No emoji. State plainly that the deposit must be paid by the deadline to keep the booking, and that the booking is at risk of cancellation otherwise. Mention the destination and the days remaining. Keep the body under 90 words. You may use the placeholder {name} for the customer's name. Return ONLY the JSON object.",
     "bulk-text": "You write clear, customer-facing travel copy. Plain text.",
     "call-summary": "You summarise a sales/advisory call in a few sentences. Plain text.",
     "reasoning": "You are a careful reasoning assistant for a travel CRM. Plain text.",

--- a/backend/lib/paymentDeadlineContent.js
+++ b/backend/lib/paymentDeadlineContent.js
@@ -1,0 +1,156 @@
+// Pay-or-cancel deposit-deadline copy for cron/paymentDeadlineEngine.js.
+//
+// Cadence (2026-06-16 product call): an `accepted` booking must have its 50%
+// deposit paid at least 7 days before departure (deadline = startDate - 7d).
+// We chase the customer daily T-10 → T-7 with escalating urgency, then — if
+// still unpaid when T-6 arrives — flag the advisor + send the customer an
+// "at-risk" notice. No auto-cancel: an advisor manually sets status "expired".
+//
+// Content source mirrors tripCountdownContent.js: LLM-generated per email
+// (task "payment-reminder") when the Q11 keys are present; otherwise the
+// deterministic template library below (already distinct per day). The LLM
+// path auto-engages once keys land (routeRequest returns stub=false).
+
+const llmRouter = require("./llmRouter");
+
+// Which days-to-go fire a deposit reminder. Deadline is T-7, so this is the
+// 4-day run-up T-10 → T-7 inclusive. The T-6 "overdue" notice is handled
+// separately by the engine (it's not a fire-day reminder).
+const FIRE_DAYS = [10, 9, 8, 7];
+
+function shouldRemind(daysToGo) {
+  return FIRE_DAYS.includes(daysToGo);
+}
+function dayTag(daysToGo) {
+  return `d${daysToGo}`;
+}
+
+// Cheap money formatter — ₹ for INR, otherwise "<CODE> <amount>". Rounds to
+// whole units (deposits are quoted in whole rupees in this CRM).
+function formatMoney(amount, currency) {
+  const n = Number(amount);
+  if (!Number.isFinite(n) || n <= 0) return "the deposit";
+  const rounded = Math.round(n).toLocaleString("en-IN");
+  return (currency || "INR") === "INR" ? `₹${rounded}` : `${currency} ${rounded}`;
+}
+
+// Per-day escalating templates. {dest} {name} {amount} {deadline} {daysToDeadline}
+// are interpolated. daysToDeadline = daysToGo - 7 (3 → 0 across the window).
+const TEMPLATES = {
+  10: {
+    subject: "Action needed: secure your {dest} trip with a 50% deposit",
+    body: "Hi {name},\n\nThank you for confirming your trip to {dest}! To lock it in, we need your 50% deposit of {amount} by {deadline} ({daysToDeadline} days away). Paying on time guarantees your booking. Let us know if you have any questions.\n\nTeam Travel Stall",
+  },
+  9: {
+    subject: "Reminder: {dest} deposit due by {deadline}",
+    body: "Hi {name},\n\nJust a friendly reminder — your 50% deposit of {amount} for {dest} is due by {deadline}. Once it's in, your booking is fully secured. Reply here if you'd like a payment link.\n\nTeam Travel Stall",
+  },
+  8: {
+    subject: "2 days left to pay your {dest} deposit",
+    body: "Hi {name},\n\nYour deposit of {amount} for {dest} is due by {deadline} — just 2 days from now. To avoid losing your booking, please complete the payment soon. We're here to help if anything's unclear.\n\nTeam Travel Stall",
+  },
+  7: {
+    subject: "Final reminder: {dest} deposit due TODAY",
+    body: "Hi {name},\n\nToday is the deadline to pay your 50% deposit of {amount} for {dest}. If we don't receive it today, your booking is at risk of cancellation. Please pay now to keep your trip confirmed — contact us immediately if you need assistance.\n\nTeam Travel Stall",
+  },
+};
+
+// Customer-facing OVERDUE notice (sent at T-6 when the deadline passed unpaid).
+// Distinct from the run-up reminders — the tone is "at risk", and we explicitly
+// invite them to contact us rather than implying the booking is already gone
+// (no auto-cancel; an advisor decides).
+const OVERDUE_TEMPLATE = {
+  subject: "Your {dest} booking is at risk — deposit overdue",
+  body: "Hi {name},\n\nWe haven't yet received the 50% deposit of {amount} for your {dest} trip, and the deadline has now passed. Your booking is at risk of cancellation. Please pay as soon as possible, or contact us right away so we can help keep your trip on track.\n\nTeam Travel Stall",
+};
+
+function interpolate(str, vars) {
+  return String(str)
+    .replace(/\{dest\}/g, vars.destination || "your destination")
+    .replace(/\{name\}/g, vars.customerName || "traveller")
+    .replace(/\{amount\}/g, vars.amountLabel || "the deposit")
+    .replace(/\{deadline\}/g, vars.deadlineLabel || "the deadline")
+    .replace(/\{daysToDeadline\}/g, String(vars.daysToDeadline != null ? vars.daysToDeadline : ""));
+}
+
+function varsFrom({ destination, customerName, depositAmount, currency, deadlineLabel, daysToGo }) {
+  return {
+    destination,
+    customerName,
+    amountLabel: formatMoney(depositAmount, currency),
+    deadlineLabel: deadlineLabel || "the deadline",
+    daysToDeadline: daysToGo != null ? daysToGo - 7 : null,
+  };
+}
+
+// Deterministic template reminder — the always-available fallback + unit-test
+// surface. Returns { subject, text, html, llmSourced: false }.
+function buildFallbackReminder(opts) {
+  const tpl = TEMPLATES[opts.daysToGo] || TEMPLATES[7];
+  const vars = varsFrom(opts);
+  const subject = interpolate(tpl.subject, vars);
+  const text = interpolate(tpl.body, vars);
+  return { subject, text, html: text.replace(/\n/g, "<br>"), llmSourced: false };
+}
+
+// Deterministic OVERDUE customer notice. No LLM path — at-risk wording stays
+// fixed so we never soften/over-promise on a cancellation-adjacent message.
+function buildOverdueNotice(opts) {
+  const vars = varsFrom({ ...opts, daysToGo: null });
+  const subject = interpolate(OVERDUE_TEMPLATE.subject, vars);
+  const text = interpolate(OVERDUE_TEMPLATE.body, vars);
+  return { subject, text, html: text.replace(/\n/g, "<br>"), llmSourced: false };
+}
+
+// Advisor flag content for the T-6 "review for cancellation" notification.
+function buildOverdueAdvisorFlag({ destination, customerName, depositAmount, currency, itineraryId }) {
+  const amountLabel = formatMoney(depositAmount, currency);
+  return {
+    title: "Deposit overdue — review for cancellation",
+    message: `Itinerary #${itineraryId} (${destination || "trip"}, ${customerName || "customer"}) passed its 50% deposit deadline unpaid (${amountLabel} due). The customer has been notified. Set the booking to "expired" to cancel, or follow up to recover the payment.`,
+  };
+}
+
+// Try the LLM for fresh, on-tone copy; fall back to the template on stub mode
+// (no keys), error, or unparseable output. Never throws.
+async function buildReminder(opts) {
+  const { tenantId, destination, daysToGo, customerName } = opts;
+  const vars = varsFrom(opts);
+  try {
+    const result = await llmRouter.routeRequest({
+      task: "payment-reminder",
+      tenantId,
+      payload: {
+        destination,
+        customerName,
+        daysToGo,
+        daysUntilDeadline: vars.daysToDeadline,
+        depositAmount: vars.amountLabel,
+        deadline: vars.deadlineLabel,
+      },
+    });
+    if (result && !result.stub && result.text) {
+      const parsed = JSON.parse(result.text);
+      if (parsed && parsed.subject && parsed.body) {
+        const subject = interpolate(parsed.subject, vars);
+        const text = interpolate(parsed.body, vars);
+        return { subject, text, html: text.replace(/\n/g, "<br>"), llmSourced: true };
+      }
+    }
+  } catch {
+    /* fall through to template */
+  }
+  return buildFallbackReminder(opts);
+}
+
+module.exports = {
+  FIRE_DAYS,
+  shouldRemind,
+  dayTag,
+  formatMoney,
+  buildFallbackReminder,
+  buildOverdueNotice,
+  buildOverdueAdvisorFlag,
+  buildReminder,
+  TEMPLATES,
+};

--- a/backend/lib/travelReviewContent.js
+++ b/backend/lib/travelReviewContent.js
@@ -1,0 +1,28 @@
+// Post-trip review-request email copy for cron/travelReviewEngine.js.
+// TEMPLATE-only. {destination} woven in so the ask reads naturally
+// ("How was your trip to Bali?"). Links to the public review page.
+
+function interp(str, vars) {
+  return String(str)
+    .replace(/\{destination\}/g, vars.destination || "your recent trip")
+    .replace(/\{name\}/g, vars.customerName || "traveller")
+    .replace(/\{url\}/g, vars.reviewUrl || "");
+}
+
+const TEMPLATE = {
+  subject: "How was your trip to {destination}? 🌍",
+  body:
+    "Hi {name},\n\nWelcome back! We hope you had a wonderful trip to {destination}. " +
+    "We'd love to hear how it went — it takes about a minute and helps us make every " +
+    "journey better.\n\nLeave your review here:\n{url}\n\nThank you,\nTeam Travel Stall",
+};
+
+// Build the review-request email. Returns { subject, text, html }.
+function buildRequestEmail({ destination, customerName, reviewUrl }) {
+  const vars = { destination, customerName, reviewUrl };
+  const subject = interp(TEMPLATE.subject, vars);
+  const text = interp(TEMPLATE.body, vars);
+  return { subject, text, html: text.replace(/\n/g, "<br>") };
+}
+
+module.exports = { buildRequestEmail, TEMPLATE };

--- a/backend/lib/travelReviewQuestions.js
+++ b/backend/lib/travelReviewQuestions.js
@@ -1,0 +1,97 @@
+// Post-trip review question set (2026-06-16) — a FIXED set (not admin-built),
+// shared by the public review page (/p/review/:token), the customer portal,
+// and the cron's request email. Question text + the "trip" section title
+// interpolate {destination} so the form reads e.g. "How was your trip to
+// Bali?". Three answer types: rating (1-5 stars), choice (options), text
+// (free / subjective). The fieldType vocabulary mirrors the generic
+// SurveyQuestion model (RATE/SELECT/TEXTAREA) but the questions live in code.
+
+const SECTION_TITLES = {
+  trip: "How was your trip to {destination}?",
+  loyalty: "Customer loyalty",
+  feedback: "Open feedback",
+};
+
+// Ordered. `id` is the stable key stored in TravelTripReview.answersJson.
+const QUESTIONS = [
+  { id: "rate_accommodation", section: "trip", text: "Accommodation & hotels", type: "rating", max: 5, required: true },
+  { id: "rate_transport", section: "trip", text: "Transportation & transfers", type: "rating", max: 5, required: true },
+  { id: "rate_activities", section: "trip", text: "Activities & sightseeing", type: "rating", max: 5, required: true },
+  { id: "rate_support", section: "trip", text: "Tour coordination & support from our team", type: "rating", max: 5, required: true },
+  { id: "rate_value", section: "trip", text: "Value for money", type: "rating", max: 5, required: true },
+  { id: "recommend", section: "loyalty", text: "Would you recommend us to friends & family?", type: "choice", options: ["Definitely", "Maybe", "Probably not"], required: true },
+  { id: "rebook", section: "loyalty", text: "How likely are you to book with us again?", type: "choice", options: ["Definitely", "Maybe", "Unlikely"], required: true },
+  { id: "loved_most", section: "feedback", text: "What did you love most about {destination}?", type: "text", required: false },
+  { id: "improve", section: "feedback", text: "Anything we could have done better?", type: "text", required: false },
+  { id: "highlight", section: "feedback", text: "Do you have a memorable moment or highlight you'd like to share?", type: "text", required: false },
+];
+
+const RATING_IDS = QUESTIONS.filter((q) => q.type === "rating").map((q) => q.id);
+const TEXT_MAX = 2000;
+
+function interp(str, destination) {
+  return String(str).replace(/\{destination\}/g, destination || "your trip");
+}
+
+// Build the destination-interpolated form definition for rendering. Returns
+// { formTitle, sections: [{ key, title, questions:[{id,text,type,options,max,required}] }] }.
+function buildForm(destination) {
+  const order = ["trip", "loyalty", "feedback"];
+  const sections = order.map((key) => ({
+    key,
+    title: interp(SECTION_TITLES[key], destination),
+    questions: QUESTIONS.filter((q) => q.section === key).map((q) => ({
+      id: q.id,
+      text: interp(q.text, destination),
+      type: q.type,
+      ...(q.options ? { options: q.options } : {}),
+      ...(q.max ? { max: q.max } : {}),
+      required: q.required,
+    })),
+  }));
+  return { formTitle: interp(SECTION_TITLES.trip, destination), sections };
+}
+
+// Validate + normalise a raw answers object ({ questionId: value }). Returns
+// { ok, errors: { qid: message }, overallRating, clean }. overallRating is the
+// rounded average of the star answers (or null if none answered).
+function validateSubmission(rawAnswers) {
+  const answers = rawAnswers && typeof rawAnswers === "object" ? rawAnswers : {};
+  const errors = {};
+  const clean = {};
+
+  for (const q of QUESTIONS) {
+    const raw = answers[q.id];
+    const provided = raw !== undefined && raw !== null && String(raw).trim() !== "";
+
+    if (!provided) {
+      if (q.required) errors[q.id] = "This question is required";
+      continue;
+    }
+
+    if (q.type === "rating") {
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n < 1 || n > q.max) {
+        errors[q.id] = `Please give a rating between 1 and ${q.max}`;
+      } else {
+        clean[q.id] = n;
+      }
+    } else if (q.type === "choice") {
+      if (!q.options.includes(String(raw))) {
+        errors[q.id] = "Please choose one of the options";
+      } else {
+        clean[q.id] = String(raw);
+      }
+    } else {
+      // text — trim + cap length
+      clean[q.id] = String(raw).slice(0, TEXT_MAX);
+    }
+  }
+
+  const ratings = RATING_IDS.map((id) => clean[id]).filter((v) => typeof v === "number");
+  const overallRating = ratings.length ? Math.round(ratings.reduce((a, b) => a + b, 0) / ratings.length) : null;
+
+  return { ok: Object.keys(errors).length === 0, errors, overallRating, clean };
+}
+
+module.exports = { QUESTIONS, SECTION_TITLES, RATING_IDS, buildForm, validateSubmission, interp };

--- a/backend/lib/tripCountdownContent.js
+++ b/backend/lib/tripCountdownContent.js
@@ -1,0 +1,119 @@
+// Pre-trip "countdown" nudge content for cron/tripCountdownEngine.js.
+//
+// Cadence (per the 2026-06-16 product call): two early check-ins (T-30, T-14)
+// then a DAILY nudge through the final week (T-7 … T-0). Each day has its own
+// upbeat, on-theme copy so consecutive emails feel fresh ("keep packing").
+//
+// Content source: LLM-generated per email (task "trip-countdown") when the
+// Q11 keys are present; otherwise the deterministic template library below —
+// which already gives distinct copy per day. The LLM path auto-engages once
+// keys land (routeRequest returns stub=false).
+
+const llmRouter = require("./llmRouter");
+
+// Which days-to-go fire a nudge. Newest-to-departure last.
+const FIRE_DAYS = [30, 14, 7, 6, 5, 4, 3, 2, 1, 0];
+
+function shouldFire(daysToGo) {
+  return FIRE_DAYS.includes(daysToGo);
+}
+function dayTag(daysToGo) {
+  return `d${daysToGo}`;
+}
+
+// Per-day creative templates. {dest} + {name} are interpolated.
+const TEMPLATES = {
+  30: {
+    subject: "{dest} in 30 days — let the countdown begin! 🌍",
+    body: "Hi {name},\n\nYour trip to {dest} is just a month away! Now's a great time to start dreaming up your must-dos and sketch a rough plan. We'll check in along the way.\n\nExcited for you,\nTeam Travel Stall",
+  },
+  14: {
+    subject: "Two weeks to {dest}! 📅",
+    body: "Hi {name},\n\n14 days to go! A good moment to confirm your leave, double-check your documents (passport validity, any visas), and start a wishlist of experiences for {dest}.\n\nAlmost there,\nTeam Travel Stall",
+  },
+  7: {
+    subject: "One week to {dest} — time to start packing! 🧳",
+    body: "Hi {name},\n\n{dest} is just 7 days away! Kick off your packing list this week — clothes for the weather, comfy shoes, and anything you can't buy there.\n\nCounting down with you,\nTeam Travel Stall",
+  },
+  6: {
+    subject: "6 days to {dest} ✈️",
+    body: "Hi {name},\n\nSix days! Quick checks today: passport in date, itinerary printed/saved offline, and any bookings confirmed. Smooth sailing from here.\n\nTeam Travel Stall",
+  },
+  5: {
+    subject: "5 days to go — keep packing! 👕",
+    body: "Hi {name},\n\nFive days to {dest}! Lay out your outfits and essentials now so the final days are stress-free. Don't forget the little things — sunscreen, adapters, chargers.\n\nTeam Travel Stall",
+  },
+  4: {
+    subject: "4 days! Pack the easy-to-forget stuff 🔌",
+    body: "Hi {name},\n\nFour days out. Today's tip: gather chargers, plug adapters, any medication, and copies of your key documents. Future-you will thank present-you.\n\nTeam Travel Stall",
+  },
+  3: {
+    subject: "3 days to {dest} — confirm the logistics 🏨",
+    body: "Hi {name},\n\nThree days! Double-check your airport pickup, hotel check-in time, and the first day's plan for {dest}. Everything lining up nicely.\n\nTeam Travel Stall",
+  },
+  2: {
+    subject: "2 days! Money, maps, and music 💱",
+    body: "Hi {name},\n\nTwo days to go! Sort a bit of local currency or a travel card, download offline maps for {dest}, and queue up a playlist for the journey.\n\nTeam Travel Stall",
+  },
+  1: {
+    subject: "Tomorrow's the day! 🎒",
+    body: "Hi {name},\n\nYour {dest} adventure begins tomorrow! Final pack, charge your devices, set an alarm, and get a good night's sleep. We can't wait for you.\n\nTeam Travel Stall",
+  },
+  0: {
+    subject: "Bon voyage — have an amazing trip! 🎉",
+    body: "Hi {name},\n\nToday's the day — safe travels to {dest}! Soak it all in and make wonderful memories. We're just a message away if you need anything.\n\nWith love,\nTeam Travel Stall",
+  },
+};
+
+function interpolate(str, { destination, customerName }) {
+  return String(str)
+    .replace(/\{dest\}/g, destination || "your destination")
+    .replace(/\{name\}/g, customerName || "traveller");
+}
+
+// Deterministic template nudge — the always-available fallback + the unit-test
+// surface. Returns { subject, text, html, llmSourced: false }.
+function buildFallbackNudge({ destination, daysToGo, customerName }) {
+  const tpl = TEMPLATES[daysToGo] || TEMPLATES[0];
+  const subject = interpolate(tpl.subject, { destination, customerName });
+  const text = interpolate(tpl.body, { destination, customerName });
+  return {
+    subject,
+    text,
+    html: text.replace(/\n/g, "<br>"),
+    llmSourced: false,
+  };
+}
+
+// Try the LLM for fresh, personalised copy; fall back to the template on stub
+// mode (no keys), error, or unparseable output. Never throws.
+async function buildNudge({ tenantId, destination, daysToGo, customerName }) {
+  try {
+    const result = await llmRouter.routeRequest({
+      task: "trip-countdown",
+      tenantId,
+      payload: {
+        destination,
+        daysToGo,
+        customerName,
+        instruction:
+          "Write a short, warm, upbeat pre-trip reminder email as JSON " +
+          '{"subject":"...","body":"..."}. One emoji max in the subject. ' +
+          "Mention the destination and the days-to-go. Keep the body under 80 words.",
+      },
+    });
+    if (result && !result.stub && result.text) {
+      const parsed = JSON.parse(result.text);
+      if (parsed && parsed.subject && parsed.body) {
+        const subject = interpolate(parsed.subject, { destination, customerName });
+        const text = interpolate(parsed.body, { destination, customerName });
+        return { subject, text, html: text.replace(/\n/g, "<br>"), llmSourced: true };
+      }
+    }
+  } catch {
+    /* fall through to template */
+  }
+  return buildFallbackNudge({ destination, daysToGo, customerName });
+}
+
+module.exports = { FIRE_DAYS, shouldFire, dayTag, buildFallbackNudge, buildNudge, TEMPLATES };

--- a/backend/lib/webCheckinContent.js
+++ b/backend/lib/webCheckinContent.js
@@ -1,0 +1,69 @@
+// Web check-in reminder EMAIL copy for cron/webCheckinEngine.js.
+//
+// This is the CUSTOMER-FACING email layer that complements the existing
+// cron/webCheckinScheduler.js (which owns the WebCheckin status lifecycle +
+// the WhatsApp nudge + agent fallback). Both read the same WebCheckin rows —
+// single source of truth. These emails fire 3 times, 12h apart, before the
+// flight's `departureAt`: T-36h (heads-up), T-24h (check-in open), T-12h (last
+// call). Each links to the customer portal, where "Yes, I've checked in" flips
+// the WebCheckin row(s) to `done` so BOTH this engine and the scheduler stop.
+//
+// TEMPLATE-only (no LLM): web check-in is procedural; wording must be clear and
+// consistent. Counts down from the flight's real `departureAt`.
+
+// Hour milestones before `departureAt` that fire a reminder. Disjoint 12h
+// windows: 36 → (24,36], 24 → (12,24], 12 → (0,12].
+const MILESTONES = [36, 24, 12];
+
+function milestoneTag(hours) {
+  return `h${hours}`;
+}
+
+// Which milestone (if any) the given hours-to-departure falls into. Returns the
+// milestone number (36/24/12) or null when outside every window.
+function dueMilestone(hoursToGo) {
+  for (const m of MILESTONES) {
+    if (hoursToGo <= m && hoursToGo > m - 12) return m;
+  }
+  return null;
+}
+
+function flightLabel({ airlineCode, flightNumber }) {
+  const code = [airlineCode, flightNumber].filter(Boolean).join(" ").trim();
+  return code || "your flight";
+}
+
+const TEMPLATES = {
+  36: {
+    subject: "Web check-in for {flight} opens soon ✈️",
+    body: "Hi {name},\n\nYour flight {flight} (PNR {pnr}) departs in about 36 hours. Online web check-in usually opens 24 hours before departure — keep your passport/ID handy.\n\nOnce you've checked in with the airline, open your portal and tap \"Yes, I've checked in\" so we can stop reminding you:\n{portalUrl}\n\nSafe travels,\nTeam Travel Stall",
+  },
+  24: {
+    subject: "Web check-in is open for {flight}",
+    body: "Hi {name},\n\nWeb check-in for {flight} (PNR {pnr}) should now be open. Please check in online, choose your seats, and save your boarding pass.\n\nAlready done it? Confirm in your portal so we stop the reminders:\n{portalUrl}\n\nTeam Travel Stall",
+  },
+  12: {
+    subject: "Last reminder: web check-in for {flight}",
+    body: "Hi {name},\n\nThis is your final reminder to complete web check-in for {flight} (PNR {pnr}) before you head to the airport — it only takes a couple of minutes online.\n\nWhen you're done, mark it in your portal to stop these reminders:\n{portalUrl}\n\nHave a wonderful trip,\nTeam Travel Stall",
+  },
+};
+
+function interpolate(str, vars) {
+  return String(str)
+    .replace(/\{name\}/g, vars.passengerName || "traveller")
+    .replace(/\{flight\}/g, vars.flight || "your flight")
+    .replace(/\{pnr\}/g, vars.pnr || "—")
+    .replace(/\{portalUrl\}/g, vars.portalUrl || "your customer portal");
+}
+
+// Build the reminder email for a given milestone from a WebCheckin row's
+// fields. Returns { subject, text, html }.
+function buildReminder({ passengerName, airlineCode, flightNumber, pnr, milestone, portalUrl }) {
+  const tpl = TEMPLATES[milestone] || TEMPLATES[12];
+  const vars = { passengerName, flight: flightLabel({ airlineCode, flightNumber }), pnr, portalUrl };
+  const subject = interpolate(tpl.subject, vars);
+  const text = interpolate(tpl.body, vars);
+  return { subject, text, html: text.replace(/\n/g, "<br>") };
+}
+
+module.exports = { MILESTONES, milestoneTag, dueMilestone, flightLabel, buildReminder, TEMPLATES };

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -187,6 +187,7 @@ model Tenant {
   travelMarkupRules                   TravelMarkupRule[]
   tmcTrips                            TmcTrip[]
   webCheckins                         WebCheckin[]
+  travelTripReviews                   TravelTripReview[]
   supplierCredentials                 SupplierCredential[]
   visaApplications                    VisaApplication[]
   // G107 — RejectionRecoveryProgram back-relation (PRD_VISA_SURE_PHASE_3 §FR-7).
@@ -5627,6 +5628,13 @@ model Itinerary {
   advancePaidAmount    Decimal?        @db.Decimal(15, 2)
   advancePaidAt        DateTime?
   paymentReference     String?
+  // Pay-or-cancel deposit deadline (2026-06-16). Set by cron/paymentDeadlineEngine
+  // when an `accepted`-but-unpaid itinerary passes its T-7 deposit deadline
+  // (startDate - 7d) without the 50% advance — i.e. it's now overdue/at-risk.
+  // Drives the advisor at-risk badge + the "review for cancellation" flag.
+  // Nullable + additive; the engine never auto-changes status (advisor sets
+  // "expired" manually). Cleared back to null if a late payment lands.
+  paymentOverdueAt     DateTime?
   // Customer's reason/feedback when they DECLINE an offer (PRD §6.1). Free
   // text the customer enters in the portal so the advisor knows what to
   // improve. Nullable; only set on a customer decline.
@@ -6129,6 +6137,11 @@ model WebCheckin {
   mealPref        String?
   status          String    @default("pending") // pending | reminded | in-progress | done | fallback-agent | failed
   attemptsJson    String?   @db.Text // [{at, result, errorReason}]
+  // Customer-facing web check-in reminder EMAILS sent by cron/webCheckinEngine.js
+  // (2026-06-16) — distinct from the scheduler's WhatsApp/status lifecycle.
+  // JSON array of milestone tags already emailed: e.g. ["h36","h24"] (T-36/24/12h
+  // before departureAt). Idempotency guard so a re-tick doesn't double-send.
+  emailRemindersJson String? @db.Text
   boardingPassUrl String?
   deliveredAt     DateTime?
   assignedAgentId Int?
@@ -6137,6 +6150,32 @@ model WebCheckin {
   updatedAt       DateTime  @updatedAt
 
   @@index([tenantId, status, windowOpenAt])
+  @@index([tenantId, contactId])
+}
+
+/// Post-trip customer review (2026-06-16). One per completed itinerary. The
+/// cron/travelReviewEngine.js creates a row (status "requested" + a public
+/// token) ~after the trip's endDate passes and emails the customer a review
+/// link; the customer submits via the public page (/p/review/:token) OR the
+/// logged-in portal — both write the same row. Questions are a fixed set in
+/// lib/travelReviewQuestions.js ({destination}-interpolated); answersJson holds
+/// the structured submission and overallRating is the rounded average of the
+/// star ratings (headline metric for advisor reporting). All sub-brands except
+/// Visa Sure.
+model TravelTripReview {
+  id            Int       @id @default(autoincrement())
+  tenantId      Int       @default(1)
+  itineraryId   Int       @unique // one review per trip
+  contactId     Int
+  token         String    @unique // public review-link slug
+  status        String    @default("requested") // requested | submitted
+  overallRating Int? // rounded avg of the 1-5 star answers (set on submit)
+  answersJson   String?   @db.Text // { questionId: value } for the full submission
+  requestedAt   DateTime  @default(now())
+  submittedAt   DateTime?
+  tenant        Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, status])
   @@index([tenantId, contactId])
 }
 
@@ -6319,6 +6358,48 @@ model EmailVerificationOtp {
   createdAt DateTime  @default(now())
 
   @@index([email, purpose])
+}
+
+/// Idempotency + audit ledger for pre-trip "countdown" nudge emails fired by
+/// cron/tripCountdownEngine.js. One row per (itinerary, day-bucket) — the
+/// @@unique guarantees a given day's nudge is sent at most once even if the
+/// hourly cron ticks multiple times that day. Tenant-scoped (derived from the
+/// itinerary).
+model TripCountdownNudge {
+  id          Int      @id @default(autoincrement())
+  tenantId    Int
+  itineraryId Int
+  dayTag      String // "d30" | "d14" | "d7" … "d0"
+  channel     String   @default("email")
+  status      String   @default("sent") // sent | failed | logged (no email key)
+  subject     String?  @db.Text
+  llmSourced  Boolean  @default(false) // true when copy came from the LLM (not the template fallback)
+  sentAt      DateTime @default(now())
+
+  @@unique([itineraryId, dayTag])
+  @@index([tenantId, itineraryId])
+}
+
+/// Pay-or-cancel deposit-deadline nudges (2026-06-16). For an `accepted` (but
+/// not yet paid) itinerary that owes a 50% deposit, the paymentDeadlineEngine
+/// chases the customer T-10 → T-7 (deadline = startDate - 7d) then, if still
+/// unpaid at T-6, flags the advisor + warns the customer (no auto-cancel —
+/// an advisor manually sets status "expired" to cancel). One row per
+/// (itineraryId, dayTag); dayTag ∈ {d10,d9,d8,d7,overdue}. Kept distinct from
+/// TripCountdownNudge so a later packing-d7 row can't collide with a payment-d7.
+model PaymentDeadlineNudge {
+  id          Int      @id @default(autoincrement())
+  tenantId    Int
+  itineraryId Int
+  dayTag      String // "d10" | "d9" | "d8" | "d7" | "overdue"
+  channel     String   @default("email")
+  status      String   @default("sent") // sent | failed | logged (no email key) | flagged (overdue advisor notice)
+  subject     String?  @db.Text
+  llmSourced  Boolean  @default(false)
+  sentAt      DateTime @default(now())
+
+  @@unique([itineraryId, dayTag])
+  @@index([tenantId, itineraryId])
 }
 
 /// Per-destination embassy quirks for Visa Sure risk-flag engine. PRD §PC-3 resolved 2026-05-24: Phase 3 in-scope structured rules; advisor-head + admin UI maintainer (PC-7).

--- a/backend/routes/portal.js
+++ b/backend/routes/portal.js
@@ -12,6 +12,7 @@ const { scoreDiagnostic, parseBank } = require("../lib/travelDiagnosticScoring")
 const { notifyMany } = require("../lib/notificationService");
 const { writeAudit } = require("../lib/audit");
 const visaDocStore = require("../lib/visaDocStore");
+const { buildForm: buildReviewForm, validateSubmission: validateReviewSubmission } = require("../lib/travelReviewQuestions");
 
 // Memory-storage multer for the travel customer's profile avatar — 5 MB cap,
 // image-only (s3Service.uploadImage re-gates the mimetype). Mirrors the staff
@@ -463,7 +464,48 @@ router.get("/travel/itineraries", verifyPortalToken, requireTravelPortalTenant, 
         items: { orderBy: { position: "asc" } },
       },
     });
-    res.json(itineraries);
+    // Attach a web-check-in "due" flag per trip: any active WebCheckin row
+    // (pending/reminded) whose flight departs within the next 36h. Drives the
+    // portal's "Have you checked in? Yes/No" banner (2026-06-16). The Yes
+    // action flips those rows to "done" → flag clears + reminders stop.
+    const ids = itineraries.map((i) => i.id);
+    let dueByItin = {};
+    if (ids.length) {
+      const now = new Date();
+      const horizon = new Date(now.getTime() + 37 * 3600000);
+      const wcRows = await prisma.webCheckin.findMany({
+        where: {
+          tenantId: req.portal.tenantId,
+          itineraryId: { in: ids },
+          status: { in: ["pending", "reminded"] },
+          departureAt: { gte: now, lte: horizon },
+        },
+        select: { itineraryId: true },
+      });
+      dueByItin = Object.fromEntries(wcRows.map((w) => [w.itineraryId, true]));
+    }
+    // Post-trip review state per trip (2026-06-16): "submitted" | "available"
+    // (trip ended + paid + non-visasure, not yet reviewed) | "none". Drives the
+    // portal "Leave a review" surface on completed trips.
+    let reviewByItin = {};
+    if (ids.length) {
+      const rows = await prisma.travelTripReview.findMany({
+        where: { tenantId: req.portal.tenantId, itineraryId: { in: ids } },
+        select: { itineraryId: true, status: true },
+      });
+      reviewByItin = Object.fromEntries(rows.map((r) => [r.itineraryId, r.status]));
+    }
+    const nowMs = Date.now();
+    const reviewState = (i) => {
+      if (reviewByItin[i.id] === "submitted") return "submitted";
+      const ended = i.endDate && new Date(i.endDate).getTime() < nowMs;
+      // Any committed booking (accepted / paid) is reviewable once it's over —
+      // payment state doesn't gate a review. Matches cron/travelReviewEngine.js.
+      const committed = ["accepted", "advance_paid", "fully_paid"].includes(i.status);
+      if (ended && committed && i.subBrand !== "visasure") return "available";
+      return "none";
+    };
+    res.json(itineraries.map((i) => ({ ...i, webCheckinDue: Boolean(dueByItin[i.id]), reviewState: reviewState(i) })));
   } catch (err) {
     console.error("[Portal][travel/itineraries]", err);
     res.status(500).json({ error: "Failed to fetch itineraries" });
@@ -623,6 +665,95 @@ router.post("/travel/itineraries/:id/decline", verifyPortalToken, requireTravelP
   } catch (err) {
     console.error("[Portal][travel/itin decline]", err);
     res.status(500).json({ error: "Failed to decline this trip" });
+  }
+});
+
+// POST /api/portal/travel/itineraries/:id/webcheckin-confirm
+//
+// The customer's "Yes, I've checked in" action for a flight trip (2026-06-16).
+// Flips every still-active WebCheckin row for this trip → status "done" — the
+// SAME rows the existing webCheckinScheduler + the email engine read, so this
+// one confirm stops BOTH (no more reminder emails, no agent-fallback
+// escalation). Ownership verified by loadPortalOwnedItinerary. Idempotent: if
+// no active rows remain it's a no-op success (updated: 0).
+router.post("/travel/itineraries/:id/webcheckin-confirm", verifyPortalToken, requireTravelPortalTenant, async (req, res) => {
+  try {
+    const itin = await loadPortalOwnedItinerary(req, res);
+    if (!itin) return;
+    const result = await prisma.webCheckin.updateMany({
+      where: {
+        itineraryId: itin.id,
+        tenantId: req.portal.tenantId,
+        status: { in: ["pending", "reminded"] },
+      },
+      data: { status: "done" },
+    });
+    res.json({ id: itin.id, confirmed: true, updated: result.count });
+  } catch (err) {
+    console.error("[Portal][travel/itin webcheckin-confirm]", err);
+    res.status(500).json({ error: "Failed to confirm web check-in" });
+  }
+});
+
+// GET /api/portal/travel/itineraries/:id/review
+// Returns the (destination-interpolated) review form + the customer's current
+// review state for their OWN completed trip. (2026-06-16)
+router.get("/travel/itineraries/:id/review", verifyPortalToken, requireTravelPortalTenant, async (req, res) => {
+  try {
+    const itin = await loadPortalOwnedItinerary(req, res);
+    if (!itin) return;
+    const existing = await prisma.travelTripReview.findUnique({
+      where: { itineraryId: itin.id },
+      select: { status: true, overallRating: true },
+    });
+    const destination = itin.destination || "your trip";
+    res.json({
+      destination,
+      status: existing ? existing.status : "available",
+      alreadySubmitted: existing ? existing.status === "submitted" : false,
+      overallRating: existing ? existing.overallRating : null,
+      form: buildReviewForm(destination),
+    });
+  } catch (err) {
+    console.error("[Portal][travel/itin review get]", err);
+    res.status(500).json({ error: "Failed to load review" });
+  }
+});
+
+// POST /api/portal/travel/itineraries/:id/review
+// The logged-in customer submits a review for their OWN trip. Upserts the
+// TravelTripReview row (the cron may have already created one in "requested"
+// state; if not, we create it). Idempotent: a re-submit on an already-submitted
+// trip returns 409. (2026-06-16)
+router.post("/travel/itineraries/:id/review", verifyPortalToken, requireTravelPortalTenant, async (req, res) => {
+  try {
+    const itin = await loadPortalOwnedItinerary(req, res);
+    if (!itin) return;
+    const { ok, errors, overallRating, clean } = validateReviewSubmission(req.body && req.body.answers);
+    if (!ok) return res.status(400).json({ error: "Some answers need attention", code: "INVALID_ANSWERS", errors });
+
+    const existing = await prisma.travelTripReview.findUnique({ where: { itineraryId: itin.id }, select: { id: true, status: true } });
+    if (existing && existing.status === "submitted") {
+      return res.status(409).json({ error: "You've already reviewed this trip — thank you!", code: "ALREADY_SUBMITTED" });
+    }
+    const data = { status: "submitted", overallRating, answersJson: JSON.stringify(clean), submittedAt: new Date() };
+    if (existing) {
+      await prisma.travelTripReview.update({ where: { id: existing.id }, data });
+    } else {
+      await prisma.travelTripReview.create({
+        data: {
+          tenantId: req.portal.tenantId,
+          itineraryId: itin.id,
+          contactId: req.portal.contactId,
+          token: crypto.randomBytes(24).toString("base64url"),
+          ...data,
+        },
+      });
+    }
+    res.status(201).json({ ok: true, overallRating });
+  } catch (err) {
+    console.error("[Portal][travel/itin review submit]", err);
+    res.status(500).json({ error: "Failed to submit review" });
   }
 });
 

--- a/backend/routes/travel_itineraries.js
+++ b/backend/routes/travel_itineraries.js
@@ -84,6 +84,10 @@ const { recordDocumentAccess } = require("../lib/documentAccessAudit");
 // (clamp 1..30 days, default 7; revoked > expired > active precedence)
 // unit-tested in test/lib/shareLinkPolicy.test.js.
 const { computeShareExpiresAt, shareLinkState } = require("../lib/shareLinkPolicy");
+// BYOK: customer payments settle into the TENANT's own Razorpay account (our
+// platform RAZORPAY_KEY_* env vars are ONLY for tenant→Globussoft subscription
+// billing). Mirrors the wellness customer-payment flow. See lib/tenantPaymentGateway.js.
+const { getTenantRazorpayClient, getTenantRazorpayCreds, NOT_CONFIGURED_MESSAGE } = require("../lib/tenantPaymentGateway");
 
 // Covers fly + non-fly (domestic) transport and general trip expenses. Keep
 // in sync with ITEM_TYPES in frontend/src/pages/travel/ItineraryDetail.jsx.
@@ -94,8 +98,14 @@ const VALID_ITEM_TYPES = [
 // Phase 2 (PRD §4.7) extends the enum with advance_paid / fully_paid for
 // the 50%-advance booking flow. Existing draft/sent/etc. semantics
 // unchanged — the two new values are only set by the public payment
-// endpoints. Routes that PATCH status accept all 7 values.
-const VALID_STATUSES = ["draft", "sent", "revised", "accepted", "rejected", "advance_paid", "fully_paid"];
+// endpoints. Routes that PATCH status accept all values.
+//
+// `expired` (2026-06-16): advisor-set terminal status for a booking
+// auto-flagged by cron/paymentDeadlineEngine.js as deposit-overdue. Kept
+// distinct from `rejected` (customer declined) so non-payment cancellations
+// are reportable separately. The engine never sets it — an advisor PATCHes
+// to "expired" after reviewing the overdue flag (no auto-cancel by design).
+const VALID_STATUSES = ["draft", "sent", "revised", "accepted", "rejected", "advance_paid", "fully_paid", "expired"];
 // Advance-deposit ratio is now per-tenant + per-sub-brand tunable via
 // the TenantSetting table — see lib/tenantSettings.js. The Phase 2
 // baseline (Travel Stall 50/50) is the helper's hard-coded fallback
@@ -3806,6 +3816,11 @@ router.get("/itineraries/public/:shareToken", async (req, res) => {
     const advanceDue = total > 0 ? Math.round(total * advanceRatio * 100) / 100 : 0;
     const advancePaid = itin.advancePaidAmount ? Number(itin.advancePaidAmount) : 0;
     const balanceDue = Math.max(0, total - advancePaid);
+    // Online pay button only shows when the TENANT has configured + activated
+    // its OWN Razorpay keys (BYOK). Otherwise the customer can't pay online here
+    // — the advisor arranges payment offline. (Our platform keys are never used
+    // for customer payments — they're subscription-billing only.)
+    const onlinePaymentEnabled = (await getTenantRazorpayCreds(itin.tenantId)) !== null;
     res.json({
       shareToken: itin.shareToken,
       tenantName: itin.tenant?.name || null,
@@ -3822,6 +3837,7 @@ router.get("/itineraries/public/:shareToken", async (req, res) => {
       advancePaid,
       advancePaidAt: itin.advancePaidAt,
       balanceDue,
+      onlinePaymentEnabled,
       items: itin.items.map(publicItemProjection),
       pdfUrl: itin.pdfUrl,
       // PRD §4.3 — operator-generated executive summary block (null
@@ -3905,6 +3921,10 @@ router.post("/itineraries/public/:shareToken/record-advance-payment", async (req
         advancePaidAmount: newAdvanceTotal,
         advancePaidAt: new Date(),
         paymentReference: String(paymentReference),
+        // Deposit landed → clear any pay-or-cancel at-risk flag set by
+        // cron/paymentDeadlineEngine.js (keeps the advisor at-risk badge honest
+        // if the customer pays late).
+        paymentOverdueAt: null,
       },
     });
 
@@ -3936,18 +3956,6 @@ router.post("/itineraries/public/:shareToken/record-advance-payment", async (req
 //
 // Both are allow-listed via the `/travel/itineraries/public` openPath prefix.
 
-let _platformRzp = null;
-function getPlatformRazorpay() {
-  const keyId = process.env.RAZORPAY_KEY_ID;
-  const keySecret = process.env.RAZORPAY_KEY_SECRET;
-  if (!keyId || !keySecret) return null;
-  if (!_platformRzp) {
-    const Razorpay = require("razorpay");
-    _platformRzp = new Razorpay({ key_id: keyId, key_secret: keySecret });
-  }
-  return { client: _platformRzp, keyId, keySecret };
-}
-
 // Amount (major units) due for a given payment kind on a shared itinerary.
 async function resolveDueAmount(itin, kind) {
   const total = itin.totalAmount ? Number(itin.totalAmount) : 0;
@@ -3965,15 +3973,17 @@ router.post("/itineraries/public/:shareToken/create-payment-order", async (req, 
     if (!token || token.length < 16) {
       return res.status(400).json({ error: "shareToken required", code: "MISSING_TOKEN" });
     }
-    const rp = getPlatformRazorpay();
-    if (!rp) {
-      return res.status(503).json({ error: "Online payment is not configured", code: "GATEWAY_NOT_CONFIGURED" });
-    }
     const itin = await prisma.itinerary.findUnique({ where: { shareToken: token } });
     if (!itin) return res.status(404).json({ error: "Itinerary not found", code: "NOT_FOUND" });
     if (itin.status === "draft") return res.status(409).json({ error: "Itinerary not yet shared", code: "NOT_SHARED" });
     if (itin.status === "rejected" || itin.status === "fully_paid") {
       return res.status(409).json({ error: `Cannot pay against an itinerary in '${itin.status}' status`, code: "INVALID_STATE" });
+    }
+    // Customer pays into the TENANT's own Razorpay account — never the platform's.
+    // No (or inactive) tenant keys → block the payment with a clear message.
+    const rp = await getTenantRazorpayClient(itin.tenantId);
+    if (!rp) {
+      return res.status(503).json({ error: NOT_CONFIGURED_MESSAGE, code: "GATEWAY_NOT_CONFIGURED" });
     }
     const kind = req.body && req.body.kind === "balance" ? "balance" : "advance";
     const due = await resolveDueAmount(itin, kind);
@@ -4015,13 +4025,18 @@ router.post("/itineraries/public/:shareToken/verify-payment", async (req, res) =
     if (!token || token.length < 16) {
       return res.status(400).json({ error: "shareToken required", code: "MISSING_TOKEN" });
     }
-    const rp = getPlatformRazorpay();
-    if (!rp) {
-      return res.status(503).json({ error: "Online payment is not configured", code: "GATEWAY_NOT_CONFIGURED" });
-    }
     const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = req.body || {};
     if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature) {
       return res.status(400).json({ error: "Missing payment fields", code: "MISSING_FIELDS" });
+    }
+    const itin = await prisma.itinerary.findUnique({ where: { shareToken: token } });
+    if (!itin) return res.status(404).json({ error: "Itinerary not found", code: "NOT_FOUND" });
+    if (itin.status === "draft") return res.status(409).json({ error: "Itinerary not yet shared", code: "NOT_SHARED" });
+    // Resolve the TENANT's own Razorpay keys (the order was created with them)
+    // and verify the checkout signature against the TENANT's key secret.
+    const rp = await getTenantRazorpayClient(itin.tenantId);
+    if (!rp) {
+      return res.status(503).json({ error: NOT_CONFIGURED_MESSAGE, code: "GATEWAY_NOT_CONFIGURED" });
     }
     // Verify checkout signature: HMAC-SHA256(order_id|payment_id, key_secret).
     const expected = crypto
@@ -4035,10 +4050,6 @@ router.post("/itineraries/public/:shareToken/verify-payment", async (req, res) =
     if (!ok) {
       return res.status(400).json({ error: "Payment verification failed", code: "BAD_SIGNATURE" });
     }
-
-    const itin = await prisma.itinerary.findUnique({ where: { shareToken: token } });
-    if (!itin) return res.status(404).json({ error: "Itinerary not found", code: "NOT_FOUND" });
-    if (itin.status === "draft") return res.status(409).json({ error: "Itinerary not yet shared", code: "NOT_SHARED" });
 
     const total = itin.totalAmount ? Number(itin.totalAmount) : 0;
 
@@ -4077,6 +4088,9 @@ router.post("/itineraries/public/:shareToken/verify-payment", async (req, res) =
         advancePaidAmount: newTotalPaid,
         advancePaidAt: new Date(),
         paymentReference: String(razorpay_payment_id),
+        // Deposit landed → clear any pay-or-cancel at-risk flag (see
+        // cron/paymentDeadlineEngine.js).
+        paymentOverdueAt: null,
       },
     });
     res.status(201).json({

--- a/backend/routes/travel_reviews.js
+++ b/backend/routes/travel_reviews.js
@@ -1,0 +1,121 @@
+// Travel CRM — post-trip review routes (2026-06-16).
+//
+//   PUBLIC (no auth, token-gated — for the email link → /p/review/:token):
+//     GET  /api/travel/reviews/public/:token         → form + destination + state
+//     POST /api/travel/reviews/public/:token/submit  → store the submission
+//
+//   ADVISOR (verifyToken + requireTravelTenant):
+//     GET  /api/travel/reviews                        → submitted reviews (sub-brand scoped)
+//
+// The portal has its own logged-in submit path (routes/portal.js) that writes
+// the SAME TravelTripReview row. Questions are the fixed set in
+// lib/travelReviewQuestions.js with {destination} woven in.
+
+const express = require("express");
+const router = express.Router();
+const prisma = require("../lib/prisma");
+const { verifyToken } = require("../middleware/auth");
+const { requireTravelTenant, getSubBrandAccessSet, canAccessSubBrand } = require("../middleware/travelGuards");
+const { buildForm, validateSubmission } = require("../lib/travelReviewQuestions");
+
+// ── PUBLIC — fetch the form (by review token) ────────────────────────
+router.get("/reviews/public/:token", async (req, res) => {
+  try {
+    const token = String(req.params.token || "");
+    const review = await prisma.travelTripReview.findUnique({
+      where: { token },
+      select: { id: true, status: true, itineraryId: true, overallRating: true },
+    });
+    if (!review) return res.status(404).json({ error: "Review link not found", code: "NOT_FOUND" });
+
+    const itin = await prisma.itinerary.findUnique({
+      where: { id: review.itineraryId },
+      select: { destination: true },
+    });
+    const destination = (itin && itin.destination) || "your trip";
+    res.json({
+      destination,
+      status: review.status, // "requested" | "submitted"
+      alreadySubmitted: review.status === "submitted",
+      overallRating: review.overallRating,
+      form: buildForm(destination),
+    });
+  } catch (e) {
+    console.error("[travel-reviews] public get error:", e.message);
+    res.status(500).json({ error: "Failed to load review" });
+  }
+});
+
+// ── PUBLIC — submit the review (by token) ────────────────────────────
+router.post("/reviews/public/:token/submit", async (req, res) => {
+  try {
+    const token = String(req.params.token || "");
+    const review = await prisma.travelTripReview.findUnique({
+      where: { token },
+      select: { id: true, status: true },
+    });
+    if (!review) return res.status(404).json({ error: "Review link not found", code: "NOT_FOUND" });
+    if (review.status === "submitted") {
+      return res.status(409).json({ error: "This review has already been submitted — thank you!", code: "ALREADY_SUBMITTED" });
+    }
+
+    const { ok, errors, overallRating, clean } = validateSubmission(req.body && req.body.answers);
+    if (!ok) return res.status(400).json({ error: "Some answers need attention", code: "INVALID_ANSWERS", errors });
+
+    await prisma.travelTripReview.update({
+      where: { id: review.id },
+      data: { status: "submitted", overallRating, answersJson: JSON.stringify(clean), submittedAt: new Date() },
+    });
+    res.status(201).json({ ok: true, overallRating });
+  } catch (e) {
+    console.error("[travel-reviews] public submit error:", e.message);
+    res.status(500).json({ error: "Failed to submit review" });
+  }
+});
+
+// ── ADVISOR — list submitted reviews (sub-brand scoped) ──────────────
+router.get("/reviews", verifyToken, requireTravelTenant, async (req, res) => {
+  try {
+    const reviews = await prisma.travelTripReview.findMany({
+      where: { tenantId: req.travelTenant.id, status: "submitted" },
+      orderBy: { submittedAt: "desc" },
+      take: 200,
+      select: { id: true, itineraryId: true, contactId: true, overallRating: true, answersJson: true, submittedAt: true },
+    });
+    // Enrich with the itinerary's destination + sub-brand AND the reviewer's
+    // contact details (name/email — so the advisor sees WHO left it), then
+    // filter by the caller's sub-brand access.
+    const itinIds = [...new Set(reviews.map((r) => r.itineraryId))];
+    const itins = itinIds.length
+      ? await prisma.itinerary.findMany({ where: { id: { in: itinIds } }, select: { id: true, destination: true, subBrand: true } })
+      : [];
+    const itinById = Object.fromEntries(itins.map((i) => [i.id, i]));
+    const contactIds = [...new Set(reviews.map((r) => r.contactId).filter(Boolean))];
+    const contacts = contactIds.length
+      ? await prisma.contact.findMany({ where: { id: { in: contactIds } }, select: { id: true, name: true, email: true, phone: true } })
+      : [];
+    const contactById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+    const allowed = await getSubBrandAccessSet(req.user.userId);
+    const out = reviews
+      .map((r) => {
+        const it = itinById[r.itineraryId] || {};
+        const c = contactById[r.contactId] || {};
+        return {
+          ...r,
+          destination: it.destination || null,
+          subBrand: it.subBrand || null,
+          contactName: c.name || null,
+          contactEmail: c.email || null,
+          contactPhone: c.phone || null,
+          answers: r.answersJson ? JSON.parse(r.answersJson) : {},
+        };
+      })
+      .filter((r) => !r.subBrand || canAccessSubBrand(allowed, r.subBrand));
+    res.json({ reviews: out, total: out.length });
+  } catch (e) {
+    console.error("[travel-reviews] advisor list error:", e.message);
+    res.status(500).json({ error: "Failed to list reviews" });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -623,6 +623,7 @@ const travelReligiousPacketsRoutes = require("./routes/travel_religious_packets"
 const travelPricingRoutes = require("./routes/travel_pricing");
 const travelTripBillingRoutes = require("./routes/travel_trip_billing");
 const travelWebcheckinRoutes = require("./routes/travel_webcheckin");
+const travelReviewsRoutes = require("./routes/travel_reviews");
 const travelCsvIoRoutes = require("./routes/travel_csv_io");
 const travelDashboardRoutes = require("./routes/travel_dashboard");
 const travelReportsRoutes = require("./routes/travel_reports");
@@ -745,7 +746,7 @@ app.use("/api", (req, res, next) => {
   // promotes a contact to a portal user. Removing the entry routes the
   // unauthenticated case through the global guard's 401 (RFC 7235), and
   // the authenticated case continues unaffected.
-  const openPaths = ["/auth/login", "/auth/signup", "/auth/register", "/auth/customer/register", "/auth/email-otp", "/auth/check-email", "/auth/public/tenants", "/auth/forgot-password", "/auth/reset-password", "/auth/2fa/verify", "/health", "/marketplace-leads/webhook", "/sms/webhook", "/whatsapp/webhook", "/telephony/webhook", "/push/subscribe/visitor", "/push/vapid-key", "/communications/track/", "/sso/google/callback", "/sso/microsoft/callback", "/sso/google/start", "/sso/microsoft/start", "/email/inbound", "/calendar/google/callback", "/calendar/outlook/callback", "/voice/webhook", "/portal/login", "/portal/register", "/portal/forgot", "/portal/reset", "/portal/me", "/portal/tickets", "/portal/invoices", "/portal/contracts", "/portal/travel", "/portal/kyc", "/signatures/sign", "/surveys/respond", "/surveys/public", "/chatbots/chat", "/web-visitors/track", "/payments/webhook", "/accounting/webhook", "/scim/v2", "/booking-pages/public", "/knowledge-base/public", "/live-chat/visitor", "/document-views/track", "/zapier/webhook", "/marketing/submit", "/v1/external", "/v1/voyagr", "/v1/flight-plugin", "/wellness/public", "/wellness/portal", "/attendance/biometric/webhook", "/travel/microsites/public", "/travel/diagnostics/public", "/travel/itineraries/public", "/travel/inbound/leads", "/travel/whatsapp/webhook", "/travel/whatsapp/media", "/v1/flyers/public", "/security/csp-report", "/privacy-policy", "/deleted-account-policy", "/terms-and-conditions", "/legal"];
+  const openPaths = ["/auth/login", "/auth/signup", "/auth/register", "/auth/customer/register", "/auth/email-otp", "/auth/check-email", "/auth/public/tenants", "/auth/forgot-password", "/auth/reset-password", "/auth/2fa/verify", "/health", "/marketplace-leads/webhook", "/sms/webhook", "/whatsapp/webhook", "/telephony/webhook", "/push/subscribe/visitor", "/push/vapid-key", "/communications/track/", "/sso/google/callback", "/sso/microsoft/callback", "/sso/google/start", "/sso/microsoft/start", "/email/inbound", "/calendar/google/callback", "/calendar/outlook/callback", "/voice/webhook", "/portal/login", "/portal/register", "/portal/forgot", "/portal/reset", "/portal/me", "/portal/tickets", "/portal/invoices", "/portal/contracts", "/portal/travel", "/portal/kyc", "/signatures/sign", "/surveys/respond", "/surveys/public", "/chatbots/chat", "/web-visitors/track", "/payments/webhook", "/accounting/webhook", "/scim/v2", "/booking-pages/public", "/knowledge-base/public", "/live-chat/visitor", "/document-views/track", "/zapier/webhook", "/marketing/submit", "/v1/external", "/v1/voyagr", "/v1/flight-plugin", "/wellness/public", "/wellness/portal", "/attendance/biometric/webhook", "/travel/microsites/public", "/travel/diagnostics/public", "/travel/itineraries/public", "/travel/reviews/public", "/travel/inbound/leads", "/travel/whatsapp/webhook", "/travel/whatsapp/media", "/v1/flyers/public", "/security/csp-report", "/privacy-policy", "/deleted-account-policy", "/terms-and-conditions", "/legal"];
   if (openPaths.some(p => req.path.startsWith(p))) return next();
   // Public marketing catalog — the /pricing page hits GET /subscriptions/plans
   // anonymously. Admin CRUD (POST/PUT/DELETE + GET /plans/admin) stays gated
@@ -964,6 +965,7 @@ app.use("/api/travel", travelReportsRoutes);
 app.use("/api/travel", travelDiagnosticsRoutes);
 app.use("/api/travel/visa/analytics", travelVisaAnalyticsRoutes);
 app.use("/api/travel/visa", travelVisaRoutes);
+app.use("/api/travel", travelReviewsRoutes); // literal /reviews paths — mount before parametric itinerary routes
 app.use("/api/travel", travelItinerariesRoutes);
 app.use("/api/travel", travelTripsRoutes);
 // Slice C2 — passport OCR upload + verification queue (stub-mode pending PC-1).
@@ -1552,6 +1554,41 @@ if (process.env.DISABLE_CRONS === '1') {
   // visible Phase 1 output.
   const { initTravelJourneyRemindersCron } = require('./cron/travelJourneyReminders');
   initTravelJourneyRemindersCron();
+
+  // Pre-trip "countdown" nudge engine (2026-06-16) — emails PAID travel
+  // customers (itinerary status ∈ {advance_paid, fully_paid}) a short creative
+  // reminder daily through the final week (T-30/T-14 then T-7…T-0).
+  // LLM-generated copy (task "trip-countdown") with a template fallback; real
+  // SendGrid email; idempotent per (itinerary, day-bucket). Accepted-but-unpaid
+  // bookings are owned by the payment-deadline engine below instead.
+  const { initTripCountdownCron } = require('./cron/tripCountdownEngine');
+  initTripCountdownCron();
+
+  // Pay-or-cancel deposit-deadline engine (2026-06-16) — chases an `accepted`
+  // (but unpaid) travel booking for its 50% deposit T-10…T-7 (deadline T-7),
+  // then at T-6 emails an at-risk notice + raises an advisor "review for
+  // cancellation" flag and stamps Itinerary.paymentOverdueAt. NO auto-cancel —
+  // an advisor sets status "expired". All sub-brands except Visa Sure.
+  const { initPaymentDeadlineCron } = require('./cron/paymentDeadlineEngine');
+  initPaymentDeadlineCron();
+
+  // Web check-in reminder EMAIL engine (2026-06-16) — the customer-facing
+  // email layer over the EXISTING WebCheckin rows (the webCheckinScheduler
+  // above owns their status lifecycle + WhatsApp + agent fallback). Emails the
+  // passenger at T-36h/T-24h/T-12h before the flight's departureAt when the
+  // parent itinerary is PAID + non-Visa-Sure; the portal "Yes, I've checked in"
+  // flips the rows to "done" so this engine AND the scheduler both stop.
+  // Travel-only (reads WebCheckin rows).
+  const { initWebCheckinCron } = require('./cron/webCheckinEngine');
+  initWebCheckinCron();
+
+  // Post-trip review engine (2026-06-16) — once a committed (accepted/paid),
+  // non-Visa-Sure trip's endDate passes, emails the customer a fixed-question review (destination
+  // woven into the wording) linking to a public review page (/p/review/:token);
+  // they can also submit from the portal. Daily 09:07; idempotent (one
+  // TravelTripReview row per trip). Travel-only (scans Itinerary).
+  const { initTravelReviewCron } = require('./cron/travelReviewEngine');
+  initTravelReviewCron();
 
   // Initialize Visa Sure risk-flagging engine (every 6 hours, SHELL).
   // PRD Phase 3 §3 FR-3 (rows V5-V7, cluster B3) — scans VisaApplication

--- a/backend/test/cron/paymentDeadlineEngine.test.js
+++ b/backend/test/cron/paymentDeadlineEngine.test.js
@@ -1,0 +1,159 @@
+// Unit tests for cron/paymentDeadlineEngine.js — scan accepted-unpaid →
+// reminder (T-10..T-7) / overdue-flag (T-6) → idempotent claim → email + advisor
+// notify. Singletons grabbed via createRequire + monkeypatched (proven idiom;
+// vi.mock can't reach the SUT's CJS require chain). shouldRemind/dayTag stay
+// REAL so the day-gate is exercised end-to-end.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const prisma = requireCJS("../../lib/prisma");
+const emailSender = requireCJS("../../lib/emailSender");
+const content = requireCJS("../../lib/paymentDeadlineContent");
+const notificationService = requireCJS("../../lib/notificationService");
+const { runPaymentDeadlineTick, userCanAccess } = requireCJS("../../cron/paymentDeadlineEngine");
+
+const NOW = new Date("2026-06-20T09:00:00Z");
+const plusDays = (n) => new Date(Date.UTC(2026, 5, 20 + n, 9, 0, 0));
+
+beforeEach(() => {
+  prisma.itinerary = { findMany: vi.fn(), update: vi.fn() };
+  prisma.contact = { findMany: vi.fn() };
+  prisma.user = { findMany: vi.fn() };
+  prisma.paymentDeadlineNudge = { create: vi.fn(), update: vi.fn() };
+  emailSender.sendEmail = vi.fn();
+  notificationService.notify = vi.fn();
+  content.buildReminder = vi.fn(async () => ({ subject: "R", text: "T", html: "T", llmSourced: false }));
+  content.buildOverdueNotice = vi.fn(() => ({ subject: "O", text: "T", html: "T", llmSourced: false }));
+  content.buildOverdueAdvisorFlag = vi.fn(() => ({ title: "Deposit overdue — review for cancellation", message: "msg #1 expired" }));
+
+  prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: "mohit@example.com" }]);
+  prisma.user.findMany.mockResolvedValue([{ id: 10, role: "USER", subBrandAccess: null }]);
+  prisma.paymentDeadlineNudge.create.mockResolvedValue({ id: 100 });
+  prisma.paymentDeadlineNudge.update.mockResolvedValue({});
+  prisma.itinerary.update.mockResolvedValue({});
+  emailSender.sendEmail.mockResolvedValue({ sent: true });
+  notificationService.notify.mockResolvedValue({});
+});
+
+function itin(overrides = {}) {
+  return {
+    id: 1, tenantId: 1, subBrand: "travelstall", contactId: 7, destination: "Goa",
+    startDate: plusDays(9), totalAmount: 100000, advancePaidAmount: null, currency: "INR", paymentOverdueAt: null,
+    ...overrides,
+  };
+}
+
+describe("paymentDeadlineEngine.runPaymentDeadlineTick — scope", () => {
+  it("scans only accepted, non-visasure itineraries in the window", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([]);
+    await runPaymentDeadlineTick(NOW);
+    const where = prisma.itinerary.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe("accepted");
+    expect(where.subBrand).toEqual({ not: "visasure" });
+    expect(where.startDate).toHaveProperty("gte");
+    expect(where.startDate).toHaveProperty("lte");
+  });
+});
+
+describe("paymentDeadlineEngine.runPaymentDeadlineTick — reminders", () => {
+  it("fires a deposit reminder on a run-up day (T-9) and emails the customer", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(9) })]);
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ itineraryId: 1, dayTag: "d9", channel: "email" }) }),
+    );
+    expect(content.buildReminder).toHaveBeenCalledWith(expect.objectContaining({ daysToGo: 9, depositAmount: 50000, destination: "Goa" }));
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "mohit@example.com", subject: "R" }));
+    expect(notificationService.notify).not.toHaveBeenCalled(); // no advisor flag during run-up
+    expect(s).toMatchObject({ remindersSent: 1, flagged: 0, sent: 1 });
+  });
+
+  it("records 'logged' (not 'sent') when SendGrid is unconfigured", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(8) })]);
+    emailSender.sendEmail.mockResolvedValue({ sent: false, reason: "no_api_key" });
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: "logged" }) }));
+    expect(s).toMatchObject({ remindersSent: 1, sent: 0 });
+  });
+
+  it("skips a day before the window (T-12) — no claim", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(12) })]);
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ remindersSent: 0, flagged: 0, skipped: 1 });
+  });
+
+  it("is idempotent — a unique-violation on the claim skips without emailing", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(9) })]);
+    prisma.paymentDeadlineNudge.create.mockRejectedValue(Object.assign(new Error("dup"), { code: "P2002" }));
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ skipped: 1 });
+  });
+});
+
+describe("paymentDeadlineEngine.runPaymentDeadlineTick — overdue (T-6)", () => {
+  it("flags the advisor + warns the customer + stamps paymentOverdueAt, without changing status", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(6) })]);
+    const s = await runPaymentDeadlineTick(NOW);
+
+    // claimed the 'overdue' bucket
+    expect(prisma.paymentDeadlineNudge.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ dayTag: "overdue" }) }),
+    );
+    // customer at-risk email
+    expect(content.buildOverdueNotice).toHaveBeenCalled();
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ subject: "O" }));
+    // at-risk stamp (NOT a status change)
+    const upd = prisma.itinerary.update.mock.calls[0][0];
+    expect(upd.data).toHaveProperty("paymentOverdueAt");
+    expect(upd.data).not.toHaveProperty("status");
+    // advisor notification raised
+    expect(notificationService.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 10, entityType: "Itinerary", entityId: 1, type: "warning" }),
+    );
+    expect(s).toMatchObject({ flagged: 1 });
+  });
+
+  it("does not re-stamp paymentOverdueAt if already flagged", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(5), paymentOverdueAt: plusDays(-1) })]);
+    await runPaymentDeadlineTick(NOW);
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("paymentDeadlineEngine.runPaymentDeadlineTick — guards", () => {
+  it("skips an itinerary with no amount due", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ totalAmount: 0 })]);
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ skipped: 1 });
+  });
+
+  it("skips when an advance already covers the 50% deposit", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ advancePaidAmount: 60000 })]); // ≥ 50% of 100k
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ skipped: 1 });
+  });
+
+  it("skips an itinerary whose contact has no email", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(9) })]);
+    prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: null }]);
+    const s = await runPaymentDeadlineTick(NOW);
+    expect(prisma.paymentDeadlineNudge.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ skipped: 1 });
+  });
+});
+
+describe("paymentDeadlineEngine.userCanAccess", () => {
+  it("honours ADMIN, unset access (= all), explicit allow, and deny-all", () => {
+    expect(userCanAccess({ role: "ADMIN", subBrandAccess: null }, "travelstall")).toBe(true);
+    expect(userCanAccess({ role: "USER", subBrandAccess: null }, "travelstall")).toBe(true);
+    expect(userCanAccess({ role: "USER", subBrandAccess: '["travelstall","rfu"]' }, "travelstall")).toBe(true);
+    expect(userCanAccess({ role: "USER", subBrandAccess: '["rfu"]' }, "travelstall")).toBe(false);
+    expect(userCanAccess({ role: "USER", subBrandAccess: "[]" }, "travelstall")).toBe(false);
+  });
+});

--- a/backend/test/cron/travelReviewEngine.test.js
+++ b/backend/test/cron/travelReviewEngine.test.js
@@ -1,0 +1,85 @@
+// Unit tests for cron/travelReviewEngine.js — scan completed (paid,
+// non-visasure) itineraries → skip already-reviewed → create review row +
+// token → email. Singletons grabbed via createRequire + monkeypatched.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const prisma = requireCJS("../../lib/prisma");
+const emailSender = requireCJS("../../lib/emailSender");
+const content = requireCJS("../../lib/travelReviewContent");
+const { runTravelReviewTick } = requireCJS("../../cron/travelReviewEngine");
+
+const NOW = new Date("2026-06-20T09:00:00Z");
+const daysAgo = (d) => new Date(NOW.getTime() - d * 86400000);
+
+beforeEach(() => {
+  prisma.itinerary = { findMany: vi.fn() };
+  prisma.travelTripReview = { findMany: vi.fn(), create: vi.fn() };
+  prisma.contact = { findMany: vi.fn() };
+  emailSender.sendEmail = vi.fn();
+  content.buildRequestEmail = vi.fn(() => ({ subject: "How was your trip?", text: "T", html: "T" }));
+
+  prisma.travelTripReview.findMany.mockResolvedValue([]); // none reviewed yet
+  prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: "mohit@example.com" }]);
+  prisma.travelTripReview.create.mockResolvedValue({ id: 100 });
+  emailSender.sendEmail.mockResolvedValue({ sent: true });
+});
+
+function itin(overrides = {}) {
+  return { id: 1, tenantId: 1, contactId: 7, destination: "Bali", endDate: daysAgo(1), ...overrides };
+}
+
+describe("travelReviewEngine — scope query", () => {
+  it("scans committed, non-visasure itineraries completed within the lookback", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([]);
+    await runTravelReviewTick(NOW);
+    const where = prisma.itinerary.findMany.mock.calls[0][0].where;
+    expect(where.status).toEqual({ in: ["accepted", "advance_paid", "fully_paid"] });
+    expect(where.subBrand).toEqual({ not: "visasure" });
+    expect(where.endDate).toHaveProperty("gte");
+    expect(where.endDate).toHaveProperty("lt");
+  });
+});
+
+describe("travelReviewEngine — fire", () => {
+  it("creates a review row (with a token) and emails the customer", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    const s = await runTravelReviewTick(NOW);
+    const createArg = prisma.travelTripReview.create.mock.calls[0][0];
+    expect(createArg.data).toMatchObject({ itineraryId: 1, contactId: 7, status: "requested" });
+    expect(typeof createArg.data.token).toBe("string");
+    expect(createArg.data.token.length).toBeGreaterThan(10);
+    expect(content.buildRequestEmail).toHaveBeenCalledWith(expect.objectContaining({ destination: "Bali" }));
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "mohit@example.com" }));
+    expect(s).toMatchObject({ requested: 1, sent: 1 });
+  });
+});
+
+describe("travelReviewEngine — guards", () => {
+  it("skips an itinerary that already has a review row", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    prisma.travelTripReview.findMany.mockResolvedValue([{ itineraryId: 1 }]);
+    const s = await runTravelReviewTick(NOW);
+    expect(prisma.travelTripReview.create).not.toHaveBeenCalled();
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ requested: 0, skipped: 1 });
+  });
+
+  it("is idempotent — a unique-violation on create skips without emailing", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    prisma.travelTripReview.create.mockRejectedValue(Object.assign(new Error("dup"), { code: "P2002" }));
+    const s = await runTravelReviewTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ skipped: 1 });
+  });
+
+  it("skips when the contact has no email", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: null }]);
+    const s = await runTravelReviewTick(NOW);
+    expect(prisma.travelTripReview.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ requested: 0, skipped: 1 });
+  });
+});

--- a/backend/test/cron/tripCountdownEngine.test.js
+++ b/backend/test/cron/tripCountdownEngine.test.js
@@ -1,0 +1,87 @@
+// Unit tests for cron/tripCountdownEngine.js — scan → fire-gate → idempotent
+// claim → email.
+//
+// Mocking strategy: import the real singletons and monkeypatch their methods
+// (the proven idiom in this repo — vi.mock can't intercept the SUT's CJS
+// require chain under this vitest setup; see leadScoringEngine.test.js). prisma
+// + emailSender + content.buildNudge are read at call time through their module
+// objects, so the patches take effect. shouldFire/dayTag stay REAL so the
+// fire-schedule behaviour is exercised end-to-end.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+// createRequire (not ESM `import`) so the singletons we monkeypatch are the
+// *same* instances the cron + SUT hold via their CJS `require(...)` — an ESM
+// default-import yields a separate namespace and the patches wouldn't take.
+const requireCJS = createRequire(import.meta.url);
+const prisma = requireCJS("../../lib/prisma");
+const emailSender = requireCJS("../../lib/emailSender");
+const content = requireCJS("../../lib/tripCountdownContent");
+const { runTripCountdownTick } = requireCJS("../../cron/tripCountdownEngine");
+
+const NOW = new Date("2026-06-20T09:00:00Z");
+const plusDays = (n) => new Date(Date.UTC(2026, 5, 20 + n, 9, 0, 0)); // 2026-06-20 + n days
+
+beforeEach(() => {
+  prisma.itinerary = { findMany: vi.fn() };
+  prisma.contact = { findMany: vi.fn() };
+  prisma.tripCountdownNudge = { create: vi.fn(), update: vi.fn() };
+  emailSender.sendEmail = vi.fn();
+  content.buildNudge = vi.fn(async () => ({ subject: "S", text: "T", html: "T", llmSourced: false }));
+
+  prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: "mohit@example.com" }]);
+  prisma.tripCountdownNudge.create.mockResolvedValue({ id: 100 });
+  prisma.tripCountdownNudge.update.mockResolvedValue({});
+  emailSender.sendEmail.mockResolvedValue({ sent: true });
+});
+
+function itin(overrides = {}) {
+  return { id: 1, tenantId: 1, subBrand: "travelstall", contactId: 7, destination: "Hyderabad", startDate: plusDays(5), ...overrides };
+}
+
+describe("tripCountdownEngine.runTripCountdownTick", () => {
+  it("fires + emails a confirmed itinerary on a fire-day (T-5)", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    const s = await runTripCountdownTick(NOW);
+    expect(prisma.tripCountdownNudge.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ itineraryId: 1, dayTag: "d5", channel: "email" }) }),
+    );
+    expect(content.buildNudge).toHaveBeenCalledWith(expect.objectContaining({ daysToGo: 5, destination: "Hyderabad", customerName: "Mohit" }));
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "mohit@example.com", subject: "S" }));
+    expect(prisma.tripCountdownNudge.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: "sent" }) }));
+    expect(s).toMatchObject({ fired: 1, sent: 1 });
+  });
+
+  it("skips a non-fire day (T-10) — no claim, no email", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(10) })]);
+    const s = await runTripCountdownTick(NOW);
+    expect(prisma.tripCountdownNudge.create).not.toHaveBeenCalled();
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("is idempotent — a unique-violation on the claim skips without emailing", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    prisma.tripCountdownNudge.create.mockRejectedValue(Object.assign(new Error("dup"), { code: "P2002" }));
+    const s = await runTripCountdownTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("skips an itinerary whose contact has no email", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin()]);
+    prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: null }]);
+    const s = await runTripCountdownTick(NOW);
+    expect(prisma.tripCountdownNudge.create).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("records 'logged' (not 'sent') when SendGrid is unconfigured", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([itin({ startDate: plusDays(1) })]);
+    emailSender.sendEmail.mockResolvedValue({ sent: false, reason: "no_api_key" });
+    const s = await runTripCountdownTick(NOW);
+    expect(prisma.tripCountdownNudge.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: "logged" }) }));
+    expect(s).toMatchObject({ fired: 1, sent: 0 });
+  });
+});

--- a/backend/test/cron/webCheckinEngine.test.js
+++ b/backend/test/cron/webCheckinEngine.test.js
@@ -1,0 +1,117 @@
+// Unit tests for cron/webCheckinEngine.js — the email layer over the existing
+// WebCheckin rows. Scan active rows → paid+non-visasure parent gate → milestone
+// gate → idempotent (emailRemindersJson) → email. Singletons grabbed via
+// createRequire + monkeypatched (proven idiom). dueMilestone/milestoneTag real.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const prisma = requireCJS("../../lib/prisma");
+const emailSender = requireCJS("../../lib/emailSender");
+const content = requireCJS("../../lib/webCheckinContent");
+const { runWebCheckinTick } = requireCJS("../../cron/webCheckinEngine");
+
+const NOW = new Date("2026-06-20T09:00:00Z");
+const plusHours = (h) => new Date(NOW.getTime() + h * 3600000);
+
+beforeEach(() => {
+  prisma.webCheckin = { findMany: vi.fn(), update: vi.fn() };
+  prisma.itinerary = { findMany: vi.fn() };
+  prisma.contact = { findMany: vi.fn() };
+  emailSender.sendEmail = vi.fn();
+  content.buildReminder = vi.fn(() => ({ subject: "WC", text: "T", html: "T" }));
+
+  // Default: parent itinerary is PAID + travelstall; contact has an email.
+  prisma.itinerary.findMany.mockResolvedValue([{ id: 50, status: "advance_paid", subBrand: "travelstall" }]);
+  prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: "mohit@example.com" }]);
+  prisma.webCheckin.update.mockResolvedValue({});
+  emailSender.sendEmail.mockResolvedValue({ sent: true });
+});
+
+function wc(overrides = {}) {
+  return {
+    id: 1, tenantId: 1, itineraryId: 50, contactId: 7,
+    pnr: "ABC123", airlineCode: "AI", flightNumber: "302", passengerName: "Mohit",
+    departureAt: plusHours(24), emailRemindersJson: null, ...overrides,
+  };
+}
+
+describe("webCheckinEngine — scope query", () => {
+  it("scans only active rows with a parent itinerary in the 37h window", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([]);
+    await runWebCheckinTick(NOW);
+    const where = prisma.webCheckin.findMany.mock.calls[0][0].where;
+    expect(where.status).toEqual({ in: ["pending", "reminded"] });
+    expect(where.itineraryId).toEqual({ not: null });
+    expect(where.departureAt).toHaveProperty("gte");
+    expect(where.departureAt).toHaveProperty("lte");
+  });
+});
+
+describe("webCheckinEngine — fire", () => {
+  it("emails the passenger at T-24h and records the milestone", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc({ departureAt: plusHours(24) })]);
+    const s = await runWebCheckinTick(NOW);
+    expect(content.buildReminder).toHaveBeenCalledWith(expect.objectContaining({ milestone: 24, airlineCode: "AI", pnr: "ABC123" }));
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "mohit@example.com", subject: "WC" }));
+    const upd = prisma.webCheckin.update.mock.calls[0][0];
+    expect(JSON.parse(upd.data.emailRemindersJson)).toContain("h24");
+    expect(s).toMatchObject({ fired: 1, sent: 1 });
+  });
+
+  it("appends to existing milestones already sent (h36 → adds h24)", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc({ departureAt: plusHours(24), emailRemindersJson: JSON.stringify(["h36"]) })]);
+    await runWebCheckinTick(NOW);
+    const upd = prisma.webCheckin.update.mock.calls[0][0];
+    expect(JSON.parse(upd.data.emailRemindersJson).sort()).toEqual(["h24", "h36"]);
+  });
+});
+
+describe("webCheckinEngine — guards", () => {
+  it("is idempotent — skips a milestone already emailed", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc({ departureAt: plusHours(24), emailRemindersJson: JSON.stringify(["h24"]) })]);
+    const s = await runWebCheckinTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("skips when the parent itinerary is NOT paid", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc()]);
+    prisma.itinerary.findMany.mockResolvedValue([{ id: 50, status: "accepted", subBrand: "travelstall" }]);
+    const s = await runWebCheckinTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("skips when the parent itinerary is Visa Sure", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc()]);
+    prisma.itinerary.findMany.mockResolvedValue([{ id: 50, status: "fully_paid", subBrand: "visasure" }]);
+    const s = await runWebCheckinTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("skips a row outside every milestone window (T-40h)", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc({ departureAt: plusHours(40) })]);
+    const s = await runWebCheckinTick(NOW);
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("skips when the contact has no email", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc()]);
+    prisma.contact.findMany.mockResolvedValue([{ id: 7, name: "Mohit", email: null }]);
+    const s = await runWebCheckinTick(NOW);
+    expect(s).toMatchObject({ fired: 0, skipped: 1 });
+  });
+
+  it("still records the milestone (no retry loop) when SendGrid is unconfigured", async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([wc({ departureAt: plusHours(12) })]);
+    emailSender.sendEmail.mockResolvedValue({ sent: false, reason: "no_api_key" });
+    const s = await runWebCheckinTick(NOW);
+    const upd = prisma.webCheckin.update.mock.calls[0][0];
+    expect(JSON.parse(upd.data.emailRemindersJson)).toContain("h12");
+    expect(s).toMatchObject({ fired: 1, sent: 0 });
+  });
+});

--- a/backend/test/lib/llmRouter.test.js
+++ b/backend/test/lib/llmRouter.test.js
@@ -166,6 +166,11 @@ describe('llmRouter — module shape', () => {
       "bulk-text": { primary: "gemini-flash", fallback: "claude-haiku" },
       "call-summary": { primary: "gemini-flash", fallback: null },
       "itinerary-suggest": { primary: "gemini-flash", fallback: "claude-haiku" },
+      // Trip-countdown (packing nudges) + payment-reminder (pay-or-cancel
+      // deposit chase) — 2026-06-16 travel notification engines. Both bulk-
+      // shape email copy → gemini-flash primary / claude-haiku fallback.
+      "trip-countdown": { primary: "gemini-flash", fallback: "claude-haiku" },
+      "payment-reminder": { primary: "gemini-flash", fallback: "claude-haiku" },
       "marketing-flyer-copy": { primary: "gemini-flash", fallback: "claude-haiku" },
       "marketing-flyer-image": { primary: "dall-e-3", fallback: "stability-xl" },
     });
@@ -178,8 +183,9 @@ describe('llmRouter — module shape', () => {
     );
     // Length cross-check — PRD §9.1's 7 task classes + FR-3.6's
     // 'itinerary-suggest' (S14) + FR-3.6.1's 'marketing-flyer-copy' (S15)
-    // + FR-3.6.3's 'marketing-flyer-image' (S16) extensions = 10.
-    expect(r.VALID_TASKS).toHaveLength(10);
+    // + FR-3.6.3's 'marketing-flyer-image' (S16) + the 2026-06-16 travel
+    // notification engines 'trip-countdown' + 'payment-reminder' = 12.
+    expect(r.VALID_TASKS).toHaveLength(12);
   });
 });
 

--- a/backend/test/lib/paymentDeadlineContent.test.js
+++ b/backend/test/lib/paymentDeadlineContent.test.js
@@ -1,0 +1,102 @@
+// Unit tests for lib/paymentDeadlineContent.js — the pay-or-cancel deposit
+// reminder copy. llmRouter is grabbed via createRequire + monkeypatched (the
+// proven idiom in this repo — vi.mock can't reach the SUT's CJS require chain;
+// see test/lib/tripCountdownContent.test.js).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const llmRouter = requireCJS("../../lib/llmRouter");
+const content = requireCJS("../../lib/paymentDeadlineContent");
+
+describe("paymentDeadlineContent — reminder schedule", () => {
+  it("reminds across the T-10 → T-7 run-up only", () => {
+    expect(content.FIRE_DAYS).toEqual([10, 9, 8, 7]);
+    expect(content.shouldRemind(10)).toBe(true);
+    expect(content.shouldRemind(7)).toBe(true);
+    expect(content.shouldRemind(6)).toBe(false); // T-6 is the overdue case, not a reminder
+    expect(content.shouldRemind(11)).toBe(false);
+    expect(content.dayTag(10)).toBe("d10");
+  });
+});
+
+describe("paymentDeadlineContent — formatMoney", () => {
+  it("uses ₹ for INR, the code for others, and a safe label for nothing", () => {
+    expect(content.formatMoney(50000, "INR")).toBe("₹50,000");
+    expect(content.formatMoney(50000, "USD")).toBe("USD 50,000");
+    expect(content.formatMoney(0, "INR")).toBe("the deposit");
+    expect(content.formatMoney(null, "INR")).toBe("the deposit");
+  });
+});
+
+describe("paymentDeadlineContent — fallback templates", () => {
+  const base = { destination: "Goa", customerName: "Mohit", depositAmount: 50000, currency: "INR", deadlineLabel: "13 Jun 2026" };
+
+  it("interpolates dest/name/amount/deadline and escalates across days", () => {
+    const ten = content.buildFallbackReminder({ ...base, daysToGo: 10 });
+    expect(ten.text).toContain("Goa");
+    expect(ten.text).toContain("Mohit");
+    expect(ten.text).toContain("₹50,000");
+    expect(ten.text).toContain("13 Jun 2026");
+    expect(ten.html).toContain("<br>");
+    expect(ten.llmSourced).toBe(false);
+
+    const seven = content.buildFallbackReminder({ ...base, daysToGo: 7 });
+    expect(seven.subject).not.toBe(ten.subject); // distinct copy per day
+    expect(seven.subject).toMatch(/today/i); // T-7 is the deadline-day urgency
+  });
+
+  it("falls back gracefully when name/destination/amount are missing", () => {
+    const n = content.buildFallbackReminder({ daysToGo: 9 });
+    expect(n.text).toContain("traveller");
+    expect(n.text).toContain("your destination");
+    expect(n.text).toContain("the deposit");
+  });
+});
+
+describe("paymentDeadlineContent — overdue notice + advisor flag", () => {
+  it("builds an at-risk customer notice (fixed wording, no LLM)", () => {
+    const n = content.buildOverdueNotice({ destination: "Goa", customerName: "Mohit", depositAmount: 50000, currency: "INR" });
+    expect(n.subject).toMatch(/at risk|overdue/i);
+    expect(n.text).toContain("Goa");
+    expect(n.text).toMatch(/at risk|overdue|deadline has now passed/i);
+    expect(n.llmSourced).toBe(false);
+  });
+
+  it("builds an advisor flag pointing at the itinerary + the 'expired' action", () => {
+    const f = content.buildOverdueAdvisorFlag({ destination: "Goa", customerName: "Mohit", depositAmount: 50000, currency: "INR", itineraryId: 42 });
+    expect(f.title).toMatch(/review for cancellation/i);
+    expect(f.message).toContain("#42");
+    expect(f.message).toContain("expired");
+  });
+});
+
+describe("paymentDeadlineContent — buildReminder (LLM ↔ fallback)", () => {
+  const base = { tenantId: 1, destination: "Goa", customerName: "Asha", depositAmount: 50000, currency: "INR", daysToGo: 9, deadlineLabel: "13 Jun 2026" };
+
+  beforeEach(() => {
+    llmRouter.routeRequest = vi.fn();
+  });
+
+  it("uses the template fallback when the LLM is in stub mode", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: true, text: "" });
+    const n = await content.buildReminder(base);
+    expect(n.llmSourced).toBe(false);
+    expect(n.text).toContain("Goa");
+  });
+
+  it("uses LLM copy when a non-stub JSON {subject,body} comes back", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: false, text: '{"subject":"Pay your Goa deposit","body":"Hi {name}, deposit due soon."}' });
+    const n = await content.buildReminder(base);
+    expect(n.llmSourced).toBe(true);
+    expect(n.subject).toBe("Pay your Goa deposit");
+    expect(n.text).toContain("Asha"); // {name} interpolated
+  });
+
+  it("falls back when the LLM returns unparseable text", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: false, text: "not json" });
+    const n = await content.buildReminder(base);
+    expect(n.llmSourced).toBe(false);
+  });
+});

--- a/backend/test/lib/travelReviewContent.test.js
+++ b/backend/test/lib/travelReviewContent.test.js
@@ -1,0 +1,24 @@
+// Unit tests for lib/travelReviewContent.js — the review-request email copy.
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const content = requireCJS("../../lib/travelReviewContent");
+
+describe("travelReviewContent — buildRequestEmail", () => {
+  it("weaves destination + name + review link into the email", () => {
+    const m = content.buildRequestEmail({ destination: "Bali", customerName: "Mohit", reviewUrl: "https://app/p/review/tok123" });
+    expect(m.subject).toContain("Bali");
+    expect(m.text).toContain("Mohit");
+    expect(m.text).toContain("Bali");
+    expect(m.text).toContain("https://app/p/review/tok123");
+    expect(m.html).toContain("<br>");
+  });
+
+  it("falls back gracefully when fields are missing", () => {
+    const m = content.buildRequestEmail({});
+    expect(m.text).toContain("traveller");
+    expect(m.text).toContain("your recent trip");
+  });
+});

--- a/backend/test/lib/travelReviewQuestions.test.js
+++ b/backend/test/lib/travelReviewQuestions.test.js
@@ -1,0 +1,69 @@
+// Unit tests for lib/travelReviewQuestions.js — the fixed post-trip review
+// question set, {destination} interpolation, and submission validation/scoring.
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const q = requireCJS("../../lib/travelReviewQuestions");
+
+describe("travelReviewQuestions — buildForm", () => {
+  it("interpolates {destination} in the title + questions and groups by section", () => {
+    const form = q.buildForm("Bali");
+    expect(form.formTitle).toBe("How was your trip to Bali?");
+    expect(form.sections.map((s) => s.key)).toEqual(["trip", "loyalty", "feedback"]);
+    expect(form.sections[0].title).toContain("Bali");
+
+    const all = form.sections.flatMap((s) => s.questions);
+    const loved = all.find((x) => x.id === "loved_most");
+    expect(loved.text).toContain("Bali"); // {destination} woven into the question
+    const stars = all.filter((x) => x.type === "rating");
+    expect(stars).toHaveLength(5);
+    expect(stars.every((x) => x.max === 5)).toBe(true);
+    const recommend = all.find((x) => x.id === "recommend");
+    expect(recommend.type).toBe("choice");
+    expect(recommend.options).toContain("Definitely");
+  });
+
+  it("falls back when destination is missing", () => {
+    const form = q.buildForm();
+    expect(form.formTitle).toBe("How was your trip to your trip?");
+  });
+});
+
+describe("travelReviewQuestions — validateSubmission", () => {
+  const fullValid = {
+    rate_accommodation: 5, rate_transport: 4, rate_activities: 5, rate_support: 4, rate_value: 5,
+    recommend: "Definitely", rebook: "Maybe",
+    loved_most: "The beaches", improve: "", highlight: "Sunset cruise",
+  };
+
+  it("accepts a complete submission and scores overallRating as the rounded star avg", () => {
+    const r = q.validateSubmission(fullValid);
+    expect(r.ok).toBe(true);
+    // (5+4+5+4+5)/5 = 4.6 → 5
+    expect(r.overallRating).toBe(5);
+    expect(r.clean.loved_most).toBe("The beaches");
+    expect(r.clean.improve).toBeUndefined(); // empty optional text dropped
+  });
+
+  it("flags a missing required rating", () => {
+    const { rate_value, ...rest } = fullValid; // eslint-disable-line no-unused-vars
+    const r = q.validateSubmission(rest);
+    expect(r.ok).toBe(false);
+    expect(r.errors.rate_value).toBeTruthy();
+  });
+
+  it("rejects an out-of-range rating + an invalid choice", () => {
+    const r = q.validateSubmission({ ...fullValid, rate_value: 9, recommend: "Nope" });
+    expect(r.ok).toBe(false);
+    expect(r.errors.rate_value).toBeTruthy();
+    expect(r.errors.recommend).toBeTruthy();
+  });
+
+  it("treats optional free-text as optional + caps length", () => {
+    const r = q.validateSubmission({ ...fullValid, highlight: "x".repeat(5000) });
+    expect(r.ok).toBe(true);
+    expect(r.clean.highlight.length).toBe(2000);
+  });
+});

--- a/backend/test/lib/tripCountdownContent.test.js
+++ b/backend/test/lib/tripCountdownContent.test.js
@@ -1,0 +1,78 @@
+// Unit tests for lib/tripCountdownContent.js — the pre-trip nudge copy.
+//
+// Mocking strategy: this repo's vitest setup does NOT reliably let vi.mock()
+// intercept a CJS module's `require()` chain (see the comment blocks in
+// test/cron/leadScoringEngine.test.js + dealInsightsEngine-tick.test.js). The
+// proven idiom is to import the real singleton and monkeypatch the method —
+// llmRouter is inlined (vitest.config server.deps.inline) so the object the
+// SUT holds and the object we import here are the same instance. buildNudge
+// reads `llmRouter.routeRequest` at call time, so the patch takes effect.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+
+// createRequire (not ESM `import`) so the llmRouter object we monkeypatch is
+// the *same* instance the SUT holds via its CJS `require("./llmRouter")` — an
+// ESM default-import yields a separate namespace and the patch wouldn't take.
+const requireCJS = createRequire(import.meta.url);
+const llmRouter = requireCJS("../../lib/llmRouter");
+const content = requireCJS("../../lib/tripCountdownContent");
+
+describe("tripCountdownContent — fire schedule", () => {
+  it("fires on the early check-ins + the final week, daily", () => {
+    expect(content.FIRE_DAYS).toEqual([30, 14, 7, 6, 5, 4, 3, 2, 1, 0]);
+    expect(content.shouldFire(5)).toBe(true);
+    expect(content.shouldFire(0)).toBe(true);
+    expect(content.shouldFire(10)).toBe(false); // not a fire day
+    expect(content.shouldFire(-1)).toBe(false); // trip already started
+    expect(content.dayTag(5)).toBe("d5");
+  });
+});
+
+describe("tripCountdownContent — fallback templates", () => {
+  it("interpolates destination + name and differs across days", () => {
+    const five = content.buildFallbackNudge({ destination: "Hyderabad", daysToGo: 5, customerName: "Mohit" });
+    expect(five.subject).toMatch(/5 days/i);
+    expect(five.text).toContain("Hyderabad");
+    expect(five.text).toContain("Mohit");
+    expect(five.llmSourced).toBe(false);
+    expect(five.html).toContain("<br>");
+
+    const zero = content.buildFallbackNudge({ destination: "Hyderabad", daysToGo: 0, customerName: "Mohit" });
+    expect(zero.subject).not.toBe(five.subject); // creative variety: T-0 ≠ T-5
+    expect(zero.subject).toMatch(/bon voyage|amazing/i);
+  });
+
+  it("falls back gracefully when name/destination are missing", () => {
+    const n = content.buildFallbackNudge({ daysToGo: 7 });
+    expect(n.text).toContain("traveller");
+    expect(n.text).toContain("your destination");
+  });
+});
+
+describe("tripCountdownContent — buildNudge (LLM ↔ fallback)", () => {
+  beforeEach(() => {
+    llmRouter.routeRequest = vi.fn();
+  });
+
+  it("uses the template fallback when the LLM is in stub mode", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: true, text: "" });
+    const n = await content.buildNudge({ tenantId: 1, destination: "Goa", daysToGo: 3, customerName: "A" });
+    expect(n.llmSourced).toBe(false);
+    expect(n.text).toContain("Goa");
+  });
+
+  it("uses LLM copy when a non-stub JSON {subject,body} comes back", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: false, text: '{"subject":"3 days to Goa!","body":"Pack your bags, {name}!"}' });
+    const n = await content.buildNudge({ tenantId: 1, destination: "Goa", daysToGo: 3, customerName: "Asha" });
+    expect(n.llmSourced).toBe(true);
+    expect(n.subject).toBe("3 days to Goa!");
+    expect(n.text).toContain("Asha"); // {name} still interpolated
+  });
+
+  it("falls back when the LLM returns unparseable text", async () => {
+    llmRouter.routeRequest.mockResolvedValue({ stub: false, text: "not json" });
+    const n = await content.buildNudge({ tenantId: 1, destination: "Goa", daysToGo: 3, customerName: "A" });
+    expect(n.llmSourced).toBe(false);
+  });
+});

--- a/backend/test/lib/webCheckinContent.test.js
+++ b/backend/test/lib/webCheckinContent.test.js
@@ -1,0 +1,60 @@
+// Unit tests for lib/webCheckinContent.js — web check-in reminder EMAIL copy
+// (built from a WebCheckin row's flight fields). Pure module (no LLM, no I/O).
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const requireCJS = createRequire(import.meta.url);
+const content = requireCJS("../../lib/webCheckinContent");
+
+describe("webCheckinContent — milestone windows", () => {
+  it("exposes the 36/24/12h milestones", () => {
+    expect(content.MILESTONES).toEqual([36, 24, 12]);
+    expect(content.milestoneTag(36)).toBe("h36");
+    expect(content.milestoneTag(12)).toBe("h12");
+  });
+
+  it("maps hours-to-departure into disjoint 12h windows", () => {
+    expect(content.dueMilestone(36)).toBe(36);
+    expect(content.dueMilestone(30)).toBe(36);
+    expect(content.dueMilestone(24)).toBe(24);
+    expect(content.dueMilestone(20)).toBe(24);
+    expect(content.dueMilestone(12)).toBe(12);
+    expect(content.dueMilestone(1)).toBe(12);
+    expect(content.dueMilestone(40)).toBe(null);
+    expect(content.dueMilestone(0)).toBe(null);
+    expect(content.dueMilestone(-5)).toBe(null);
+  });
+});
+
+describe("webCheckinContent — flightLabel", () => {
+  it("joins airline + flight, falls back when missing", () => {
+    expect(content.flightLabel({ airlineCode: "AI", flightNumber: "302" })).toBe("AI 302");
+    expect(content.flightLabel({})).toBe("your flight");
+  });
+});
+
+describe("webCheckinContent — buildReminder", () => {
+  const base = { passengerName: "Mohit", airlineCode: "AI", flightNumber: "302", pnr: "ABC123", portalUrl: "https://app/travel/portal" };
+
+  it("interpolates passenger/flight/pnr/portal and varies copy per milestone", () => {
+    const h36 = content.buildReminder({ ...base, milestone: 36 });
+    expect(h36.subject).toContain("AI 302");
+    expect(h36.text).toContain("Mohit");
+    expect(h36.text).toContain("ABC123");
+    expect(h36.text).toContain("https://app/travel/portal");
+    expect(h36.html).toContain("<br>");
+
+    const h24 = content.buildReminder({ ...base, milestone: 24 });
+    const h12 = content.buildReminder({ ...base, milestone: 12 });
+    expect(h24.subject).not.toBe(h36.subject);
+    expect(h12.subject).toMatch(/last reminder/i);
+  });
+
+  it("falls back gracefully when fields are missing", () => {
+    const n = content.buildReminder({ milestone: 24 });
+    expect(n.text).toContain("traveller");
+    expect(n.text).toContain("your flight");
+    expect(n.text).toContain("your customer portal");
+  });
+});

--- a/docs/TMC_PLATFORM_MASTER_PLAN_CODEBASE_STATUS_2026-06-16.md
+++ b/docs/TMC_PLATFORM_MASTER_PLAN_CODEBASE_STATUS_2026-06-16.md
@@ -1,0 +1,148 @@
+an# TMC Platform – Master Plan → Codebase Tick-list (2026-06-16)
+
+Cross-references the Google Doc **"TMC Platform – Master Plan"** (Phase Deliverables + Test
+Scenarios checklists) against the **actual `globussoft-crm` working tree**, verified by a
+read-only code sweep (file:line evidence per row).
+
+**Important caveat — stack mismatch.** The plan proposes Next.js + NestJS + PostgreSQL + Redis.
+This repo is **React/Vite + Express/Prisma/MySQL**. Ticks below judge whether the _functionality_
+exists, not the named stack. The four "tenants" (TMC, RFU, Travelstall, Visa Sure) are implemented
+as **sub-brands under one travel tenant** (`subBrandAccess[]`), not separate tenants — functionally
+equivalent for everything in the plan.
+
+**Legend:** ✅ done · 🟡 partial (core built, a sub-part missing/different) · ⬜ not built (absent,
+or only for non-travel providers) · ⚙️ process/ops item (not code-verifiable).
+
+---
+
+## 2. Phase Deliverables Checklist — ✅ 27 · 🟡 8 · ⬜ 4 · ⚙️ 3 (of 42)
+
+### Phase 0 — Foundations
+
+- [x] ✅ **Repo & CI/CD** — `.github/workflows/deploy.yml` (6-gate pipeline)
+- [x] ✅ **Three environments** — `deploy.yml` branches `main` + `staging_crm` (staging mirror + prod)
+- [x] ✅ **Tenant theming** — `routes/sub_brand_themes.js`; `frontend/src/theme/travel.css`
+- [x] ✅ **Data model + RLS** — `schema.prisma` tenantId on all tenant-owned models + `middleware/travelGuards.js` _(app-layer scoping, not DB row-level RLS)_
+- [x] ✅ **Audit log** — `schema.prisma` `AuditLog` (hash-chained, tamper-evident) + `writeAudit`
+
+### Phase 1 — Multi-tenant & Identity
+
+- [x] ✅ **Tenant provisioning (4 tenants + Ops)** — `prisma/seed-travel.js` (4 sub-brands under travel tenant)
+- [x] ✅ **Workspace SSO** — `routes/sso.js` (Google OAuth) + JIT provisioning
+- [x] ✅ **Role-permission matrix** — `schema.prisma` `Role`/`RolePermission` + `verifyRole`
+- [x] ✅ **Login Vault** — `routes/travel_suppliers.js` (AES-256-GCM creds, ADMIN-gated reveal + access log)
+
+### Phase 2 — Sales Pipeline
+
+- [x] ✅ **8-status pipeline** — `routes/pipelines.js` + `pipeline_stages.js` + transition guard in `deals.js`
+- [x] ✅ **8 Lost Reasons** — `routes/win_loss.js` `WinLossReason` _(configurable; not pinned to exactly 8)_
+- [ ] 🟡 **Manager View** — Kanban (`Pipeline.jsx`) + funnel (`routes/funnel.js`) + SLA-breach engine exist; **ageing-in-stage + lost-reason-mix dashboard not assembled**
+- [x] ✅ **Assignment rule engine** — `routes/lead_routing.js` + `lib/leadAutoRouter.js`
+
+### Phase 3 — Diagnostic & Lead Intake
+
+- [x] ✅ **Diagnostic engine** — `lib/tmcDiagnosticEngine.js` + `lib/travelDiagnosticScoring.js`
+- [x] ✅ **Editable question bank** — `routes/travel_diagnostics.js` (versioned banks per sub-brand)
+- [x] ✅ **Curriculum mapping** — `CurriculumAdmin.jsx` + `TravelCurriculumMapping`
+- [ ] 🟡 **Eligibility gate** — `lib/tmcLeadQuality.js` 5-rule classifier + ICP tiering; **ICP criteria feed scoring, not a hard binary admit/reject gate**
+- [x] ✅ **PDF Recommendation Report** — `services/pdfRenderer.js renderTmcReadinessReport` (covers all 5 deliverables)
+- [x] ✅ **48-hour SLA task** — `cron/leadSlaEngine.js` + `lib/leadSla.js computeFirstResponseDueAt`
+
+### Phase 4 — Workspace Integrations
+
+- [ ] 🟡 **Gmail integration** — inbound email via **Mailgun webhook** (`routes/email_inbound.js`); **no IMAP/Gmail-sync layer**
+- [x] ✅ **Calendar integration** — `routes/calendar_google.js` + `calendar_outlook.js` + `lib/calendarSlots.js`
+- [ ] ⬜ **Drive integration** — no Google Drive / per-record folder code found
+
+### Phase 5 — Wati + WhatsApp
+
+- [ ] 🟡 **3 Wati workspaces connected** — `services/watiClient.js` (travel transport) with per-sub-brand channel via `lib/subBrandConfig.js`; **config-level routing, not 3 distinct connected workspaces**
+- [x] ✅ **Meta templates** — `WhatsAppTemplate` + `submitTemplateToMeta` + `cron/whatsappTemplateSyncEngine.js` _(capability built; actual submissions are an ops step)_
+- [x] ✅ **Embedded WhatsApp Web** — `WhatsAppChat.jsx` + `routes/whatsapp.js` threads
+- [x] ✅ **Inbound mapping** — `routes/whatsapp_webhook.js` upserts `WhatsAppThread` → contact
+
+### Phase 6 — Ad-Platform APIs
+
+- [ ] ⬜ **Meta Lead Ads ingest** — `marketplace_leads.js` covers IndiaMART/JustDial/TradeIndia only; no Meta Lead Ads
+- [ ] ⬜ **Google Ads offline conversion** — no refs found
+- [ ] ⬜ **Spend/impression sync** — no ad-spend/impression sync (only LLM-spend observability)
+
+### Phase 7 — Trip / Ops / Accounting
+
+- [ ] 🟡 **Trip auto-creation** — trip records + management exist (`routes/travel_trips.js`); **quote/itinerary accept does NOT auto-create a trip (`travel_quotes.js` only transitions status)**
+- [x] ✅ **Trip microsite** — `routes/travel_microsites.js` + `PublicTripMicrosite.jsx` (+ OTP)
+- [x] ✅ **Parent portal** — `routes/portal.js` + `TravelCustomerPortal.jsx` (register, add traveller, upload, pay)
+- [ ] 🟡 **Passport OCR + verification** — upload + manual-verification queue shipped (`PassportVerificationQueue.jsx`, `routes/travel_passport.js`); **automated OCR extraction is cred-blocked / stubbed**
+- [ ] 🟡 **Payment plan + rooming + departure checklist** — payment plan ✅ (`travel_trip_billing.js`), rooming ✅ (+ XLSX export); **departure = a readiness _score_, no checklist document**
+- [x] ✅ **GST + CA export** — `routes/travel_invoice_ledgers.js` (customer ledger, TDS register, commission ledger; CSV/Tally shape)
+
+### Phase 8 — Delivery Package
+
+- [x] ✅ **Brand assets per tenant** — `routes/brand_kits.js` `BrandKit` (logo/palette/templates per sub-brand) _(actual Yasin brand pack still pending — Q22)_
+- [x] ✅ **KPI definitions catalog** — `lib/widgetCatalog.js` / `lib/pageCatalog.js`
+- [x] ✅ **Reminder schedules** — `cron/travelMilestoneRemindersEngine.js` (T-7/T-3/T-1/T+0)
+- [ ] 🟡 **Report scaffolding** — `routes/travel_reports.js` + `cron/reportEngine.js` (scheduled PDF/CSV); **named digests (daily ops / weekly sales / monthly KPI / per-trip closeout) not all built**
+
+### Phase 9 — Hardening, UAT, Launch
+
+- [ ] ⚙️ **UAT pass** — process (large automated test suite exists; formal UAT not code-verifiable)
+- [ ] ⚙️ **Security review** — process (`security-review` skill + gitleaks `secret-scan.yml` exist)
+- [ ] ⚙️ **Go-live + 30-day hypercare** — process (demo is deployed at crm.globusdemos.com)
+
+---
+
+## 3. Test Scenarios Checklist — ✅ 9 · 🟡 10 · ⬜ 6 (of 25)
+
+- [ ] 🟡 **Landing pages render all required sections** — landing-page system exists (`landing_pages.js`); per-Architecture-PDF section parity unverified
+- [ ] ⬜ **FAQ schema validates (Rich Results)** — no JSON-LD / schema.org markup found
+- [ ] ⬜ **No pricing exposed pre-diagnostic** — no pricing-visibility gating found on public surfaces
+- [ ] 🟡 **Diagnostic form fields match exactly (8 fields)** — diagnostic + public TMC form exist (`TmcReadiness.jsx`, 12-Q); exact 8-field intake parity not verified
+- [x] ✅ **48-hour SLA task auto-created** — `cron/leadSlaEngine.js`
+- [ ] 🟡 **Eligibility gate flags non-ICP** — classifier scores, not a hard flag (see Phase 3)
+- [x] ✅ **PDF Recommendation Report has 5 deliverables** — `pdfRenderer.js`
+- [ ] 🟡 **Qualified→Discovery Call; disqualified→nurture** — qualified→booking link ✅ (`travel_diagnostics.js`); **disqualified→nurture flow not found**
+- [ ] ⬜ **Calendar booking respects timezones** — no timezone-conversion code in `calendarSlots.js`
+- [x] ✅ **Quotation v2 supersedes v1 (audit visible)** — `TravelQuoteSnapshot` version history
+- [ ] 🟡 **Trip auto-creation on confirmation** — no auto-trigger (see Phase 7)
+- [ ] 🟡 **Parent invite via OTP + magic link (email & WhatsApp)** — email-OTP ✅ + WhatsApp OTP (Wati) ✅; **magic-link URL not implemented**
+- [ ] 🟡 **Passport OCR partial-fills; manual verification corrects** — manual verification ✅; **OCR auto-fill cred-blocked**
+- [ ] ⬜ **Room conflict blocked at allocation** — rooming CRUD exists; no conflict/duplicate-allocation guard
+- [x] ✅ **GST invoice CGST/SGST/IGST split by state** — `travel_invoice_ledgers.js`
+- [ ] 🟡 **CA export totals match analytics revenue** — CA export ✅ + revenue-by-destination analytics ✅; reconciliation is a test to run
+- [x] ✅ **Repeat-school metric increments** — `travel_reports.js` `repeatSchools` / `repeatRatePct`
+- [ ] 🟡 **Manager View shows ageing + SLA breaches** — SLA-breach engine ✅; ageing-in-stage view partial
+- [x] ✅ **8 Lost Reasons enforced on close** — `win_loss.js` (configurable count)
+- [x] ✅ **Rule-based assignment routes leads** — `lead_routing.js` + `leadAutoRouter.js`
+- [x] ✅ **Login Vault reveal requires step-up MFA + audit** — `routes/auth_stepup.js` + supplier-credential access log
+- [ ] ⬜ **Impersonation banner, time-boxed, audit-logged** — no staff impersonation feature found
+- [ ] 🟡 **Tenant switcher re-issues scoped session + re-themes** — per-sub-brand theming + `ActiveSubBrand` ✅; **full tenant-switch session re-issue is single-tenant-per-session (log out to switch)**
+- [x] ✅ **Customer cannot access another's resource by URL** — `routes/portal.js` (all reads scoped by `contactId`+`tenantId`)
+- [ ] ⬜ **Owner Group view aggregates KPIs across 4 tenants** — OWNER cross-tenant _access_ exists; no aggregated KPI dashboard
+
+---
+
+## 4. Headline
+
+**Built & working (✅):** identity/SSO/RBAC/vault/MFA, multi-tenant + audit, pipeline + lost
+reasons + assignment, diagnostic engine + question bank + curriculum + 5-deliverable PDF + 48h SLA,
+calendar, WhatsApp (templates/embed/inbound mapping), microsite, customer portal + resource-scoped
+IDOR guard, GST + CA export, brand-kit system, KPI catalog, reminders, quotation versioning,
+repeat-school metric.
+
+**Genuinely NOT built in this codebase (⬜):**
+
+1. **Ad platforms** — Meta Lead Ads, Google Ads offline conversion, spend/impression sync (Phase 6 entirely)
+2. **Google Drive** per-record folders
+3. **Staff impersonation** (banner / time-box / audit)
+4. **Owner Group cross-tenant KPI dashboard**
+5. **FAQ JSON-LD schema** + **pre-diagnostic pricing gate** + **calendar timezone handling** (website/booking polish)
+6. **Room-conflict guard** at allocation
+
+**⚠️ Security flag (already tracked, jumps the queue):** **uploaded visa/passport documents are stored
+UNENCRYPTED** — `lib/visaDocStore.js` writes plaintext to S3/disk and never calls
+`lib/fieldEncryption.js` (which exists). Matches Gap A1 in
+[VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md](VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md).
+
+**Biggest "almost done" (🟡) worth a short push:** Manager-View ageing/lost-mix dashboard;
+trip auto-creation trigger on quote acceptance; magic-link customer auth; departure-checklist doc;
+named report digests.

--- a/docs/TRAVEL_PRD_GAP_ANALYSIS_2026-06-16.md
+++ b/docs/TRAVEL_PRD_GAP_ANALYSIS_2026-06-16.md
@@ -1,0 +1,209 @@
+# Travel CRM — Consolidated PRD ↔ Codebase Gap Analysis — 2026-06-16
+
+> **Supersedes** [TRAVEL_PRD_GAP_ANALYSIS_2026-06-15.md](TRAVEL_PRD_GAP_ANALYSIS_2026-06-15.md).
+> **Scope:** the **entire travel vertical** — all 4 sub-brands (TMC · RFU · Travel
+> Stall · Visa Sure) + shared infra (sales/itinerary/quote, finance/supplier/GST,
+> integrations, branding, security). Visa Sure has a companion deep-dive:
+> [VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md](VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md).
+>
+> **Method:** fresh code-verification sweep against the current working tree
+> (≈HEAD `043b9ab3`) across 6 areas (TMC, RFU+Travel Stall, sales/itinerary/quote,
+> finance/supplier/GST, integrations/cross-cutting, Visa Sure) + first-hand audit
+> of this cycle's customer-portal/auth work. Cross-checked vs
+> [CREDS_TRACKER.md](CREDS_TRACKER.md), [DECISIONS_TRACKER.md](DECISIONS_TRACKER.md),
+> [MANUAL_CODING_BACKLOG.md](MANUAL_CODING_BACKLOG.md).
+>
+> **Legend:** ✅ SHIPPED · 🟡 PARTIAL (core shipped, pieces missing) · 🔌 STUB
+> (code complete, blocked on external cred/decision) · ❌ MISSING (no code) ·
+> ⏭️ DEFERRED (out of Phase 1 per contract)
+
+---
+
+## 1. Executive summary
+
+The travel vertical is **broadly built**: TMC, the shared sales/itinerary/quote
+stack, finance/supplier core, and Visa Sure are largely shipped; RFU core
+(profiles, packets, hotel-prefs) is done with ground-services in stub/missing;
+Travel Stall is an intentional Phase-2 shell; integrations are mostly
+stub-or-decision-gated; and a few cross-cutting builds (B2B portal, security
+hardening) are early.
+
+**Delta since 2026-06-15** (this cycle's work): Visa Sure FR-5/FR-6 lifecycle
+(checklist seed→verify→auto-advance, quotation-template admin), customer
+self-serve portal ("My Visa": start/upload/cancel/multiple apps), unified login
+(portal fallback), and email-OTP registration all landed.
+
+**The gaps that matter most (engineering-actionable, no external blocker):**
+
+| | Gap | Where | Why it matters |
+|---|---|---|---|
+| 🔴 1 | **Visa documents stored UNENCRYPTED** | `lib/visaDocStore.js:33-43` | Passport/bank scans in plaintext; PRD NFR requires AES-256-GCM. Security. |
+| 🔴 2 | **GST rates hardcoded (no `TaxRateMaster`)** | `lib/gstCalculation.js:57-66` | Rate change needs a redeploy; no operator CRUD. (Also DD-5.2.) |
+| 🔴 3 | **TCS Form 27EQ export missing** | billing FR-3.4.d / AC-6.12 | TCS is computed but there's no govt-spec filing report. |
+| 🔴 4 | **Auto-PO on quote→booking missing** | supplier FR-3.2.a | POs are manual; supplier-ledger integrity gap. |
+| 🟠 5 | Visa FR-5.2 **quote-template consumer** + FR-3.2 rejection-history not populated + FR-3.1(c) `familySize` not consumed | see §2 Visa Sure | Risk engine + quotation are admin-only/partial. |
+
+**Highest-fan-out external blocker:** **Q22 (Yasin brand pack)** — one cred
+unblocks 4 PRDs (per-sub-brand branding, theme, billing PDF, marketing flyer).
+**Q9 (Wati WhatsApp)** and **Q11 (LLM keys)** are the next two highest-fanout.
+
+**Entirely-unbuilt big rocks (decision/cred-gated):** B2B agent portal (0%),
+Flight-plugin Chrome extension (backend shipped, extension repo not created),
+RFU 5-portal Saudi hotel scraper, Booking/Expedia cancellation-normalizer +
+inventory-sync.
+
+---
+
+## 2. Status by area
+
+### 2.1 TMC (school trips) — ✅ largely shipped
+| Feature | Status | Evidence / gap |
+|---|---|---|
+| 12-Q public readiness diagnostic → engine + lead-quality + LLM A/B + guardrail + report + PDF | ✅ | `lib/tmcDiagnosticEngine.js`, `lib/tmcLeadQuality.js`, `services/tmcDiagnosticPrompts.js`, `lib/tmcReportGuard.js`; `travel_diagnostics.js:2188/2430/2608`; `TmcReadiness.jsx`/`TmcReadinessReport.jsx` |
+| Curriculum mapping + FR-5 diagnostic recommendations | ✅ (data pending) | `TravelCurriculumMapping` `schema:7317`; `travel_curriculum.js`; engine integration `travel_diagnostics.js:2268-2282`; **V1 rows authored by Yasin's academic team (PC-1)** |
+| TMC trip catalogue + human-verify gate | ✅ | `TmcTripCatalogue` `schema:7496`; `travel_tmc_catalogue.js`; 5 seed trips w/ **placeholder curriculum-hook copy** |
+| TMC microsites + OTP | ✅ (SMS cred pending) | `travel_microsites.js`; `PublicTripMicrosite.jsx`/`TmcMicrositePreview.jsx` |
+| School term calendar | 🟡 | model + `travel_school_terms.js` shipped; **`SchoolTermCalendar.jsx` frontend NOT FOUND** |
+| **Open:** SchoolTermCalendar UI (eng, ~½d); curriculum rows + hook copy + Google-Meet creds + 6 OQ / 3 DD (Yasin) | | |
+
+### 2.2 RFU (Umrah) — ✅ core; 🔌/❌ ground services
+| Feature | Status | Evidence / gap |
+|---|---|---|
+| Pilgrim/lead profiles | ✅ | `RfuLeadProfile` `schema:6297`; `travel_rfu_profiles.js` (+stats/by-month/quarter/year, dup-passport 409); `RfuCustomerProfile.jsx` |
+| Religious guidance packets | ✅ | `ReligiousGuidancePacket` `schema:6355`; `travel_religious_packets.js`; `ReligiousPackets.jsx`; `cron/religiousGuidanceEngine.js` |
+| Hotel-preference attrs (haram/kaaba facing, floor, room) | ✅ | `travel_cost_master.js:33-156` |
+| Zikr Cabs ground transfer (FR-3.1) | 🔌 STUB | `services/zikrCabsClient.js` (quote stub); **booking/cancel/track/webhook/markup/audit MISSING**; `TravelGroundTransfer` model MISSING — Q-RFU-1 |
+| 5-portal Saudi hotel scraper (FR-3.2) | ❌ MISSING | no orchestrator/adapters/cache cron; `SaudiHotelRateCache`/`TravelContractedRate` MISSING — Q-RFUG-1 decision + 5 vendor creds; ~8-10d build |
+| Haramain HSR pricing (FR-3.3) | 🔌 STUB | `services/haramainRailClient.js` (quote stub); booking/cancel/ticket MISSING — Q-RFU-7/Q-RFUG-8 |
+
+### 2.3 Travel Stall (family holidays) — ⏭️ Phase-2 shell
+| Feature | Status | Evidence / gap |
+|---|---|---|
+| Dashboard | 🔌 shell | `TravelStallDashboard.jsx` (4 quick-action cards → existing surfaces with `?subBrand=travelstall`) |
+| Personalised-destination PDF | 🔌 STUB | `travel_travelstall.js` (LLM prose via llmRouter; placeholder branding) — Q11 + Q22 |
+| Family travel quiz + quiz-to-lead + booking surface | ❌ MISSING | not built — **DEFERRED to Phase 2 per contract** (Phase 1 = TMC + RFU) |
+
+### 2.4 Visa Sure — ✅ largely shipped (see companion doc)
+Highlights: advisor list/detail/checklist-admin/quotation-template-admin, document
+checklist lifecycle (seed→verify→auto-advance), recovery program, analytics (3+bonus),
+customer self-serve portal, email-OTP all SHIPPED. **Gaps:** FR-6.4 encryption
+(❌ plaintext), FR-5.2 consumer (❌), `visa-summary` LLM (❌, Q11), rejection-history
+population (🟡), `familySize` consumption (🟡), high-rejection-rate destination (🟡,
+PC-3), embassy-rule consumption breadth (🟡, PC-1..5), retention rows (❌),
+Reports sidebar link (🟡), PDF/theme branding (🟡, Q22). Full detail in
+[VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md](VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md).
+
+### 2.5 Shared — sales / itinerary / quote — ✅ shipped
+| Feature | Status | Evidence / gap |
+|---|---|---|
+| Pipeline kanban + travel sub-brand filter (+touch/keyboard/virtualization) | ✅ | `Pipeline.jsx` (TRAVEL_SUB_BRANDS, URL-persisted filter) |
+| Itinerary builder + templates + day-editor + Leaflet map + suggest + versioning + sightseeing master + POI dedup | ✅ | `travel_itineraries.js`, `travel_itinerary_templates.js`, `travel_sightseeing.js`, `lib/poiDedup.js`; `ItineraryEditor.jsx`/`ItineraryTemplates.jsx`/`SightseeingMaster.jsx` |
+| Quote builder (3-pane, line dims, pricing-preview/markup, accept/reject/counter, snapshots, convert-to-invoice) | ✅ | `travel_quotes.js`/`travel_quotes_public.js`; `QuoteBuilder.jsx`/`QuoteCounterReview.jsx` |
+| Flight quote plugin endpoint + agent fallback | ✅ | `travel_flight_quotes.js`; `FlightQuoteAgent.jsx` |
+| **Open:** quote **send via WhatsApp** (🔌 Q9); itinerary **suggest LLM** (🔌 Q11, deterministic stub today); OpenTripMap POI seed (licensing review ~1h) | | |
+
+### 2.6 Shared — finance / supplier / GST — ✅ core; key gaps
+| Feature | Status | Evidence / gap |
+|---|---|---|
+| Invoice + line model, GST split (CGST/SGST/IGST), place-of-supply | ✅ | `TravelInvoice`/`TravelInvoiceLine`; `lib/gstCalculation.js`; `travel_invoices.js` tax-persist |
+| GSTR-1 / GSTR-3B / HSN-summary exports | ✅ | `travel_invoices.js:597/3309/3002` |
+| Customer-ledger / TDS-register / commission-ledger | ✅ | `travel_invoice_ledgers.js:74/260/329` |
+| Tally-XML + CA-CSV + Excel invoice export | ✅ | `lib/travelAccountingExport.js` |
+| Payment schedule + milestone reminders + anchor dates + settlement Gantt | ✅ | `TravelPaymentSchedule`; `cron/travelMilestoneRemindersEngine.js`; `travel_settlement_timeline.js` |
+| Supplier master + credential vault + KYC + disputes + commissions + reconciliation + payable batches + POs | ✅ | `travel_suppliers.js`, `travel_supplier_commissions.js`, `travel_supplier_reconciliation.js`, `travel_payable_batches.js`, `travel_purchase_orders.js` |
+| TCS auto-detect + apply | ✅ | `lib/tcsCalculation.js`; `travel_invoices.js:/apply-tcs` |
+| **`TaxRateMaster` model + admin CRUD** | ❌ MISSING | rates hardcoded `gstCalculation.js:57-66` — **DD-5.2** |
+| **TCS Form 27EQ export** | ❌ MISSING | AC-6.12 — TCS computed, no filing report |
+| **Auto-PO on quote→booking** | ❌ MISSING | supplier FR-3.2.a — POs manual |
+| GSTIN validator gated on write | 🟡 | `lib/gstinValidator.js` exists but not enforced at route layer |
+| Payment-schedule **templates** library, **receipt PDF numbering**, overdue escalation, per-brand invoice PDF | 🟡 | partial; per-brand PDF blocked on Q22 |
+
+### 2.7 Integrations + cross-cutting
+| PRD | Status | Evidence / gap |
+|---|---|---|
+| RateHawk | 🔌 STUB | `services/ratehawkClient.js` + `routes/ratehawk.js` + `lib/quoteRanker.js` shipped; `/quote/unified-search` real-mode blocked on **Q19** |
+| Booking.com / Expedia direct | 🔌 STUB | `bookingExpediaClient.js` + routes shipped; Booking=Phase 1.5, Expedia=Phase 2 (503 gated); cancellation-normalizer + inventory-sync cron ❌ |
+| Flight-plugin Chrome extension | 🟡 | **backend `/api/v1/flight-plugin/*` SHIPPED**; **extension repo NOT created** (DC-1/DC-2 pending) |
+| Multichannel lead capture | 🟡 (~25%) | `travel_inbound_leads.js` intake + Touchpoint + phone-dedup + cooldowns SHIPPED; routing rules 🔌 stub; `/settings/lead-capture` UI ❌; path-mismatch vs spec (G015 alias) |
+| Per-sub-brand branding | 🟡 | `BrandKit` model + `/api/brand-kits` CRUD SHIPPED; **consumer wiring (PDF/email/portal/microsite/sidebar) mostly ❌** — Q22 |
+| B2B / corporate agent portal | ❌ MISSING | **entire PRD 0%** — 7 design calls (DD-5.1..5.7) unresolved |
+| Security architecture | 🟡 (~32%) | httpOnly-cookie groundwork + cross-tenant interceptor + ESLint guard SHIPPED; opaque `publicId` IDs ❌, list-PII reduction ❌, CSP `unsafe-inline` removal 🔌, full cookie-only auth 🟡 — DD-5.1/5.2/5.5 |
+
+### 2.8 This-cycle customer-portal / auth (verified first-hand)
+| Feature | Status | Evidence |
+|---|---|---|
+| Customer self-serve "My Visa" (preview, start, upload, cancel, **multiple** apps) | ✅ | `TravelCustomerPortal.jsx` `VisaApplicationCard`; `portal.js` GET/POST/DELETE `/travel/visa/applications` + `/checklist-preview` + `/documents/:itemId/upload` |
+| Unified login (staff `/login` → portal fallback) + standalone portal login retired | ✅ | `Login.jsx` `performLogin`→`tryPortalLogin`; `TravelCustomerPortal.jsx` unauth→`/login` |
+| Email-OTP registration (org signup + customer) | ✅ | `lib/emailOtp.js`; `auth.js /email-otp/{request,verify}`; `EmailOtpField.jsx`; `emailVerifiedAt` on Tenant/User/Contact |
+| **Open:** OTP is UI-hard-gated + records + rejects tampered tokens, but an absent-token raw-API register still succeeds (back-compat) — close with strict enforcement (~1h + ~5 test files) | | |
+
+---
+
+## 3. Consolidated PENDING — by blocker
+
+### A. Engineering-actionable now (no external dependency)
+| # | Item | Effort |
+|---|---|---|
+| A1 | **Encrypt visa documents at rest** (AES-256-GCM in `visaDocStore.js`) | ½d · **do first** |
+| A2 | Visa **FR-5.2 quote-template consumer** (template → quote → Itinerary) | 1d |
+| A3 | Visa **rejection-history population** at diagnostic submit + **`familySize`** rule in risk engine | 1d |
+| A4 | **TCS Form 27EQ** export endpoint | 1d |
+| A5 | **Auto-PO** hook on quote→booking confirm | ½d |
+| A6 | **GSTIN validation** gated on Contact/Tenant write | ½h |
+| A7 | Visa + finance **retention rows** (`VisaApplication`/`VisaDocumentChecklistItem` → retentionEngine ENTITY_MAP) | ½d |
+| A8 | Diagnostic-report **email delivery** (SendGrid configured; WA stays Q9) | ½d |
+| A9 | Visa **Reports sidebar link** + `SchoolTermCalendar.jsx` frontend | ½d |
+| A10 | **Email-OTP strict server enforcement** (close raw-API bypass) | 1h + tests |
+| A11 | Per-sub-brand **branding consumer wiring** (PDF/email/portal/microsite read BrandKit) | 2-3d |
+| A12 | Multichannel **`/settings/lead-capture` UI** + finish routing-rule resolver | 1-2d |
+| A13 | Security: **list-PII reduction** + **CSP `unsafe-inline` removal** | 1-2d |
+
+### B. Decision-blocked (product call needed first)
+- **Visa Sure PC-1..PC-8** — complex-case def, embassy-rule catalogue + maintainer, recovery-diagnostic reuse, cool-down gate, categories, region.
+- **GST DD-5.2** — tax-rate source (operator CRUD vs hardcoded vs SaaS).
+- **Billing DD-5.5 / DD-5.7** — TDS ownership boundary, brand handover; schedule-template policy.
+- **Flight plugin DC-1/DC-2/DC-3** — repo topology, Chrome-store publisher.
+- **B2B portal DD-5.1..DD-5.7** — entire PRD gated on 7 decisions.
+- **Security DD-5.1/5.2/5.5** — cookie shape, opaque-ID migration, rollout cadence.
+- **Itinerary OQ-9.x** — suggest-billing, cross-sub-brand POI sharing, prompt hygiene.
+- **RFU ground services Q-RFUG-1..5/8** — scrape-vs-partner per portal, PNR model, cancellation cascade, HHR partner-program existence.
+
+### C. Cred-blocked (code shipped in stub; flips on cred drop)
+| Cred | Unblocks |
+|---|---|
+| **Q9 — Wati WhatsApp** | quote send, visa advisor alerts, diagnostic WA delivery, microsite OTP SMS |
+| **Q11 — LLM keys** | `visa-summary`, itinerary-suggest, Travel Stall PDF prose, TMC LLM jobs |
+| **Q19 — RateHawk API** | `/quote/unified-search` live mode |
+| **Booking Partner Centre / Expedia EAN** | Booking (1.5) + Expedia (2) live |
+| **Q-RFU-1..8** | Zikr Cabs, 5 Saudi hotel portals, Haramain HSR |
+| **Q-GST-2 / Q-BILL-1** | GSTIN reverse-check, TCS filer verification |
+| Passport OCR vendor | optional (on-box `tesseract.js` + MRZ shipped as interim) |
+
+### D. Brand-asset-blocked (Yasin **Q22** — highest fan-out)
+Per-sub-brand branding · theme palettes · billing PDF cover · Travel Stall PDF ·
+marketing-flyer content · Visa Sure PDF/theme. **One drop unblocks all of these.**
+
+---
+
+## 4. Top blockers by blast radius (action list)
+
+1. **Ship A1 (document encryption)** — only true security gap; no blocker. ½d.
+2. **Q22 brand pack** (Yasin) — unblocks ~5 branding/PDF surfaces across sub-brands.
+3. **Q9 WhatsApp + Q11 LLM** (creds) — flip ~6 stubbed flows to live across all sub-brands.
+4. **GST: build `TaxRateMaster` + 27EQ + auto-PO** (after DD-5.2) — closes the finance compliance gaps.
+5. **Decide the big-rock PRDs** (B2B portal, Flight-plugin repo, RFU hotel-scraper) — each is a multi-day build gated on a product/cred decision, not on engineering availability.
+
+---
+
+## 5. Notes
+- Line numbers reflect the current working tree (~HEAD `043b9ab3`) on 2026-06-16.
+- Phase scoping per contract: **Phase 1 = TMC + RFU**; Travel Stall + Visa Sure
+  were Phase 2 — Visa Sure has since been largely built ahead of schedule.
+- A handful of "shipped" claims in the sales/itinerary/quote sweep are inferred
+  from route+schema presence; the **gaps** above are the high-confidence,
+  actionable set. The finance/supplier/GST + integrations findings carry the
+  strongest evidence.
+- This supersedes 2026-06-15; the §A/B/C/D structure + per-PRD trackers
+  (CREDS/DECISIONS/MANUAL_CODING) remain the operational source of truth.
+
+*Generated 2026-06-16 from a 6-cluster parallel code-verification sweep + first-hand audit of this cycle's portal/auth work.*

--- a/docs/VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md
+++ b/docs/VISA_SURE_PHASE_3_GAP_ANALYSIS_2026-06-16.md
@@ -1,0 +1,152 @@
+# Visa Sure (Phase 3) — Gap Analysis vs. Codebase — 2026-06-16
+
+**Scope:** [PRD_VISA_SURE_PHASE_3.md](PRD_VISA_SURE_PHASE_3.md) FR-1…FR-8 + NFRs, **plus** the
+customer-facing + auth work shipped this cycle (self-serve portal, unified
+login, email-OTP registration). Verified against the **current working tree**
+(not assumptions) via a 5-cluster code sweep; every line below cites real
+`file:line` evidence or marks `NOT FOUND`.
+
+**Method:** parallel read-only verification of (1) diagnostic+PDF, (2) risk
+engine+embassy rules, (3) advisor dashboard+LLM, (4) quotation+documents,
+(5) analytics+nav+portal+auth+retention. Synthesised here.
+
+---
+
+## 1. Executive summary
+
+Visa Sure Phase 3 is **largely shipped** — the advisor surface, document
+checklist lifecycle, quotation-template admin, analytics, recovery program,
+customer self-serve portal, and email-OTP registration all work end-to-end.
+The remaining gaps cluster into four buckets:
+
+| Bucket | Count | Headline items |
+|---|---|---|
+| **A — Engineering-actionable now** (no external blocker) | 9 | **FR-6.4 documents stored UNENCRYPTED** (security); FR-5.2 quote-template *consumer*; rejection-history not populated at diagnostic submit; `familySize` not consumed by risk engine; visa retention rows missing; Reports sidebar link missing; diagnostic-report **email** delivery; email-OTP API-bypass |
+| **B — Decision-blocked** (product call) | 5 | High-rejection-rate destination (PC-3); EmbassyRule consumption breadth (PC-1..PC-5/PC-7); recovery diagnostic reuse (PC-2); cool-down gate (PC-4) |
+| **C — Cred-blocked** | 3 | `visa-summary` LLM (Q11); WhatsApp advisor alerts + diagnostic WA delivery (Q9); passport OCR (C-cluster) |
+| **D — Brand-asset-blocked** (Yasin Q22) | 3 | Visa-Sure PDF brand template + tone (FR-1.3/2); `visa-sure.css` theme; visa quote-PDF branding (FR-5.3) |
+
+**The one item that should jump the queue:** **FR-6.4 — uploaded visa
+documents (passport scans, bank statements) are stored in plaintext** (S3/disk,
+unguessable filename only). The PRD NFR explicitly requires AES-256-GCM at rest
+via `lib/fieldEncryption.js`. This is a real compliance/security gap, not a
+deferral.
+
+---
+
+## 2. FR-by-FR status
+
+| FR | Requirement | Status | Evidence |
+|---|---|---|---|
+| **FR-1.1** | 15-Q visa diagnostic + weighted-sum + 4 readiness levels | ✅ SHIPPED | `prisma/seed-travel.js:352-523`; `lib/travelDiagnosticScoring.js:35-113` |
+| **FR-1.2** | Editable scoring via admin endpoint | ✅ SHIPPED | `routes/travel_diagnostics.js:172-236` (versioned banks) |
+| **FR-1.3 / FR-2** | Visa-Sure-**branded** PDF report | 🟡 PARTIAL | `services/pdfRenderer.js:3071-3234` — generic template, only label + accent colour; no visa tone/copy, no `visa-sure.pdfkit.js` |
+| **FR-1.3 / FR-2** | Report **emailed** / WA-delivered | ❌ MISSING | `routes/travel_diagnostics.js:403-513` — PDF generated, never dispatched |
+| **FR-3.1(a)** | Complex = applicationType ∈ {work,student,business,hajj} | ✅ SHIPPED | `cron/visaRiskFlagEngine.js:149-153` |
+| **FR-3.1(b)** | Complex = priorRejectionCount ≥ 1 | ❌ MISSING | No `priorRejectionCount` column (only `priorApplicationId` FK, `schema.prisma:~6149`); trigger not implemented |
+| **FR-3.1(c)** | Complex = family/dependents | 🟡 PARTIAL | `VisaApplication.familySize` exists (`schema.prisma:6140`) but the engine never reads it — PC-8 "resolved" yet uncoded |
+| **FR-3.1(d)** | Complex = high-rejection-rate destination | 🟡 PARTIAL | `visaRiskFlagEngine.js:271-277` — "new destination" **proxy** only; real rejection-rate lookup deferred (PC-3) |
+| **FR-3.2** | Rejection-history tagging | 🟡 PARTIAL | Engine reads `rejectionHistoryJson` (`visaRiskFlagEngine.js:168-180`) but it is **never populated at diagnostic submit** (`routes/travel_diagnostics.js` has zero refs); no diagnostic→application mirror |
+| **FR-3.3** | Advisor priority alerts | 🟡 PARTIAL | `Notification` created (`visaRiskFlagEngine.js:492-502`); WhatsApp/email dispatch deferred (Q9) |
+| **FR-4 list** | Applications list + filters | ✅ SHIPPED | `pages/travel/visa/Applications.jsx`; `routes/travel_visa.js:343-465`; `?status=` deep-link `Applications.jsx:206-210` |
+| **FR-4 detail** | Diagnostic Q/A + risk chips + checklist + status + history + recovery | ✅ SHIPPED | `AdvisorDashboard.jsx` (diagnostic 466-527, risk 546-605, checklist 792-1019, status 432-463, recovery 607-787); `routes/travel_visa.js:1507-1618` |
+| **FR-4 AI summary** | `visa-summary` LLM consumer | ❌ MISSING | Static placeholder `AdvisorDashboard.jsx:532-541`; no `visa-summary` in `lib/llmRouter.js`; no `aiSummary` field — Q11-blocked |
+| **FR-4 checklist admin** | Checklist template CRUD | ✅ SHIPPED | `Checklists.jsx`; `routes/travel_visa.js:2769-2932` |
+| **FR-5.1** | Manual quotation (visa surface) | 🟡 PARTIAL | Generic `QuoteBuilder.jsx:115-120` (`visasure` is a subBrand option); no visa-specific surface |
+| **FR-5.2 admin** | Quotation template CRUD | ✅ SHIPPED | `VisaQuotationTemplate` `schema.prisma:6240-6254`; `routes/travel_visa.js:3151-3320`; Checklists tab |
+| **FR-5.2 consumer** | Pick template → auto-populate quote → persist Itinerary | ❌ MISSING | No endpoint/UI to apply a template to a quote |
+| **FR-5.3** | Branded visa quote PDF | 🟡 PARTIAL | Generic `TravelQuote` PDF reused; no `visa-quote.pdfkit.js`; branding unverified |
+| **FR-5.4** | Stored as `Itinerary.subBrand="visa-sure"` | ✅ SHIPPED | `Itinerary.subBrand` `schema.prisma:~5447` |
+| **FR-6.1** | Checklist templates per type×destination | ✅ SHIPPED | `VisaChecklistTemplate`; `routes/travel_visa.js:2767-2937` |
+| **FR-6.2** | Per-application document upload + seed-on-create | ✅ SHIPPED | Portal upload `routes/portal.js:1341-1412` via `lib/visaDocStore.js`; seed `routes/travel_visa.js:165-187,1761-1777` |
+| **FR-6.3** | Status tracking pending→uploaded→verified/rejected | ✅ SHIPPED | `schema.prisma:6195`; PATCH `routes/travel_visa.js:3052-3150` |
+| **FR-6.4** | **Encryption at rest (AES-256-GCM)** | ❌ **MISSING** | `lib/visaDocStore.js:33-43` writes **plaintext** to S3/disk; `fieldEncryption.js` not used (UUID filename only) |
+| **FR-6.5** | Auto-advance docs-pending → filed | ✅ SHIPPED | `routes/travel_visa.js:234-302` (`maybeAdvanceOnChecklist`) |
+| **FR-7** | Analytics: recovery-rate, conversion-by-readiness, lead-source-rate | ✅ SHIPPED (+bonus) | `routes/travel_visa_analytics.js:106-943` (3 spec'd + by-month/quarter/year); `Reports.jsx` |
+| **FR-7** | Secondary: time-to-file/decision, tier-mix, advisor-productivity | ❌ MISSING | Not implemented |
+| **FR-8 nav** | Visa Sure sidebar group | 🟡 PARTIAL | 4/5 links `Sidebar.jsx:1596-1601` — **Reports link missing** (route exists `App.jsx:1587`) |
+| **FR-8 landing** | `/travel/visa` lands on dashboard | ✅ SHIPPED | `App.jsx:1578` |
+| **FR-8 theme** | `visa-sure.css` brand palette | 🟡 PARTIAL | No dedicated file; uses generic `theme/travel.css` (pending Yasin Q22) |
+
+### This-cycle additions (beyond the original PRD FR list)
+
+| Feature | Status | Evidence |
+|---|---|---|
+| Rejection-recovery program (model + admin + enrol) | ✅ SHIPPED | `RejectionRecoveryProgram` `schema.prisma:6165-6187`; `RecoveryProgram.jsx`; enrol route `routes/travel_visa.js` |
+| EmbassyRule model + CRUD + admin | ✅ SHIPPED | `routes/embassy_rules.js`; `EmbassyRulesAdmin.jsx`; `schema.prisma:6275-6294` |
+| EmbassyRule **consumption** | 🟡 PARTIAL | Only R13 cooldown reads it (`visaRiskFlagEngine.js:353-363`); checklist engine has zero refs — PC-1..PC-5/PC-7 |
+| Customer self-serve portal — "My Visa" (preview, start, upload, cancel, **multiple** apps) | ✅ SHIPPED | `TravelCustomerPortal.jsx` (`VisaApplicationCard`); `routes/portal.js` GET/POST/DELETE `/travel/visa/applications`, `/checklist-preview`, `/documents/:itemId/upload` |
+| Unified login (staff `/login` falls back to portal auth) | ✅ SHIPPED | `Login.jsx` `performLogin`→`tryPortalLogin`; standalone portal login retired (`TravelCustomerPortal.jsx` redirects unauth→`/login`) |
+| Email-OTP registration (org signup + customer) | ✅ SHIPPED | `lib/emailOtp.js`; `routes/auth.js` `/email-otp/{request,verify}`; `EmailOtpField.jsx`; `emailVerifiedAt` on Tenant/User/Contact |
+
+---
+
+## 3. Gaps by blocker
+
+### A — Engineering-actionable now (no external dependency)
+
+| # | Gap | Evidence | Effort | Recommendation |
+|---|---|---|---|---|
+| A1 | **FR-6.4: documents stored unencrypted** | `lib/visaDocStore.js:33-43` | ~½ day | Encrypt the buffer with `lib/fieldEncryption.js` (AES-256-GCM) before write; decrypt on the authenticated download path. **Do this first** — passport/bank scans in plaintext is a compliance risk. |
+| A2 | **FR-5.2 consumer missing** (template → quote) | NOT FOUND | ~1 day | Add "Apply quotation template" in the visa quote flow: fetch template lines → create an `Itinerary` (`subBrand="visa-sure"`) pre-filled. |
+| A3 | **FR-3.2: rejection-history never populated** | `routes/travel_diagnostics.js` (no refs) | ~½ day | At diagnostic submit, derive `priorRejectionCount`/`rejectionHistoryJson` from the relevant answers; mirror onto `VisaApplication` at create. Unblocks FR-3.1(b) too. |
+| A4 | **FR-3.1(c): `familySize` not consumed** | `schema.prisma:6140`; engine no-ref | ~½ hr | Add the rule in `visaRiskFlagEngine.js` (`familySize > N` → complex). Column already exists. |
+| A5 | **NFR retention: visa models unmapped** | `cron/retentionEngine.js` ENTITY_MAP | ~½ day | Add `VisaApplication` (84 mo post-`decidedAt` for rejection history) + `VisaDocumentChecklistItem` (24 mo) to the ENTITY_MAP + seed `RetentionPolicy` rows. |
+| A6 | **FR-8: Reports link missing from sidebar** | `Sidebar.jsx:1596-1601` | ~10 min | Add the Reports child link to the Visa Sure nav group (route already mounted). |
+| A7 | **Diagnostic report email delivery** | `routes/travel_diagnostics.js:403-513` | ~½ day | Wire the existing SendGrid sender to email the generated PDF on submit (SendGrid is configured). WA stays Q9-blocked. |
+| A8 | **Email-OTP API bypass** | `routes/auth.js` register/signup; `routes/portal.js:116-138` | ~1 hr + test updates | Make the `verificationToken` **required** (not just UI-gated). Update the ~5 affected register/signup tests. |
+| A9 | **FR-7 secondary metrics** | `travel_visa_analytics.js` | ~1 day | Add time-to-file/decision, tier-mix, advisor-productivity (data already on `VisaApplication`: `createdAt/filedAt/decidedAt`). |
+
+### B — Decision-blocked (need a product call before building)
+
+| # | Gap | PRD ref | Blocking question |
+|---|---|---|---|
+| B1 | High-rejection-rate destination signal (FR-3.1(d)) | PC-3 / PC-7 | Do we model per-embassy rejection rates, and who maintains the catalogue? Engine ships a proxy today. |
+| B2 | EmbassyRule consumption breadth | PC-1..PC-5 | Which rule types feed the checklist/risk engines (document-required, interview-required, funds)? Model + CRUD exist; only cooldown is wired. |
+| B3 | Recovery diagnostic reuse vs retake | PC-2 | Does the recovery program reuse the original diagnostic + a follow-up Q-set, or a full retake? |
+| B4 | Recovery cool-down gate (FR / PC-4) | PC-4 | Does the system enforce `createdAt > decidedAt + cooldown`, or just advise? |
+| B5 | FR-3.1(b) `priorRejectionCount` column | PC-1 | Confirm the complex-case definition before adding the column (A3 supplies the data either way). |
+
+### C — Cred-blocked
+
+| # | Gap | Cred | Notes |
+|---|---|---|---|
+| C1 | `visa-summary` LLM (FR-4 AI notes) | Q11 (LLM keys) | UI placeholder + router stub pattern ready; flips on when keys land. |
+| C2 | WhatsApp advisor alerts (FR-3.3) + diagnostic WA delivery (FR-1.3) | Q9 (Wati BSP) | `Notification` row already created; WA dispatch is the only missing leg. |
+| C3 | Passport OCR for uploaded docs (FR-6 enhancement) | C-cluster OCR | Optional; the portal already shares the passport-upload storage posture. |
+
+### D — Brand-asset-blocked (Yasin Q22 brand pack)
+
+| # | Gap | PRD ref |
+|---|---|---|
+| D1 | Visa-Sure PDF brand template + tone/copy (FR-1.3/FR-2) | FR-1.3 |
+| D2 | `frontend/src/theme/visa-sure.css` palette (FR-8.3) | FR-8.3 |
+| D3 | Visa quote-PDF branding (FR-5.3) | FR-5.3 |
+
+---
+
+## 4. Recommended sequencing
+
+1. **A1 — encrypt documents at rest** (security; ~½ day). Highest priority.
+2. **A3 + A4** — populate rejection-history at submit + consume `familySize`
+   (makes the risk engine's FR-3.1/3.2 faithful; ~1 day combined).
+3. **A2 — quotation-template consumer** (completes FR-5.2 end-to-end; ~1 day).
+4. **A5 — visa retention rows** (compliance; ~½ day).
+5. **A6 + A7 + A8 + A9** — quick wins (Reports link, email delivery, OTP
+   hard-enforce, secondary analytics).
+6. Hold **B1–B5** for the next product call with Yasin (they're PRD-tracked
+   PC-1..PC-8 decisions, not engineering gaps).
+7. **C1–C3 / D1–D3** flip on automatically when the Q11 / Q9 / OCR creds and the
+   Q22 brand pack land — the seams are already in place.
+
+---
+
+## 5. Notes
+
+- Counts/line numbers reflect the current working tree on 2026-06-16; a few
+  totals (e.g. analytics endpoint count) **exceed** the PRD because bonus
+  time-series endpoints shipped.
+- Items D1–D3 + C1–C3 match the PRD's own §5.2 cred-chase / §6 deferral notes —
+  they are tracked, not overlooked.
+- This analysis is scoped to **Visa Sure Phase 3 + the travel customer-portal /
+  auth work** (the active surface). A whole-CRM gap sweep is a separate exercise.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,6 +62,7 @@ const TmcReadiness = lazy(() => import("./pages/public/TmcReadiness"));
 const TmcReadinessReport = lazy(() => import("./pages/public/TmcReadinessReport"));
 // PRD_TRAVEL_QUOTE_BUILDER §3.7 / slice C9 — public quote-accept landing.
 const QuoteAcceptLanding = lazy(() => import("./pages/public/QuoteAcceptLanding"));
+const TravelReview = lazy(() => import("./pages/public/TravelReview"));
 // Public flyer share/embed viewer — /p/flyer/:slug?t=<jwt>[&embed=1].
 const FlyerView = lazy(() => import("./pages/public/FlyerView"));
 // Cross-vertical staff attendance dashboard — visible to wellness + travel
@@ -225,6 +226,7 @@ const TravelCancellationPolicies = lazy(() => import("./pages/travel/Cancellatio
 const TravelLeads = lazy(() => import("./pages/travel/Leads"));
 const TravelPricingRules = lazy(() => import("./pages/travel/PricingRules"));
 const TravelReports = lazy(() => import("./pages/travel/Reports"));
+const TravelReviews = lazy(() => import("./pages/travel/Reviews"));
 const TravelRfuCustomerProfile = lazy(() => import("./pages/travel/RfuCustomerProfile"));
 const TravelSuppliers = lazy(() => import("./pages/travel/Suppliers"));
 const TravelSuppliersAdmin = lazy(() => import("./pages/travel/SuppliersAdmin"));
@@ -984,6 +986,8 @@ export default function App() {
                   <Route path="/p/tmc/report/:slug" element={<TmcReadinessReport />} />
                   {/* PRD_TRAVEL_QUOTE_BUILDER §3.7 / slice C9 — customer-accept landing. */}
                   <Route path="/p/quote/:shareToken" element={<QuoteAcceptLanding />} />
+                  {/* Public post-trip review (no auth; token in path). */}
+                  <Route path="/p/review/:token" element={<TravelReview />} />
                   {/* Public flyer share + iframe-embed viewer (no auth; JWT in ?t=). */}
                   <Route path="/p/flyer/:slug" element={<FlyerView />} />
                   <Route path="/travel/kyc/callback" element={<TravelKycCallback flow="microsite" />} />
@@ -1481,6 +1485,7 @@ export default function App() {
               <Route path="travel/rfu/customers/:contactId" element={<TravelOnly><TravelRfuCustomerProfile /></TravelOnly>} />
               <Route path="travel/pricing-rules" element={<TravelOnly><TravelPricingRules /></TravelOnly>} />
               <Route path="travel/reports" element={<TravelOnly><TravelReports /></TravelOnly>} />
+              <Route path="travel/reviews" element={<TravelOnly><TravelReviews /></TravelOnly>} />
               <Route path="travel/suppliers" element={<TravelOnly><TravelSuppliers /></TravelOnly>} />
               <Route path="travel/suppliers-admin" element={<TravelOnly><TravelSuppliersAdmin /></TravelOnly>} />
               {/* PRD_TRAVEL_SUPPLIER_MASTER G035/G036 — Supplier PO ledger */}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1566,6 +1566,7 @@ function renderTravelNav({
       <Link to="/travel/itinerary-templates" icon={LayoutTemplate} label="Itinerary Templates" requiredPermission={{ module: "itinerary_templates", action: "read" }} />
       <Link to="/travel/pricing-rules" icon={BadgePercent} label="Pricing Rules" requiredPermission={{ module: "pricing", action: "manage" }} />
       <Link to="/travel/reports" icon={BarChart3} label="Reports" requiredPermission={{ module: "reports", action: "read" }} />
+      <Link to="/travel/reviews" icon={MessageSquare} label="Reviews" requiredPermission={{ module: "reports", action: "read" }} />
       <Link to="/travel/suppliers-admin" icon={Building2} label="Suppliers" requiredPermission={{ module: "suppliers", action: "read" }} />
       <Link to="/admin/ratehawk-search" icon={Hotel} label="RateHawk Search" requiredPermission={{ module: "suppliers", action: "read" }} />
       <Link to="/admin/booking-expedia-search" icon={BedDouble} label="Booking / Expedia" requiredPermission={{ module: "suppliers", action: "read" }} />

--- a/frontend/src/components/TravelReviewForm.jsx
+++ b/frontend/src/components/TravelReviewForm.jsx
@@ -1,0 +1,137 @@
+// Shared post-trip review form (2026-06-16). Renders a destination-interpolated
+// form definition ({ formTitle, sections:[{ title, questions:[{id,text,type,
+// options,max,required}] }] }) from the backend (lib/travelReviewQuestions.js)
+// and collects answers. Question types: "rating" (1-max stars), "choice"
+// (option pills), "text" (textarea). Used by BOTH the public review page
+// (/p/review/:token) and the customer portal.
+//
+// Self-contained: owns the answers state, does client-side required-field
+// validation, then calls onSubmit(answers). The parent handles the API call and
+// passes `submitting` + `submitError`.
+
+import { useState } from "react";
+import { Star } from "lucide-react";
+
+const PRIMARY = "var(--primary-color, var(--accent-color, #122647))";
+
+function StarRating({ value, max, onChange }) {
+  return (
+    <div role="radiogroup" style={{ display: "flex", gap: 4 }}>
+      {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+        <button
+          key={n}
+          type="button"
+          role="radio"
+          aria-checked={value === n}
+          aria-label={`${n} star${n > 1 ? "s" : ""}`}
+          onClick={() => onChange(n)}
+          style={{ background: "none", border: "none", cursor: "pointer", padding: 2, lineHeight: 0 }}
+        >
+          <Star
+            size={26}
+            aria-hidden
+            fill={value && n <= value ? "#F5B301" : "none"}
+            color={value && n <= value ? "#F5B301" : "var(--text-secondary, #94a3b8)"}
+          />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function TravelReviewForm({ form, onSubmit, submitting, submitError }) {
+  const [answers, setAnswers] = useState({});
+  const [errors, setErrors] = useState({});
+
+  if (!form || !Array.isArray(form.sections)) return null;
+  const set = (id, val) => setAnswers((a) => ({ ...a, [id]: val }));
+
+  const allQuestions = form.sections.flatMap((s) => s.questions);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const errs = {};
+    for (const q of allQuestions) {
+      const v = answers[q.id];
+      if (q.required && (v === undefined || v === null || String(v).trim() === "")) {
+        errs[q.id] = "Required";
+      }
+    }
+    setErrors(errs);
+    if (Object.keys(errs).length === 0) onSubmit(answers);
+  };
+
+  const labelStyle = { display: "block", fontSize: 14, fontWeight: 600, marginBottom: 6, color: "var(--text-primary, #1e293b)" };
+  const sectionTitleStyle = { fontSize: 16, fontWeight: 700, margin: "20px 0 10px", color: PRIMARY };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {form.sections.map((section) => (
+        <div key={section.key}>
+          <h3 style={sectionTitleStyle}>{section.title}</h3>
+          {section.questions.map((q) => (
+            <div key={q.id} style={{ marginBottom: 16 }}>
+              <label style={labelStyle} htmlFor={`q-${q.id}`}>
+                {q.text} {q.required && <span style={{ color: "#dc2626" }}>*</span>}
+              </label>
+              {q.type === "rating" && (
+                <StarRating value={answers[q.id]} max={q.max || 5} onChange={(n) => set(q.id, n)} />
+              )}
+              {q.type === "choice" && (
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  {(q.options || []).map((opt) => {
+                    const active = answers[q.id] === opt;
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        onClick={() => set(q.id, opt)}
+                        aria-pressed={active}
+                        style={{
+                          padding: "7px 14px", borderRadius: 20, fontSize: 14, fontWeight: 600, cursor: "pointer",
+                          border: `1px solid ${active ? PRIMARY : "var(--border-light, #d1d5db)"}`,
+                          background: active ? PRIMARY : "transparent",
+                          color: active ? "#fff" : "var(--text-secondary, #475569)",
+                        }}
+                      >
+                        {opt}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {q.type === "text" && (
+                <textarea
+                  id={`q-${q.id}`}
+                  value={answers[q.id] || ""}
+                  onChange={(e) => set(q.id, e.target.value)}
+                  rows={3}
+                  maxLength={2000}
+                  placeholder="Share your thoughts…"
+                  style={{
+                    width: "100%", padding: 10, borderRadius: 8, fontSize: 14, fontFamily: "inherit",
+                    border: "1px solid var(--border-light, #d1d5db)", boxSizing: "border-box", resize: "vertical",
+                  }}
+                />
+              )}
+              {errors[q.id] && <div style={{ color: "#dc2626", fontSize: 12, marginTop: 4 }}>{errors[q.id]}</div>}
+            </div>
+          ))}
+        </div>
+      ))}
+
+      {submitError && <div role="alert" style={{ color: "#b91c1c", fontSize: 13, margin: "8px 0" }}>{submitError}</div>}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        style={{
+          marginTop: 8, padding: "10px 22px", border: "none", borderRadius: 8, fontSize: 15, fontWeight: 700,
+          cursor: submitting ? "default" : "pointer", background: PRIMARY, color: "#fff", opacity: submitting ? 0.7 : 1,
+        }}
+      >
+        {submitting ? "Submitting…" : "Submit review"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/public/TravelReview.jsx
+++ b/frontend/src/pages/public/TravelReview.jsx
@@ -1,0 +1,87 @@
+// Public post-trip review page (2026-06-16) — lands at /p/review/:token from
+// the review-request email. No auth: the token IS the credential. Fetches the
+// destination-interpolated form, collects answers, submits.
+//
+//   GET  /api/travel/reviews/public/:token
+//   POST /api/travel/reviews/public/:token/submit
+//
+// Uses raw fetch() (renders outside the AuthContext shell), matching the other
+// public travel pages (TripBooking.jsx).
+
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import TravelReviewForm from "../../components/TravelReviewForm";
+
+const wrap = { minHeight: "100vh", background: "var(--cream-bg, #f7f3ec)", padding: "32px 16px", color: "var(--text-primary, #1e293b)" };
+const card = { maxWidth: 640, margin: "0 auto", background: "#fff", borderRadius: 16, padding: "28px 28px 32px", boxShadow: "0 6px 30px rgba(18,38,71,0.10)" };
+
+export default function TravelReview() {
+  const { token } = useParams();
+  const [state, setState] = useState({ loading: true, error: null, data: null, done: false });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch(`/api/travel/reviews/public/${encodeURIComponent(token || "")}`)
+      .then(async (r) => {
+        const body = await r.json().catch(() => ({}));
+        if (!r.ok) throw new Error(body.error || "This review link is not valid.");
+        return body;
+      })
+      .then((data) => { if (alive) setState({ loading: false, error: null, data, done: data.alreadySubmitted }); })
+      .catch((e) => { if (alive) setState({ loading: false, error: e.message, data: null, done: false }); });
+    return () => { alive = false; };
+  }, [token]);
+
+  const submit = async (answers) => {
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const r = await fetch(`/api/travel/reviews/public/${encodeURIComponent(token || "")}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(body.error || "Could not submit your review. Please try again.");
+      setState((s) => ({ ...s, done: true }));
+    } catch (e) {
+      setSubmitError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (state.loading) {
+    return <div style={wrap}><div style={card}>Loading…</div></div>;
+  }
+  if (state.error) {
+    return <div style={wrap}><div style={card}><h2 style={{ marginTop: 0 }}>Review unavailable</h2><p style={{ color: "var(--text-secondary,#64748b)" }}>{state.error}</p></div></div>;
+  }
+  if (state.done) {
+    return (
+      <div style={wrap}>
+        <div style={{ ...card, textAlign: "center" }}>
+          <div style={{ fontSize: 44, lineHeight: 1 }}>🌟</div>
+          <h2 style={{ margin: "12px 0 6px" }}>Thank you for your review!</h2>
+          <p style={{ color: "var(--text-secondary,#64748b)" }}>
+            Your feedback on {state.data?.destination || "your trip"} helps us make every journey better.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <p style={{ fontSize: 13, color: "var(--text-secondary,#64748b)", margin: 0, textTransform: "uppercase", letterSpacing: 0.5 }}>
+          Travel Stall · Trip review
+        </p>
+        <h1 style={{ fontSize: 24, margin: "6px 0 18px" }}>{state.data?.form?.formTitle || "How was your trip?"}</h1>
+        <TravelReviewForm form={state.data?.form} onSubmit={submit} submitting={submitting} submitError={submitError} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/public/TripBooking.jsx
+++ b/frontend/src/pages/public/TripBooking.jsx
@@ -276,7 +276,7 @@ function PaymentCTA({ itin, paying, onPayAdvance, onPayBalance }) {
           <CheckCircle2 size={20} aria-hidden style={{ color: "#2ecc71" }} />
           <span><strong>Advance received.</strong> Your trip is confirmed. Settle the balance any time before departure.</span>
         </div>
-        {itin.balanceDue > 0 && (
+        {itin.balanceDue > 0 && itin.onlinePaymentEnabled && (
           <button
             type="button"
             onClick={onPayBalance}
@@ -286,6 +286,9 @@ function PaymentCTA({ itin, paying, onPayAdvance, onPayBalance }) {
             <CreditCard size={16} aria-hidden />
             {paying ? "Processing…" : `Pay balance · ${fmtMoneyCompact(itin.balanceDue, itin.currency)}`}
           </button>
+        )}
+        {itin.balanceDue > 0 && !itin.onlinePaymentEnabled && (
+          <div style={infoBox} role="status">Your advisor will share payment details for the balance.</div>
         )}
       </>
     );
@@ -299,6 +302,16 @@ function PaymentCTA({ itin, paying, onPayAdvance, onPayBalance }) {
   }
   // sent / accepted / revised / draft (draft is filtered server-side
   // already, but the branch is harmless).
+  // Online pay is only offered when the agency has configured its own payment
+  // gateway (itin.onlinePaymentEnabled). Otherwise the advisor arranges payment
+  // offline — we never route customer money through the platform account.
+  if (!itin.onlinePaymentEnabled) {
+    return (
+      <div style={infoBox} role="status">
+        Your advisor will share payment details to confirm this trip.
+      </div>
+    );
+  }
   return (
     <button
       type="button"
@@ -439,6 +452,11 @@ const successBox = {
   background: "#e8f6ee", border: "1px solid #b7e4c7",
   color: "#1e6e3a", borderRadius: 10, fontSize: 14,
   display: "flex", alignItems: "center", gap: 10,
+};
+const infoBox = {
+  marginTop: 16, padding: "12px 16px",
+  background: "#eef2f8", border: "1px solid #cdd7e6",
+  color: "#3b4a63", borderRadius: 10, fontSize: 14,
 };
 const fineprint = {
   textAlign: "center", color: "#7a8294",

--- a/frontend/src/pages/travel/Itineraries.jsx
+++ b/frontend/src/pages/travel/Itineraries.jsx
@@ -16,7 +16,7 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Map, Filter, Plane, Hotel, MapPin, Briefcase, FileText, Shield, Plus, X,
-  Sparkles,
+  Sparkles, AlertTriangle,
 } from "lucide-react";
 import { fetchApi } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
@@ -53,6 +53,7 @@ const STATUSES = [
   { value: "revised", label: "Revised" },
   { value: "accepted", label: "Accepted" },
   { value: "rejected", label: "Rejected" },
+  { value: "expired", label: "Expired" },
 ];
 
 // #879 (Itineraries slice) — pre-refactor used inline `${bg}` + `${color}`
@@ -66,6 +67,9 @@ const STATUS_VARIANT = {
   revised: "revised",
   accepted: "accepted",
   rejected: "rejected",
+  // expired = advisor-cancelled for non-payment (cron/paymentDeadlineEngine
+  // flags it; advisor sets the status). Reuses the "rejected" red-ish pill.
+  expired: "rejected",
 };
 
 // PRD §6.4 — tier badge palette. productTier on each Itinerary is captured
@@ -656,6 +660,29 @@ export default function Itineraries() {
                       <span className={`travel-itin-status-pill travel-itin-status-pill--${statusVariant}`}>
                         {it.status}
                       </span>
+                      {/* Pay-or-cancel at-risk flag: an accepted booking whose
+                          50% deposit deadline passed unpaid (paymentOverdueAt
+                          set by cron/paymentDeadlineEngine). Prompts the advisor
+                          to follow up or set status → expired. */}
+                      {it.status === "accepted" && it.paymentOverdueAt && (
+                        <span
+                          title={`Deposit overdue since ${fmt(it.paymentOverdueAt)} — review for cancellation`}
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 4,
+                            marginLeft: 6,
+                            padding: "1px 6px",
+                            borderRadius: 10,
+                            fontSize: 11,
+                            fontWeight: 600,
+                            background: "rgba(220,38,38,0.12)",
+                            color: "#b91c1c",
+                          }}
+                        >
+                          <AlertTriangle size={11} aria-hidden="true" /> Deposit overdue
+                        </span>
+                      )}
                     </td>
                     <td style={td}><TierBadge tier={it.productTier} /></td>
                     <td style={td}>{new Date(it.updatedAt).toLocaleDateString()}</td>

--- a/frontend/src/pages/travel/Reviews.jsx
+++ b/frontend/src/pages/travel/Reviews.jsx
@@ -1,0 +1,154 @@
+// Travel CRM — admin "Customer Reviews" page (2026-06-16).
+//
+// Lands at /travel/reviews. Lists submitted post-trip reviews for the tenant
+// (sub-brand scoped server-side) from GET /api/travel/reviews. Shows the
+// headline star rating + the full per-question breakdown (the fixed set from
+// backend/lib/travelReviewQuestions.js).
+
+import { useEffect, useState } from "react";
+import { Star, RefreshCw, MessageSquareText } from "lucide-react";
+import { fetchApi } from "../../utils/api";
+import { useNotify } from "../../utils/notify";
+
+const PRIMARY = "var(--primary-color, var(--accent-color, #122647))";
+
+// Mirrors the fixed question set in backend/lib/travelReviewQuestions.js so the
+// stored answer keys render with human labels.
+const Q_LABELS = {
+  rate_accommodation: "Accommodation & hotels",
+  rate_transport: "Transportation & transfers",
+  rate_activities: "Activities & sightseeing",
+  rate_support: "Tour coordination & support",
+  rate_value: "Value for money",
+  recommend: "Would recommend?",
+  rebook: "Book again?",
+  loved_most: "Loved most",
+  improve: "Could do better",
+  highlight: "Memorable moment",
+};
+const RATING_IDS = ["rate_accommodation", "rate_transport", "rate_activities", "rate_support", "rate_value"];
+const CHOICE_IDS = ["recommend", "rebook"];
+const TEXT_IDS = ["loved_most", "improve", "highlight"];
+
+function Stars({ value, size = 16 }) {
+  const v = Number(value) || 0;
+  return (
+    <span style={{ display: "inline-flex", gap: 1, verticalAlign: "middle" }} aria-label={`${v} of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star key={n} size={size} aria-hidden fill={n <= v ? "#F5B301" : "none"} color={n <= v ? "#F5B301" : "var(--text-secondary,#94a3b8)"} />
+      ))}
+    </span>
+  );
+}
+
+const fmtDate = (d) => (d ? new Date(d).toLocaleDateString() : "—");
+// Theme-safe surface — uses the travel theme's --surface-color / --text-* so it
+// reads correctly in BOTH light and dark mode (the earlier --card-bg/#fff
+// fallback rendered light-on-white in dark mode).
+const card = {
+  background: "var(--surface-color, #fff)",
+  border: "1px solid var(--border-color, var(--border-light, #e2e8f0))",
+  borderRadius: 12, padding: 18, marginBottom: 14,
+  color: "var(--text-primary)", boxShadow: "var(--shadow-sm)",
+};
+
+export default function Reviews() {
+  const notify = useNotify();
+  const [reviews, setReviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = () => {
+    setLoading(true);
+    fetchApi("/api/travel/reviews")
+      .then((res) => setReviews(Array.isArray(res?.reviews) ? res.reviews : []))
+      .catch((e) => { notify.error(e?.body?.error || "Failed to load reviews"); setReviews([]); })
+      .finally(() => setLoading(false));
+  };
+  useEffect(load, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const rated = reviews.filter((r) => typeof r.overallRating === "number");
+  const avg = rated.length ? (rated.reduce((s, r) => s + r.overallRating, 0) / rated.length) : 0;
+
+  return (
+    <div style={{ padding: 24, maxWidth: 1000, margin: "0 auto" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12, marginBottom: 8 }}>
+        <h1 style={{ display: "flex", alignItems: "center", gap: 10, margin: 0 }}>
+          <MessageSquareText size={26} aria-hidden /> Customer Reviews
+        </h1>
+        <button type="button" onClick={load} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "8px 14px", borderRadius: 8, border: "1px solid var(--border-light,#d1d5db)", background: "transparent", cursor: "pointer", fontWeight: 600 }}>
+          <RefreshCw size={15} aria-hidden /> Refresh
+        </button>
+      </div>
+      <p style={{ color: "var(--text-secondary)", marginTop: 0 }}>
+        Post-trip feedback from your customers.{" "}
+        {rated.length > 0 && (
+          <strong>{reviews.length} review{reviews.length !== 1 ? "s" : ""} · average <Stars value={Math.round(avg)} /> {avg.toFixed(1)}/5</strong>
+        )}
+      </p>
+
+      {loading && <p style={{ color: "var(--text-secondary)" }}>Loading…</p>}
+      {!loading && reviews.length === 0 && (
+        <div style={{ ...card, textAlign: "center", color: "var(--text-secondary)" }}>
+          No reviews yet. Customers are asked for a review after their trip ends.
+        </div>
+      )}
+
+      {!loading && reviews.map((r) => {
+        const a = r.answers || {};
+        return (
+          <div key={r.id} style={card}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 8 }}>
+              <div>
+                <div style={{ fontSize: 17, fontWeight: 700, color: "var(--text-primary)" }}>{r.destination || "Trip"}</div>
+                {/* WHO left the review — name + contact, so the advisor can follow up. */}
+                <div style={{ fontSize: 14, fontWeight: 600, color: "var(--text-primary)", marginTop: 3 }}>
+                  {r.contactName || `Contact #${r.contactId}`}
+                </div>
+                <div style={{ fontSize: 12, color: "var(--text-secondary)", marginTop: 2 }}>
+                  {r.subBrand && <span style={{ textTransform: "uppercase", letterSpacing: 0.5, marginRight: 8 }}>{r.subBrand}</span>}
+                  {r.contactEmail && <span style={{ marginRight: 8 }}>{r.contactEmail}</span>}
+                  {r.contactPhone && <span style={{ marginRight: 8 }}>{r.contactPhone}</span>}
+                  · {fmtDate(r.submittedAt)}
+                </div>
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <Stars value={r.overallRating} size={20} />
+                <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>{r.overallRating}/5 overall</div>
+              </div>
+            </div>
+
+            {/* Ratings */}
+            <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 240px), 1fr))", gap: "6px 18px" }}>
+              {RATING_IDS.filter((id) => a[id] != null).map((id) => (
+                <div key={id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 13 }}>
+                  <span style={{ color: "var(--text-secondary)" }}>{Q_LABELS[id]}</span>
+                  <Stars value={a[id]} size={14} />
+                </div>
+              ))}
+            </div>
+
+            {/* Loyalty choices */}
+            {CHOICE_IDS.some((id) => a[id]) && (
+              <div style={{ marginTop: 10, display: "flex", gap: 18, flexWrap: "wrap" }}>
+                {CHOICE_IDS.filter((id) => a[id]).map((id) => (
+                  <span key={id} style={{ fontSize: 13 }}>
+                    <span style={{ color: "var(--text-secondary)" }}>{Q_LABELS[id]} </span>
+                    <strong style={{ color: PRIMARY }}>{a[id]}</strong>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Free text */}
+            {TEXT_IDS.filter((id) => a[id]).map((id) => (
+              <div key={id} style={{ marginTop: 10 }}>
+                <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>{Q_LABELS[id]}</div>
+                <div style={{ fontSize: 14, fontStyle: "italic", color: "var(--text-primary)", borderLeft: `3px solid ${PRIMARY}`, paddingLeft: 10, marginTop: 2 }}>“{a[id]}”</div>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/travel/TravelCustomerPortal.jsx
+++ b/frontend/src/pages/travel/TravelCustomerPortal.jsx
@@ -39,8 +39,9 @@ import {
   ShieldCheck, ShieldAlert, LogOut, Plane, User as UserIcon,
   CheckCircle2, AlertCircle, Loader2, ClipboardCheck, Award, LayoutDashboard,
   ChevronRight, ChevronLeft, Hotel, Ticket, FileUp, Upload, UserPlus,
-  Mail, Phone, Sun, Moon, Stamp,
+  Mail, Phone, Sun, Moon, Stamp, Star,
 } from "lucide-react";
+import TravelReviewForm from "../../components/TravelReviewForm";
 
 const PORTAL_TOKEN_KEY = "portalToken";
 const PORTAL_CONTACT_KEY = "portalContact";
@@ -1908,9 +1909,33 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
   const [decideErr, setDecideErr] = useState(null);
   const [declining, setDeclining] = useState(false); // reason form open?
   const [reasonText, setReasonText] = useState("");
+  // Web check-in prompt (2026-06-16): customer confirms they've checked in for
+  // a flight trip → stops the T-36/24/12h reminder emails.
+  const [wcBusy, setWcBusy] = useState(false);
+  const [wcErr, setWcErr] = useState(null);
+  const [wcDismissed, setWcDismissed] = useState(false); // "Not yet" hides for this view
+  const [wcConfirmed, setWcConfirmed] = useState(false); // set after a successful "Yes"
+  // Post-trip review (2026-06-16) — only on completed trips (reviewState).
+  const [reviewForm, setReviewForm] = useState(null);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const [reviewError, setReviewError] = useState(null);
+  const [reviewDone, setReviewDone] = useState(false);
   // "What-if" headcount the customer types into the estimate calculator.
   // Empty string = use the advisor's quoted traveler count (pax).
   const [headcount, setHeadcount] = useState("");
+
+  // Post-trip review: fetch the destination-interpolated form once when the
+  // trip is review-able. Declared BEFORE the early return so the hook order
+  // stays stable (react-hooks/rules-of-hooks). Guards on itinerary internally.
+  useEffect(() => {
+    let alive = true;
+    if (itinerary && itinerary.reviewState === "available" && !reviewForm) {
+      portalFetch(`/travel/itineraries/${itinerary.id}/review`, { token })
+        .then((res) => { if (alive && res && res.form) setReviewForm(res.form); })
+        .catch(() => { /* non-fatal — section just won't render the form */ });
+    }
+    return () => { alive = false; };
+  }, [itinerary, token, reviewForm]);
 
   if (!itinerary) {
     return (
@@ -1938,6 +1963,42 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
   const canDecide = DECIDABLE_BOOKING_STATUSES.includes(status);
   const isAccepted = ["accepted", "advance_paid", "fully_paid"].includes(status);
   const isDeclined = status === "rejected";
+  // Web check-in: the server attaches `webCheckinDue` (an active WebCheckin row
+  // for this trip whose flight departs within 36h). Clicking "Yes" flips those
+  // rows to "done" → the flag clears on refresh + the reminder emails stop.
+  const webCheckinDue = Boolean(itinerary.webCheckinDue) && !wcConfirmed;
+
+  const confirmWebCheckin = async () => {
+    setWcBusy(true);
+    setWcErr(null);
+    try {
+      await portalFetch(`/travel/itineraries/${itinerary.id}/webcheckin-confirm`, { token, method: "POST" });
+      setWcConfirmed(true); // show the confirmed line immediately
+      if (onChanged) await onChanged(); // refresh so webCheckinDue clears
+    } catch (e) {
+      setWcErr(e.message || "Couldn't save that. Please try again.");
+    } finally {
+      setWcBusy(false);
+    }
+  };
+
+  // Post-trip review state ("available" | "submitted" | "none"); the form
+  // fetch itself runs in the useEffect declared above the early return.
+  const reviewState = itinerary.reviewState;
+
+  const submitReview = async (answers) => {
+    setReviewSubmitting(true);
+    setReviewError(null);
+    try {
+      await portalFetch(`/travel/itineraries/${itinerary.id}/review`, { token, method: "POST", body: { answers } });
+      setReviewDone(true);
+      if (onChanged) await onChanged();
+    } catch (e) {
+      setReviewError(e.message || "Couldn't submit your review. Please try again.");
+    } finally {
+      setReviewSubmitting(false);
+    }
+  };
 
   const decide = async (action, reason) => {
     setBusy(action);
@@ -1981,6 +2042,76 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
           {itinerary.endDate ? new Date(itinerary.endDate).toLocaleDateString() : "—"}
         </div>
       </section>
+
+      {/* Web check-in prompt — a PAID flight trip within 36h that the customer
+          hasn't confirmed yet. Clicking "Yes" stops the reminder emails. */}
+      {webCheckinDue && !wcDismissed && (
+        <section style={{ ...cardStyle, borderLeft: "4px solid var(--primary-color, var(--accent-color))" }} aria-labelledby="webcheckin-heading">
+          <h3 id="webcheckin-heading" style={{ margin: 0, fontSize: 16, display: "flex", alignItems: "center", gap: 8 }}>
+            <ClipboardCheck size={18} aria-hidden /> Web check-in for {itinerary.destination || "your trip"}
+          </h3>
+          <p style={{ color: "var(--text-secondary)", margin: "6px 0 12px", fontSize: 14 }}>
+            Your flight is coming up soon. Online web check-in usually opens 24 hours before departure — check in with the airline, then let us know so we can stop reminding you. <strong>Have you checked in?</strong>
+          </p>
+          {wcErr && (
+            <p role="alert" style={{ color: "#b91c1c", fontSize: 13, margin: "0 0 10px" }}>{wcErr}</p>
+          )}
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={confirmWebCheckin}
+              disabled={wcBusy}
+              style={{
+                display: "inline-flex", alignItems: "center", gap: 6, padding: "8px 16px",
+                border: "none", borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: wcBusy ? "default" : "pointer",
+                background: "var(--primary-color, var(--accent-color))", color: "#fff", opacity: wcBusy ? 0.7 : 1,
+              }}
+            >
+              {wcBusy ? <Loader2 size={15} className="spin" aria-hidden /> : <CheckCircle2 size={15} aria-hidden />}
+              Yes, I’ve checked in
+            </button>
+            <button
+              type="button"
+              onClick={() => setWcDismissed(true)}
+              disabled={wcBusy}
+              style={{
+                padding: "8px 16px", borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: "pointer",
+                background: "transparent", border: "1px solid var(--border-light, #d1d5db)", color: "var(--text-secondary)",
+              }}
+            >
+              Not yet
+            </button>
+          </div>
+        </section>
+      )}
+      {wcConfirmed && (
+        <section style={{ ...cardStyle, display: "flex", alignItems: "center", gap: 8 }}>
+          <CheckCircle2 size={18} aria-hidden style={{ color: "#16a34a" }} />
+          <span style={{ fontSize: 14, color: "var(--text-secondary)" }}>You’ve confirmed web check-in for this trip — no more reminders.</span>
+        </section>
+      )}
+
+      {/* Post-trip review (completed trips). "submitted"/just-done → thanks;
+          "available" → the star/options/text form. */}
+      {(reviewState === "submitted" || reviewDone) && (
+        <section style={{ ...cardStyle, display: "flex", alignItems: "center", gap: 8 }}>
+          <Star size={18} aria-hidden fill="#F5B301" color="#F5B301" />
+          <span style={{ fontSize: 14, color: "var(--text-secondary)" }}>Thanks for reviewing your trip — we appreciate your feedback!</span>
+        </section>
+      )}
+      {reviewState === "available" && !reviewDone && (
+        <section style={cardStyle} aria-labelledby="trip-review-heading">
+          <h3 id="trip-review-heading" style={{ margin: "0 0 4px", fontSize: 16 }}>
+            How was your trip to {itinerary.destination || "your destination"}?
+          </h3>
+          <p style={{ color: "var(--text-secondary)", margin: "0 0 12px", fontSize: 14 }}>
+            Your trip has wrapped up — we’d love a quick review. It takes about a minute.
+          </p>
+          {reviewForm
+            ? <TravelReviewForm form={reviewForm} onSubmit={submitReview} submitting={reviewSubmitting} submitError={reviewError} />
+            : <p style={{ color: "var(--text-secondary)", fontSize: 13 }}>Loading the review form…</p>}
+        </section>
+      )}
 
       {/* Customer's decision on the offer — accepting/declining is the
           customer's right, not the advisor's. */}


### PR DESCRIPTION
## Summary
Adds the customer-lifecycle automation the travel vertical was missing — pre-trip
nudges, a pay-or-cancel deposit deadline, web check-in reminders, and post-trip
reviews — and fixes a payment-routing bug so customer money settles into the
**tenant's** Razorpay account, never the platform's.

All five pieces are **travel-only** (they scan the `Itinerary` model, which doesn't
exist for wellness/generic), scoped to **all sub-brands except Visa Sure**, and
deliver via the existing SendGrid setup. The full backend unit suite shows **zero
new failures** vs. the branch baseline.

## What's included

### 1. Pre-trip "countdown" nudges (`cron/tripCountdownEngine.js`)
Emails **paid** trips (`advance_paid`/`fully_paid`) a short, creative reminder at
T-30/T-14 then daily T-7→T-0 ("keep packing!"). LLM-generated copy (Gemini Flash)
with a deterministic template fallback. Idempotent per (itinerary, day).

### 2. Pay-or-cancel deposit deadline (`cron/paymentDeadlineEngine.js`)
For an **accepted-but-unpaid** booking: 50% deposit due 7 days before departure.
Escalating reminders T-10→T-7, then at **T-6** (deadline missed) it emails an
at-risk notice **+ raises an advisor "review for cancellation" flag** and stamps
`Itinerary.paymentOverdueAt`. **No auto-cancel by design** — an advisor manually
sets the new `expired` status. `paymentOverdueAt` clears automatically when a
payment lands. Advisor list shows a "⚠ Deposit overdue" badge.

### 3. Web check-in reminders (`cron/webCheckinEngine.js`)
The customer-facing **email layer over the existing `WebCheckin` system** (reuses
those rows — single source of truth; the scheduler still owns status/WhatsApp/agent
fallback). Emails the passenger T-36/24/12h before the real per-flight `departureAt`.
The customer's "Yes, I've checked in" in the portal flips the trip's `WebCheckin`
rows to `done`, stopping **both** the emails and the scheduler's escalation.
Idempotent via `WebCheckin.emailRemindersJson`.

### 4. Post-trip reviews (`cron/travelReviewEngine.js` + `routes/travel_reviews.js`)
After a committed trip's `endDate` passes, emails a fixed-question review whose
wording weaves in the destination ("How was your trip to Bali?"). 5 star ratings +
2 multiple-choice + 3 free-text. Submittable via a **public page** (`/p/review/:token`,
no login) **and** the logged-in **portal** — both write one `TravelTripReview` row.
New **admin Reviews page** at `/travel/reviews` (sidebar → Reviews) shows the
reviewer's name/contact, headline + category stars, and all answers.

### 5. BYOK customer payments (security fix) 🔐
The travel itinerary pay endpoints (`create-payment-order` / `verify-payment`) were
using the **platform** Razorpay keys (`process.env.RAZORPAY_KEY_*`) — so customer
trip payments would have settled into Globussoft's account. Switched to the
**tenant's own** keys via `lib/tenantPaymentGateway.js` (the same resolver wellness
uses), blocking the charge with a clear message when the tenant hasn't configured +
enabled their gateway. Public booking page now hides the Pay button until the tenant
configures online payments (`onlinePaymentEnabled`). Platform keys remain for
tenant→Globussoft **subscription billing only**.