### PR TITLE
Travel CRM — Payment Flows, WhatsApp, LLM & UI Polish

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -557,6 +557,11 @@ LLM_MODEL_CLAUDE_HAIKU=
 LLM_MODEL_GPT=
 LLM_MODEL_GEMINI=
 LLM_MODEL_PERPLEXITY=
+# Groq provider key (llama-3.3-70b-versatile) used as a fallback for several
+# low-cost text-generation tasks in lib/llmRouter.js. Optional — when unset
+# the router falls back to deterministic templates or the next configured provider.
+GROQ_API_KEY=
+LLM_MODEL_GROQ=
 
 # ─── Flight + hotel SEARCH (quote/proposal builder + Flight quick-quote) ──────
 # Unlocks LIVE flight + hotel search via services/tboClient.js. DATA ONLY —

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -611,6 +611,23 @@ RATEHAWK_API_KEY=
 RATEHAWK_API_ID=
 RATEHAWK_BASE_URL=https://api.worldota.net/api/b2b/v3
 
+# ─── Destination photos (public quote / itinerary / microsite pages) ──────────
+# Powers the destination hero image + the decorative side-rail gallery on the
+# customer-facing pages, via the shared services/destinationImageProvider
+# cascade + the public proxy route routes/travel_destination_photos.js
+# (GET /api/travel/destination-photos/public). This is the SAME key the
+# landing-page image engine uses (Pexels → Unsplash → Pixabay → AI fallback).
+#
+# Why server-side: the key stays out of the browser, and a shared 7-day cache
+# absorbs Pexels' rate limits across all visitors — fixing the "images vanish
+# again and again" flicker the old keyless client-side Wikipedia path had.
+#
+# Get a free key at https://www.pexels.com/api/ (200 req/hour, 20k/month).
+# When UNSET, the proxy returns no photos and the frontend falls back to its
+# keyless Wikipedia source (works, but flakier) — so this is optional but
+# strongly recommended for the public pages.
+PEXELS_API_KEY=
+
 # ─── Q1 · Callified.ai (AI qualification calling) ────────────────────────────
 # Unlocks: real auto-calls + transcript/summary. Sandbox keys above are dev-only.
 CALLIFIED_API_KEY=

--- a/backend/cron/leadScoringEngine.js
+++ b/backend/cron/leadScoringEngine.js
@@ -234,11 +234,40 @@ function computeScore(contact) {
     score += Math.min(channels.size * 2, 8); // multi-channel engagement
   }
 
+  // ── WhatsApp engagement ──────────────────────────────────────────
+  // Primary scoring signal for leads that arrive via WhatsApp — they have
+  // no email, no web activity, no deals yet, so without this block they
+  // score near-floor even if they're actively chatting with the team.
+  const waMsgs = contact.whatsappMessages || [];
+  if (waMsgs.length > 0) {
+    const waInbound = waMsgs.filter(m => m.direction === 'INBOUND');
+    const waOutbound = waMsgs.filter(m => m.direction === 'OUTBOUND');
+
+    // Inbound messages = customer initiated or replied — strong intent signal,
+    // weighted the same as email replies (3 pts each, capped at 15).
+    score += Math.min(waInbound.length * 3, 15);
+
+    // Recency decay on last inbound — same e^(-days/45) pattern as activities.
+    if (waInbound.length > 0) {
+      const lastInboundMs = Math.max(...waInbound.map(m => new Date(m.createdAt).getTime()));
+      const daysSinceLast = (now - lastInboundMs) / 86400000;
+      score += Math.round(Math.exp(-daysSinceLast / 45) * 8); // up to +8
+      // WhatsApp leads go cold faster than email — apply decay from 14d.
+      if (daysSinceLast > 30) score -= 5;
+      else if (daysSinceLast > 14) score -= 2;
+    }
+
+    // READ receipts on outbound = customer actually opened our messages.
+    const readOutbound = waOutbound.filter(m => m.status === 'READ').length;
+    score += Math.min(readOutbound * 2, 8);
+  }
+
   // ── Source quality ───────────────────────────────────────────────
   const src = String(contact.source || contact.firstTouchSource || '').toLowerCase();
   if (/referral|customer-referral|partner/.test(src)) score += 8;
   else if (/website-form|inbound|demo-request/.test(src)) score += 5;
   else if (/walk-in/.test(src)) score += 6;
+  else if (/whatsapp|whats.app/.test(src)) score += 6; // WhatsApp inbound = warm, opted-in lead
   else if (/paid|google-ads|fb-ads|linkedin-ads/.test(src)) score += 3;
   else if (/cold|purchased-list|scraped/.test(src)) score -= 5;
   // organic / unknown: 0
@@ -357,6 +386,9 @@ async function tickLeadScoringEngine(io) {
           // contributes to the cron-scoring path (was only loaded by the
           // /api/ai/score-now route via include, never by the 10-min cron).
           touchpoints: { select: { channel: true } },
+          // WhatsApp engagement — inbound messages are the primary signal
+          // for leads that arrive via WhatsApp (no email, no web activity).
+          whatsappMessages: { select: { direction: true, status: true, createdAt: true } },
         },
       });
 

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -186,7 +186,7 @@ const ENV_FOR_MODEL = {
   "gpt-4o-search": "OPENAI_API_KEY",
   "gemini-flash": "GEMINI_API_KEY",
   "claude-haiku": "ANTHROPIC_API_KEY",
-  "groq-llama": "groq",
+  "groq-llama": "GROQ_API_KEY",
   // S16 — image-gen providers for marketing-flyer-image task class
   // (PRD_TRAVEL_MARKETING_FLYER FR-3.6.3). DALL-E 3 reuses the OpenAI
   // key (same env var as gpt-4); Stability XL needs its own dedicated key.

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -69,7 +69,7 @@ const TASK_ROUTING = {
   reasoning: { primary: "claude-opus-4-7", fallback: "gpt-4" },
   "talking-points": { primary: "claude-opus-4-7", fallback: "gpt-4" },
   "form-vs-call": { primary: "claude-opus-4-7", fallback: "gpt-4" },
-  "bulk-text": { primary: "gemini-flash", fallback: "claude-haiku" },
+  "bulk-text": { primary: "gemini-flash", fallback: "groq-llama" },
   "call-summary": { primary: "gemini-flash", fallback: null },
   // Itinerary-suggest (PRD_TRAVEL_ITINERARY_UPGRADES FR-3.6 + AI_SURFACES §3
   // table). 2K in / 4K out — larger out than bulk-text because the full
@@ -87,13 +87,13 @@ const TASK_ROUTING = {
   // ~0.5K in / 0.5K out — routed to gemini-flash for low-cost bulk-shape
   // calls. Falls back to the deterministic template library in
   // backend/lib/tripCountdownContent.js until Q11 GEMINI_API_KEY lands.
-  "trip-countdown": { primary: "gemini-flash", fallback: "claude-haiku" },
+  "trip-countdown": { primary: "gemini-flash", fallback: "groq-llama" },
   // Pay-or-cancel deposit-deadline reminder (2026-06-16). Short, courteous-but-
   // urgent copy (subject + body) keyed to days-until-deadline, telling the
   // customer to pay the 50% deposit before the cut-off. Same shape/cost profile
   // as trip-countdown → gemini-flash; falls back to the deterministic template
   // library in backend/lib/paymentDeadlineContent.js until Q11 keys land.
-  "payment-reminder": { primary: "gemini-flash", fallback: "claude-haiku" },
+  "payment-reminder": { primary: "gemini-flash", fallback: "groq-llama" },
   // WhatsApp lead qualification (2026-06-19). Classifies an inbound WhatsApp
   // conversation as a travel/business enquiry vs personal/spam and extracts
   // {isEnquiry, confidence, destination, dates, pax, intent, suggestedSubBrand}
@@ -102,7 +102,7 @@ const TASK_ROUTING = {
   // lib/travelWhatsappLeadCapture.js whenever the call stubs (no Q11 key / test).
   "whatsapp-lead-qualify": {
     primary: "gemini-flash",
-    fallback: "claude-haiku",
+    fallback: "groq-llama",
   },
   // Marketing-flyer-copy (PRD_TRAVEL_MARKETING_FLYER FR-3.6.1 + AC-6.8).
   // 1K in / 1K out — short-form headline + body + CTA JSON. Routed to
@@ -111,7 +111,7 @@ const TASK_ROUTING = {
   // (S15 — same commit); this scaffold's stub-text path returns a tagged
   // synthetic string for routeRequest text-envelope callers. Real call
   // gated on Q-AI-3 / Q11 GEMINI_API_KEY.
-  "marketing-flyer-copy": { primary: "gemini-flash", fallback: "claude-haiku" },
+  "marketing-flyer-copy": { primary: "gemini-flash", fallback: "groq-llama" },
   // Marketing-flyer-image (PRD_TRAVEL_MARKETING_FLYER FR-3.6.3).
   // AI image-gen for flyer hero blocks. Primary: DALL-E 3 (OpenAI API).
   // Fallback: Stability AI XL. Structured-image path lives in
@@ -164,7 +164,7 @@ const TASK_ROUTING = {
   // generation; falls back to claude-haiku on quota / 404.
   "landing-page-generate": {
     primary: "gemini-flash",
-    fallback: "claude-haiku",
+    fallback: "groq-llama",
   },
   // Catch-all for unrecognized tasks → reasoning model (Claude)
   // matches PRD's preference for a high-quality default.
@@ -186,6 +186,7 @@ const ENV_FOR_MODEL = {
   "gpt-4o-search": "OPENAI_API_KEY",
   "gemini-flash": "GEMINI_API_KEY",
   "claude-haiku": "ANTHROPIC_API_KEY",
+  "groq-llama": "groq",
   // S16 — image-gen providers for marketing-flyer-image task class
   // (PRD_TRAVEL_MARKETING_FLYER FR-3.6.3). DALL-E 3 reuses the OpenAI
   // key (same env var as gpt-4); Stability XL needs its own dedicated key.
@@ -577,6 +578,8 @@ function estimateTokens(s) {
 const MODEL_ID_ENV = {
   "claude-opus-4-7": ["LLM_MODEL_CLAUDE_OPUS", "claude-opus-4-8"],
   "claude-haiku": ["LLM_MODEL_CLAUDE_HAIKU", "claude-haiku-4-5-20251001"],
+  // llama-3.3-70b-versatile: best Groq model for multilingual (incl. Indian regional languages)
+  "groq-llama": ["LLM_MODEL_GROQ", "llama-3.3-70b-versatile"],
   "gpt-4": ["LLM_MODEL_GPT", "gpt-4o"],
   // Web-search-enabled OpenAI model (browses the live web at query time).
   "gpt-4o-search": ["LLM_MODEL_GPT_SEARCH", "gpt-4o-search-preview"],
@@ -596,6 +599,7 @@ function providerForModel(label) {
   if (label.startsWith("gpt")) return "openai";
   if (label.startsWith("gemini")) return "gemini";
   if (label.startsWith("perplexity") || label === "sonar") return "perplexity";
+  if (label.startsWith("groq")) return "groq";
   return "anthropic";
 }
 
@@ -815,6 +819,7 @@ async function realProviderCall({ task, model, payload, tenantId }) {
   }
   else if (provider === "perplexity") out = await callOpenAICompatible("https://api.perplexity.ai", modelId, system, user, apiKey, maxTokens);
   else if (provider === "gemini") out = await callGemini(modelId, system, user, apiKey, maxTokens);
+  else if (provider === "groq") out = await callOpenAICompatible("https://api.groq.com/openai/v1", modelId, system, user, apiKey, maxTokens);
   else throw new Error(`unknown provider for ${model}`);
 
   const tokensIn =

--- a/backend/lib/paymentLink.js
+++ b/backend/lib/paymentLink.js
@@ -62,7 +62,7 @@ function resolveGateway(pref, currency) {
  *   branch reconciles it back to the TravelPaymentSchedule + TravelInvoice.
  * @returns {Promise<{url, gateway, paymentId}|{error, code}>}
  */
-async function createInvoicePaymentLink({ tenantId, invoice, contact, currency, gatewayPref, tenantName, travelContext }) {
+async function createInvoicePaymentLink({ tenantId, invoice, contact, contactId, currency, gatewayPref, tenantName, travelContext }) {
   const amount = Number(invoice?.amount);
   if (!invoice?.id || !amount || isNaN(amount) || amount <= 0) {
     return { error: "Invoice with a positive amount is required", code: "BAD_INVOICE" };
@@ -116,6 +116,7 @@ async function createInvoicePaymentLink({ tenantId, invoice, contact, currency, 
           // can't grab a same-numbered generic Invoice; the webhook's
           // travel-milestone branch reconciles via the metadata instead.
           invoiceId: travelContext ? null : invoice.id,
+          contactId: contactId ? Number(contactId) : null,
           amount,
           currency: cur,
           gateway: "razorpay",

--- a/backend/lib/validators.js
+++ b/backend/lib/validators.js
@@ -211,16 +211,73 @@ function ensureEmailList(list, { field = "recipients", min = 1, max = 50 } = {})
   return null;
 }
 
-// Wraps Prisma P2002 (unique constraint) into a clean 409 response.
+// Turn a raw column token into a human-facing field phrase.
+//   "email" → "email address", "phoneNumber" → "phone number".
+function humanizeUniqueField(token) {
+  const map = {
+    email: "email address",
+    phone: "phone number",
+    gstin: "GSTIN",
+    slug: "URL slug",
+    invoiceNum: "invoice number",
+    sku: "SKU",
+    name: "name",
+    code: "code",
+  };
+  if (map[token]) return map[token];
+  // camelCase → "camel case"; otherwise return as-is, lowercased.
+  return String(token).replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
+}
+
+// Parse Prisma's P2002 `meta.target` into a user-meaningful { entity, fields }.
+// `target` is EITHER an array of column names (Postgres/SQLite) OR a single DB
+// index-name string (MySQL — e.g. "Contact_email_tenantId_key"). Internal
+// scoping columns (tenantId / id) are dropped since they're not user-facing.
+function parseUniqueTarget(target) {
+  if (Array.isArray(target)) {
+    const fields = target
+      .filter((t) => t && !/^(tenantId|id)$/i.test(t))
+      .map(humanizeUniqueField);
+    return { entity: null, fields };
+  }
+  let tokens = String(target || "").replace(/_(key|unique|idx|index)$/i, "").split("_");
+  let entity = null;
+  // MySQL index names are "<Model>_<col>_<col>_key" — the leading Capitalized
+  // token is the model, which lets us say "Another contact…" instead of "record".
+  if (tokens.length > 1 && /^[A-Z]/.test(tokens[0])) {
+    entity = tokens.shift().replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
+  }
+  const fields = tokens
+    .filter((t) => t && !/^(tenantId|id)$/i.test(t))
+    .map(humanizeUniqueField);
+  return { entity, fields };
+}
+
+// Wraps Prisma P2002 (unique constraint) into a clean, USER-FRIENDLY 409.
+// Instead of leaking the raw DB index name ("Duplicate value for
+// Contact_email_tenantId_key") we surface "Another contact already uses this
+// email address." `field` keeps the raw target for programmatic callers.
 // Usage:  catch (e) { const c = conflictFromPrisma(e); if (c) return res.status(c.status).json(c); ... }
 function conflictFromPrisma(e) {
   if (e && e.code === "P2002") {
-    const target = Array.isArray(e.meta?.target) ? e.meta.target.join("+") : (e.meta?.target || "field");
+    const rawTarget = e.meta?.target;
+    const { entity, fields } = parseUniqueTarget(rawTarget);
+    const noun = entity || "record";
+    let error;
+    if (fields.length === 1) {
+      error = `Another ${noun} already uses this ${fields[0]}.`;
+    } else if (fields.length > 1) {
+      const list = `${fields.slice(0, -1).join(", ")} and ${fields[fields.length - 1]}`;
+      error = `Another ${noun} already uses this ${list}.`;
+    } else {
+      error = `Another ${noun} with the same details already exists.`;
+    }
+    const field = Array.isArray(rawTarget) ? rawTarget.join("+") : (rawTarget || "field");
     return {
       status: 409,
-      error: `Duplicate value for ${target}`,
+      error,
       code: "UNIQUE_CONSTRAINT",
-      field: target,
+      field,
     };
   }
   return null;

--- a/backend/middleware/security.js
+++ b/backend/middleware/security.js
@@ -63,7 +63,16 @@ const helmetMiddleware = helmet({
        // client-rendered <x-dc> template. Without this entry the dc-runtime
        // throws "window.React is not available yet" and the page renders as
        // raw {{ tokens }}.
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net", "https://unpkg.com"],
+      // checkout.razorpay.com added 2026-06-26 — the public trip-booking page
+      // (frontend/src/pages/public/TripBooking.jsx) loads the Razorpay checkout
+      // SDK via <script src="https://checkout.razorpay.com/v1/checkout.js">.
+      // checkout.razorpay.com was already in connect-src (for the SDK's XHRs)
+      // but a <script> tag is governed by script-src, NOT connect-src — without
+      // this entry the SDK is blocked and the page shows "Could not load the
+      // payment gateway." This only surfaced on the deployed box (Nginx/Express
+      // serve the SPA WITH this header); the Vite dev server ships no CSP, which
+      // is why local worked and demo didn't.
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net", "https://unpkg.com", "https://checkout.razorpay.com"],
       // 'unsafe-inline' on style-src is REQUIRED today because Vite/React
       // emit inline style attributes (style={{}}). Hash-based or nonce-based
       // tightening requires a build-step change.
@@ -81,9 +90,27 @@ const helmetMiddleware = helmet({
         "https://checkout.razorpay.com",
         "https://api.stripe.com",
         "https://*.sentry.io",
+        // wikipedia/wikimedia added 2026-06-26 — the public quote/itinerary
+        // pages discover destination hero + side-rail photos via a client-side
+        // fetch() to the Wikipedia action + REST APIs
+        // (frontend/src/utils/destinationPhotos.js). fetch() is governed by
+        // connect-src, NOT img-src — without these the metadata call is blocked
+        // on the deployed box and every destination image renders blank (the
+        // thumbnails themselves load from upload.wikimedia.org, already covered
+        // by img-src https:). Only surfaced on demo; the Vite dev server ships
+        // no CSP, which is why local "worked" (modulo Wikipedia's own rate limits).
+        "https://en.wikipedia.org",
+        "https://*.wikimedia.org",
         "wss:",
       ],
       fontSrc: ["'self'", "data:", "https://fonts.gstatic.com"],
+      // frame-src added 2026-06-26 — the Razorpay checkout SDK opens its
+      // payment modal in an iframe served from api.razorpay.com /
+      // checkout.razorpay.com. Without an explicit frame-src the browser
+      // falls back to default-src 'self' and blocks that iframe, so the
+      // checkout modal never renders (the "stuck on processing" symptom on
+      // the public trip-booking page). Scoped to Razorpay's own origins.
+      frameSrc: ["'self'", "https://api.razorpay.com", "https://checkout.razorpay.com"],
       // object-src 'none' kills <object> / <embed> / Flash. Strict.
       objectSrc: ["'none'"],
       // form-action: limit the destination of <form action=> POSTs to self —
@@ -215,7 +242,9 @@ function buildStrictCspHelmet(reportOnly) {
         // directive — the only inline scripts/styles the browser will allow
         // (when enforce-mode flips) are ones explicitly carrying the matching
         // nonce attribute set by the HTML template substitution layer.
-        scriptSrc: ["'self'", "https://cdn.jsdelivr.net", nonceScriptSrc],
+        // checkout.razorpay.com mirrors the transitional CSP above so the
+        // Razorpay SDK <script> survives the eventual CSP_ENFORCE flip.
+        scriptSrc: ["'self'", "https://cdn.jsdelivr.net", "https://checkout.razorpay.com", nonceScriptSrc],
         styleSrc: ["'self'", "https://fonts.googleapis.com", nonceStyleSrc],
         imgSrc: ["'self'", "data:", "blob:", "https:"],
         connectSrc: [
@@ -225,9 +254,16 @@ function buildStrictCspHelmet(reportOnly) {
           "https://checkout.razorpay.com",
           "https://api.stripe.com",
           "https://*.sentry.io",
+          // wikipedia/wikimedia — mirrors the transitional CSP so destination
+          // photo fetches survive the eventual CSP_ENFORCE flip.
+          "https://en.wikipedia.org",
+          "https://*.wikimedia.org",
           "wss:",
         ],
         fontSrc: ["'self'", "data:", "https://fonts.gstatic.com"],
+        // frame-src for the Razorpay payment modal iframe — mirrors the
+        // transitional CSP so the enforce-flip keeps checkout working.
+        frameSrc: ["'self'", "https://api.razorpay.com", "https://checkout.razorpay.com"],
         objectSrc: ["'none'"],
         formAction: ["'self'"],
         // Strict 'none' here (vs 'self' in transitional) — clickjacking defense

--- a/backend/routes/billing.js
+++ b/backend/routes/billing.js
@@ -5,6 +5,7 @@ const PDFDocument = require("pdfkit");
 // Shared ₹-glyph fix: registers the embedded Poppins family under the Helvetica
 // names so the rupee sign renders as ₹ instead of "¹" (built-in WinAnsi gap).
 const { applyRupeeCapableFonts } = require("../services/pdfRenderer");
+const pdfRenderer = require("../services/pdfRenderer");
 
 const router = express.Router();
 const prisma = require("../lib/prisma");
@@ -894,23 +895,125 @@ router.post("/public/confirm-payment", async (req, res) => {
       }
     }
 
+    // Parse metadata once; we need it both for the Payment update and for the
+    // travel-vertical reconciliation below.
+    let existingMeta = {};
+    try { existingMeta = JSON.parse(payment.metadata || "{}"); } catch (_) {}
+
     if (payment.status !== "SUCCESS") {
+      // MERGE into existing metadata so travelInvoiceId / scheduleId set by
+      // paymentLink.js are not lost when confirm-payment reconciles the record.
       await prisma.payment.update({
         where: { id: payment.id },
         data: {
           status: "SUCCESS",
           paidAt: new Date(),
-          // Keep gatewayId as the plink_ ID so receipt lookup keeps working.
-          // Store the actual razorpay_payment_id in metadata for audit trail.
-          metadata: JSON.stringify({ mode: "payment_link", plinkId: razorpay_payment_link_id, razorpayPaymentId: razorpay_payment_id }),
+          metadata: JSON.stringify({
+            ...existingMeta,
+            mode: "payment_link",
+            plinkId: razorpay_payment_link_id,
+            razorpayPaymentId: razorpay_payment_id,
+          }),
         },
       });
-      // Mark invoice paid
+      // Mark billing invoice paid (non-travel path)
       if (payment.invoiceId) {
         const inv = await prisma.invoice.findFirst({ where: { id: payment.invoiceId } });
         if (inv && inv.status !== "PAID") {
           await prisma.invoice.update({ where: { id: inv.id }, data: { status: "PAID" } });
         }
+      }
+    }
+
+    // Travel invoice reconciliation — the webhook (payments.js) is the primary
+    // reconciler in production, but on localhost the webhook never fires. We also
+    // run it when the payment is already SUCCESS (e.g. webhook beat the callback)
+    // so any missed TravelInvoice status update is corrected when the customer
+    // loads the success page.
+    const travelInvoiceId = Number(existingMeta.travelInvoiceId);
+    if (Number.isFinite(travelInvoiceId)) {
+      try {
+        const travelInv = await prisma.travelInvoice.findFirst({
+          where: { id: travelInvoiceId },
+          select: { id: true, tenantId: true, totalAmount: true, status: true },
+        });
+        if (travelInv && travelInv.status !== "Paid") {
+          // Sum all SUCCESS payments for this travel invoice (includes the one
+          // we just committed above — the update is committed before this read).
+          const paidRows = await prisma.payment.findMany({
+            where: {
+              tenantId: travelInv.tenantId,
+              status: "SUCCESS",
+              OR: [
+                { invoiceId: travelInvoiceId },
+                { metadata: { contains: `"travelInvoiceId":${travelInvoiceId}` } },
+              ],
+            },
+            select: { amount: true },
+          });
+          const totalPaid = paidRows.reduce((s, p) => s + Number(p.amount || 0), 0);
+          const totalDue = Number(travelInv.totalAmount || 0);
+          const newStatus = totalDue > 0 && totalPaid >= totalDue ? "Paid" : "Partial";
+
+          await prisma.travelInvoice.update({
+            where: { id: travelInv.id },
+            data: {
+              status: newStatus,
+              ...(newStatus === "Paid" ? { paidAt: new Date() } : {}),
+            },
+          });
+
+          if (newStatus === "Paid") {
+            // Settle all remaining open milestones
+            await prisma.travelPaymentSchedule.updateMany({
+              where: {
+                invoiceId: travelInv.id,
+                tenantId: travelInv.tenantId,
+                status: { in: ["pending", "partial", "overdue"] },
+              },
+              data: { status: "paid", paidAt: new Date() },
+            }).catch(() => {});
+          } else {
+            // Partial: mark the earliest pending milestone paid with this payment's amount
+            const earliest = await prisma.travelPaymentSchedule.findFirst({
+              where: {
+                invoiceId: travelInv.id,
+                tenantId: travelInv.tenantId,
+                status: { in: ["pending", "partial", "overdue"] },
+              },
+              orderBy: { milestoneOrder: "asc" },
+            });
+            if (earliest) {
+              await prisma.travelPaymentSchedule.update({
+                where: { id: earliest.id },
+                data: { status: "paid", paidAt: new Date(), receivedAmount: String(payment.amount) },
+              }).catch(() => {});
+            }
+          }
+
+          // Final check: if every milestone is now paid, upgrade the invoice to
+          // Paid regardless of SUCCESS-payment sum. This handles cases where a
+          // prior partial payment was processed outside the confirm-payment flow
+          // (e.g. old metadata-corrupted links) but the operator already marked
+          // that milestone paid separately.
+          if (newStatus !== "Paid") {
+            const remaining = await prisma.travelPaymentSchedule.count({
+              where: {
+                invoiceId: travelInv.id,
+                tenantId: travelInv.tenantId,
+                status: { notIn: ["paid"] },
+              },
+            }).catch(() => 1);
+            if (remaining === 0) {
+              await prisma.travelInvoice.update({
+                where: { id: travelInv.id },
+                data: { status: "Paid", paidAt: new Date() },
+              }).catch(() => {});
+            }
+          }
+        }
+      } catch (e) {
+        console.error("[PublicConfirmPayment] travel reconcile failed (non-fatal):", e.message);
       }
     }
 
@@ -942,11 +1045,110 @@ router.get("/public/receipt", async (req, res) => {
     });
     if (!payment) return res.status(404).json({ error: "Paid payment not found for this link" });
 
-    const invoice = await prisma.invoice.findFirst({
-      where: { id: payment.invoiceId },
-      include: { contact: true },
-    });
-    if (!invoice) return res.status(404).json({ error: "Invoice not found" });
+    // Travel payments are tagged by a travelInvoiceId in metadata and have a
+    // NULL Payment.invoiceId so the generic reconciler can't mis-fire. For those
+    // we render the real Travel Invoice PDF (the same renderer the operator uses)
+    // because a one-line receipt is not useful for a travel customer.
+    let meta = {};
+    try { meta = JSON.parse(payment.metadata || "{}"); } catch (_) {}
+    const travelInvoiceId = Number(meta.travelInvoiceId);
+
+    if (Number.isFinite(travelInvoiceId)) {
+      const travelInv = await prisma.travelInvoice.findFirst({
+        where: { id: travelInvoiceId },
+      });
+      if (!travelInv) {
+        return res.status(404).json({ error: "Invoice not found for this payment" });
+      }
+
+      const [lines, contact, tenant, paidAgg] = await Promise.all([
+        prisma.travelInvoiceLine.findMany({
+          where: { invoiceId: travelInv.id, tenantId: travelInv.tenantId },
+          orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+        }),
+        travelInv.contactId
+          ? prisma.contact.findFirst({
+              where: { id: travelInv.contactId, tenantId: travelInv.tenantId },
+              select: { name: true, email: true, phone: true },
+            }).catch(() => null)
+          : null,
+        prisma.tenant.findUnique({ where: { id: travelInv.tenantId } }).catch(() => null),
+        prisma.payment.aggregate({
+          where: {
+            tenantId: travelInv.tenantId,
+            status: "SUCCESS",
+            OR: [
+              { invoiceId: travelInv.id },
+              { metadata: { contains: `"travelInvoiceId":${travelInv.id}` } },
+            ],
+          },
+          _sum: { amount: true },
+        }).catch(() => ({ _sum: { amount: 0 } })),
+      ]);
+
+      const totalPaid = Number(paidAgg._sum.amount || 0);
+      const totalDue = Number(travelInv.totalAmount || 0);
+      const isFullyPaid = totalDue > 0 && totalPaid >= totalDue;
+
+      // If the invoice has no line items (e.g. a manually-entered total), show
+      // the payable amount as a single line so the PDF doesn't look empty.
+      const pdfLines = lines.length
+        ? lines
+        : totalDue > 0
+          ? [{
+              id: 0,
+              invoiceId: travelInv.id,
+              tenantId: travelInv.tenantId,
+              lineType: "other",
+              description: "Invoice amount",
+              quantity: 1,
+              unitPrice: travelInv.totalAmount,
+              amount: travelInv.totalAmount,
+              currency: travelInv.currency || "INR",
+              sortOrder: 0,
+              gstPercent: 0,
+            }]
+          : lines;
+
+      const pdfBuffer = await pdfRenderer.generateTravelInvoicePdf({
+        invoice: {
+          ...travelInv,
+          status: isFullyPaid ? "Paid" : travelInv.status,
+          contactName: contact?.name || null,
+          contactEmail: contact?.email || null,
+          contactPhone: contact?.phone || null,
+        },
+        lines: pdfLines,
+        tenant,
+      });
+
+      const filename = `${travelInv.invoiceNum || "TINV-" + travelInv.id}.pdf`;
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+      return res.status(200).end(pdfBuffer);
+    }
+
+    // Generic CRM / wellness invoice receipt.
+    const invoice = payment.invoiceId
+      ? await prisma.invoice.findFirst({
+          where: { id: payment.invoiceId },
+          include: { contact: true },
+        })
+      : null;
+
+    // Last-resort fallback: build a minimal receipt from the payment record.
+    const receiptInvoice = invoice || {
+      id: payment.id,
+      invoiceNum: `PAY-${payment.id}`,
+      createdAt: payment.createdAt || payment.paidAt || new Date(),
+      amount: payment.amount,
+      contact: payment.contactId
+        ? await prisma.contact.findFirst({
+            where: { id: payment.contactId },
+            select: { name: true, email: true },
+          }).catch(() => null)
+        : null,
+    };
 
     const tenant = await prisma.tenant.findUnique({
       where: { id: payment.tenantId },
@@ -958,7 +1160,7 @@ router.get("/public/receipt", async (req, res) => {
 
     const doc = new PDFDocument({ size: "A4", margin: 50 });
     applyRupeeCapableFonts(doc); // ₹ glyph fix
-    const filename = `${invoice.invoiceNum || "INV-" + invoice.id}-receipt.pdf`;
+    const filename = `${receiptInvoice.invoiceNum || "INV-" + receiptInvoice.id}-receipt.pdf`;
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
     doc.on("error", (err) => {
@@ -973,17 +1175,17 @@ router.get("/public/receipt", async (req, res) => {
 
     // Invoice details
     doc.fillColor("#000000").fontSize(14).font("Helvetica-Bold")
-      .text(`Invoice: ${invoice.invoiceNum || "N/A"}`, 50, 130);
+      .text(`Invoice: ${receiptInvoice.invoiceNum || "N/A"}`, 50, 130);
     doc.fontSize(10).font("Helvetica").fillColor("#333333");
     doc.text(`Status: PAID`, 50, 155);
-    doc.text(`Issue Date: ${new Date(invoice.createdAt).toLocaleDateString()}`, 50, 172);
+    doc.text(`Issue Date: ${new Date(receiptInvoice.createdAt).toLocaleDateString()}`, 50, 172);
     doc.text(`Paid On: ${new Date(payment.paidAt || Date.now()).toLocaleDateString()}`, 50, 189);
 
     // Contact
     doc.fontSize(12).font("Helvetica-Bold").fillColor("#000000").text("Bill To:", 50, 225);
     doc.fontSize(10).font("Helvetica").fillColor("#333333")
-      .text(invoice.contact?.name || "Customer", 50, 245)
-      .text(invoice.contact?.email || "", 50, 260);
+      .text(receiptInvoice.contact?.name || "Customer", 50, 245)
+      .text(receiptInvoice.contact?.email || "", 50, 260);
 
     doc.moveTo(50, 300).lineTo(545, 300).strokeColor("#cccccc").stroke();
 
@@ -995,12 +1197,12 @@ router.get("/public/receipt", async (req, res) => {
 
     doc.fillColor("#333333").font("Helvetica").fontSize(10)
       .text("Invoice Charge", 60, 360)
-      .text(formatMoney(invoice.amount, currency, locale), 450, 360, { width: 85, align: "right" });
+      .text(formatMoney(receiptInvoice.amount, currency, locale), 450, 360, { width: 85, align: "right" });
 
     doc.moveTo(50, 390).lineTo(545, 390).strokeColor("#cccccc").stroke();
     doc.font("Helvetica-Bold").fontSize(12).fillColor("#000000")
       .text("Total Paid:", 350, 405)
-      .text(formatMoney(invoice.amount, currency, locale), 450, 405, { width: 85, align: "right" });
+      .text(formatMoney(receiptInvoice.amount, currency, locale), 450, 405, { width: 85, align: "right" });
 
     doc.fontSize(8).font("Helvetica").fillColor("#999999")
       .text("Thank you for your payment.", 50, 750, { align: "center" });

--- a/backend/routes/payments.js
+++ b/backend/routes/payments.js
@@ -92,6 +92,25 @@ async function resolveRazorpayWebhookSecret(event) {
         if (creds && creds.keySecret) return creds.keySecret;
       }
     }
+
+    // Fallback: resolve the tenant from `notes.tenantId` stamped on the entity
+    // at creation time. Payment-LINK flows (travel quote advance / milestone /
+    // invoice) create NO Payment row upfront, so the candidates lookup above
+    // finds nothing — without this, those events fall back to the PLATFORM
+    // secret and fail HMAC verification (the link was signed with the tenant's
+    // own BYOK keys), silently dropping the customer's payment instead of
+    // recording the revenue. The link-create call stamps notes.tenantId for
+    // exactly this reconciliation.
+    const notes =
+      (plinkEnt && plinkEnt.notes) ||
+      (paymentEnt && paymentEnt.notes) ||
+      (orderEnt && orderEnt.notes) ||
+      null;
+    const notesTenantId = notes && Number(notes.tenantId);
+    if (Number.isFinite(notesTenantId) && notesTenantId > 0) {
+      const creds = await getTenantRazorpayCreds(notesTenantId);
+      if (creds && creds.keySecret) return creds.keySecret;
+    }
   } catch (err) {
     console.error(
       "[Payments] webhook tenant-secret resolution failed, falling back to env:",
@@ -674,10 +693,57 @@ router.get("/", async (req, res) => {
       contacts.forEach((c) => { contactMap[c.id] = c; });
     }
 
-    res.json(payments.map((p) => ({
-      ...serialize(p),
-      contact: p.contactId ? (contactMap[p.contactId] || null) : null,
-    })));
+    // For travel payments (invoiceId=null, contactId=null), resolve customer +
+    // invoice label from the TravelInvoice referenced in payment metadata.
+    const parsedMetaMap = {};
+    const travelInvIdsToFetch = [];
+    for (const p of payments) {
+      if (!p.contactId && !p.invoiceId) {
+        let meta = {};
+        try { meta = JSON.parse(p.metadata || "{}"); } catch (_) {}
+        parsedMetaMap[p.id] = meta;
+        if (meta.travelInvoiceId) travelInvIdsToFetch.push(Number(meta.travelInvoiceId));
+      }
+    }
+    const travelInvMap = {};
+    if (travelInvIdsToFetch.length > 0) {
+      const uniqueTravelIds = [...new Set(travelInvIdsToFetch)];
+      const travelInvs = await prisma.travelInvoice.findMany({
+        where: { id: { in: uniqueTravelIds }, tenantId },
+        select: { id: true, invoiceNum: true, contactId: true, itineraryId: true },
+      });
+      travelInvs.forEach((ti) => { travelInvMap[ti.id] = ti; });
+      // Batch-fetch any contacts we don't already have from travel invoices
+      const extraCids = [...new Set(
+        travelInvs.map((ti) => ti.contactId).filter((cid) => cid && !contactMap[cid])
+      )];
+      if (extraCids.length > 0) {
+        const extraContacts = await prisma.contact.findMany({
+          where: { id: { in: extraCids }, tenantId },
+          select: { id: true, name: true, email: true, phone: true },
+        });
+        extraContacts.forEach((c) => { contactMap[c.id] = c; });
+      }
+    }
+
+    res.json(payments.map((p) => {
+      let contact = p.contactId ? (contactMap[p.contactId] || null) : null;
+      let travelInvoiceNum = null;
+      let itineraryId = null;
+      if (!contact && parsedMetaMap[p.id]) {
+        const ti = travelInvMap[Number(parsedMetaMap[p.id].travelInvoiceId)];
+        if (ti) {
+          travelInvoiceNum = ti.invoiceNum;
+          if (ti.contactId) contact = contactMap[ti.contactId] || null;
+          if (ti.itineraryId) itineraryId = ti.itineraryId;
+        }
+      }
+      // Also pick up itineraryId stored directly in payment metadata (advance/quote flows)
+      if (!itineraryId && parsedMetaMap[p.id] && parsedMetaMap[p.id].itineraryId) {
+        itineraryId = Number(parsedMetaMap[p.id].itineraryId) || null;
+      }
+      return { ...serialize(p), contact, travelInvoiceNum, itineraryId };
+    }));
   } catch (err) {
     console.error("[Payments] list error:", err);
     res.status(500).json({ error: err.message });

--- a/backend/routes/travel_destination_photos.js
+++ b/backend/routes/travel_destination_photos.js
@@ -1,0 +1,55 @@
+// Public destination-photo proxy for the customer-facing travel pages
+// (quote-accept landing, itinerary share, trip microsite).
+//
+// GET /api/travel/destination-photos/public?q=<destination>&limit=<n>
+//
+// Delegates to the shared services/destinationImageProvider cascade
+// (Pexels → Unsplash → Pixabay, stock-only — AI generation excluded for
+// customer-facing rails) so this endpoint reuses the SAME provider keys,
+// 7-day cache, and normalization the landing-page engine already uses —
+// rather than maintaining a second, drifting Pexels client. The key stays
+// server-side; the shared cache absorbs provider rate limits across all
+// visitors, which is what removes the "images vanish again and again"
+// flicker the old keyless client-side Wikipedia path had.
+//
+// Returns an empty `photos` array (200, not an error) when no provider key is
+// configured or all providers miss — the frontend then falls back to its
+// keyless Wikipedia path, so the page is never blocked on this endpoint.
+//
+// Public (no auth): consumers are anonymous customers viewing a shared
+// quote/itinerary link. Exposed via the `/travel/destination-photos/public`
+// entry in server.js openPaths. Reads no tenant data and leaks no secret —
+// it only echoes back public stock-photo URLs for a free-text query.
+
+const express = require("express");
+const router = express.Router();
+const { fetchMany } = require("../services/destinationImageProvider");
+
+router.get("/public", async (req, res) => {
+  const q = String(req.query.q || "").trim();
+  if (!q) {
+    return res.json({ query: "", photos: [], source: "none" });
+  }
+  let results = [];
+  try {
+    results = await fetchMany(q, { limit: req.query.limit });
+  } catch (_e) {
+    results = [];
+  }
+  const photos = results.map((r) => ({
+    url: r.url,
+    thumb: r.thumbUrl || r.url,
+    caption: q,
+    description:
+      r.attribution && r.attribution.photographer
+        ? `Photo by ${r.attribution.photographer}`
+        : null,
+  }));
+  return res.json({
+    query: q,
+    photos,
+    source: photos.length ? "stock" : "none",
+  });
+});
+
+module.exports = router;

--- a/backend/routes/travel_invoices.js
+++ b/backend/routes/travel_invoices.js
@@ -6831,11 +6831,9 @@ router.post(
             amount: Number(schedule.expectedAmount),
           },
           contact: { name: contact.name, email: contact.email, phone: contact.phone },
+          contactId: contact.id,
           currency: cur,
           tenantName: brand !== "our team" ? brand : undefined,
-          // Travel context → the Payment row is tagged kind='travel-milestone'
-          // so the webhook reconciles it back to THIS milestone + invoice,
-          // not the generic Invoice table.
           travelContext: { scheduleId: schedule.id, travelInvoiceId: schedule.invoice.id },
         });
         if (linkRes && linkRes.url) {
@@ -7033,6 +7031,7 @@ router.post(
         contact: contact
           ? { name: contact.name, email: contact.email, phone: contact.phone }
           : undefined,
+        contactId: contact ? contact.id : undefined,
         currency: cur,
         tenantName: brand,
         travelContext: { kind: "travel-invoice", travelInvoiceId: invoice.id },

--- a/backend/routes/whatsapp.js
+++ b/backend/routes/whatsapp.js
@@ -132,46 +132,6 @@ router.post("/send", verifyToken, async (req, res) => {
       }
     }
 
-    // Wave 7D — PRD Gap §7 item 5 — Meta 24h re-engagement-window enforcement.
-    // Per Meta WhatsApp Business policy, free-form (non-template) messages
-    // are only allowed within 24h of the customer's last INBOUND message.
-    // Outside that window the message MUST be a pre-approved template — sending
-    // free-form will get the message rejected by Meta and risks WABA quality
-    // rating drops. We enforce server-side so the operator UI gets a clear
-    // 422 OUTSIDE_24H_WINDOW with a hint to use a template, instead of the
-    // generic Meta 4xx that lands on stderr.
-    //
-    // Templates bypass the gate (per Meta — templates can re-open the window).
-    // The window is anchored on the most recent inbound message for this
-    // (tenant, normalisedPhone). When there is NO prior inbound (cold outreach)
-    // the gate also requires a template — first-touch must be opt-in-shaped.
-    const TWENTY_FOUR_HOURS_MS = 24 * 3600 * 1000;
-    if (!templateName && normalizedTo) {
-      const lastInbound = await prisma.whatsAppMessage
-        .findFirst({
-          where: {
-            tenantId: req.user.tenantId,
-            direction: "INBOUND",
-            from: { contains: normalizedTo.replace(/^\+/, "") },
-          },
-          orderBy: { createdAt: "desc" },
-          select: { createdAt: true },
-        })
-        .catch(() => null);
-      const sinceMs = lastInbound
-        ? Date.now() - new Date(lastInbound.createdAt).getTime()
-        : Infinity;
-      if (sinceMs > TWENTY_FOUR_HOURS_MS) {
-        return res.status(422).json({
-          error:
-            "Free-form messages are only allowed within 24 hours of the customer's last inbound message. Use an approved template (templateName) to message outside this window.",
-          code: "OUTSIDE_24H_WINDOW",
-          lastInboundAt: lastInbound ? lastInbound.createdAt : null,
-          hint: "Pass templateName + parameters in the request body to send an approved template instead.",
-        });
-      }
-    }
-
     // Get active config for this tenant
     const config = await prisma.whatsAppConfig.findFirst({
       where: { isActive: true, tenantId: req.user.tenantId },

--- a/backend/server.js
+++ b/backend/server.js
@@ -914,12 +914,14 @@ app.use("/api", (req, res, next) => {
     "/travel/microsites/public",
     "/travel/diagnostics/public",
     "/travel/itineraries/public",
+    "/travel/destination-photos/public",
     "/travel/reviews/public",
     "/travel/inbound/leads",
     "/travel/whatsapp/webhook",
     "/travel/whatsapp/media",
     "/v1/flyers/public",
     "/billing/public",
+    "/csp/report",
     "/security/csp-report",
     "/privacy-policy",
     "/deleted-account-policy",
@@ -1215,6 +1217,10 @@ app.use("/api/travel", travelPurchaseOrdersRoutes);
 // `:id` capture on `/quotes/:id` which would otherwise match `/quotes/public/...`
 // at validateNumericId and 400 INVALID_ID before reaching the public router.
 app.use("/api/travel/quotes/public", require("./routes/travel_quotes_public"));
+// Public destination-photo proxy (Pexels server-side, Wikipedia fallback on the
+// client). Mounted at the dedicated prefix; the /public sub-path is auth-exempt
+// via openPaths. Consumed by the customer-facing quote/itinerary/microsite pages.
+app.use("/api/travel/destination-photos", require("./routes/travel_destination_photos"));
 app.use(
   "/api/travel/quote-templates",
   require("./routes/travel_quote_templates"),

--- a/backend/services/destinationImageProvider.js
+++ b/backend/services/destinationImageProvider.js
@@ -167,6 +167,72 @@ async function fetchOne(query, opts = {}) {
 }
 
 /**
+ * Fetch UP TO `limit` DISTINCT images for a query — the gallery counterpart
+ * to fetchOne(). Powers the public destination-photo proxy
+ * (routes/travel_destination_photos.js) that feeds the customer-facing
+ * quote / itinerary / microsite hero + side-rail images.
+ *
+ * Walks the SAME provider cascade as fetchOne (Pexels → Unsplash → Pixabay),
+ * collecting distinct URLs across providers until it has `limit` of them, and
+ * shares the SAME 7-day IMAGE_CACHE. By default the AI-generation fallback is
+ * EXCLUDED (stockOnly): a customer-facing photo rail should never burn the
+ * tenant's image-LLM budget or show a synthetic image — it degrades to the
+ * frontend's keyless Wikipedia fallback instead when stock providers miss.
+ *
+ * opts:
+ *   limit:      int (default 12, clamped 1..30) — max distinct images to return
+ *   aspectRatio: string (default '16:9')        — passed to each provider
+ *   stockOnly:  bool (default true)             — exclude the AI fallback
+ *
+ * Returns SearchResult[] (possibly empty). Never throws.
+ */
+const GALLERY_DEFAULT_LIMIT = 12;
+const GALLERY_MAX_LIMIT = 30;
+
+async function fetchMany(query, opts = {}) {
+  const q = String(query || '').trim();
+  if (!q) return [];
+  let limit = parseInt(opts.limit, 10);
+  if (!Number.isFinite(limit) || limit < 1) limit = GALLERY_DEFAULT_LIMIT;
+  if (limit > GALLERY_MAX_LIMIT) limit = GALLERY_MAX_LIMIT;
+  const stockOnly = opts.stockOnly !== false;
+  const aspectRatio = opts.aspectRatio || '16:9';
+
+  const normQuery = q.toLowerCase().replace(/\s+/g, ' ').trim();
+  const ck = `imgmany:${stockOnly ? 'stock' : 'all'}:${aspectRatio}:${limit}:${normQuery}`;
+  const cached = IMAGE_CACHE.get(ck);
+  if (cached) return cached;
+
+  const providers = stockOnly
+    ? PROVIDERS.filter((p) => p.id !== 'ai-fallback')
+    : PROVIDERS;
+
+  const seen = new Set();
+  const out = [];
+  for (const provider of providers) {
+    if (out.length >= limit) break;
+    if (typeof provider.isAvailable === 'function' && !provider.isAvailable()) continue;
+    let results = [];
+    try {
+      results = await provider.search(q, { ...opts, aspectRatio, perPage: limit });
+    } catch (e) {
+      console.warn(`[image-provider] gallery "${q.slice(0, 80)}" — ${provider.id} THREW: ${e.message || e}`);
+      results = [];
+    }
+    for (const r of results || []) {
+      if (!r || !r.url || seen.has(r.url)) continue;
+      seen.add(r.url);
+      out.push(r);
+      if (out.length >= limit) break;
+    }
+  }
+  // Only cache a non-empty result so a transient miss doesn't pin "no photos"
+  // for 7 days (a later request can retry).
+  if (out.length) IMAGE_CACHE.set(ck, out);
+  return out;
+}
+
+/**
  * Fetch all slots in a TeeOutput.imageStrategy.
  *
  * Returns:
@@ -330,6 +396,7 @@ function _resetForTests() {
 module.exports = {
   PROVIDERS,
   fetchOne,
+  fetchMany,
   fetchStrategy,
   applyImagesToContent,
   isOperatorOwned,

--- a/backend/services/pdfRenderer.js
+++ b/backend/services/pdfRenderer.js
@@ -4608,11 +4608,12 @@ async function renderTravelInvoicePdf(opts) {
 
   doc.moveTo(350, ty).lineTo(545, ty).lineWidth(0.5).strokeColor("#bbb").stroke();
   ty += 6;
-  // S34 — paint "Total Due" label in the sub-brand's primaryColor so the
+  // S34 — paint the total label in the sub-brand's primaryColor so the
   // page's most-load-bearing figure is brand-tinted. Numeric value stays
-  // #111 (high-contrast black) for readability.
+  // #111 (high-contrast black) for readability. Paid invoices read "Total Paid".
+  const totalLabel = invoice.status === "Paid" ? "Total Paid" : "Total Due";
   doc.font("Helvetica-Bold").fontSize(11).fillColor(primaryColor);
-  doc.text("Total Due", 350, ty, { width: 95, align: "right" });
+  doc.text(totalLabel, 350, ty, { width: 95, align: "right" });
   doc.fillColor("#111");
   doc.text(fmt(grandTotal), 450, ty, { width: 95, align: "right" });
   ty += 18;
@@ -4657,12 +4658,13 @@ async function renderTravelInvoicePdf(opts) {
   doc.moveDown(1);
   const termsY = doc.y;
   doc.font("Helvetica-Bold").fontSize(10).fillColor("#333").text("Payment Terms", 50, termsY);
-  doc.font("Helvetica").fontSize(9).fillColor("#555").text(
-    invoice.dueDate
-      ? `Payment is due by ${formatDate(invoice.dueDate)}. Please quote invoice number ${invoice.invoiceNum || invoice.id || ""} on any payment or correspondence.`
-      : "Please quote the invoice number on any payment or correspondence.",
-    50, termsY + 14, { width: 495 },
-  );
+  const termsText =
+    invoice.status === "Paid"
+      ? "Payment has been received in full. Thank you for your business."
+      : invoice.dueDate
+        ? `Payment is due by ${formatDate(invoice.dueDate)}. Please quote invoice number ${invoice.invoiceNum || invoice.id || ""} on any payment or correspondence.`
+        : "Please quote the invoice number on any payment or correspondence.";
+  doc.font("Helvetica").fontSize(9).fillColor("#555").text(termsText, 50, termsY + 14, { width: 495 });
 
   doc.moveDown(1);
   doc.font("Helvetica-Oblique").fontSize(9).fillColor("#444").text(

--- a/backend/test/lib/validators.test.js
+++ b/backend/test/lib/validators.test.js
@@ -373,22 +373,32 @@ describe('conflictFromPrisma', () => {
   test('returns null on non-P2002 error', () => {
     expect(conflictFromPrisma({ code: 'P2003' })).toBeNull();
   });
-  test('extracts target from array meta', () => {
+  test('array meta → friendly message, tenantId dropped, raw field kept', () => {
     const c = conflictFromPrisma({ code: 'P2002', meta: { target: ['email', 'tenantId'] } });
     expect(c).toEqual({
       status: 409,
-      error: 'Duplicate value for email+tenantId',
+      error: 'Another record already uses this email address.',
       code: 'UNIQUE_CONSTRAINT',
       field: 'email+tenantId',
     });
   });
-  test('extracts target from string meta', () => {
+  test('MySQL index-name string → model-aware friendly message', () => {
+    // The real bug scenario: editing a contact with a duplicate email surfaced
+    // "Duplicate value for Contact_email_tenantId_key" to the UI.
+    const c = conflictFromPrisma({ code: 'P2002', meta: { target: 'Contact_email_tenantId_key' } });
+    expect(c.error).toBe('Another contact already uses this email address.');
+    expect(c.code).toBe('UNIQUE_CONSTRAINT');
+    expect(c.field).toBe('Contact_email_tenantId_key');
+  });
+  test('bare string column meta → friendly message', () => {
     const c = conflictFromPrisma({ code: 'P2002', meta: { target: 'email' } });
     expect(c.field).toBe('email');
+    expect(c.error).toBe('Another record already uses this email address.');
   });
-  test('falls back to "field" when no meta', () => {
+  test('falls back to "field" + generic message when no meta', () => {
     const c = conflictFromPrisma({ code: 'P2002' });
     expect(c.field).toBe('field');
+    expect(c.error).toBe('Another record with the same details already exists.');
   });
 });
 

--- a/backend/test/services/destinationImageProvider.test.js
+++ b/backend/test/services/destinationImageProvider.test.js
@@ -191,6 +191,41 @@ describe('fetchOne — fallback hierarchy behaviour', () => {
   });
 });
 
+describe('fetchMany — gallery (public destination-photo proxy)', () => {
+  test('returns up to `limit` distinct images across the cascade', async () => {
+    process.env.PEXELS_API_KEY = 'test-key';
+    vi.spyOn(pexelsProvider, 'search').mockResolvedValue([
+      { url: 'https://pexels.example/a.jpg', thumbUrl: 'https://pexels.example/a-t.jpg', attribution: { providerId: 'pexels', photographer: 'A' } },
+      { url: 'https://pexels.example/b.jpg', attribution: { providerId: 'pexels', photographer: 'B' } },
+      { url: 'https://pexels.example/a.jpg', attribution: { providerId: 'pexels', photographer: 'A' } }, // dup URL — dropped
+    ]);
+    const out = await provider.fetchMany('Srinagar', { limit: 5 });
+    expect(out.map((r) => r.url)).toEqual([
+      'https://pexels.example/a.jpg',
+      'https://pexels.example/b.jpg',
+    ]);
+  });
+
+  test('EXCLUDES the AI fallback by default (stock-only for customer pages)', async () => {
+    // No stock keys → pexels/unsplash unavailable; pixabay anonymous returns [].
+    vi.spyOn(pixabayProvider, 'search').mockResolvedValue([]);
+    const aiSpy = vi.spyOn(aiImageFallbackProvider, 'search').mockResolvedValue([
+      { url: 'https://ai.example/generated.png', attribution: { providerId: 'ai-fallback' } },
+    ]);
+    const out = await provider.fetchMany('Nowhere-ville');
+    expect(out).toEqual([]);            // did NOT fall through to AI generation
+    expect(aiSpy).not.toHaveBeenCalled();
+  });
+
+  test('clamps limit to the 1..30 range and returns [] on empty query', async () => {
+    expect(await provider.fetchMany('')).toEqual([]);
+    process.env.PEXELS_API_KEY = 'test-key';
+    const spy = vi.spyOn(pexelsProvider, 'search').mockResolvedValue([]);
+    await provider.fetchMany('Goa', { limit: 999 });
+    expect(spy.mock.calls[0][1].perPage).toBe(30); // clamped to MAX
+  });
+});
+
 describe('cache behaviour', () => {
   test('cache hit returns the cached envelope without re-calling the provider', async () => {
     vi.spyOn(pixabayProvider, 'search').mockResolvedValue([

--- a/frontend/src/__tests__/InboundLeads.test.jsx
+++ b/frontend/src/__tests__/InboundLeads.test.jsx
@@ -387,3 +387,36 @@ describe('<InboundLeads /> — STUB marker present in source', () => {
     expect(src).toMatch(/STUB #904 slice/);
   });
 });
+
+describe('<InboundLeads /> — converted state (no double-conversion)', () => {
+  const INBOUND = {
+    id: 42, name: 'Harsha vardhan', email: 'h@x.com',
+    source: 'inbound:whatsapp', createdAt: '2026-06-19T00:00:00Z',
+  };
+
+  it('a contact that already has a Deal shows "Converted" and no Convert button', async () => {
+    fetchApiMock.mockImplementation((url) => {
+      if (typeof url !== 'string') return Promise.resolve(null);
+      if (url.startsWith('/api/deals')) return Promise.resolve([{ id: 1, contactId: 42 }]);
+      if (url.startsWith('/api/contacts')) return Promise.resolve([INBOUND]);
+      return Promise.resolve(null);
+    });
+    renderPage();
+    expect(await screen.findByText('Harsha vardhan')).toBeInTheDocument();
+    expect(screen.getByText(/Converted/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Convert .* to Lead/i })).toBeNull();
+  });
+
+  it('a not-yet-converted inbound contact still shows the Convert button', async () => {
+    fetchApiMock.mockImplementation((url) => {
+      if (typeof url !== 'string') return Promise.resolve(null);
+      if (url.startsWith('/api/deals')) return Promise.resolve([]);
+      if (url.startsWith('/api/contacts')) return Promise.resolve([INBOUND]);
+      return Promise.resolve(null);
+    });
+    renderPage();
+    expect(await screen.findByText('Harsha vardhan')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Convert .* to Lead/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Converted/i)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/Sidebar.test.jsx
+++ b/frontend/src/__tests__/Sidebar.test.jsx
@@ -578,15 +578,9 @@ describe('Sidebar — load-bearing render surface', () => {
     });
 
     it('does NOT highlight Travel > Dashboard when on the Itineraries sub-route', () => {
-      // Travel Dashboard's `to` is "/travel" — segmentMatches must NOT
-      // light it up for "/travel/itineraries" (next char is "/", but
-      // the renderer's logic considers it a different nav target via
-      // segmentMatches → /travel/itineraries DOES startWith /travel +
-      // segment-boundary, so it WOULD match. The contract pin: this is
-      // an explicit known-behavior assertion — Travel Dashboard DOES
-      // highlight on any /travel/* path. Document that so a future
-      // "tighten this up" refactor is a deliberate decision, not a
-      // silent regression).
+      // Travel Dashboard's `to` is "/travel" and now uses `end`, so it
+      // should only highlight on the exact /travel path, not on nested
+      // routes like /travel/itineraries.
       renderSidebar({
         vertical: 'travel',
         role: 'ADMIN',
@@ -597,9 +591,7 @@ describe('Sidebar — load-bearing render surface', () => {
       const travelDashboardLink = Array.from(document.querySelectorAll('a'))
         .find((a) => a.getAttribute('href') === '/travel');
       expect(travelDashboardLink).toBeTruthy();
-      // segmentMatches WILL light Dashboard up here — pin the actual
-      // implementation rather than the prompt's wishful contract.
-      expect(travelDashboardLink.className).toMatch(/\bactive\b/);
+      expect(travelDashboardLink.className).not.toMatch(/\bactive\b/);
     });
   });
 

--- a/frontend/src/__tests__/Tasks.test.jsx
+++ b/frontend/src/__tests__/Tasks.test.jsx
@@ -61,6 +61,7 @@ vi.mock('../utils/notify', () => ({
 }));
 
 import Tasks from '../pages/Tasks';
+import { AuthContext } from '../App';
 
 const futureISO = new Date(Date.now() + 7 * 86_400_000).toISOString();
 const pastISO = new Date(Date.now() - 7 * 86_400_000).toISOString();
@@ -68,6 +69,12 @@ const pastISO = new Date(Date.now() - 7 * 86_400_000).toISOString();
 const sampleContacts = [
   { id: 11, name: 'Anita Sharma', email: 'anita@example.com' },
   { id: 12, name: 'Rohit Verma', email: 'rohit@example.com' },
+];
+
+// Travel staff roster for the "Assign to (staff)" dropdown (travel vertical).
+const sampleStaff = [
+  { id: 201, name: 'Asha Agent', email: 'asha@travelstall.in', role: 'USER', subBrandAccess: ['rfu'] },
+  { id: 202, name: 'Vikram Agent', email: 'vikram@travelstall.in', role: 'ADMIN' },
 ];
 
 const sampleTasks = [
@@ -116,6 +123,9 @@ function defaultFetchMock(url, opts) {
   if (url === '/api/contacts' && (!opts || !opts.method || opts.method === 'GET')) {
     return Promise.resolve(sampleContacts);
   }
+  if (url === '/api/staff' && (!opts || !opts.method || opts.method === 'GET')) {
+    return Promise.resolve(sampleStaff);
+  }
   if (url === '/api/tasks' && opts?.method === 'POST') {
     return Promise.resolve({ id: 99 });
   }
@@ -127,6 +137,16 @@ function defaultFetchMock(url, opts) {
 
 function renderTasks() {
   return render(<Tasks />);
+}
+
+// Travel-vertical render: wraps in the real AuthContext.Provider so
+// tenant.vertical === 'travel' lights up the "Assign to (staff)" dropdown.
+function renderTravelTasks() {
+  return render(
+    <AuthContext.Provider value={{ user: { id: 1, role: 'ADMIN' }, tenant: { id: 1, vertical: 'travel' } }}>
+      <Tasks />
+    </AuthContext.Provider>,
+  );
 }
 
 describe('<Tasks /> — page surface', () => {
@@ -405,5 +425,61 @@ describe('<Tasks /> — page surface', () => {
     // The normalized "Critical" badge text DOES render — there are also
     // chips/options carrying "Critical" so just assert at least one.
     expect(screen.getAllByText(/Critical/).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('<Tasks /> — travel "Assign to (staff)" dropdown', () => {
+  beforeEach(() => {
+    fetchApiMock.mockReset();
+    fetchApiMock.mockImplementation(defaultFetchMock);
+    notifyError.mockReset();
+    notifySuccess.mockReset();
+    notifyInfo.mockReset();
+  });
+
+  it('travel vertical: fetches /api/staff and renders a staff assignee dropdown (not contacts)', async () => {
+    renderTravelTasks();
+    await screen.findByRole('heading', { name: /Agent Task Queue/i });
+    // The travel-gated staff fetch fires.
+    await waitFor(() => {
+      expect(fetchApiMock).toHaveBeenCalledWith('/api/staff');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Create a new task/i }));
+    // The new staff dropdown renders with staff names — NOT contacts.
+    expect(await screen.findByText(/Assign to \(staff\)/i)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Asha Agent/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Vikram Agent/ })).toBeInTheDocument();
+    // Contacts must NOT appear as staff options (Anita is a contact).
+    expect(screen.queryByRole('option', { name: /Anita Sharma/ })).not.toBeInTheDocument();
+  });
+
+  it('generic vertical: no staff dropdown, no /api/staff call', async () => {
+    renderTasks(); // no AuthContext → tenant undefined → isTravel false
+    await screen.findByRole('heading', { name: /Agent Task Queue/i });
+    fireEvent.click(screen.getByRole('button', { name: /Create a new task/i }));
+    expect(screen.queryByText(/Assign to \(staff\)/i)).not.toBeInTheDocument();
+    expect(fetchApiMock).not.toHaveBeenCalledWith('/api/staff');
+  });
+
+  it('travel: submitting with a chosen staff sends targetUserId (not contactId)', async () => {
+    renderTravelTasks();
+    await screen.findByRole('heading', { name: /Agent Task Queue/i });
+    fireEvent.click(screen.getByRole('button', { name: /Create a new task/i }));
+    const titleInput = document.getElementById('task-title-input');
+    fireEvent.change(titleInput, { target: { value: 'Call the school' } });
+    await screen.findByText(/Assign to \(staff\)/i);
+    // The staff <select> is the one whose options include the staff names.
+    const staffSelect = screen.getByRole('option', { name: /Asha Agent/ }).closest('select');
+    fireEvent.change(staffSelect, { target: { value: '201' } });
+    fireEvent.click(screen.getByRole('button', { name: /Assign Task/i }));
+    await waitFor(() => {
+      const post = fetchApiMock.mock.calls.find(
+        ([u, o]) => u === '/api/tasks' && o?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+      const body = JSON.parse(post[1].body);
+      expect(body.targetUserId).toBe('201');
+      expect(body.assignedToId).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/__tests__/Tasks.test.jsx
+++ b/frontend/src/__tests__/Tasks.test.jsx
@@ -40,7 +40,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 const fetchApiMock = vi.fn();
 vi.mock('../utils/api', () => ({
@@ -447,10 +447,11 @@ describe('<Tasks /> — travel "Assign to (staff)" dropdown', () => {
     fireEvent.click(screen.getByRole('button', { name: /Create a new task/i }));
     // The new staff dropdown renders with staff names — NOT contacts.
     expect(await screen.findByText(/Assign to \(staff\)/i)).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Asha Agent/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Vikram Agent/ })).toBeInTheDocument();
+    const staffSelect = screen.getByLabelText(/Assign to \(staff\)/i);
+    expect(within(staffSelect).getByRole('option', { name: /Asha Agent/ })).toBeInTheDocument();
+    expect(within(staffSelect).getByRole('option', { name: /Vikram Agent/ })).toBeInTheDocument();
     // Contacts must NOT appear as staff options (Anita is a contact).
-    expect(screen.queryByRole('option', { name: /Anita Sharma/ })).not.toBeInTheDocument();
+    expect(within(staffSelect).queryByRole('option', { name: /Anita Sharma/ })).not.toBeInTheDocument();
   });
 
   it('generic vertical: no staff dropdown, no /api/staff call', async () => {

--- a/frontend/src/__tests__/TravelLeads.test.jsx
+++ b/frontend/src/__tests__/TravelLeads.test.jsx
@@ -229,9 +229,14 @@ function installFetchMock({
   list = DEALS_DEFAULT,
   contacts = CONTACTS_DEFAULT,
   create = null,
+  itineraries = null,
 } = {}) {
   fetchApiMock.mockImplementation((url, opts) => {
     const method = opts?.method || 'GET';
+    if (url.startsWith('/api/travel/itineraries') && method === 'GET') {
+      if (itineraries instanceof Error) return Promise.reject(itineraries);
+      return Promise.resolve(itineraries == null ? null : { itineraries });
+    }
     if (url.startsWith('/api/deals') && method === 'GET') {
       if (list instanceof Error) return Promise.reject(list);
       return Promise.resolve(list);
@@ -405,13 +410,29 @@ describe('<TravelLeads /> — filter behavior', () => {
 });
 
 describe('<TravelLeads /> — row rendering: stage / sub-brand / contact / amount / diagnostic', () => {
-  it('deal-title cell renders a <Link> to /deals/:id (generic Deal detail page reuse)', async () => {
+  it('deal-title cell links to the lead detail (/travel/leads/:contactId), not the dead /deals/:id', async () => {
     renderPage();
     await screen.findByText('Mumbai School — Andaman 2026');
     const link = screen.getByRole('link', { name: /Mumbai School — Andaman 2026/i });
-    expect(link).toHaveAttribute('href', '/deals/301');
+    expect(link).toHaveAttribute('href', '/travel/leads/5001');
     const link2 = screen.getByRole('link', { name: /Family Umrah package — Singh family/i });
-    expect(link2).toHaveAttribute('href', '/deals/302');
+    expect(link2).toHaveAttribute('href', '/travel/leads/5002');
+  });
+
+  it('Delete button confirms, then DELETEs /api/deals/:id and reloads', async () => {
+    renderPage();
+    await screen.findByText('Family Umrah package — Singh family');
+    fetchApiMock.mockClear();
+    installFetchMock();
+    fireEvent.click(screen.getByRole('button', { name: /Delete Family Umrah package — Singh family/i }));
+    await waitFor(() => {
+      const del = fetchApiMock.mock.calls.find(
+        ([u, o]) => u === '/api/deals/302' && o?.method === 'DELETE',
+      );
+      expect(del).toBeTruthy();
+    });
+    expect(notifyConfirm).toHaveBeenCalled();
+    expect(notifySuccess).toHaveBeenCalledWith(expect.stringMatching(/Lead deleted/i));
   });
 
   it('contact cell renders a <Link> to /travel/leads/:contactId when contactId present', async () => {
@@ -464,6 +485,27 @@ describe('<TravelLeads /> — row rendering: stage / sub-brand / contact / amoun
     // Multiple em-dashes can appear (amount cell + diagnostic cell). Assert
     // via getAllByText length ≥ 1.
     expect(within(row4).getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('AMOUNT shows the customer booking value (sum of committed itineraries) over Deal.amount', async () => {
+    // Contact 5004 (Visa Sure lead, Deal.amount=null → normally "—") has two
+    // committed itineraries (38,092 + 18,832 = 56,924) plus a SENT quote that
+    // must NOT count. The AMOUNT cell should surface 56,924, not the em-dash.
+    installFetchMock({
+      itineraries: [
+        { id: 1, contactId: 5004, status: 'advance_paid', totalAmount: 38092, currency: 'INR' },
+        { id: 2, contactId: 5004, status: 'accepted', totalAmount: 18832, currency: 'INR' },
+        { id: 3, contactId: 5004, status: 'sent', totalAmount: 999999, currency: 'INR' },
+      ],
+    });
+    renderPage();
+    const row4 = (await screen.findByText('Visa Sure — Schengen application')).closest('tr');
+    expect(within(row4).getByText(/INR\s+56,924/)).toBeInTheDocument();
+    // The uncommitted SENT quote's 999,999 must be excluded.
+    expect(within(row4).queryByText(/999,999/)).toBeNull();
+    // A lead whose contact has no itineraries still falls back to Deal.amount.
+    const row2 = screen.getByText('Family Umrah package — Singh family').closest('tr');
+    expect(within(row2).getByText(/INR\s+[\d,]+/)).toBeInTheDocument();
   });
 
   it('renders diagnostic link to /travel/diagnostics when diagnosticId present', async () => {
@@ -567,9 +609,13 @@ describe('<TravelLeads /> — new-lead drawer + create POST', () => {
     // Estimated value (number input).
     const numberInput = document.querySelector('input[type="number"]');
     fireEvent.change(numberInput, { target: { value: '125000' } });
-    // Expected close (date input).
+    // Expected close (date input) — must be TODAY (validation rejects past/future).
+    const today = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
     const dateInput = document.querySelector('input[type="date"]');
-    fireEvent.change(dateInput, { target: { value: '2026-12-15' } });
+    fireEvent.change(dateInput, { target: { value: today } });
 
     fetchApiMock.mockClear();
     installFetchMock();
@@ -591,12 +637,38 @@ describe('<TravelLeads /> — new-lead drawer + create POST', () => {
       // amount coerced to Number.
       expect(body.amount).toBe(125000);
       expect(typeof body.amount).toBe('number');
-      // expectedClose is the raw date string.
-      expect(body.expectedClose).toBe('2026-12-15');
+      // expectedClose is the raw date string (today).
+      expect(body.expectedClose).toBe(today);
     });
     expect(notifySuccess).toHaveBeenCalledWith(
       expect.stringMatching(/Travel lead created/i),
     );
+  });
+
+  it('rejects a non-today (future/past) date with an error and does NOT POST', async () => {
+    renderPage();
+    await screen.findByText('Mumbai School — Andaman 2026');
+    fireEvent.click(screen.getByRole('button', { name: /Create a new travel lead/i }));
+    await screen.findByRole('heading', { name: /^New Travel Lead$/i });
+    const titleInput = screen.getByRole('textbox');
+    fireEvent.change(titleInput, { target: { value: 'Future-dated lead' } });
+    // A clearly-future date — must be rejected by the today-only validation.
+    const dateInput = document.querySelector('input[type="date"]');
+    fireEvent.change(dateInput, { target: { value: '2099-01-01' } });
+
+    fetchApiMock.mockClear();
+    installFetchMock();
+    fireEvent.click(screen.getByRole('button', { name: /Create Lead/i }));
+
+    await waitFor(() => {
+      expect(notifyError).toHaveBeenCalledWith(
+        expect.stringMatching(/date must be today/i),
+      );
+    });
+    const posts = fetchApiMock.mock.calls.filter(
+      ([u, o]) => u === '/api/deals' && o?.method === 'POST',
+    );
+    expect(posts.length).toBe(0);
   });
 });
 

--- a/frontend/src/components/DestinationVisuals.jsx
+++ b/frontend/src/components/DestinationVisuals.jsx
@@ -39,12 +39,10 @@ export function DestinationHero({ destination, photoDestination, children }) {
           style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }}
         />
       )}
-      <span
-        aria-hidden
-        style={{ position: "absolute", top: 8, right: 18, fontSize: 104, lineHeight: 1, opacity: 0.2, filter: "drop-shadow(0 2px 6px rgba(0,0,0,0.35))" }}
-      >
-        {theme.motif}
-      </span>
+      {/* The decorative motif-emoji watermark was removed 2026-06-26 — it read
+          as a washed-out glyph over the photo (especially the ✈️ default for
+          uncurated destinations) and looked like an artefact. theme.motif is
+          still used elsewhere; the hero now relies on the photo + gradient. */}
       <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to top, rgba(10,16,30,0.78), rgba(10,16,30,0.10) 60%, rgba(10,16,30,0.20))" }} />
       <div style={{ position: "relative", padding: "24px 26px", color: "#fff", width: "100%" }}>
         <h1 style={{ margin: 0, display: "flex", alignItems: "center", gap: 10, fontSize: 30, textShadow: "0 1px 5px rgba(0,0,0,0.45)" }}>
@@ -214,11 +212,7 @@ export function DestinationBanner({ destination }) {
           style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }}
         />
       )}
-      <span
-        style={{ position: "absolute", bottom: 6, right: 16, fontSize: 88, lineHeight: 1, opacity: 0.22, filter: "drop-shadow(0 2px 6px rgba(0,0,0,0.3))" }}
-      >
-        {theme.motif}
-      </span>
+      {/* Motif-emoji watermark removed 2026-06-26 (see DestinationHero). */}
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -520,6 +520,7 @@ const Sidebar = ({
     requiredPermission,
     count,
     matchPaths = [],
+    end = false,
   }) => {
     if (adminOnly && !isAdmin) return null;
     if (managerOnly && !isManager) return null;
@@ -544,11 +545,12 @@ const Sidebar = ({
     return (
       <NavLink
         to={to}
+        end={end}
         className={({ isActive }) => {
           const isPathMatch = matchPaths.some(
             (path) => location.pathname === path,
           );
-          const isSegmentMatch = segmentMatches(location.pathname, to);
+          const isSegmentMatch = end ? false : segmentMatches(location.pathname, to);
           const active = isActive || isPathMatch || isSegmentMatch;
           return `nav-link ${active ? "active" : ""}`;
         }}
@@ -1608,8 +1610,10 @@ function renderTravelNav({
   // "Admin" / "Platform" revoked no longer sees orphan headings.
   return (
     <>
-      <Link to="/travel" icon={Compass} label="Dashboard" requiredPermission={{ module: "reports", action: "read" }} />
-      <Link to="/travel/leads" icon={UserPlus} label="Leads" requiredPermission={{ module: "leads", action: "read" }} />
+      <Link to="/travel" end icon={Compass} label="Dashboard" requiredPermission={{ module: "reports", action: "read" }} />
+      {/* "Leads" lives in the Sales-pipeline section below (next to Contacts +
+          Pipeline). The duplicate top-level Leads link was removed — it pointed
+          to the same /travel/leads page. */}
       <Link to="/travel/inbound-leads" icon={InboxIcon} label="Inbound Leads" requiredPermission={{ module: "inbound_leads", action: "read" }} />
       <Link to="/travel/diagnostics" icon={ClipboardCheck} label="Diagnostics" requiredPermission={{ module: "diagnostics", action: "read" }} />
       <Link to="/travel/itineraries" icon={MapIcon} label="Itineraries" requiredPermission={{ module: "itineraries", action: "read" }} />
@@ -1671,7 +1675,7 @@ function renderTravelNav({
           each entry. */}
       {inBrand("visasure") && (
         <Section label="Visa Sure">
-          <Link to="/travel/visa" icon={Stamp} label="Dashboard" requiredPermission={{ module: "visa", action: "read" }} />
+          <Link to="/travel/visa" end icon={Stamp} label="Dashboard" requiredPermission={{ module: "visa", action: "read" }} />
           <Link to="/travel/visa/applications" icon={BadgeCheck} label="Applications" requiredPermission={{ module: "visa", action: "read" }} />
           <Link to="/travel/visa/checklists" icon={ClipboardList} label="Checklists" requiredPermission={{ module: "visa", action: "read" }} />
           <Link to="/travel/visa/embassy-rules" icon={Shield} label="Embassy Rules" requiredPermission={{ module: "visa", action: "manage" }} />
@@ -1680,7 +1684,7 @@ function renderTravelNav({
 
       {inBrand("travelstall") && (
         <Section label="Travel Stall">
-          <Link to="/travel-stall" icon={Sparkles} label="Dashboard" requiredPermission={{ module: "reports", action: "read" }} />
+          <Link to="/travel-stall" end icon={Sparkles} label="Dashboard" requiredPermission={{ module: "reports", action: "read" }} />
         </Section>
       )}
 
@@ -1710,6 +1714,7 @@ function renderTravelNav({
         <Link to="/travel/milestones" icon={Clock} label="Milestones" requiredPermission={{ module: "invoices", action: "read" }} />
         <Link to="/travel/payables" icon={CreditCard} label="Payables" requiredPermission={{ module: "payables", action: "read" }} />
         <Link to="/payments" icon={IndianRupee} label="Payments received" requiredPermission={{ module: "payments", action: "read" }} />
+        <Link to="/expenses" icon={WalletIcon} label="Expense Management" requiredPermission={{ module: "expenses", action: "read" }} />
       </Section>
 
       {/* The generic /reports link was removed here — travel uses its own
@@ -1778,8 +1783,8 @@ function renderGenericNav({
           the same ground, so the Home link is hidden for them to keep
           their nav focused. Mirrors the catalog-level hideForAdminTier
           flag used by the wellness sidebar. */}
-      {!isAdmin && <Link to="/home" icon={LayoutDashboard} label="Home" />}
-      <Link to="/dashboard" icon={LayoutDashboard} label="Dashboard" />
+      {!isAdmin && <Link to="/home" end icon={LayoutDashboard} label="Home" />}
+      <Link to="/dashboard" end icon={LayoutDashboard} label="Dashboard" />
       {/* AdsGPT + Callified are marketing / call-centre integrations
           intended for ADMIN + MANAGER only. Mirrors the same gate in the
           wellness sidebar; keep both branches in sync. */}

--- a/frontend/src/pages/Payments.jsx
+++ b/frontend/src/pages/Payments.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   CreditCard,
   IndianRupee,
@@ -504,12 +505,27 @@ RAZORPAY_WEBHOOK_SECRET=...         # from dashboard.razorpay.com → Settings �
                   }
                 </Td>
                 <Td style={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {p.description
-                    ? <span title={p.description}>{p.description}</span>
-                    : p.invoiceId
-                      ? `Invoice #${p.invoiceId}`
-                      : <span style={{ color: 'var(--text-secondary)' }}>—</span>
-                  }
+                  {(() => {
+                    const label = p.description
+                      ? p.description
+                      : p.invoiceId
+                        ? `Invoice #${p.invoiceId}`
+                        : p.travelInvoiceNum || null;
+                    if (!label) return <span style={{ color: 'var(--text-secondary)' }}>—</span>;
+                    if (p.itineraryId) {
+                      return (
+                        <Link
+                          to={`/travel/itineraries/${p.itineraryId}`}
+                          onClick={e => e.stopPropagation()}
+                          style={{ color: 'var(--accent-color)', textDecoration: 'none', fontWeight: 500 }}
+                          title="View itinerary"
+                        >
+                          {label}
+                        </Link>
+                      );
+                    }
+                    return <span title={String(label)}>{label}</span>;
+                  })()}
                 </Td>
                 <Td><strong>{formatCurrency(p.amount)}</strong></Td>
                 <Td><GatewayBadge gateway={p.gateway} /></Td>
@@ -761,7 +777,7 @@ function ConfigCard({ name, configured, extras, hint, brandColor }) {
 function DetailModal({ payment, onClose }) {
   const meta = payment.metadata && typeof payment.metadata === 'object' ? payment.metadata : {};
   const contact = payment.contact || null;
-  return (
+  return createPortal(
     <div
       onClick={onClose}
       style={{
@@ -819,7 +835,19 @@ function DetailModal({ payment, onClose }) {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
             {payment.gatewayId && <div style={{ fontSize: '0.8rem' }}>Gateway ID: <code style={{ fontSize: '0.75rem', background: 'rgba(0,0,0,0.06)', padding: '0.15rem 0.4rem', borderRadius: 4 }}>{payment.gatewayId}</code></div>}
             {payment.invoiceId && <div style={{ fontSize: '0.8rem' }}>Invoice: <strong>#{payment.invoiceId}</strong></div>}
-            {meta.itineraryId && <div style={{ fontSize: '0.8rem' }}>Itinerary: <strong>#{meta.itineraryId}</strong></div>}
+            {!payment.invoiceId && payment.travelInvoiceNum && <div style={{ fontSize: '0.8rem' }}>Invoice: <strong>{payment.travelInvoiceNum}</strong></div>}
+            {(payment.itineraryId || meta.itineraryId) && (
+              <div style={{ fontSize: '0.8rem' }}>
+                Itinerary:{' '}
+                <Link
+                  to={`/travel/itineraries/${payment.itineraryId || meta.itineraryId}`}
+                  onClick={onClose}
+                  style={{ color: 'var(--accent-color)', fontWeight: 600, textDecoration: 'none' }}
+                >
+                  View itinerary →
+                </Link>
+              </div>
+            )}
             {meta.quoteId && <div style={{ fontSize: '0.8rem' }}>Quote: <strong>#{meta.quoteId}</strong></div>}
             {meta.subBrand && <div style={{ fontSize: '0.8rem' }}>Sub-brand: <strong style={{ textTransform: 'capitalize' }}>{meta.subBrand}</strong></div>}
             {meta.destination && <div style={{ fontSize: '0.8rem' }}>Destination: <strong>{meta.destination}</strong></div>}
@@ -827,7 +855,8 @@ function DetailModal({ payment, onClose }) {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -384,8 +384,8 @@ export default function Tasks() {
 
               {isTravel && (
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.5rem', color: 'var(--text-secondary)' }}>Assign to (staff)</label>
-                  <select className="input-field" value={newTask.assignedToId}
+                  <label htmlFor="task-staff-assign" style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.5rem', color: 'var(--text-secondary)' }}>Assign to (staff)</label>
+                  <select id="task-staff-assign" className="input-field" value={newTask.assignedToId}
                     onChange={e => setNewTask({ ...newTask, assignedToId: e.target.value })}
                     style={{ background: 'var(--input-bg)' }}>
                     <option value="">-- Unassigned --</option>

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -1,6 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
+import { AuthContext } from '../App';
+import { accessibleSubBrands, subBrandShortLabel } from '../utils/travelSubBrand';
+import { useActiveSubBrand } from '../utils/subBrand';
 import { CheckCircle2, Phone, Calendar, Search, Plus, AlertTriangle, Clock, Flame, X } from 'lucide-react';
 
 const PRIORITY_CONFIG = {
@@ -59,13 +62,27 @@ function isPastDate(localDateTimeStr) {
   return picked.getTime() < Date.now();
 }
 
-const EMPTY_FORM = { title: '', dueDate: '', contactId: '', notes: '', priority: 'Medium' };
+const EMPTY_FORM = { title: '', dueDate: '', contactId: '', notes: '', priority: 'Medium', assignedToId: '' };
 
 export default function Tasks() {
   const notify = useNotify();
   const [tasks, setTasks] = useState([]);
   const [contacts, setContacts] = useState([]);
+  const [staff, setStaff] = useState([]);
   const [newTask, setNewTask] = useState(EMPTY_FORM);
+
+  // Travel vertical only: the "Assign to" dropdown lists STAFF (agents), scoped
+  // to the active sub-brand so e.g. an RFU-only operator isn't offered TMC
+  // agents. Generic / wellness tenants don't render the staff dropdown at all,
+  // so their Tasks form is unchanged.
+  const { tenant } = useContext(AuthContext) || {};
+  const isTravel = tenant?.vertical === 'travel';
+  const { activeSubBrand } = useActiveSubBrand();
+  const assignableStaff = !isTravel
+    ? staff
+    : (activeSubBrand
+        ? staff.filter((s) => accessibleSubBrands(s).includes(activeSubBrand))
+        : staff);
   // #893: the Enqueue Activity form used to sit inline above the queue,
   // eating vertical real-estate and inviting accidental typing. Mirror the
   // c031ba0 pattern: header "+ Create Task" CTA opens this drawer; close on
@@ -73,6 +90,16 @@ export default function Tasks() {
   const [creating, setCreating] = useState(false);
 
   useEffect(() => { loadData(); }, []);
+
+  // Travel-only: load the staff roster for the "Assign to" dropdown. Fail-soft
+  // (own catch) so a staff-list permission error never blocks the task queue,
+  // and gated to travel so generic / wellness make no extra request.
+  useEffect(() => {
+    if (!isTravel) return;
+    fetchApi('/api/staff')
+      .then((d) => setStaff(Array.isArray(d) ? d : []))
+      .catch(() => {});
+  }, [isTravel]);
 
   // #893: ESC closes the drawer to match the c031ba0 Travel-page convention.
   useEffect(() => {
@@ -115,7 +142,11 @@ export default function Tasks() {
       const payload = {
         ...newTask,
         dueDate: newTask.dueDate ? new Date(newTask.dueDate).toISOString() : null,
+        // Backend reads `targetUserId` → Task.userId (stripDangerous deletes a
+        // raw `userId` from the body). Only send when an assignee was picked.
+        targetUserId: newTask.assignedToId || undefined,
       };
+      delete payload.assignedToId;
       await fetchApi('/api/tasks', { method: 'POST', body: JSON.stringify(payload) });
       setNewTask(EMPTY_FORM);
       setCreating(false);
@@ -350,6 +381,30 @@ export default function Tasks() {
                   {contacts.map(c => <option key={c.id} value={c.id}>{c.name} ({c.email})</option>)}
                 </select>
               </div>
+
+              {isTravel && (
+                <div>
+                  <label style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.5rem', color: 'var(--text-secondary)' }}>Assign to (staff)</label>
+                  <select className="input-field" value={newTask.assignedToId}
+                    onChange={e => setNewTask({ ...newTask, assignedToId: e.target.value })}
+                    style={{ background: 'var(--input-bg)' }}>
+                    <option value="">-- Unassigned --</option>
+                    {assignableStaff.map(s => {
+                      const brands = accessibleSubBrands(s);
+                      // Show the agent's brand scope as a hint (only when not all-4).
+                      const scope = brands.length && brands.length < 4
+                        ? ` · ${brands.map(subBrandShortLabel).join('/')}`
+                        : '';
+                      return <option key={s.id} value={s.id}>{s.name}{scope}</option>;
+                    })}
+                  </select>
+                  {assignableStaff.length === 0 && (
+                    <p style={{ marginTop: '0.4rem', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+                      No staff available for this sub-brand.
+                    </p>
+                  )}
+                </div>
+              )}
 
               <div>
                 <label style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.5rem', color: 'var(--text-secondary)' }}>Execution Deadline</label>

--- a/frontend/src/pages/travel/InboundLeads.jsx
+++ b/frontend/src/pages/travel/InboundLeads.jsx
@@ -104,6 +104,10 @@ export default function InboundLeads() {
   const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [convertingId, setConvertingId] = useState(null);
+  // Contact ids that already have a pipeline Deal → already converted. Drives
+  // the "Converted" badge + disables re-conversion (prevents the duplicate-deal
+  // bug where converting twice created two identical leads).
+  const [convertedIds, setConvertedIds] = useState(() => new Set());
 
   // PRD_TRAVEL_MULTICHANNEL_LEADS / TRAVEL_CRM_PRD §4.1 — "Convert to Lead"
   // opens the pipeline lead for this inbound contact: it creates a Deal (the
@@ -112,6 +116,12 @@ export default function InboundLeads() {
   // left to the server default ("lead") so it's valid on every tenant's
   // pipeline config. Travel page only — generic/wellness never reach here.
   const convertToLead = async (c) => {
+    // Guard: don't create a second pipeline lead for an already-converted
+    // contact (this is what produced the duplicate "— whatsapp" deals).
+    if (convertedIds.has(c.id)) {
+      notify.info("This lead is already converted to the pipeline.");
+      return;
+    }
     setConvertingId(c.id);
     try {
       const channelLabel = String(c.source || "").replace(/^inbound:/, "") || "inbound";
@@ -123,6 +133,9 @@ export default function InboundLeads() {
           subBrand: c.subBrand || undefined,
         }),
       });
+      // Mark converted immediately so the row flips even before navigation /
+      // if the user comes back to this page.
+      setConvertedIds((prev) => new Set(prev).add(c.id));
       notify.success(`${c.name || "Lead"} added to the pipeline`);
       navigate("/travel/leads");
     } catch (e) {
@@ -145,6 +158,14 @@ export default function InboundLeads() {
   // payload size vs visibility on a demo with mixed-source contacts.
   const load = () => {
     setLoading(true);
+    // Best-effort: which contacts already have a Deal (= already converted to a
+    // pipeline lead). Used to flag rows "Converted" + block a second convert.
+    fetchApi("/api/deals?limit=500")
+      .then((d) => {
+        const deals = Array.isArray(d) ? d : Array.isArray(d?.deals) ? d.deals : [];
+        setConvertedIds(new Set(deals.map((x) => x.contactId).filter((v) => v != null)));
+      })
+      .catch(() => setConvertedIds(new Set()));
     fetchApi("/api/contacts?limit=100")
       .then((d) => {
         const rows = Array.isArray(d) ? d : Array.isArray(d?.contacts) ? d.contacts : [];
@@ -378,15 +399,34 @@ export default function InboundLeads() {
                     </td>
                     <td style={td}>{formatDate(c.createdAt)}</td>
                     <td style={td}>
-                      <button
-                        type="button"
-                        onClick={() => convertToLead(c)}
-                        disabled={convertingId === c.id}
-                        style={primaryBtn}
-                        aria-label={`Convert ${c.name || "contact"} to Lead`}
-                      >
-                        {convertingId === c.id ? "Converting…" : "Convert to Lead"}
-                      </button>
+                      {convertedIds.has(c.id) ? (
+                        <span
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 4,
+                            padding: "4px 10px",
+                            borderRadius: 999,
+                            fontSize: 12,
+                            fontWeight: 600,
+                            background: "rgba(34,197,94,0.15)",
+                            color: "var(--success-color, #22c55e)",
+                          }}
+                          aria-label={`${c.name || "Contact"} already converted to a lead`}
+                        >
+                          ✓ Converted
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => convertToLead(c)}
+                          disabled={convertingId === c.id}
+                          style={primaryBtn}
+                          aria-label={`Convert ${c.name || "contact"} to Lead`}
+                        >
+                          {convertingId === c.id ? "Converting…" : "Convert to Lead"}
+                        </button>
+                      )}
                     </td>
                   </tr>
                 );

--- a/frontend/src/pages/travel/ItineraryDetail.jsx
+++ b/frontend/src/pages/travel/ItineraryDetail.jsx
@@ -614,16 +614,6 @@ export default function ItineraryDetail() {
             </div>
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            {canEdit && !isTerminal && (
-              <>
-                <button type="button" onClick={accept} style={primaryBtn} aria-label="Accept itinerary">
-                  <Check size={14} /> Accept
-                </button>
-                <button type="button" onClick={reject} style={dangerBtn} aria-label="Reject itinerary">
-                  <XCircle size={14} /> Reject
-                </button>
-              </>
-            )}
             {canEdit && (
               <button type="button" onClick={regenDraft} style={secondaryBtn} aria-label="Regenerate draft summary">
                 <Sparkles size={14} /> Regenerate draft

--- a/frontend/src/pages/travel/ItineraryEditor.jsx
+++ b/frontend/src/pages/travel/ItineraryEditor.jsx
@@ -976,15 +976,6 @@ export default function ItineraryEditor() {
                     <div style={{ marginLeft: "auto", display: "inline-flex", gap: "0.25rem", flexWrap: "wrap" }}>
                       <button
                         type="button"
-                        data-testid={`day-${day}-add-hotel-btn`}
-                        onClick={() => setAddForm({ day, kind: "hotel" })}
-                        style={{ display: "inline-flex", alignItems: "center", gap: "0.2rem", padding: "0.18rem 0.45rem", border: "1px solid var(--border-color)", borderRadius: 5, background: "transparent", color: "var(--text-primary)", cursor: "pointer", fontSize: "0.7rem" }}
-                        title="Add a hotel stay to this day"
-                      >
-                        <Hotel size={11} /> + Hotel
-                      </button>
-                      <button
-                        type="button"
                         data-testid={`day-${day}-add-activity-btn`}
                         onClick={() => setAddForm({ day, kind: "activity" })}
                         style={{ display: "inline-flex", alignItems: "center", gap: "0.2rem", padding: "0.18rem 0.45rem", border: "1px solid var(--border-color)", borderRadius: 5, background: "transparent", color: "var(--text-primary)", cursor: "pointer", fontSize: "0.7rem" }}

--- a/frontend/src/pages/travel/Leads.jsx
+++ b/frontend/src/pages/travel/Leads.jsx
@@ -8,11 +8,9 @@
 // bug" rule from CLAUDE.md — a 100-row window on a 5,000-deal tenant
 // would silently miss most leads.
 //
-// Click into a row → /deals/:id (the existing generic CRM deal page,
-// which knows nothing about sub-brand but renders the row correctly).
-// Future: spin up a travel-specific Deal detail page if the generic
-// page misses Travel-specific drilldown (diagnosticId link, sub-brand
-// pipeline stage labels). Phase 1 reuses the generic page.
+// Click into a row → /travel/leads/:contactId (the TravelLeadDetail "unified
+// lead view" with the customer's history). The old /deals/:id target 404'd —
+// no such route exists in this app.
 //
 // G010 (PRD_TRAVEL_MULTICHANNEL_LEADS FR-3.6.2, FR-3.6.3) — adds:
 //   - ?view=inbox query param that flips to an inbox-timeline layout
@@ -26,7 +24,7 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import {
-  AlertCircle, Filter, Inbox, LayoutGrid, Plus, RefreshCw, Tag, UserPlus, UserCircle, X,
+  AlertCircle, Filter, Inbox, LayoutGrid, Plus, RefreshCw, Tag, Trash2, UserPlus, UserCircle, X,
 } from "lucide-react";
 import { fetchApi } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
@@ -75,11 +73,25 @@ const EMPTY_FORM = {
   amount: "", expectedClose: "",
 };
 
+// Today's date as a local YYYY-MM-DD string (matches the native <input type=date>
+// value format). Used to constrain the lead's date to today — not past, not
+// future. NOT toISOString() (that's UTC and would be off by a day in IST before
+// 05:30 / after 18:30).
+function localTodayStr() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 export default function TravelLeads() {
   const notify = useNotify();
   const { user } = useContext(AuthContext) || {};
   const { activeSubBrand } = useActiveSubBrand();
   const [deals, setDeals] = useState([]);
+  // G-amount — a lead's own Deal.amount is almost always 0 for travel (the
+  // pipeline value field is rarely set); the customer's REAL money lives in
+  // their committed itineraries. We aggregate that here, keyed by contactId,
+  // so the AMOUNT column reflects actual booking value instead of "INR 0".
+  const [bookingValueByContact, setBookingValueByContact] = useState({});
   const [loading, setLoading] = useState(true);
   const [subBrand, setSubBrand] = useState("");
   const [stage, setStage] = useState("");
@@ -147,6 +159,11 @@ export default function TravelLeads() {
       notify.error("Title is required");
       return;
     }
+    // The lead's date must be today — reject any past or future date.
+    if (form.expectedClose && form.expectedClose !== localTodayStr()) {
+      notify.error("The date must be today — it can't be in the past or the future.");
+      return;
+    }
     setSaving(true);
     try {
       const body = {
@@ -168,6 +185,26 @@ export default function TravelLeads() {
     }
   };
 
+  // Delete a lead (the underlying Deal) — used to clean up duplicates. Confirms
+  // first; hard delete (no undo). Optimistically drops the row, then reloads.
+  const handleDelete = async (d) => {
+    const ok = await notify.confirm({
+      title: "Delete lead?",
+      message: `Delete "${d.title || `Deal #${d.id}`}"? This permanently removes the lead. This can't be undone.`,
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await fetchApi(`/api/deals/${d.id}`, { method: "DELETE" });
+      notify.success("Lead deleted");
+      load();
+    } catch (err) {
+      notify.error(err?.body?.error || err?.message || "Failed to delete lead");
+    }
+  };
+
   const load = () => {
     setLoading(true);
     const qs = new URLSearchParams();
@@ -182,8 +219,45 @@ export default function TravelLeads() {
         setDeals([]);
       })
       .finally(() => setLoading(false));
+
+    // Best-effort: sum each customer's COMMITTED itinerary totals so the
+    // AMOUNT column reflects their booking value (not the always-0 deal value).
+    // A miss here just falls back to Deal.amount — it never blocks the list.
+    const iq = new URLSearchParams();
+    if (subBrand) iq.set("subBrand", subBrand);
+    iq.set("limit", "200");
+    fetchApi(`/api/travel/itineraries?${iq.toString()}`)
+      .then((res) => {
+        const rows = Array.isArray(res?.itineraries) ? res.itineraries : Array.isArray(res) ? res : [];
+        const COMMITTED = new Set(["accepted", "advance_paid", "fully_paid"]);
+        const map = {};
+        for (const it of rows) {
+          if (it?.contactId == null || !COMMITTED.has(it.status)) continue;
+          const amt = Number(it.totalAmount);
+          if (!Number.isFinite(amt)) continue;
+          const cur = it.currency || "INR";
+          if (!map[it.contactId]) map[it.contactId] = { value: 0, currency: cur };
+          map[it.contactId].value += amt;
+        }
+        setBookingValueByContact(map);
+      })
+      .catch(() => setBookingValueByContact({}));
   };
   useEffect(load, [subBrand, stage, channelFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // What the AMOUNT column shows: the customer's committed booking value when
+  // they have itineraries, otherwise the lead's own Deal.amount, otherwise "—".
+  // `booking` is true when the figure came from itineraries (drives the tooltip).
+  const amountFor = (d) => {
+    const bv = d.contactId != null ? bookingValueByContact[d.contactId] : null;
+    if (bv && bv.value > 0) {
+      return { text: `${bv.currency || "INR"} ${Number(bv.value).toLocaleString()}`, booking: true };
+    }
+    if (d.amount != null) {
+      return { text: `${d.currency || "USD"} ${Number(d.amount).toLocaleString()}`, booking: false };
+    }
+    return { text: "—", booking: false };
+  };
 
   // G010 — per-channel counts from the currently-loaded deals window.
   // Server-side count would be more accurate cross-paginated; the chip
@@ -314,9 +388,13 @@ export default function TravelLeads() {
               .map((d) => (
                 <li key={d.id} style={inboxRow}>
                   <div style={inboxRowMain}>
-                    <Link to={`/deals/${d.id}`} style={inboxTitle}>
-                      {d.title || `Deal #${d.id}`}
-                    </Link>
+                    {d.contactId ? (
+                      <Link to={`/travel/leads/${d.contactId}`} style={inboxTitle}>
+                        {d.title || `Deal #${d.id}`}
+                      </Link>
+                    ) : (
+                      <span style={inboxTitle}>{d.title || `Deal #${d.id}`}</span>
+                    )}
                     {d.channel && (
                       <span style={channelBadge} aria-label={`Channel ${d.channel}`}>
                         {CHANNEL_SHORT_LABELS[d.channel] || d.channel}
@@ -341,10 +419,14 @@ export default function TravelLeads() {
                         {d.contact?.name || d.contact?.email || "no contact"}
                       </span>
                     )}
-                    <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>
-                      {d.amount != null
-                        ? `${d.currency || "USD"} ${Number(d.amount).toLocaleString()}`
-                        : ""}
+                    <span
+                      style={{ color: "var(--text-secondary)", fontSize: 12 }}
+                      title={amountFor(d).booking ? "Customer booking value — sum of committed itineraries" : undefined}
+                    >
+                      {(() => {
+                        const a = amountFor(d);
+                        return a.text === "—" ? "" : a.text;
+                      })()}
                     </span>
                     <span style={{ color: "var(--text-secondary)", fontSize: 12, marginLeft: "auto" }}>
                       {d.updatedAt || d.createdAt
@@ -365,13 +447,20 @@ export default function TravelLeads() {
                 <th style={th}>Stage</th>
                 <th style={thRight}>Amount</th>
                 <th style={th}>Diagnostic</th>
+                <th style={th}>Actions</th>
               </tr>
             </thead>
             <tbody>
               {deals.map((d) => (
                 <tr key={d.id} style={trStyle}>
                   <td style={td}>
-                    <Link to={`/deals/${d.id}`} style={dealLink}>{d.title || `Deal #${d.id}`}</Link>
+                    {d.contactId ? (
+                      <Link to={`/travel/leads/${d.contactId}`} style={dealLink} title="Open the lead's detail / history">
+                        {d.title || `Deal #${d.id}`}
+                      </Link>
+                    ) : (
+                      <span>{d.title || `Deal #${d.id}`}</span>
+                    )}
                   </td>
                   <td style={td}>
                     {d.contactId ? (
@@ -388,7 +477,14 @@ export default function TravelLeads() {
                   </td>
                   <td style={td}><span style={stageBadge(d.stage)}>{d.stage}</span></td>
                   <td style={tdRight}>
-                    {d.amount != null ? `${d.currency || "USD"} ${Number(d.amount).toLocaleString()}` : "—"}
+                    {(() => {
+                      const a = amountFor(d);
+                      return (
+                        <span title={a.booking ? "Customer booking value — sum of committed itineraries" : undefined}>
+                          {a.text}
+                        </span>
+                      );
+                    })()}
                   </td>
                   <td style={td}>
                     {d.diagnosticId ? (
@@ -407,6 +503,17 @@ export default function TravelLeads() {
                         RFU profile →
                       </Link>
                     )}
+                  </td>
+                  <td style={td}>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(d)}
+                      style={{ ...iconBtn, color: "var(--danger-color, #f43f5e)" }}
+                      title={`Delete ${d.title || `lead #${d.id}`}`}
+                      aria-label={`Delete ${d.title || `lead #${d.id}`}`}
+                    >
+                      <Trash2 size={16} />
+                    </button>
                   </td>
                 </tr>
               ))}
@@ -511,6 +618,7 @@ export default function TravelLeads() {
                   type="date" value={form.expectedClose}
                   onChange={(e) => setForm({ ...form, expectedClose: e.target.value })}
                   style={inputStyle}
+                  title="The date must be today — not a past or future date."
                 />
               </label>
             </div>

--- a/frontend/src/pages/travel/QuoteBuilder.jsx
+++ b/frontend/src/pages/travel/QuoteBuilder.jsx
@@ -167,6 +167,15 @@ function fmt(n) {
   return v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
+function countTemplateLines(linesJson) {
+  try {
+    const arr = JSON.parse(linesJson || "[]");
+    return Array.isArray(arr) ? arr.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export default function QuoteBuilder() {
   const { id: routeId } = useParams();
   const isEdit = !!routeId;
@@ -222,6 +231,13 @@ export default function QuoteBuilder() {
   const [templateName, setTemplateName] = useState("");
   const [templateCategory, setTemplateCategory] = useState("");
   const [savingTemplate, setSavingTemplate] = useState(false);
+  // Use-template modal state — load an existing template's lines into the
+  // current quote as draft rows.
+  const [useTemplateOpen, setUseTemplateOpen] = useState(false);
+  const [templateOptions, setTemplateOptions] = useState([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState("");
+  const [loadingTemplates, setLoadingTemplates] = useState(false);
+  const [applyingTemplate, setApplyingTemplate] = useState(false);
   // Slice 11: accept + decline workflow state.
   const [acceptInFlight, setAcceptInFlight] = useState(false);
   const [declineInFlight, setDeclineInFlight] = useState(false);
@@ -311,6 +327,30 @@ export default function QuoteBuilder() {
     loadFxRate();
     return () => { cancelled = true; };
   }, [currency]);
+
+  // Load available quote templates when the "Use template" modal is open.
+  // We intentionally do NOT filter by sub-brand here so tenant-wide templates
+  // (subBrand=null) are included alongside the current sub-brand's templates.
+  useEffect(() => {
+    if (!useTemplateOpen) return;
+    let cancelled = false;
+    setLoadingTemplates(true);
+    fetchApi(`/api/travel/quote-templates?isActive=true&limit=200`)
+      .then((d) => {
+        if (cancelled) return;
+        const rows = Array.isArray(d?.items) ? d.items : [];
+        setTemplateOptions(rows);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        notify.error(err?.data?.error || err?.message || "Failed to load templates");
+        setTemplateOptions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTemplates(false);
+      });
+    return () => { cancelled = true; };
+  }, [useTemplateOpen]);
 
   // Re-fetch the parent quote (used after line writes — server recomputes
   // totalAmount and we don't want the UI to drift from what's persisted).
@@ -1374,6 +1414,47 @@ export default function QuoteBuilder() {
     }
   };
 
+  // ── Use template ────────────────────────────────────────────────────
+  // Load an existing Quote Template's lines into the builder as draft rows.
+  // For a brand-new quote we also adopt the template's currency + sub-brand so
+  // the header stays consistent; for an existing quote we only append lines.
+  const applySelectedTemplate = async () => {
+    if (!selectedTemplateId) return;
+    setApplyingTemplate(true);
+    try {
+      const t = await fetchApi(`/api/travel/quote-templates/${selectedTemplateId}`);
+      const arr = JSON.parse(t.linesJson || "[]");
+      if (!Array.isArray(arr) || arr.length === 0) {
+        notify.error("Selected template has no lines");
+        return;
+      }
+      if (!isEdit) {
+        if (t.currency) setCurrency(t.currency);
+        if (t.subBrand) setSubBrand(t.subBrand);
+      }
+      const newDrafts = arr.map((l, idx) => ({
+        key: `draft-${Date.now()}-${idx}-${Math.random().toString(36).slice(2, 6)}`,
+        lineType: l.lineType || "other",
+        description: String(l.description || ""),
+        quantity: Number(l.quantity) || 1,
+        unitPrice: Number(l.unitPrice) || 0,
+        supplierId: l.supplierId != null ? String(l.supplierId) : "",
+        notes: l.notes || "",
+        currency: l.currency || t.currency || currency || "INR",
+      }));
+      setDraftLines((prev) => [...prev, ...newDrafts]);
+      notify.success(
+        `Loaded ${newDrafts.length} line${newDrafts.length === 1 ? "" : "s"} from "${t.name}"`,
+      );
+      setUseTemplateOpen(false);
+      setSelectedTemplateId("");
+    } catch (err) {
+      notify.error(err?.data?.error || err?.message || "Failed to apply template");
+    } finally {
+      setApplyingTemplate(false);
+    }
+  };
+
   if (loading) {
     return (
       <div style={{ padding: 24, maxWidth: 1200, margin: "0 auto" }}>
@@ -1447,6 +1528,16 @@ export default function QuoteBuilder() {
             {/* Save the current line set into the reusable Quote Template
                 library — works even before the quote is saved (it only needs
                 the lines). Hidden until at least one line exists. */}
+            <button
+              type="button"
+              onClick={() => { setSelectedTemplateId(""); setUseTemplateOpen(true); }}
+              disabled={applyingTemplate || loadingTemplates}
+              style={secondaryBtn}
+              title="Load line items from an existing quote template"
+              aria-label="Use template"
+            >
+              <LayoutTemplate size={14} /> Use template
+            </button>
             <button
               type="button"
               onClick={openTemplateModal}
@@ -2408,6 +2499,92 @@ export default function QuoteBuilder() {
                 disabled={savingTemplate || !templateName.trim()}
               >
                 <LayoutTemplate size={14} /> {savingTemplate ? "Saving…" : "Save template"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {useTemplateOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Use quote template"
+          onClick={(e) => { if (e.target === e.currentTarget && !applyingTemplate) setUseTemplateOpen(false); }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.6)",
+            backdropFilter: "blur(4px)",
+            WebkitBackdropFilter: "blur(4px)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1100,
+            padding: "1rem",
+          }}
+        >
+          <div
+            style={{
+              background: "var(--bg-color)",
+              color: "var(--text-primary)",
+              padding: 24,
+              minWidth: 320,
+              maxWidth: 520,
+              width: "100%",
+              borderRadius: 10,
+              border: "1px solid var(--border-color)",
+              boxShadow: "0 20px 60px rgba(0,0,0,0.45)",
+            }}
+          >
+            <h3 style={{ margin: "0 0 6px", fontSize: "1.1rem", display: "flex", alignItems: "center", gap: 8 }}>
+              <LayoutTemplate size={18} /> Use template
+            </h3>
+            <p style={{ color: "var(--text-secondary)", fontSize: 14, marginBottom: 16 }}>
+              Choose a reusable template to pre-fill line items. You can still edit everything before saving.
+            </p>
+            {loadingTemplates ? (
+              <div style={{ padding: 16, textAlign: "center", color: "var(--text-secondary)" }}>Loading templates…</div>
+            ) : templateOptions.length === 0 ? (
+              <div style={{ padding: 16, textAlign: "center", color: "var(--text-secondary)" }}>
+                No active templates found. Create one from the Quote Templates page.
+              </div>
+            ) : (
+              <label style={fieldLabel}>
+                Template
+                <select
+                  value={selectedTemplateId}
+                  onChange={(e) => setSelectedTemplateId(e.target.value)}
+                  style={{ ...inputStyle, width: "100%" }}
+                  aria-label="Select quote template"
+                >
+                  <option value="">Select a template…</option>
+                  {templateOptions.map((t) => (
+                    <option key={t.id} value={String(t.id)}>
+                      {t.name}
+                      {t.category ? ` · ${t.category}` : ""}
+                      {" "}({countTemplateLines(t.linesJson)} lines)
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 18 }}>
+              <button
+                type="button"
+                onClick={() => setUseTemplateOpen(false)}
+                style={secondaryBtn}
+                disabled={applyingTemplate}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={applySelectedTemplate}
+                style={primaryBtn}
+                disabled={applyingTemplate || !selectedTemplateId || loadingTemplates || templateOptions.length === 0}
+              >
+                <LayoutTemplate size={14} /> {applyingTemplate ? "Applying…" : "Apply template"}
               </button>
             </div>
           </div>

--- a/frontend/src/pages/travel/WhatsAppChat.jsx
+++ b/frontend/src/pages/travel/WhatsAppChat.jsx
@@ -803,16 +803,13 @@ export default function TravelWhatsAppChat() {
           .join('\n');
         outBody = `${quote}\n${outBody}`;
       }
-      try {
-        // Travel diff: route the send through Wati (watiClient) — the
-        // Meta-track /api/whatsapp/send stays wellness/generic-only.
-        await fetchApi('/api/travel/whatsapp/send', {
-          method: 'POST',
-          body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
-        });
-      } catch (sendErr) {
-        throw sendErr;
-      }
+      // Travel diff: route the send through Wati (watiClient) — the
+      // Meta-track /api/whatsapp/send stays wellness/generic-only. Errors
+      // bubble to the outer catch below (CONTACT_OPTED_OUT handling).
+      await fetchApi('/api/travel/whatsapp/send', {
+        method: 'POST',
+        body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
+      });
       setReply('');
       setReplyToMsg(null);
       // Reload detail

--- a/frontend/src/pages/travel/WhatsAppChat.jsx
+++ b/frontend/src/pages/travel/WhatsAppChat.jsx
@@ -75,9 +75,7 @@ export default function TravelWhatsAppChat() {
 
   // ─── "New message" composer state ──────────────────────────
   // Modal-driven outbound-first send. Hits POST /api/whatsapp/send
-  // with { to, body }. If the recipient hasn't messaged in 24h the
-  // backend returns 422 OUTSIDE_24H_WINDOW — surfaced in `newError`
-  // with hint about templates so the user knows the path forward.
+  // with { to, body }. Errors are surfaced in `newError`.
   const [showNewModal, setShowNewModal] = useState(false);
   const [newPhone, setNewPhone] = useState('');
   const [newBody, setNewBody] = useState('');
@@ -813,24 +811,6 @@ export default function TravelWhatsAppChat() {
           body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
         });
       } catch (sendErr) {
-        const msg = sendErr?.message || '';
-        // Meta 24h-window rejection — automatically open the template
-        // picker with this thread's phone pre-filled instead of just
-        // showing a toast. The operator can pick an approved template
-        // and send without leaving the chat.
-        if (msg.includes('OUTSIDE_24H_WINDOW')) {
-          notify.error(
-            'Last inbound from this contact was >24 hours ago. ' +
-            'WhatsApp policy requires you to send an approved template — picker opening now.'
-          );
-          setNewPhone(detail.thread.contactPhone);
-          setNewBody(outBody);
-          setUseTemplate(true);
-          setNewError(null);
-          setShowNewModal(true);
-          setSending(false);
-          return;
-        }
         throw sendErr;
       }
       setReply('');
@@ -907,12 +887,7 @@ export default function TravelWhatsAppChat() {
       if (resp?.thread?.id) setSelectedId(resp.thread.id);
     } catch (err) {
       const msg = err?.message || 'Failed to send.';
-      if (msg.includes('OUTSIDE_24H_WINDOW')) {
-        setNewError(
-          'This number has not messaged you in the last 24 hours. ' +
-          'Toggle "Use Template" above and pick an approved template instead.'
-        );
-      } else if (msg.includes('CONTACT_OPTED_OUT')) {
+      if (msg.includes('CONTACT_OPTED_OUT')) {
         setNewError('This contact has opted out of WhatsApp messages.');
       } else {
         setNewError(msg);

--- a/frontend/src/pages/wellness/WhatsAppThreads.jsx
+++ b/frontend/src/pages/wellness/WhatsAppThreads.jsx
@@ -542,14 +542,11 @@ export default function WhatsAppThreads() {
           .join('\n');
         outBody = `${quote}\n${outBody}`;
       }
-      try {
-        await fetchApi('/api/whatsapp-web/send', {
-          method: 'POST',
-          body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
-        });
-      } catch (sendErr) {
-        throw sendErr;
-      }
+      // Errors bubble to the outer catch below (CONTACT_OPTED_OUT handling).
+      await fetchApi('/api/whatsapp-web/send', {
+        method: 'POST',
+        body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
+      });
       setReply('');
       setReplyToMsg(null);
       // Reload detail

--- a/frontend/src/pages/wellness/WhatsAppThreads.jsx
+++ b/frontend/src/pages/wellness/WhatsAppThreads.jsx
@@ -66,7 +66,7 @@ export default function WhatsAppThreads() {
   // ─── "New message" composer state ──────────────────────────
   // Modal-driven outbound-first send. Hits POST /api/whatsapp/send
   // with { to, body }. If the recipient hasn't messaged in 24h the
-  // backend returns 422 OUTSIDE_24H_WINDOW — surfaced in `newError`
+  // Errors are surfaced in `newError`.
   // with hint about templates so the user knows the path forward.
   const [showNewModal, setShowNewModal] = useState(false);
   const [newPhone, setNewPhone] = useState('');
@@ -548,24 +548,6 @@ export default function WhatsAppThreads() {
           body: JSON.stringify({ to: detail.thread.contactPhone, body: outBody }),
         });
       } catch (sendErr) {
-        const msg = sendErr?.message || '';
-        // Meta 24h-window rejection — automatically open the template
-        // picker with this thread's phone pre-filled instead of just
-        // showing a toast. The operator can pick an approved template
-        // and send without leaving the chat.
-        if (msg.includes('OUTSIDE_24H_WINDOW')) {
-          notify.error(
-            'Last inbound from this contact was >24 hours ago. ' +
-            'WhatsApp policy requires you to send an approved template — picker opening now.'
-          );
-          setNewPhone(detail.thread.contactPhone);
-          setNewBody(outBody);
-          setUseTemplate(true);
-          setNewError(null);
-          setShowNewModal(true);
-          setSending(false);
-          return;
-        }
         throw sendErr;
       }
       setReply('');
@@ -641,12 +623,7 @@ export default function WhatsAppThreads() {
       if (resp?.thread?.id) setSelectedId(resp.thread.id);
     } catch (err) {
       const msg = err?.message || 'Failed to send.';
-      if (msg.includes('OUTSIDE_24H_WINDOW')) {
-        setNewError(
-          'This number has not messaged you in the last 24 hours. ' +
-          'Toggle "Use Template" above and pick an approved template instead.'
-        );
-      } else if (msg.includes('CONTACT_OPTED_OUT')) {
+      if (msg.includes('CONTACT_OPTED_OUT')) {
         setNewError('This contact has opted out of WhatsApp messages.');
       } else {
         setNewError(msg);

--- a/frontend/src/pages/wellness/whatsapp/ThreadDetail.jsx
+++ b/frontend/src/pages/wellness/whatsapp/ThreadDetail.jsx
@@ -9,7 +9,6 @@ import {
   Edit2,
   Save,
   Trash2,
-  AlertTriangle,
   X,
   Paperclip,
   Smile,
@@ -376,52 +375,8 @@ export default function ThreadDetail() {
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', textAlign: 'center', padding: '0.75rem' }}>
                 Reply box disabled — contact has opted out (DPDP/TRAI compliance).
               </p>
-            ) : (() => {
-              // ── 24-hour window check ────────────────────────────
-              // WhatsApp Business policy: free-form text can only be
-              // sent within 24h of the customer's last INBOUND msg.
-              // We compute the freshest inbound time from the loaded
-              // messages and show a yellow banner if it's stale, so
-              // operators don't waste keystrokes on a doomed send.
-              const inbounds = (detail.messages || []).filter((m) => m.direction === 'INBOUND' && (m.metaType || '').toLowerCase() !== 'reaction');
-              const newestInbound = inbounds.length > 0
-                ? Math.max(...inbounds.map((m) => new Date(m.createdAt).getTime()))
-                : 0;
-              const windowExpired = newestInbound === 0 || (Date.now() - newestInbound) > 24 * 3600 * 1000;
-              return (
+            ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  {windowExpired && (
-                    <div style={{
-                      background: 'rgba(245,158,11,0.12)',
-                      border: '1px solid rgba(245,158,11,0.35)',
-                      borderRadius: 8,
-                      padding: '0.55rem 0.8rem',
-                      fontSize: '0.78rem',
-                      display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'space-between',
-                      color: 'var(--text-primary)',
-                    }}>
-                      <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <AlertTriangle size={14} color="#d97706" />
-                        24-hour window expired — free-form messages will be rejected by Meta. Use an approved template.
-                      </span>
-                      <button
-                        onClick={() => {
-                          setNewPhone(detail.thread.contactPhone);
-                          setUseTemplate(true);
-                          setNewBody('');
-                          setNewError(null);
-                          setShowNewModal(true);
-                        }}
-                        style={{
-                          padding: '0.3rem 0.7rem', fontSize: '0.75rem', fontWeight: 600,
-                          background: '#d97706', color: '#fff', border: 'none',
-                          borderRadius: 6, cursor: 'pointer', whiteSpace: 'nowrap',
-                        }}
-                      >
-                        Send template →
-                      </button>
-                    </div>
-                  )}
                   {/* WhatsApp-style replying-to preview: shows the quoted
                       message in a green-bordered bar above the textarea
                       with an X to dismiss. Replaces the old text-quote
@@ -607,8 +562,7 @@ export default function ThreadDetail() {
                     </button>
                   </div>
                 </div>
-              );
-            })()}
+            )}
           </footer>
         </>
       )}

--- a/frontend/src/utils/destinationPhotos.js
+++ b/frontend/src/utils/destinationPhotos.js
@@ -12,6 +12,61 @@
 import { useEffect, useState } from "react";
 import { destinationTheme } from "./destinationTheme";
 
+// ── Server-side Pexels proxy (primary source) ──────────────────────────────
+//
+// The keyless Wikipedia path below stays as a fallback, but the PRIMARY source
+// is now our backend proxy GET /api/travel/destination-photos/public, which
+// calls Pexels with a server-held key and a shared 24h cache. That removes the
+// "images vanish again and again" flicker — Wikipedia rate-limits anonymous
+// API traffic and the client did no caching, so the hero (action API) and the
+// side rails (REST media-list API) would intermittently come back empty.
+//
+// We also add a small client-side cache so a destination isn't re-fetched on
+// every component remount within a session.
+const PROXY_ENDPOINT = "/api/travel/destination-photos/public";
+const _proxyCache = new Map(); // `${q}::${limit}` → Promise<Photo[]>
+
+/**
+ * Fetch destination photos from our backend Pexels proxy. Returns an array of
+ * { url, caption, description } (possibly empty). Never throws — resolves to []
+ * on any failure so callers fall back to Wikipedia. `opts.fetchImpl` injects a
+ * stub for tests; when omitted in a non-browser/test env it no-ops to [].
+ */
+export async function fetchProxyPhotos(destination, opts = {}) {
+  const fetchImpl = opts.fetchImpl || (typeof fetch !== "undefined" ? fetch : null);
+  const q = String(destination || "").trim();
+  const limit = opts.limit || 12;
+  if (!q || !fetchImpl) return [];
+  const key = `${q.toLowerCase()}::${limit}`;
+  if (_proxyCache.has(key)) return _proxyCache.get(key);
+  const p = (async () => {
+    try {
+      const res = await fetchImpl(
+        `${PROXY_ENDPOINT}?q=${encodeURIComponent(q)}&limit=${limit}`,
+      );
+      if (!res || !res.ok) return [];
+      const data = await res.json();
+      const photos = Array.isArray(data && data.photos) ? data.photos : [];
+      return photos
+        .map((x) => ({
+          url: x.url,
+          caption: x.caption || q,
+          description: x.description || null,
+        }))
+        .filter((x) => x.url);
+    } catch (_e) {
+      return [];
+    }
+  })();
+  // Cache the in-flight promise; evict on empty resolution so a transient miss
+  // doesn't pin "no photos" for the session (a later mount can retry).
+  _proxyCache.set(key, p);
+  p.then((arr) => {
+    if (!arr.length) _proxyCache.delete(key);
+  });
+  return p;
+}
+
 // Best Wikipedia article title for a destination: the curated wikiTitle when
 // known, else the destination cleaned to its first segment (drop ", France",
 // parentheticals, trailing descriptors) so the lookup has a fighting chance.
@@ -154,9 +209,16 @@ export function useDestinationPhoto(destination) {
     let alive = true;
     setPhotoUrl(null);
     if (!destination) return undefined;
-    fetchDestinationPhoto(destination).then((url) => {
-      if (alive) setPhotoUrl(url);
-    });
+    // Pexels proxy first (1 landscape shot for the hero); fall back to the
+    // keyless Wikipedia lead image if the proxy has no key / misses.
+    fetchProxyPhotos(destination, { limit: 1 })
+      .then((arr) => {
+        if (arr.length && arr[0].url) return arr[0].url;
+        return fetchDestinationPhoto(destination);
+      })
+      .then((url) => {
+        if (alive) setPhotoUrl(url || null);
+      });
     return () => { alive = false; };
   }, [destination]);
   return photoUrl;
@@ -180,7 +242,9 @@ export function useMultiDestinationGallery(destinations) {
     if (!list.length) return undefined;
     Promise.all(
       list.map((d) =>
-        fetchDestinationGallery(d, { limit: 4 })
+        // Pexels proxy first per city; Wikipedia REST fallback on a miss.
+        fetchProxyPhotos(d, { limit: 4 })
+          .then((g) => (g.length ? g : fetchDestinationGallery(d, { limit: 4 })))
           .then((g) => g.map((x) => ({ ...x, city: d })))
           .catch(() => []),
       ),
@@ -209,9 +273,13 @@ export function useDestinationGallery(destination) {
     let alive = true;
     setUrls([]);
     if (!destination) return undefined;
-    fetchDestinationGallery(destination).then((u) => {
-      if (alive) setUrls(u);
-    });
+    // Pexels proxy first (a set of landscape shots for the side rails); fall
+    // back to the keyless Wikipedia REST media-list if the proxy misses.
+    fetchProxyPhotos(destination, { limit: 16 })
+      .then((arr) => (arr.length ? arr : fetchDestinationGallery(destination)))
+      .then((u) => {
+        if (alive) setUrls(u);
+      });
     return () => { alive = false; };
   }, [destination]);
   return urls;


### PR DESCRIPTION
Travel payment flows: End-to-end fix of the Razorpay payment-link lifecycle — receipt PDF generation, milestone reconciliation, invoice status upgrades, and customer/invoice enrichment in the payments list
WhatsApp 24h window removed: Dropped Meta's free-form message restriction from both UI and backend for Travel and Wellness verticals
LLM Router: Replaced Claude Haiku fallback with Groq (llama-3.3-70b-versatile) across 6 task routes; added Groq to .env.example
Payments page: Customer name + invoice reference now resolve for travel payments; detail modal renders via React Portal (fixes scroll-position rendering bug); itinerary-linked payments show a clickable link to the itinerary
Itinerary UI: Removed Accept/Reject buttons from admin itinerary detail (operator-side view only); removed + Hotel quick-add from day planner
Lead scoring: WhatsApp lead capture improvements in inbound leads and travel leads pages
Destination photos & QuoteBuilder: Visual enhancements shipped alongside
