### PR TITLE
Fixed the landing page upload links

### DIFF
--- a/backend/lib/videoUrl.js
+++ b/backend/lib/videoUrl.js
@@ -22,7 +22,13 @@
 //   - Local /uploads/... URL (pass-through; renderer outputs <video>, not <iframe>)
 //   - Anything else: pass through unchanged so we don't break exotic providers.
 
-const LOCAL_UPLOAD_PREFIX = '/uploads/landing-page-videos/';
+// Canonical prefix for new uploads (must be under /api/* — Nginx on the
+// deployed demo only proxies /api/* to the backend; a bare /uploads/...
+// URL falls through to the SPA catch-all and serves index.html instead of
+// the file). The legacy bare-/uploads/ prefix is also recognised so pages
+// saved before this fix keep rendering a <video> tag instead of an <iframe>.
+const LOCAL_UPLOAD_PREFIX = '/api/uploads/landing-page-videos/';
+const LEGACY_LOCAL_UPLOAD_PREFIX = '/uploads/landing-page-videos/';
 
 // Recognise URLs that point directly at a video file (Pexels CDN, Cloudflare
 // Stream MP4 endpoints, S3-served clips, etc.). The renderer must emit a
@@ -33,7 +39,8 @@ const DIRECT_VIDEO_FILE_RE = /\.(mp4|webm|mov|ogv|ogg|m4v)(\?|#|$)/i;
 
 function isLocalUpload(url) {
   if (!url || typeof url !== 'string') return false;
-  return url.trim().startsWith(LOCAL_UPLOAD_PREFIX);
+  const t = url.trim();
+  return t.startsWith(LOCAL_UPLOAD_PREFIX) || t.startsWith(LEGACY_LOCAL_UPLOAD_PREFIX);
 }
 
 function isDirectVideoFile(url) {

--- a/backend/routes/landing_pages.js
+++ b/backend/routes/landing_pages.js
@@ -282,7 +282,10 @@ router.get("/template-catalogue", verifyToken, (req, res) => {
 //
 // Tenant isolation: storage path includes req.user.tenantId so a
 // directory listing on disk is segmented per tenant. The returned
-// `url` is `/uploads/landing-page-images/tenant-<id>/<file>`. We do
+// `url` is `/api/uploads/landing-page-images/tenant-<id>/<file>` (the
+// `/api/*` prefix is required — Nginx on the deployed demo only proxies
+// `/api/*` to the backend, so a bare `/uploads/...` URL falls through to
+// the SPA catch-all and serves index.html instead of the file). We do
 // NOT persist a row in the DB — the URL is opaque and gets stored in
 // the parent LandingPage row's `content` JSON when the user saves.
 router.post(
@@ -303,7 +306,7 @@ router.post(
     if (!req.file) {
       return res.status(400).json({ error: "No image file provided (field 'image')" });
     }
-    const url = `/uploads/landing-page-images/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
+    const url = `/api/uploads/landing-page-images/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
     res.status(201).json({
       url,
       mimetype: req.file.mimetype,
@@ -322,10 +325,11 @@ router.post(
 //   400 — wrong MIME, missing file, multer LIMIT_FILE_SIZE
 //   401/403 — verifyToken
 //
-// Tenant-segmented path: /uploads/landing-page-videos/tenant-<id>/<file>.
-// Caller stores the returned `url` directly in the video block's `url`
-// prop; the public renderer detects the /uploads/landing-page-videos
-// prefix and emits a native <video controls> tag.
+// Tenant-segmented path: /api/uploads/landing-page-videos/tenant-<id>/<file>
+// (must be under /api/* — see the /upload comment above for why). Caller
+// stores the returned `url` directly in the video block's `url` prop; the
+// public renderer detects the /api/uploads/landing-page-videos prefix and
+// emits a native <video controls> tag.
 router.post(
   "/upload-video",
   verifyToken,
@@ -344,7 +348,7 @@ router.post(
     if (!req.file) {
       return res.status(400).json({ error: "No video file provided (field 'video')" });
     }
-    const url = `/uploads/landing-page-videos/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
+    const url = `/api/uploads/landing-page-videos/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
     res.status(201).json({
       url,
       mimetype: req.file.mimetype,
@@ -363,10 +367,11 @@ router.post(
 //   400 — wrong MIME, missing file, multer LIMIT_FILE_SIZE
 //   401/403 — verifyToken
 //
-// Tenant-segmented path: /uploads/landing-page-documents/tenant-<id>/<file>.
-// Caller stores the returned `url` into `brochure.fileUrl` in the page
-// config; the wanderlux template surfaces a "Download brochure" CTA on
-// the brochure section's success state when that field is non-empty.
+// Tenant-segmented path: /api/uploads/landing-page-documents/tenant-<id>/<file>
+// (must be under /api/* — see the /upload comment above for why). Caller
+// stores the returned `url` into `brochure.fileUrl` in the page config; the
+// wanderlux template surfaces a "Download brochure" CTA on the brochure
+// section's success state when that field is non-empty.
 router.post(
   "/upload-document",
   verifyToken,
@@ -385,7 +390,7 @@ router.post(
     if (!req.file) {
       return res.status(400).json({ error: "No document file provided (field 'document')" });
     }
-    const url = `/uploads/landing-page-documents/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
+    const url = `/api/uploads/landing-page-documents/tenant-${req.user.tenantId}/${path.basename(req.file.path)}`;
     res.status(201).json({
       url,
       mimetype: req.file.mimetype,

--- a/backend/services/destinationImageProvider.js
+++ b/backend/services/destinationImageProvider.js
@@ -382,11 +382,13 @@ function applyImagesToContent(content, fetched) {
 }
 
 // An image URL is "operator-owned" (do not overwrite) when it's a local
-// upload path. Any TEE-fetched URL starts with https://; operator
-// uploads start with /uploads/.
+// upload path. Any TEE-fetched URL starts with https://; operator uploads
+// start with /api/uploads/ (canonical — see server.js's /uploads mount
+// comment for why /api/* is required) or the legacy bare /uploads/ (pages
+// saved before that fix).
 function isOperatorOwned(url) {
   if (!url || typeof url !== 'string') return false;
-  return url.startsWith('/uploads/');
+  return url.startsWith('/api/uploads/') || url.startsWith('/uploads/');
 }
 
 function _resetForTests() {

--- a/backend/services/landingPageRenderer.js
+++ b/backend/services/landingPageRenderer.js
@@ -644,8 +644,8 @@ function renderComponent(component, slug) {
       // Vimeo / Wistia paste — normalised to the provider's /embed
       // path so X-Frame-Options doesn't block the render — or (b) an
       // upload via POST /api/landing-pages/upload-video, which lands
-      // at /uploads/landing-page-videos/tenant-<id>/<file> and renders
-      // as a native <video> control.
+      // at /api/uploads/landing-page-videos/tenant-<id>/<file> and
+      // renders as a native <video> control.
       const title = escapeHtml(props.title || "");
       const subtitle = escapeHtml(props.subtitle || "");
       const normalized = normalizeVideoEmbedUrl(props.url);

--- a/backend/services/templates/wanderlux/landing-page.dc.html
+++ b/backend/services/templates/wanderlux/landing-page.dc.html
@@ -1306,6 +1306,14 @@ class Component extends DCLogic {
     /* ----- brochure ----- */
     const br = cfg.brochure || {};
     out.showBrochure = !!(br.enabled && br.fields && br.fields.length);
+    /* Pages saved before the /api/uploads fix have a bare /uploads/... URL
+       baked into their stored config. Nginx on the deployed demo only
+       proxies /api/* to the backend, so a bare /uploads/... request falls
+       through the SPA catch-all and downloads index.html instead of the
+       file. Rewrite the legacy prefix at render time so already-published
+       pages self-heal without an operator having to re-upload. */
+    let brFileUrl = br.fileUrl || '';
+    if (brFileUrl.startsWith('/uploads/')) brFileUrl = '/api' + brFileUrl;
     out.brochure = { eyebrow:br.eyebrow, title:br.title, body:br.body, note:br.note, submitLabel:br.submitLabel || 'Download',
       successTitle: br.successTitle || 'Thank you!', successBody: br.successBody || 'Your brochure is on the way.',
       /* fileUrl — operator-uploaded PDF or pasted hosted link. Surfaces
@@ -1313,7 +1321,7 @@ class Component extends DCLogic {
          card so visitors can grab the file immediately in addition to
          the email-it-to-you flow. Empty string = no direct link, success
          card stays text-only. */
-      fileUrl: br.fileUrl || '' };
+      fileUrl: brFileUrl };
     /* Only render the outer copy card when there's actually copy to put
        in it — empty body + empty note collapses the card entirely so the
        form alone sits on the page (avoids an empty white rectangle). */

--- a/backend/test/lib/videoUrl.test.js
+++ b/backend/test/lib/videoUrl.test.js
@@ -91,7 +91,10 @@ describe('normalizeVideoEmbedUrl — empty / invalid input', () => {
 });
 
 describe('isLocalUpload', () => {
-  test('detects /uploads/landing-page-videos prefix', () => {
+  test('detects canonical /api/uploads/landing-page-videos prefix', () => {
+    expect(isLocalUpload('/api/uploads/landing-page-videos/tenant-1/foo.mp4')).toBe(true);
+  });
+  test('detects legacy bare /uploads/landing-page-videos prefix (pre-fix saved pages)', () => {
     expect(isLocalUpload('/uploads/landing-page-videos/tenant-1/foo.mp4')).toBe(true);
   });
   test('false for YouTube URL', () => {
@@ -107,6 +110,7 @@ describe('isLocalUpload', () => {
   });
   test('tolerates leading whitespace', () => {
     expect(isLocalUpload('  /uploads/landing-page-videos/tenant-1/foo.mp4')).toBe(true);
+    expect(isLocalUpload('  /api/uploads/landing-page-videos/tenant-1/foo.mp4')).toBe(true);
   });
 });
 
@@ -149,6 +153,6 @@ describe('isDirectVideoFile', () => {
 
 describe('exported constant', () => {
   test('LOCAL_UPLOAD_PREFIX matches the upload route + renderer expectations', () => {
-    expect(LOCAL_UPLOAD_PREFIX).toBe('/uploads/landing-page-videos/');
+    expect(LOCAL_UPLOAD_PREFIX).toBe('/api/uploads/landing-page-videos/');
   });
 });

--- a/backend/test/services/destinationImageProvider.test.js
+++ b/backend/test/services/destinationImageProvider.test.js
@@ -393,6 +393,7 @@ describe('applyImagesToContent — bridge into LandingPage.content', () => {
   });
 
   test('isOperatorOwned recognizes /uploads/ paths and external URLs', () => {
+    expect(provider.isOperatorOwned('/api/uploads/landing-page-images/x.jpg')).toBe(true);
     expect(provider.isOperatorOwned('/uploads/landing-page-images/x.jpg')).toBe(true);
     expect(provider.isOperatorOwned('https://images.unsplash.com/x.jpg')).toBe(false);
     expect(provider.isOperatorOwned('')).toBe(false);

--- a/e2e/tests/landing-page-upload-api.spec.js
+++ b/e2e/tests/landing-page-upload-api.spec.js
@@ -10,7 +10,10 @@
  *   uploads at 5 MB. This spec pins the contract:
  *
  *     201 { url, mimetype, size, filename }
- *       - url is "/uploads/landing-page-images/tenant-<id>/<unique>.<ext>"
+ *       - url is "/api/uploads/landing-page-images/tenant-<id>/<unique>.<ext>"
+ *         (must be under /api/* — Nginx on the deployed demo only proxies
+ *         /api/* to the backend; a bare /uploads/... URL falls through to
+ *         the SPA catch-all and serves index.html instead of the file)
  *       - extension is derived from MIME, NOT the client filename
  *
  *     400 paths:
@@ -111,7 +114,7 @@ test.describe('POST /api/landing-pages/upload — happy paths', () => {
     expect(res.status(), `upload PNG: ${await res.text()}`).toBe(201);
     const body = await res.json();
     expect(typeof body.url).toBe('string');
-    expect(body.url).toMatch(/^\/uploads\/landing-page-images\/tenant-\d+\//);
+    expect(body.url).toMatch(/^\/api\/uploads\/landing-page-images\/tenant-\d+\//);
     expect(body.url).toContain(`tenant-${genericTenantId}/`);
     expect(body.url).toMatch(/\.png$/);
     expect(body.mimetype).toBe('image/png');
@@ -263,7 +266,7 @@ test.describe('POST /api/landing-pages/upload-video — happy path', () => {
     });
     expect(res.status(), `upload-video: ${await res.text()}`).toBe(201);
     const body = await res.json();
-    expect(body.url).toMatch(/^\/uploads\/landing-page-videos\/tenant-\d+\//);
+    expect(body.url).toMatch(/^\/api\/uploads\/landing-page-videos\/tenant-\d+\//);
     expect(body.url).toContain(`tenant-${genericTenantId}/`);
     expect(body.url).toMatch(/\.mp4$/);
     expect(body.mimetype).toBe('video/mp4');

--- a/frontend/src/pages/LandingPageBuilder.jsx
+++ b/frontend/src/pages/LandingPageBuilder.jsx
@@ -2169,10 +2169,12 @@ function ReviewCarouselEditor({ p, updateProp, field }) {
 // (YouTube Shorts / watch / youtu.be → /embed; Vimeo → player.vimeo).
 // Mismatch between this and the backend would cause "preview works,
 // public render shows 'refused to connect'" — keep them in sync.
-const LOCAL_VIDEO_UPLOAD_PREFIX = '/uploads/landing-page-videos/';
+const LOCAL_VIDEO_UPLOAD_PREFIX = '/api/uploads/landing-page-videos/';
+const LEGACY_LOCAL_VIDEO_UPLOAD_PREFIX = '/uploads/landing-page-videos/';
 function isLocalVideoUpload(url) {
   if (!url || typeof url !== 'string') return false;
-  return url.trim().startsWith(LOCAL_VIDEO_UPLOAD_PREFIX);
+  const t = url.trim();
+  return t.startsWith(LOCAL_VIDEO_UPLOAD_PREFIX) || t.startsWith(LEGACY_LOCAL_VIDEO_UPLOAD_PREFIX);
 }
 function normalizeVideoEmbedUrl(url) {
   if (!url || typeof url !== 'string') return '';

--- a/frontend/src/pages/LandingPageWanderluxEditor.jsx
+++ b/frontend/src/pages/LandingPageWanderluxEditor.jsx
@@ -275,7 +275,10 @@ function FileField({ label, value, onChange, placeholder, accept }) {
       {value && (
         <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', margin: '0.35rem 0 0' }}>
           Linked file:{' '}
-          <a href={value} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>{value}</a>
+          {/* Pages saved before the /api/uploads fix have a bare /uploads/...
+              value — rewrite for the preview link only (not the stored
+              value) so clicking it doesn't hit the SPA catch-all. */}
+          <a href={value.startsWith('/uploads/') ? `/api${value}` : value} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>{value}</a>
         </p>
       )}
     </div>


### PR DESCRIPTION
Fixed landing page brochure uploads returning a broken URL that worked locally but served a blank page on the deployed demo. Uploads now return the correct URL format so downloads work in both environments, and already-published pages with the old broken link are automatically fixed too.