### PR TITLE
fix(externalAuth): detect webhook signing secret pasted as API key + …

### DIFF
--- a/backend/middleware/externalAuth.js
+++ b/backend/middleware/externalAuth.js
@@ -2,10 +2,17 @@
  * API-key authentication for the external partner API (/api/v1/external).
  *
  * Partner products (Callified.ai, Globus Phone, etc.) authenticate with:
- *   X-API-Key: glbs_<hex> (CRM-generated, 48+ hex chars with prefix)
- *   X-API-Key: <hex> (external-generated e.g. GlobusPhone, raw 48-96 hex chars)
+ *   X-API-Key: glbs_<hex> (CRM-generated, 48-96 hex chars after the prefix)
  *
- * Both formats are accepted; validation looks up the key in the ApiKey table.
+ * The glbs_ prefix is REQUIRED. Every key ever minted into the ApiKey table
+ * is glbs_-prefixed (routes/developer.js, scripts/mint-api-key.js and
+ * prisma/seed-wellness.js are the only insert sites), so a bare-hex value
+ * can never match a row. f9cfd96f briefly accepted raw 48-96 hex
+ * "external-generated" keys, but that leniency only deferred the failure to
+ * a misleading "Invalid API key": partners have twice pasted the per-tenant
+ * webhook signing secret (bare 64 hex, routes/settings.js, shown once on the
+ * Settings page) into the X-API-Key field. That shape now gets a specific
+ * 401 pointing at Developer → API Keys instead.
  *
  * On success, req.apiKey, req.tenant, and req.tenantId are populated.
  * We deliberately do NOT populate req.user — this isn't a human session —
@@ -39,10 +46,17 @@ module.exports = async function externalAuth(req, res, next) {
     if (!token) {
       return res.status(401).json({ error: "Missing X-API-Key header" });
     }
-    // Accept both glbs_<hex> (CRM-generated) and raw hex (GlobusPhone/external-generated).
-    // Format validation: either "glbs_<hex>" or raw 48-96 hex chars (24-48 bytes).
-    const isValidFormat = /^(glbs_)?[a-f0-9]{48,96}$/i.test(token);
-    if (!isValidFormat) {
+    // The glbs_ prefix is required — see header. Bare 64-hex is the exact
+    // shape of the per-tenant webhook signing secret (routes/settings.js,
+    // shown once on the Settings page); name that mistake specifically
+    // instead of failing with a generic 401 later.
+    if (!/^glbs_[a-f0-9]{48,96}$/i.test(token)) {
+      if (/^[a-f0-9]{64}$/i.test(token)) {
+        return res.status(401).json({
+          error:
+            "This looks like a webhook signing secret, not an API key. API keys start with glbs_ — generate one from Developer → API Keys.",
+        });
+      }
       return res.status(401).json({ error: "Malformed API key" });
     }
 

--- a/backend/test/middleware/externalAuth.test.js
+++ b/backend/test/middleware/externalAuth.test.js
@@ -229,8 +229,8 @@ describe('externalAuth', () => {
     expect(findUniqueMock).not.toHaveBeenCalled();
   });
 
-  test('returns 401 malformed when hex segment is shorter than 32 chars', async () => {
-    // Per regex /^glbs_[a-f0-9]{32,}$/i — 31 hex chars fails.
+  test('returns 401 malformed when hex segment is shorter than 48 chars', async () => {
+    // Per regex /^glbs_[a-f0-9]{48,96}$/i — 31 hex chars fails.
     const { req, res, next } = makeReqResNext({
       headers: { 'x-api-key': 'glbs_' + 'a'.repeat(31) },
     });
@@ -334,95 +334,95 @@ describe('externalAuth', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Raw hex key support wave (+6 cases): accept raw hex keys from external
-  // partners (e.g. GlobusPhone) without glbs_ prefix. Both formats valid.
+  // Wrong-secret detection wave: the glbs_ prefix is required again (the
+  // f9cfd96f raw-hex leniency never matched a real key — all three ApiKey
+  // insert sites mint glbs_-prefixed secrets). A bare 64-hex value is the
+  // exact shape of the per-tenant webhook signing secret (routes/settings.js,
+  // shown once on the Settings page) and gets a specific 401 pointing at
+  // Developer → API Keys; other bare hex stays generic "Malformed API key".
+  // Neither reaches the DB lookup.
   // -------------------------------------------------------------------------
 
-  test('accepts raw hex key (48 chars) without glbs_ prefix', async () => {
-    const rawKey = '83000168aabbccddeeff0011223344556677889900112233445566778899';
-    findUniqueMock.mockResolvedValueOnce({
-      id: 300,
-      tenantId: 9,
-      userId: 5,
-      keySecret: rawKey,
-      tenant: { id: 9, isActive: true },
-    });
+  const WEBHOOK_SECRET_ERROR =
+    'This looks like a webhook signing secret, not an API key. API keys start with glbs_ — generate one from Developer → API Keys.';
+
+  test('bare 64-hex (webhook signing secret shape) returns the wrong-secret 401 without a DB lookup', async () => {
+    // crypto.randomBytes(32).toString('hex') shape — what Settings hands out.
+    const webhookSecretShaped = 'b'.repeat(32) + '0'.repeat(32);
     const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': rawKey },
+      headers: { 'x-api-key': webhookSecretShaped },
     });
     await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(res.status).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('bare 64-hex with uppercase hex also hits the wrong-secret 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'F'.repeat(64) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('bare 48-hex (not webhook-secret shape) returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'c'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('bare 96-hex returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'a'.repeat(96) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('glbs_-prefixed 64-hex is format-valid and proceeds to the DB lookup', async () => {
+    // Guard: the prefix check dominates — a prefixed key whose hex segment
+    // happens to be 64 chars must NOT trip the wrong-secret branch.
+    findUniqueMock.mockResolvedValueOnce(null);
+    const prefixed64 = 'glbs_' + 'd'.repeat(64);
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': prefixed64 },
+    });
+    await externalAuth(req, res, next);
     expect(findUniqueMock).toHaveBeenCalledWith({
-      where: { keySecret: rawKey },
+      where: { keySecret: prefixed64 },
       include: { tenant: true },
     });
-  });
-
-  test('accepts raw hex key at maximum length (96 chars)', async () => {
-    const rawKey = 'a'.repeat(96);
-    findUniqueMock.mockResolvedValueOnce({
-      id: 301,
-      tenantId: 10,
-      userId: 6,
-      keySecret: rawKey,
-      tenant: { id: 10, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': rawKey },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(res.status).not.toHaveBeenCalled();
-  });
-
-  test('returns 401 malformed when raw hex is too short (< 48 chars)', async () => {
-    const tooShort = 'a'.repeat(47);
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': tooShort },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('returns 401 malformed when raw hex is too long (> 96 chars)', async () => {
-    const tooLong = 'b'.repeat(97);
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': tooLong },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('returns 401 invalid when raw hex key not found in database', async () => {
-    findUniqueMock.mockResolvedValueOnce(null);
-    const rawKey = 'c'.repeat(48);
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': rawKey },
-    });
-    await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
   });
 
-  test('accepts raw hex key with mixed case (A-F uppercase)', async () => {
-    const mixedKey = 'F'.repeat(24) + '0'.repeat(24);
-    findUniqueMock.mockResolvedValueOnce({
-      id: 302,
-      tenantId: 11,
-      userId: 7,
-      keySecret: mixedKey,
-      tenant: { id: 11, isActive: true },
-    });
+  test('glbs_ key with hex segment shorter than 48 returns generic malformed 401', async () => {
     const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': mixedKey },
+      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(47) },
     });
     await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(res.status).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('glbs_ key with hex segment longer than 96 returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'b'.repeat(97) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/WebhookSigningCredential.test.jsx
+++ b/frontend/src/__tests__/WebhookSigningCredential.test.jsx
@@ -189,6 +189,28 @@ describe('<WebhookSigningCredential />', () => {
     });
   });
 
+  // Wrong-secret disambiguation (partners twice pasted this secret into an
+  // X-API-Key field): both the card body and the show-once reveal modal must
+  // say it is NOT an API key and point at Developer → API Keys.
+  it('card body warns the secret is NOT an API key and links to Developer → API Keys', async () => {
+    fetchApiMock.mockImplementation(withCred(credActive));
+    render(<WebhookSigningCredential />);
+    await screen.findByText('whid_abcd1234');
+    expect(screen.getByText(/This is a webhook signing secret/i)).toBeInTheDocument();
+    expect(screen.getByText(/For API keys, go to/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Developer → API Keys/i })).toHaveAttribute('href', '/developer');
+  });
+
+  it('reveal modal warns the show-once secret must not be used as an X-API-Key', async () => {
+    fetchApiMock.mockImplementation(withCred(credNone(true)));
+    render(<WebhookSigningCredential />);
+    fireEvent.click(await screen.findByRole('button', { name: /Generate signing secret/i }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Do not use it as an/i)).toBeInTheDocument();
+    expect(within(dialog).getByText('glbs_')).toBeInTheDocument();
+    expect(within(dialog).getByRole('link', { name: /Developer → API Keys/i })).toHaveAttribute('href', '/developer');
+  });
+
   it('non-admin (GET rejects with 403) renders nothing', async () => {
     fetchApiMock.mockImplementation(() => Promise.reject(Object.assign(new Error('forbidden'), { status: 403 })));
     const { container } = render(<WebhookSigningCredential />);

--- a/frontend/src/components/WebhookSigningCredential.jsx
+++ b/frontend/src/components/WebhookSigningCredential.jsx
@@ -90,9 +90,19 @@ export default function WebhookSigningCredential() {
         <h3 style={{ fontSize: '1.25rem', fontWeight: '600', marginBottom: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <ShieldCheck size={20} color="var(--primary-color, var(--accent-color))" /> Webhook Signing Credential
         </h3>
-        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
           One HMAC secret signs every outbound webhook for your account. Configure it in GlobusPhone (or any receiver)
           so it can verify each delivery. The secret is shown only once — rotate if you lose it.
+        </p>
+        {/* Partners have twice pasted this secret into an X-API-Key field —
+            it copies as a bare 64-hex string that looks like a plausible API
+            key. Disambiguate at the source, regardless of what partner docs say. */}
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1.5rem', display: 'flex', alignItems: 'flex-start', gap: '0.4rem' }}>
+          <AlertTriangle size={15} color="#f59e0b" style={{ flexShrink: 0, marginTop: 2 }} />
+          <span>
+            This is a webhook signing secret, <strong>not</strong> your API key. For API keys, go to{' '}
+            <a href="/developer" style={{ color: 'var(--primary-color, var(--accent-color))', fontWeight: 600 }}>Developer → API Keys</a>.
+          </span>
         </p>
 
         {/* Not entitled → disable generation, point to /pricing. */}
@@ -229,8 +239,17 @@ export default function WebhookSigningCredential() {
               </code>
             </div>
 
-            <p style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', margin: '0 0 1.25rem' }}>
+            <p style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', margin: '0 0 0.75rem' }}>
               Paste this into GlobusPhone (or any receiver) as <code style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>WEBHOOK_HMAC_SECRET_CRM</code>.
+            </p>
+            <p style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', margin: '0 0 1.25rem', display: 'flex', alignItems: 'flex-start', gap: '0.4rem' }}>
+              <AlertTriangle size={14} color="#f59e0b" style={{ flexShrink: 0, marginTop: 1 }} />
+              <span>
+                This is a webhook signing secret, <strong>not</strong> your API key. Do not use it as an{' '}
+                <code style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>X-API-Key</code> — API keys start with{' '}
+                <code style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>glbs_</code> and are generated from{' '}
+                <a href="/developer" style={{ color: 'var(--primary-color, var(--accent-color))', fontWeight: 600 }}>Developer → API Keys</a>.
+              </span>
             </p>
 
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem' }}>


### PR DESCRIPTION
…require glbs_ prefix again

Partners (GlobusPhone) have twice pasted the per-tenant webhook signing secret (bare 64 hex, routes/settings.js, shown once on the Settings page) into the X-API-Key field and got a generic 401 "Invalid API key" with no hint about what went wrong.

- middleware/externalAuth.js: restore the required glbs_ prefix. f9cfd96f's raw-hex leniency could never match a real key — routes/developer.js, scripts/mint-api-key.js and prisma/seed-wellness.js are the only ApiKey insert sites and all mint glbs_-prefixed secrets — so it only deferred the failure to a misleading "key not found". Bare 64-hex (the webhook-secret shape) now gets a specific 401 naming the mistake and pointing at Developer → API Keys; other non-glbs_ values stay "Malformed API key". DB lookup + tenant scoping unchanged.
- components/WebhookSigningCredential.jsx: inline "this is NOT your API key" warning in the card body and in the show-once reveal modal next to the copy button, both linking to /developer.
- test/middleware/externalAuth.test.js: replace the 6 raw-hex-acceptance cases with 7 wrong-secret/boundary cases (bare 64-hex hits the specific 401 without a DB lookup; prefix dominates for glbs_+64hex; bare 48/96 hex stay generic malformed).
- __tests__/WebhookSigningCredential.test.jsx: +2 cases pinning the new warnings.

Verified: vitest 23/23 backend + 11/11 frontend; live express probe with the incident key returns the new specific 401.