### PR TITLE
 Multi-brand branding refactor

### DIFF
--- a/backend/lib/brandResolver.js
+++ b/backend/lib/brandResolver.js
@@ -1,0 +1,86 @@
+// Effective-brand resolver — the single source of truth for "what logo and
+// color should this tenant show for sub-brand X" (2026-07-08).
+//
+// Fallback chain (documented in schema.prisma:92-98 for Tenant.defaultSubBrand
+// but never actually implemented until now — see PRD_TRAVEL_PER_SUBBRAND_BRANDING):
+//   1. The active BrandKit for the requested subBrand (if it has a logoUrl).
+//   2. The tenant's DEFAULT BRAND — the active BrandKit for
+//      Tenant.defaultSubBrand (if set), else the tenant-wide (subBrand=null)
+//      active BrandKit.
+//   3. Tenant.logoUrl / Tenant.brandColor (the legacy single-brand fields).
+//   4. null — caller renders the bundled system-default logo.
+//
+// Every layer is independently allowed to have a color but no logo (or vice
+// versa) — the chain resolves logoUrl and primaryColor SEPARATELY so e.g. a
+// sub-brand with a color but no logo still shows its own color while
+// borrowing the default brand's logo.
+
+const prisma = require("./prisma");
+
+async function findActiveKit(tenantId, subBrand) {
+  return prisma.brandKit.findFirst({
+    where: { tenantId, subBrand, isActive: true },
+  });
+}
+
+// Resolve the tenant's "default brand" BrandKit row: the active kit for
+// Tenant.defaultSubBrand when set, else the tenant-wide (subBrand=null) kit.
+// Returns null if neither exists.
+async function resolveDefaultBrandKit(tenantId, tenant) {
+  const t = tenant || (await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { defaultSubBrand: true, logoUrl: true, brandColor: true },
+  }));
+  if (!t) return null;
+  if (t.defaultSubBrand) {
+    const kit = await findActiveKit(tenantId, t.defaultSubBrand);
+    if (kit) return kit;
+  }
+  return findActiveKit(tenantId, null);
+}
+
+/**
+ * Resolve the effective logo + color for a tenant + (optional) sub-brand,
+ * walking the full fallback chain. Never throws — a resolution failure
+ * degrades to nulls so callers render their own system default.
+ *
+ * @param {number} tenantId
+ * @param {string|null} subBrand — null/undefined means "no sub-brand context"
+ *   (skips straight to the default-brand step).
+ * @returns {Promise<{
+ *   logoUrl: string|null, primaryColor: string|null,
+ *   source: "subBrand"|"default"|"tenant"|"system",
+ *   subBrandKit: object|null, defaultKit: object|null,
+ * }>}
+ */
+async function resolveEffectiveBrand(tenantId, subBrand) {
+  try {
+    const tenant = await prisma.tenant.findUnique({
+      where: { id: tenantId },
+      select: { defaultSubBrand: true, logoUrl: true, brandColor: true },
+    });
+    if (!tenant) {
+      return { logoUrl: null, primaryColor: null, source: "system", subBrandKit: null, defaultKit: null };
+    }
+
+    const subBrandKit = subBrand ? await findActiveKit(tenantId, subBrand) : null;
+    const defaultKit = await resolveDefaultBrandKit(tenantId, tenant);
+
+    const logoUrl =
+      subBrandKit?.logoUrl || defaultKit?.logoUrl || tenant.logoUrl || null;
+    const primaryColor =
+      subBrandKit?.primaryColor || defaultKit?.primaryColor || tenant.brandColor || null;
+
+    let source = "system";
+    if (subBrandKit?.logoUrl || subBrandKit?.primaryColor) source = "subBrand";
+    else if (defaultKit?.logoUrl || defaultKit?.primaryColor) source = "default";
+    else if (tenant.logoUrl || tenant.brandColor) source = "tenant";
+
+    return { logoUrl, primaryColor, source, subBrandKit: subBrandKit || null, defaultKit: defaultKit || null };
+  } catch (e) {
+    console.error(`[brandResolver] resolveEffectiveBrand failed (tenant=${tenantId}, subBrand=${subBrand}): ${e.message}`);
+    return { logoUrl: null, primaryColor: null, source: "system", subBrandKit: null, defaultKit: null };
+  }
+}
+
+module.exports = { resolveEffectiveBrand, resolveDefaultBrandKit, findActiveKit };

--- a/backend/routes/brand_kits.js
+++ b/backend/routes/brand_kits.js
@@ -44,6 +44,37 @@ const {
   validateAssetUpload,
   ASSET_CLASSES,
 } = require("../lib/brandAssetValidation");
+const {
+  uploadFile,
+  deleteFile,
+  extractKeyFromUrl,
+  BUCKET_NAME: S3_BUCKET_NAME,
+} = require("../services/s3Service");
+const { resolveEffectiveBrand } = require("../lib/brandResolver");
+
+// Best-effort delete of a previously-saved BrandKit asset so replacing/
+// clearing an image never leaves an orphan behind. Mirrors
+// routes/wellness.js's deleteOldBrandingLogo — handles both S3 URLs
+// (http/https → deleteFile) and local /uploads paths (→ fs.unlink). Never
+// throws; a failed cleanup must not block the write that triggered it.
+async function deleteOldBrandAsset(oldUrl) {
+  if (!oldUrl) return;
+  try {
+    if (/^https?:\/\//i.test(oldUrl)) {
+      const fileKey = extractKeyFromUrl(oldUrl);
+      if (fileKey) await deleteFile(fileKey);
+    } else {
+      const m = oldUrl.match(/\/(?:api\/)?uploads\/(.+)$/);
+      if (m) {
+        const rel = m[1].split("?")[0];
+        const abs = path.join(__dirname, "..", "uploads", rel);
+        if (fs.existsSync(abs)) fs.unlinkSync(abs);
+      }
+    }
+  } catch (e) {
+    console.warn("[brand-kits] old asset cleanup warning:", e.message);
+  }
+}
 
 // ── W4.A G099 — Multer upload pipeline ─────────────────────────────
 // Disk-storage pattern mirrored from booking_pages.js — files land under
@@ -139,6 +170,20 @@ const ASSET_FIELDS = [
   "supportEmail",
   "supportPhone",
   "socialLinksJson",
+];
+
+// Subset of ASSET_FIELDS that are actual FILES produced by this route's own
+// /upload endpoint (S3 or local /uploads/brand-kits/... paths) — cleaned up
+// on replace/clear. Excludes fontUrl (usually a Google Fonts CDN URL, not
+// our storage) and text/color fields.
+const FILE_ASSET_FIELDS = [
+  "logoUrl",
+  "logoDarkUrl",
+  "faviconUrl",
+  "wordmarkUrl",
+  "heroUrl",
+  "headerImageUrl",
+  "invoiceStampUrl",
 ];
 
 function pickAssetFields(body) {
@@ -566,6 +611,16 @@ router.put(
         });
       });
 
+      // Best-effort cleanup of any FILE-asset field that was replaced or
+      // cleared (never leaves an orphan in S3/disk). Only the fields this
+      // route's own /upload endpoint actually produces — fontUrl usually
+      // points at Google Fonts CDN, not our storage, so it's excluded.
+      for (const f of FILE_ASSET_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(data, f) && existing[f] && existing[f] !== data[f]) {
+          await deleteOldBrandAsset(existing[f]);
+        }
+      }
+
       await writeAudit(
         "BrandKit",
         "UPDATE",
@@ -588,6 +643,59 @@ router.put(
     }
   },
 );
+
+// DELETE /api/brand-kits/:id/logo — ADMIN only (2026-07-08).
+//
+// Clears the ACTIVE kit's logoUrl (sets it to null) and deletes the
+// underlying file from S3/disk — distinct from DELETE /:id, which
+// hard-deletes an entire (inactive) version row. This is what the
+// Settings → Branding "Delete Logo" button calls: after this, the
+// sub-brand falls straight through to the tenant's default-brand /
+// system-default logo via lib/brandResolver.js, with no page reload
+// needed (callers re-fetch GET /active/:subBrand or /effective/:subBrand).
+router.delete("/:id/logo", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: "id must be a number", code: "INVALID_ID" });
+    }
+    const existing = await prisma.brandKit.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing) {
+      return res.status(404).json({ error: "Brand kit not found", code: "NOT_FOUND" });
+    }
+    const allowed = await getSubBrandAccessSet(req.user.userId);
+    if (existing.subBrand !== null && !canAccessSubBrand(allowed, existing.subBrand)) {
+      return res.status(403).json({ error: "Sub-brand access denied", code: "SUB_BRAND_DENIED" });
+    }
+    if (!existing.logoUrl) {
+      return res.status(200).json(existing); // already logo-less — no-op
+    }
+
+    const oldLogoUrl = existing.logoUrl;
+    const updated = await prisma.brandKit.update({
+      where: { id },
+      data: { logoUrl: null },
+    });
+    await deleteOldBrandAsset(oldLogoUrl);
+
+    await writeAudit(
+      "BrandKit",
+      "DELETE_LOGO",
+      id,
+      req.user.userId,
+      req.user.tenantId,
+      { subBrand: existing.subBrand, version: existing.version },
+    );
+
+    res.json(updated);
+  } catch (e) {
+    if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+    console.error("[brand-kits] delete-logo error:", e.message);
+    res.status(500).json({ error: "Failed to delete logo" });
+  }
+});
 
 // DELETE /api/brand-kits/:id — ADMIN only.
 // Hard-delete. Refuses to delete an active kit (caller must demote first
@@ -709,25 +817,35 @@ router.post(
         });
       }
 
-      // Disk write — segmented by tenant + sub-brand so cross-tenant access
-      // via path-traversal stays impossible at the filesystem level.
+      // S3-primary, local-FS fallback (same contract as the tenant-wide
+      // branding logo upload in routes/wellness.js). Segmented by tenant +
+      // sub-brand so cross-tenant access via path-traversal stays impossible
+      // at the filesystem level even in local-disk mode.
       const sbSegment = subBrand || "_default";
-      const targetDir = path.join(UPLOAD_DIR, String(req.user.tenantId), sbSegment);
-      try {
-        fs.mkdirSync(targetDir, { recursive: true });
-      } catch (e) {
-        console.error("[brand-kits] upload mkdir failed:", e.message);
-      }
       const stamp = Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
       const filename = `${assetType}-${stamp}${result.ext}`;
-      const fullPath = path.join(targetDir, filename);
 
-      // Write the SANITIZED buffer — SVG payloads have been re-encoded
-      // by sanitize-html so any silently-tolerated tag is dropped before
-      // disk write. Raster buffers pass through unchanged.
-      fs.writeFileSync(fullPath, result.sanitizedBuffer);
-
-      const url = `/uploads/brand-kits/${req.user.tenantId}/${sbSegment}/${filename}`;
+      let url;
+      if (S3_BUCKET_NAME) {
+        // Write the SANITIZED buffer — SVG payloads have been re-encoded by
+        // sanitize-html so any silently-tolerated tag is dropped before upload.
+        url = await uploadFile(
+          result.sanitizedBuffer,
+          filename,
+          result.mime,
+          `brand-kits/${req.user.tenantId}/${sbSegment}`,
+        );
+      } else {
+        const targetDir = path.join(UPLOAD_DIR, String(req.user.tenantId), sbSegment);
+        try {
+          fs.mkdirSync(targetDir, { recursive: true });
+        } catch (e) {
+          console.error("[brand-kits] upload mkdir failed:", e.message);
+        }
+        const fullPath = path.join(targetDir, filename);
+        fs.writeFileSync(fullPath, result.sanitizedBuffer);
+        url = `/uploads/brand-kits/${req.user.tenantId}/${sbSegment}/${filename}`;
+      }
 
       await writeAudit(
         "BrandKit",
@@ -993,5 +1111,83 @@ router.post(
     }
   },
 );
+
+// GET /api/brand-kits/effective/:subBrand — the FULL fallback-resolved
+// branding for a sub-brand (2026-07-08). Unlike GET /active/:subBrand (a
+// flat single-row lookup with no fallback), this endpoint walks the whole
+// chain via lib/brandResolver.js: subBrand kit → tenant default-brand kit
+// → Tenant.logoUrl/brandColor → null. This is the endpoint the Sidebar and
+// Settings → Branding card should call so branding is consistent (and
+// consumers other than the two legacy endpoints can migrate onto it too).
+router.get("/effective/:subBrand", verifyToken, async (req, res) => {
+  try {
+    let sb = req.params.subBrand;
+    if (sb === "_" || sb === "null" || sb === "") {
+      sb = null;
+    } else {
+      assertValidSubBrand(sb);
+    }
+    const allowed = await getSubBrandAccessSet(req.user.userId);
+    if (sb !== null && !canAccessSubBrand(allowed, sb)) {
+      return res.status(403).json({ error: "Sub-brand access denied", code: "SUB_BRAND_DENIED" });
+    }
+    const effective = await resolveEffectiveBrand(req.user.tenantId, sb);
+    res.json(effective);
+  } catch (e) {
+    if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+    console.error("[brand-kits] effective lookup error:", e.message);
+    res.status(500).json({ error: "Failed to resolve effective brand" });
+  }
+});
+
+// POST /api/brand-kits/:id/set-default — ADMIN only (2026-07-08).
+//
+// Marks this kit's sub-brand as the tenant's DEFAULT BRAND by writing
+// Tenant.defaultSubBrand (schema.prisma:92-98 — designed for exactly this
+// purpose but had no write path until now). Only one sub-brand can be the
+// default at a time; passing the tenant-wide (subBrand=null) kit CLEARS
+// defaultSubBrand, restoring the original "subBrand=null bucket wins"
+// behaviour. Every branding consumer (Sidebar, Settings, and — once wired
+// — PDFs/email) that goes through lib/brandResolver.js picks this up
+// immediately, no separate propagation step needed.
+router.post("/:id/set-default", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: "id must be a number", code: "INVALID_ID" });
+    }
+    const kit = await prisma.brandKit.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+      select: { id: true, subBrand: true },
+    });
+    if (!kit) {
+      return res.status(404).json({ error: "Brand kit not found", code: "NOT_FOUND" });
+    }
+    const allowed = await getSubBrandAccessSet(req.user.userId);
+    if (kit.subBrand !== null && !canAccessSubBrand(allowed, kit.subBrand)) {
+      return res.status(403).json({ error: "Sub-brand access denied", code: "SUB_BRAND_DENIED" });
+    }
+
+    await prisma.tenant.update({
+      where: { id: req.user.tenantId },
+      data: { defaultSubBrand: kit.subBrand },
+    });
+
+    await writeAudit(
+      "Tenant",
+      "SET_DEFAULT_BRAND",
+      req.user.tenantId,
+      req.user.userId,
+      req.user.tenantId,
+      { defaultSubBrand: kit.subBrand, brandKitId: id },
+    );
+
+    res.json({ defaultSubBrand: kit.subBrand });
+  } catch (e) {
+    if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+    console.error("[brand-kits] set-default error:", e.message);
+    res.status(500).json({ error: "Failed to set default brand" });
+  }
+});
 
 module.exports = router;

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -11390,6 +11390,30 @@ router.post(
   },
 );
 
+// DELETE /branding/logo (2026-07-08) — clears Tenant.logoUrl and removes the
+// underlying file from S3/disk. Companion to POST /branding/logo, whose only
+// prior path to "remove a logo" was uploading a replacement.
+router.delete("/branding/logo", requireTenantAdmin, async (req, res) => {
+  try {
+    const current = await prisma.tenant.findUnique({
+      where: { id: req.user.tenantId },
+      select: { logoUrl: true },
+    });
+    if (!current?.logoUrl) {
+      return res.json({ logoUrl: null }); // already logo-less — no-op
+    }
+    await prisma.tenant.update({
+      where: { id: req.user.tenantId },
+      data: { logoUrl: null },
+    });
+    await deleteOldBrandingLogo(current.logoUrl);
+    res.json({ logoUrl: null });
+  } catch (e) {
+    console.error("[wellness] branding logo delete error:", e.message);
+    res.status(500).json({ error: "Failed to delete logo" });
+  }
+});
+
 router.put("/branding/color", requireTenantAdmin, async (req, res) => {
   try {
     const { brandColor } = req.body || {};

--- a/backend/routes/whatsapp.js
+++ b/backend/routes/whatsapp.js
@@ -327,6 +327,38 @@ router.get("/messages", verifyToken, async (req, res) => {
   }
 });
 
+// DELETE /api/whatsapp/messages/dispatch-log — ADMIN only (2026-07-08).
+//
+// Powers the "Clear dispatch log" button on the travel WhatsApp dispatch
+// log page (frontend/src/pages/travel/WhatsAppLog.jsx). WhatsAppMessage is
+// the SAME table the interactive WhatsApp Chat/Inbox feature uses (Sync
+// Lead, live customer conversations) — a naive tenant-wide deleteMany would
+// destroy real chat history, not just automated dispatches. Scoped to
+// `threadId: null` ONLY: rows with no linked WhatsAppThread are exactly the
+// automated sends (OTPs, cron reminders, boarding-pass/itinerary pushes)
+// that were never part of an interactive chat — see
+// services/watiClient.js's persistMessageRow() comment, which explicitly
+// documents thread-linked vs thread-less rows sharing this one persist
+// path. Messages inside an active chat thread are never touched.
+router.delete("/messages/dispatch-log", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+  try {
+    const where = { tenantId: req.user.tenantId, threadId: null };
+    const { count } = await prisma.whatsAppMessage.deleteMany({ where });
+    await writeAudit(
+      "WhatsAppMessage",
+      "CLEAR_DISPATCH_LOG",
+      0,
+      req.user.userId,
+      req.user.tenantId,
+      { deletedCount: count },
+    );
+    res.json({ success: true, deletedCount: count });
+  } catch (err) {
+    console.error("[whatsapp] clear dispatch log error:", err.message);
+    res.status(500).json({ error: "Failed to clear dispatch log" });
+  }
+});
+
 // ─── WhatsApp Stats — tenant-wide aggregate ────────────────────────────────
 //
 // GET /api/whatsapp/stats — first /stats endpoint on the WhatsApp route.

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -148,9 +148,10 @@ import { launchCallifiedSSO } from "../utils/callified";
 import { useNotify } from "../utils/notify";
 import { useActiveSubBrand } from "../utils/subBrand";
 import { usePermissions } from "../hooks/usePermissions";
-// Branding Wave 4 G096: per-sub-brand BrandKit lookup for the pinned logo
-// shown at the top of the travel sidebar (FR-3.3.a).
-import { useBrandKit, brandLogoUrl } from "../hooks/useBrandKit";
+// Branding refactor (2026-07-08): the sidebar shows exactly ONE logo, driven
+// by the fallback-resolved effective brand for the active sub-brand — never
+// a separate, always-on tenant-wide logo stacked alongside a sub-brand logo.
+import { useEffectiveBrand } from "../hooks/useEffectiveBrand";
 
 // T2.1: focus trap selector. Limited to actually-focusable elements inside the
 // drawer (anchors, buttons, [tabindex]). Used by the focus-trap effect below
@@ -168,11 +169,14 @@ const Sidebar = ({
   const notify = useNotify();
   const navigate = useNavigate();
   const { activeSubBrand, setActiveSubBrand } = useActiveSubBrand();
-  // G096: BrandKit for the active sub-brand. Module-level cache keeps this
-  // cheap on every sidebar re-render; null subBrand resolves to the
-  // tenant-wide (subBrand=null) kit which is also fine for the pinned-logo
-  // slot — it shows the tenant default until a sub-brand is selected.
-  const { brandKit: activeBrandKit } = useBrandKit(activeSubBrand);
+  // Branding refactor (2026-07-08): fallback-resolved effective brand for
+  // the active sub-brand (subBrand kit → tenant default-brand →
+  // Tenant.logoUrl/brandColor → system default). This is the SINGLE source
+  // the sidebar's one logo reads from — non-travel tenants pass subBrand=null
+  // and get the tenant-wide kit / Tenant.logoUrl, unchanged from before.
+  const { effective: effectiveBrand } = useEffectiveBrand(
+    tenant?.vertical === "travel" ? activeSubBrand : null,
+  );
   const role = user?.role || "USER";
   const isAdmin = role === "ADMIN";
   const isManager = role === "ADMIN" || role === "MANAGER";
@@ -478,6 +482,23 @@ const Sidebar = ({
       !subBrandAccess.includes(activeSubBrand)
     ) {
       setActiveSubBrand(null);
+      return;
+    }
+    // Single-brand-scoped user (e.g. an "RFU Advisor" with
+    // subBrandAccess=["rfu"]): there's no switcher to pick a brand from (see
+    // soleBrand below), so without this, activeSubBrand stays null forever
+    // and branding/data silently falls through to the tenant-wide default
+    // even though the read-only "RFU" chip visually claims they're on RFU.
+    // Auto-select their one accessible brand so branding + scoping actually
+    // match what the chip shows. Multi-brand users are untouched — they
+    // pick explicitly via the switcher.
+    if (
+      isTravel &&
+      !activeSubBrand &&
+      subBrandAccess !== null &&
+      subBrandAccess.length === 1
+    ) {
+      setActiveSubBrand(subBrandAccess[0]);
     }
   }, [isTravel, activeSubBrand, subBrandAccess, setActiveSubBrand]);
   // Stable identity for the sub-brand switcher's onChange — without this,
@@ -520,7 +541,11 @@ const Sidebar = ({
     [setActiveSubBrand, navigate],
   );
   const brand = tenant?.name || "Globussoft";
-  const logoUrl = tenant?.logoUrl || null;
+  // Single logo source (2026-07-08): the active sub-brand's fallback-resolved
+  // logo when one exists, else the tenant-wide default — never both shown
+  // at once. Non-travel tenants (effectiveBrand always resolved with
+  // subBrand=null) get exactly the old tenant.logoUrl behaviour.
+  const logoUrl = effectiveBrand?.logoUrl || tenant?.logoUrl || null;
   const brandColor = tenant?.brandColor || null;
   // Inline style applied to wellness section labels — overrides the gold
   // accent (#E0A68B) defined in wellness.css when a tenant brand color is set.
@@ -963,10 +988,12 @@ const Sidebar = ({
             subBrandAccess,
             activeSubBrand,
             onSubBrandChange: handleSubBrandChange,
-            // G096: BrandKit-driven pinned logo for the active sub-brand.
-            // Resolved here at the parent (hooks must run unconditionally;
-            // safe because the hook short-circuits when subBrand is null).
-            brandKit: activeBrandKit,
+            // Branding refactor (2026-07-08): the pinned second logo strip
+            // was removed — the single top-of-sidebar logo (driven by
+            // effectiveBrand) already reflects the active sub-brand, so a
+            // second logo here would just duplicate it. The accent color
+            // underline is preserved via accentColor below.
+            accentColor: effectiveBrand?.primaryColor || null,
           })}
 
         <nav
@@ -1583,7 +1610,7 @@ function renderTravelSubBrandHeader({
   subBrandAccess = null,
   activeSubBrand = null,
   onSubBrandChange = () => {},
-  brandKit = null,
+  accentColor = null,
 }) {
   const labelStyle = sectionLabelStyle || sectionLabel;
   const ALL_SUB_BRANDS = [
@@ -1597,12 +1624,6 @@ function renderTravelSubBrandHeader({
       ? ALL_SUB_BRANDS
       : ALL_SUB_BRANDS.filter((s) => subBrandAccess.includes(s.value));
   const showSwitcher = visibleSubBrands.length >= 2;
-  // G096: pinned logo URL for the active sub-brand (FR-3.3.a). Renders only
-  // when the active BrandKit row carries a logoUrl — falls back silently to
-  // no logo when missing (the global brand image at the top of the sidebar
-  // is already shown adjacent to this section).
-  const pinnedLogoUrl = brandLogoUrl(brandKit);
-  const pinnedAccent = brandKit?.primaryColor || null;
   // Single-brand scoped user (e.g. a TMC-only manager): there's nothing to
   // switch between, so we don't render the dropdown — but we DO surface a
   // static read-only chip so they can see which sub-brand they're scoped to
@@ -1614,36 +1635,16 @@ function renderTravelSubBrandHeader({
       : null;
   return (
     <div style={{ flexShrink: 0 }}>
-      {/* G096 (FR-3.3.a): pinned sub-brand logo at the top of the travel
-          sidebar section. Shows only when the active BrandKit carries a
-          logoUrl. The accent border underneath is driven by the kit's
-          primaryColor when present — a subtle visual cue that "this is
-          the brand you're operating under" without disrupting the
-          existing label + switcher chrome below. */}
-      {pinnedLogoUrl && (
+      {/* Branding refactor (2026-07-08): the pinned sub-brand LOGO strip was
+          removed — the single top-of-sidebar logo already reflects the
+          active sub-brand (see Sidebar's `logoUrl` const). This thin accent
+          strip is the only remaining visual cue for "this is the brand
+          you're operating under" when that brand has its own color. */}
+      {accentColor && (
         <div
-          data-testid="travel-sidebar-pinned-logo"
-          style={{
-            padding: "8px 12px 6px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            borderBottom: pinnedAccent
-              ? `2px solid ${pinnedAccent}`
-              : "1px solid var(--border-color)",
-            marginBottom: 4,
-          }}
-        >
-          <img
-            src={pinnedLogoUrl}
-            alt={`${activeSubBrand || "Brand"} logo`}
-            style={{
-              maxHeight: 32,
-              maxWidth: 160,
-              objectFit: "contain",
-            }}
-          />
-        </div>
+          data-testid="travel-sidebar-accent-strip"
+          style={{ height: 2, background: accentColor, marginBottom: 4 }}
+        />
       )}
       <div style={labelStyle}>Travel</div>
       {soleBrand && (

--- a/frontend/src/hooks/useEffectiveBrand.js
+++ b/frontend/src/hooks/useEffectiveBrand.js
@@ -1,0 +1,131 @@
+// Effective-brand hook (2026-07-08) — the fallback-RESOLVED counterpart to
+// useBrandKit(). useBrandKit(subBrand) answers "does THIS sub-brand have its
+// own kit" (used by operator pages to show sub-brand-specific accents,
+// returning null with no fallback walk). This hook answers "what logo/color
+// should actually be DISPLAYED for this sub-brand right now" — walking the
+// full chain server-side via GET /api/brand-kits/effective/:subBrand
+// (lib/brandResolver.js): subBrand kit → tenant default-brand kit →
+// Tenant.logoUrl/brandColor → null (system default).
+//
+// This is the single source of truth the Sidebar's one logo and the
+// Settings → Branding card should both read from, so switching the active
+// sub-brand updates both consistently with no separate propagation step.
+//
+//   const { effective, loading } = useEffectiveBrand(activeSubBrand);
+//   // effective?.logoUrl, effective?.primaryColor, effective?.source
+//
+// Caching: per-subBrand module-level cache + in-flight de-dupe, same shape
+// as useBrandKit's. Callers that just wrote a new logo/color/default should
+// call invalidateEffectiveBrandCache() before re-fetching so they don't see
+// stale data (there is no TTL — writes must actively bust the cache).
+
+import { useEffect, useState } from 'react';
+import { fetchApi } from '../utils/api';
+
+const _cache = new Map();
+const _inflight = new Map();
+
+// Cross-component sync: Settings.jsx (writer) and Sidebar.jsx (persistent,
+// always-mounted reader) each hold their OWN useEffectiveBrand(subBrand)
+// instance. Invalidating the module-level cache alone doesn't make an
+// already-rendered Sidebar refetch — it needs to be TOLD to. A DOM
+// CustomEvent is the simplest reader-agnostic broadcast: every mounted
+// instance listens and re-fetches on invalidate, regardless of which
+// component triggered the write.
+const BROADCAST_EVENT = 'globussoft:effective-brand-invalidated';
+
+function cacheKey(subBrand) {
+  return subBrand == null ? '__null__' : String(subBrand);
+}
+
+/** Clear the whole cache (or just one subBrand's entry) after a write, and
+ * tell every mounted useEffectiveBrand() instance to re-fetch. */
+export function invalidateEffectiveBrandCache(subBrand) {
+  if (subBrand === undefined) {
+    _cache.clear();
+    _inflight.clear();
+  } else {
+    _cache.delete(cacheKey(subBrand));
+    _inflight.delete(cacheKey(subBrand));
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(BROADCAST_EVENT));
+  } catch {
+    /* non-browser environment (tests) — safe to skip */
+  }
+}
+
+async function fetchEffective(subBrand) {
+  const path = subBrand ? encodeURIComponent(subBrand) : '_';
+  try {
+    const res = await fetchApi(`/api/brand-kits/effective/${path}`, { silent: true });
+    if (res && typeof res === 'object' && ('logoUrl' in res || 'primaryColor' in res)) {
+      return res;
+    }
+    return null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
+ * Read the fully fallback-resolved brand for a sub-brand.
+ * @param {string|null|undefined} subBrand
+ * @returns {{effective: {logoUrl:string|null, primaryColor:string|null, source:string}|null, loading: boolean, reload: Function}}
+ */
+export function useEffectiveBrand(subBrand) {
+  const key = cacheKey(subBrand);
+  const cached = _cache.get(key);
+  const [effective, setEffective] = useState(cached !== undefined ? cached : null);
+  const [loading, setLoading] = useState(cached === undefined);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    const k = cacheKey(subBrand);
+    if (_cache.has(k) && reloadTick === 0) {
+      setEffective(_cache.get(k));
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+    setLoading(true);
+    let p = _inflight.get(k);
+    if (!p) {
+      p = fetchEffective(subBrand).then((res) => {
+        _cache.set(k, res);
+        _inflight.delete(k);
+        return res;
+      });
+      _inflight.set(k, p);
+    }
+    p.then((res) => {
+      if (!active) return;
+      setEffective(res);
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [subBrand, reloadTick]);
+
+  // Listen for invalidation broadcasts from OTHER components (e.g. Settings
+  // saving a logo while Sidebar stays mounted) and re-fetch this instance's
+  // subBrand. Cheap no-op re-render when this subBrand's cache entry is
+  // already gone (the effect above just re-fetches it).
+  useEffect(() => {
+    const onInvalidate = () => setReloadTick((t) => t + 1);
+    window.addEventListener(BROADCAST_EVENT, onInvalidate);
+    return () => window.removeEventListener(BROADCAST_EVENT, onInvalidate);
+  }, []);
+
+  const reload = () => {
+    invalidateEffectiveBrandCache(subBrand);
+    setReloadTick((t) => t + 1);
+  };
+
+  return { effective, loading, reload };
+}
+
+export default useEffectiveBrand;

--- a/frontend/src/pages/Contacts.jsx
+++ b/frontend/src/pages/Contacts.jsx
@@ -279,7 +279,7 @@ const Contacts = () => {
   const handleDelete = async (id) => {
     if (!await notify.confirm({
       title: 'Delete contact',
-      message: 'Are you sure you want to delete this contact?',
+      message: 'Are you sure you want to delete this contact? This action cannot be undone.',
       confirmText: 'Delete',
       destructive: true,
     })) return;

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -34,6 +34,9 @@ import { ThemeContext, AuthContext } from "../App";
 import PasswordInput from "../components/PasswordInput";
 import WebhookSigningCredential from "../components/WebhookSigningCredential";
 import RoleHistoryDialog from "../components/RoleHistoryDialog";
+import { SUB_BRAND_IDS, subBrandShortLabel, subBrandBackground } from "../utils/travelSubBrand";
+import { useActiveSubBrand } from "../utils/subBrand";
+import { useEffectiveBrand, invalidateEffectiveBrandCache } from "../hooks/useEffectiveBrand";
 
 // #391: single source of truth for the default brand color so the color
 // picker swatch, the placeholder hint, and the color actually applied
@@ -46,6 +49,19 @@ export default function Settings() {
   const { theme, setTheme, toggleTheme } = useContext(ThemeContext);
   const { tenant: ctxTenant, setTenant } = useContext(AuthContext);
   const { isOwner, hasPermission } = usePermissions();
+
+  // Branding refactor (2026-07-08): the Branding card follows whichever
+  // sub-brand is currently selected in the sidebar dropdown — travel
+  // tenants only; non-travel tenants always get activeSubBrand=null (the
+  // context defaults to null anyway when unmounted, so this is a no-op
+  // there) and the card behaves exactly as it always has (Tenant.logoUrl /
+  // brandColor, edited via /api/wellness/branding*).
+  const { activeSubBrand } = useActiveSubBrand();
+  const brandingSubBrand = ctxTenant?.vertical === "travel" ? activeSubBrand : null;
+  // Only `reload` is consumed here (busts the shared cache Sidebar also
+  // reads from after a save/delete) — the card displays the brand's OWN
+  // values via `branding` state, not the fallback-resolved `effective`.
+  const { reload: reloadEffectiveBrand } = useEffectiveBrand(brandingSubBrand);
 
   // ── Role Recovery section ────────────────────────────────────────
   // Lockout-scenario recovery surface. Reuses the existing /api/roles
@@ -111,6 +127,24 @@ export default function Settings() {
   const logoInputRef = useRef(null);
   const [logoUploading, setLogoUploading] = useState(false);
   const [brandingMsg, setBrandingMsg] = useState("");
+  // Multi-brand (BrandKit) — travel-vertical only. "Your Brands" list below
+  // the default-brand card, backed by the existing /api/brand-kits CRUD
+  // (same system /admin/brand-kits already manages). Settings only ever
+  // touches the ACTIVE kit per sub-brand; version history / advanced fields
+  // stay on the dedicated admin page.
+  const [brandKits, setBrandKits] = useState([]);
+  const [brandKitsLoading, setBrandKitsLoading] = useState(false);
+  const [showAddBrand, setShowAddBrand] = useState(false);
+  const [addBrandForm, setAddBrandForm] = useState({ subBrand: "", logoUrl: "", primaryColor: "" });
+  const [addBrandFile, setAddBrandFile] = useState(null);
+  const [addBrandFilePreviewUrl, setAddBrandFilePreviewUrl] = useState(null);
+  const pickAddBrandFile = (file) => {
+    if (addBrandFilePreviewUrl) URL.revokeObjectURL(addBrandFilePreviewUrl);
+    setAddBrandFile(file || null);
+    setAddBrandFilePreviewUrl(file ? URL.createObjectURL(file) : null);
+  };
+  const [addBrandSaving, setAddBrandSaving] = useState(false);
+  const [addBrandError, setAddBrandError] = useState("");
   // AdsGPT configuration
   const [adsgptLogin, setAdsgptLogin] = useState("");
   const [adsgptSaving, setAdsgptSaving] = useState(false);
@@ -167,6 +201,48 @@ export default function Settings() {
       .catch(() => setCallifiedLoading(false));
   }, []);
 
+  // Multi-brand (BrandKit) list — travel vertical only (sub-brands are a
+  // travel-only concept; generic/wellness tenants only ever have the
+  // tenant-wide default kit, which the Branding card above already covers).
+  const loadBrandKits = () => {
+    setBrandKitsLoading(true);
+    fetchApi("/api/brand-kits?isActive=true")
+      .then((res) => setBrandKits(Array.isArray(res?.brandKits) ? res.brandKits : []))
+      .catch(() => setBrandKits([]))
+      .finally(() => setBrandKitsLoading(false));
+  };
+
+  useEffect(() => {
+    if (ctxTenant?.vertical === "travel") loadBrandKits();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctxTenant?.vertical]);
+
+  // The BrandKit row (if any) for whichever sub-brand is currently active —
+  // this drives what the Branding card shows/edits when brandingSubBrand is
+  // set. Sourced from the same brandKits list "Your Brands" already loads
+  // (no extra fetch); its OWN logoUrl/primaryColor (not the fallback-
+  // resolved effectiveBrand) are what "Save" should read/write, so an
+  // unmodified save never accidentally writes a borrowed fallback value
+  // onto this sub-brand.
+  const activeBrandKitRow = brandingSubBrand
+    ? brandKits.find((k) => k.subBrand === brandingSubBrand) || null
+    : null;
+
+  // Sync the editable branding fields whenever the selected brand changes
+  // (dropdown switch, or the kit list finishes loading). Default-brand mode
+  // (brandingSubBrand null) is untouched — it keeps loading from
+  // /api/wellness/branding, exactly as before.
+  useEffect(() => {
+    if (!brandingSubBrand) return; // default-brand fetch effect handles this case
+    setBranding({
+      logoUrl: activeBrandKitRow?.logoUrl || null,
+      brandColor: activeBrandKitRow?.primaryColor || "",
+    });
+    setLogoBroken(false);
+    setBrandingMsg("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brandingSubBrand, activeBrandKitRow?.id, activeBrandKitRow?.logoUrl, activeBrandKitRow?.primaryColor]);
+
   // Stage a picked file locally — render a preview, wait for the user to
   // hit "Save logo" before doing the actual upload. URL.createObjectURL
   // returns a blob: URL we must revoke when replacing or unmounting to
@@ -193,32 +269,94 @@ export default function Settings() {
     setBrandingMsg("");
   };
 
+  // Create-or-update the active sub-brand's BrandKit row with a patch of
+  // asset fields. Shared by the logo save/delete and color save paths below
+  // so there's exactly one place that knows "POST when no kit exists yet,
+  // PUT when one does."
+  const upsertActiveBrandKit = async (patch) => {
+    if (activeBrandKitRow) {
+      return fetchApi(`/api/brand-kits/${activeBrandKitRow.id}`, {
+        method: "PUT",
+        body: JSON.stringify(patch),
+      });
+    }
+    return fetchApi("/api/brand-kits", {
+      method: "POST",
+      body: JSON.stringify({ subBrand: brandingSubBrand, isActive: true, ...patch }),
+    });
+  };
+
   const handleSaveLogo = async () => {
     if (!stagedLogo) return;
     setLogoUploading(true);
     setBrandingMsg("");
     try {
-      const fd = new FormData();
-      fd.append("logo", stagedLogo);
-      const token = getAuthToken();
-      const resp = await fetch("/api/wellness/branding/logo", {
-        method: "POST",
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-        body: fd,
-      });
-      const json = await resp.json().catch(() => ({}));
-      if (!resp.ok) throw new Error(json.error || "Upload failed");
-      setBranding((b) => ({ ...b, logoUrl: json.logoUrl }));
+      let logoUrl;
+      if (brandingSubBrand) {
+        const fd = new FormData();
+        fd.append("file", stagedLogo);
+        fd.append("assetType", "logo");
+        fd.append("subBrand", brandingSubBrand);
+        const uploadRes = await fetchApi("/api/brand-kits/upload", { method: "POST", body: fd });
+        logoUrl = uploadRes?.url || null;
+        await upsertActiveBrandKit({ logoUrl });
+        loadBrandKits();
+        reloadEffectiveBrand();
+      } else {
+        const fd = new FormData();
+        fd.append("logo", stagedLogo);
+        const token = getAuthToken();
+        const resp = await fetch("/api/wellness/branding/logo", {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          body: fd,
+        });
+        const json = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(json.error || "Upload failed");
+        logoUrl = json.logoUrl;
+        // Reflect into sidebar instantly
+        if (setTenant && ctxTenant) setTenant({ ...ctxTenant, logoUrl });
+        reloadEffectiveBrand();
+      }
+      setBranding((b) => ({ ...b, logoUrl }));
       setLogoBroken(false);
-      // Reflect into sidebar instantly
-      if (setTenant && ctxTenant)
-        setTenant({ ...ctxTenant, logoUrl: json.logoUrl });
       setBrandingMsg("Logo updated.");
       cancelStagedLogo();
     } catch (err) {
-      setBrandingMsg(err.message || "Logo upload failed");
+      setBrandingMsg(err?.body?.error || err?.message || "Logo upload failed");
     } finally {
       setLogoUploading(false);
+    }
+  };
+
+  // Delete Logo (2026-07-08) — clears the current brand's logo (BrandKit.logoUrl
+  // for a sub-brand, or Tenant.logoUrl for the default brand) and removes the
+  // underlying file from S3/disk. Immediately falls back to whatever the next
+  // link in the chain resolves to (default brand → system logo) with no
+  // reload — reloadEffectiveBrand() busts the shared cache Sidebar reads too.
+  const [logoDeleting, setLogoDeleting] = useState(false);
+  const handleDeleteLogo = async () => {
+    if (!branding.logoUrl) return;
+    const ok = await notify.confirm("Delete this logo? This removes the file permanently.");
+    if (!ok) return;
+    setLogoDeleting(true);
+    setBrandingMsg("");
+    try {
+      if (brandingSubBrand && activeBrandKitRow) {
+        await fetchApi(`/api/brand-kits/${activeBrandKitRow.id}/logo`, { method: "DELETE" });
+        loadBrandKits();
+      } else if (!brandingSubBrand) {
+        await fetchApi("/api/wellness/branding/logo", { method: "DELETE" });
+        if (setTenant && ctxTenant) setTenant({ ...ctxTenant, logoUrl: null });
+      }
+      setBranding((b) => ({ ...b, logoUrl: null }));
+      setLogoBroken(false);
+      reloadEffectiveBrand();
+      setBrandingMsg("Logo deleted.");
+    } catch (err) {
+      setBrandingMsg(err?.body?.error || err?.message || "Failed to delete logo");
+    } finally {
+      setLogoDeleting(false);
     }
   };
 
@@ -226,6 +364,7 @@ export default function Settings() {
   useEffect(() => {
     return () => {
       if (stagedPreviewUrl) URL.revokeObjectURL(stagedPreviewUrl);
+      if (addBrandFilePreviewUrl) URL.revokeObjectURL(addBrandFilePreviewUrl);
     };
   }, []);
 
@@ -237,18 +376,136 @@ export default function Settings() {
       if (value && !/^#[0-9a-fA-F]{6}$/.test(value)) {
         throw new Error("Brand color must be a 6-digit hex (e.g. #265855).");
       }
-      const res = await fetchApi("/api/wellness/branding/color", {
-        method: "PUT",
-        body: JSON.stringify({ brandColor: value || null }),
-      });
-      setBranding((b) => ({ ...b, brandColor: res.brandColor || "" }));
-      if (setTenant && ctxTenant)
-        setTenant({ ...ctxTenant, brandColor: res.brandColor || null });
+      if (brandingSubBrand) {
+        const updated = await upsertActiveBrandKit({ primaryColor: value || null });
+        setBranding((b) => ({ ...b, brandColor: updated?.primaryColor || "" }));
+        loadBrandKits();
+      } else {
+        const res = await fetchApi("/api/wellness/branding/color", {
+          method: "PUT",
+          body: JSON.stringify({ brandColor: value || null }),
+        });
+        setBranding((b) => ({ ...b, brandColor: res.brandColor || "" }));
+        if (setTenant && ctxTenant)
+          setTenant({ ...ctxTenant, brandColor: res.brandColor || null });
+      }
+      reloadEffectiveBrand();
       setBrandingMsg("Brand color saved.");
     } catch (err) {
-      setBrandingMsg(err.message || "Failed to save brand color");
+      setBrandingMsg(err?.body?.error || err?.message || "Failed to save brand color");
     } finally {
       setBrandingSaving(false);
+    }
+  };
+
+  // Sub-brands that don't yet have an active BrandKit — offered in the
+  // "Add Another Brand" picker. Sub-brands that already have one are edited
+  // in place (same modal, pre-filled, PUT instead of POST) rather than
+  // re-created.
+  const brandKitSubBrands = new Set(brandKits.map((k) => k.subBrand));
+  const availableSubBrands = SUB_BRAND_IDS.filter((id) => !brandKitSubBrands.has(id));
+
+  // `editingKit` is null when adding a brand new-to-this-tenant, or the
+  // existing BrandKit row when editing one that already exists.
+  const [editingKit, setEditingKit] = useState(null);
+
+  const openAddBrand = () => {
+    setEditingKit(null);
+    setAddBrandForm({ subBrand: availableSubBrands[0] || "", logoUrl: "", primaryColor: "" });
+    pickAddBrandFile(null);
+    setAddBrandError("");
+    setShowAddBrand(true);
+  };
+
+  const openEditBrand = (kit) => {
+    setEditingKit(kit);
+    setAddBrandForm({
+      subBrand: kit.subBrand,
+      logoUrl: kit.logoUrl || "",
+      primaryColor: kit.primaryColor || "",
+    });
+    pickAddBrandFile(null);
+    setAddBrandError("");
+    setShowAddBrand(true);
+  };
+
+  const handleAddBrandSubmit = async (e) => {
+    e.preventDefault();
+    if (!addBrandForm.subBrand) {
+      setAddBrandError("Brand name is required.");
+      return;
+    }
+    setAddBrandSaving(true);
+    setAddBrandError("");
+    try {
+      let logoUrl = editingKit ? addBrandForm.logoUrl || null : null;
+      if (addBrandFile) {
+        const form = new FormData();
+        form.append("file", addBrandFile);
+        form.append("assetType", "logo");
+        form.append("subBrand", addBrandForm.subBrand);
+        const uploadRes = await fetchApi("/api/brand-kits/upload", {
+          method: "POST",
+          body: form,
+        });
+        logoUrl = uploadRes?.url || null;
+      }
+      const color = addBrandForm.primaryColor || "";
+      if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) {
+        throw new Error("Brand color must be a 6-digit hex (e.g. #265855).");
+      }
+      if (editingKit) {
+        await fetchApi(`/api/brand-kits/${editingKit.id}`, {
+          method: "PUT",
+          body: JSON.stringify({
+            logoUrl,
+            primaryColor: color || null,
+          }),
+        });
+        notify.success(`${subBrandShortLabel(addBrandForm.subBrand)} brand updated.`);
+      } else {
+        await fetchApi("/api/brand-kits", {
+          method: "POST",
+          body: JSON.stringify({
+            subBrand: addBrandForm.subBrand,
+            logoUrl,
+            primaryColor: color || null,
+            isActive: true,
+          }),
+        });
+        notify.success(`${subBrandShortLabel(addBrandForm.subBrand)} brand added.`);
+      }
+      setShowAddBrand(false);
+      loadBrandKits();
+      invalidateEffectiveBrandCache(addBrandForm.subBrand);
+      reloadEffectiveBrand();
+    } catch (err) {
+      setAddBrandError(err?.body?.error || err?.message || "Failed to save brand.");
+    } finally {
+      setAddBrandSaving(false);
+    }
+  };
+
+  // "Set as Default" (2026-07-08) — marks a sub-brand as the tenant-wide
+  // fallback (Tenant.defaultSubBrand) that every consumer surface falls back
+  // to before the system default, once its own sub-brand has no branding.
+  // Only one brand can be default at a time; the backend clears
+  // defaultSubBrand entirely to restore old behaviour if this ever needs
+  // to point back at the plain default-brand card instead of a sub-brand.
+  const [settingDefaultId, setSettingDefaultId] = useState(null);
+  const handleSetDefaultBrand = async (kit) => {
+    setSettingDefaultId(kit.id);
+    try {
+      await fetchApi(`/api/brand-kits/${kit.id}/set-default`, { method: "POST" });
+      setTenantState((t) => (t ? { ...t, defaultSubBrand: kit.subBrand } : t));
+      if (setTenant && ctxTenant) setTenant({ ...ctxTenant, defaultSubBrand: kit.subBrand });
+      invalidateEffectiveBrandCache();
+      reloadEffectiveBrand();
+      notify.success(`${subBrandShortLabel(kit.subBrand)} is now the default brand.`);
+    } catch (err) {
+      notify.error(err?.body?.error || err?.message || "Failed to set default brand.");
+    } finally {
+      setSettingDefaultId(null);
     }
   };
 
@@ -1532,13 +1789,14 @@ export default function Settings() {
               style={{
                 fontSize: "1.25rem",
                 fontWeight: "600",
-                marginBottom: "1.5rem",
+                marginBottom: "0.35rem",
                 display: "flex",
                 alignItems: "center",
                 gap: "0.5rem",
               }}
             >
-              <Palette size={20} color="var(--accent-color)" /> Branding
+              <Palette size={20} color="var(--accent-color)" />
+              {brandingSubBrand ? `Branding — ${subBrandShortLabel(brandingSubBrand)}` : "Branding"}
             </h3>
             <p
               style={{
@@ -1547,8 +1805,9 @@ export default function Settings() {
                 marginBottom: "1.25rem",
               }}
             >
-              Upload your clinic logo and pick a brand color. These appear in
-              the sidebar and on branded PDFs.
+              {brandingSubBrand
+                ? `Editing the logo and color for ${subBrandShortLabel(brandingSubBrand)}. Switch the Sub Brand dropdown in the sidebar to edit a different brand.`
+                : "Upload your default logo and pick a brand color. These are the company-wide fallback shown in the sidebar and on branded PDFs whenever a sub-brand has no branding of its own."}
             </p>
 
             {/* #479: Branding two-column (Logo | Brand color) collapses to
@@ -1717,17 +1976,37 @@ export default function Settings() {
                         </button>
                       </>
                     ) : (
-                      <button
-                        type="button"
-                        className="btn-primary"
-                        onClick={() => logoInputRef.current?.click()}
-                        disabled={logoUploading}
-                        style={{ whiteSpace: "nowrap" }}
-                      >
-                        {branding.logoUrl && !logoBroken
-                          ? "Replace logo"
-                          : "Upload logo"}
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          className="btn-primary"
+                          onClick={() => logoInputRef.current?.click()}
+                          disabled={logoUploading}
+                          style={{ whiteSpace: "nowrap" }}
+                        >
+                          {branding.logoUrl && !logoBroken
+                            ? "Replace logo"
+                            : "Upload logo"}
+                        </button>
+                        {branding.logoUrl && !logoBroken && (
+                          <button
+                            type="button"
+                            onClick={handleDeleteLogo}
+                            disabled={logoDeleting}
+                            style={{
+                              padding: "0.5rem 0.9rem",
+                              background: "transparent",
+                              border: "1px solid var(--border-color)",
+                              borderRadius: 6,
+                              color: "var(--danger-color, #ef4444)",
+                              cursor: "pointer",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {logoDeleting ? "Deleting…" : "Delete logo"}
+                          </button>
+                        )}
+                      </>
                     )}
                   </div>
                 </div>
@@ -1835,6 +2114,298 @@ export default function Settings() {
               </p>
             )}
           </div>
+
+          {/* Your Brands — multi-brand (BrandKit) management. Travel-vertical
+              only: sub-brands (TMC / RFU / Travel Stall / Visa Sure) are a
+              travel-only concept, so generic/wellness tenants never see this
+              card and their experience is byte-for-byte unchanged (single
+              default brand above, no "Add Another Brand" affordance). Reuses
+              the same /api/brand-kits backend the full /admin/brand-kits
+              page manages — this card only handles the common "add a new
+              brand with a logo + color" path; version history / advanced
+              fields (fonts, PDF headers, etc.) stay on the dedicated page. */}
+          {ctxTenant?.vertical === "travel" && (
+            <div className="card" style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  marginBottom: "1rem",
+                  flexWrap: "wrap",
+                  gap: "0.75rem",
+                }}
+              >
+                <h3
+                  style={{
+                    fontSize: "1.25rem",
+                    fontWeight: "600",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                    margin: 0,
+                  }}
+                >
+                  <Palette size={20} color="var(--accent-color)" /> Your Brands
+                </h3>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                  <Link
+                    to="/admin/brand-kits"
+                    style={{ fontSize: "0.8rem", color: "var(--accent-color)", display: "inline-flex", alignItems: "center", gap: 4 }}
+                  >
+                    Manage all brands <ArrowRight size={13} />
+                  </Link>
+                  {availableSubBrands.length > 0 && (
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={openAddBrand}
+                      style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}
+                    >
+                      <Plus size={15} /> Add Another Brand
+                    </button>
+                  )}
+                </div>
+              </div>
+              <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem", marginBottom: "1.25rem" }}>
+                Give each sub-brand its own logo and color. The sidebar shows a brand's own
+                logo when set, and falls back to the default brand above otherwise.
+              </p>
+
+              {brandKitsLoading ? (
+                <p style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>Loading…</p>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                  {SUB_BRAND_IDS.map((id) => {
+                    const kit = brandKits.find((k) => k.subBrand === id);
+                    return (
+                      <div
+                        key={id}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "0.75rem",
+                          padding: "0.6rem 0.85rem",
+                          borderRadius: 8,
+                          border: "1px solid var(--border-color)",
+                          background: subBrandBackground(id),
+                        }}
+                      >
+                        {kit?.logoUrl ? (
+                          <img
+                            src={kit.logoUrl}
+                            alt=""
+                            style={{ width: 32, height: 32, borderRadius: 6, objectFit: "cover" }}
+                          />
+                        ) : (
+                          <div
+                            style={{
+                              width: 32,
+                              height: 32,
+                              borderRadius: 6,
+                              border: "1px dashed var(--border-color)",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              color: "var(--text-secondary)",
+                            }}
+                          >
+                            <ImageIcon size={14} />
+                          </div>
+                        )}
+                        <span style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontWeight: 500, fontSize: "0.9rem", flex: 1 }}>
+                          {subBrandShortLabel(id)}
+                          {ctxTenant?.defaultSubBrand === id && (
+                            <span
+                              style={{
+                                fontSize: "0.65rem", fontWeight: 700, textTransform: "uppercase",
+                                padding: "0.15rem 0.45rem", borderRadius: 999,
+                                background: "var(--accent-color)", color: "#fff",
+                              }}
+                            >
+                              Default
+                            </span>
+                          )}
+                        </span>
+                        {kit ? (
+                          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                            {ctxTenant?.defaultSubBrand !== id && (
+                              <button
+                                type="button"
+                                onClick={() => handleSetDefaultBrand(kit)}
+                                disabled={settingDefaultId === kit.id}
+                                style={{ fontSize: "0.8rem", color: "var(--text-secondary)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+                              >
+                                {settingDefaultId === kit.id ? "Setting…" : "Set as Default"}
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => openEditBrand(kit)}
+                              style={{ fontSize: "0.8rem", color: "var(--accent-color)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+                            >
+                              Edit logo / color
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingKit(null);
+                              setAddBrandForm({ subBrand: id, logoUrl: "", primaryColor: "" });
+                              pickAddBrandFile(null);
+                              setAddBrandError("");
+                              setShowAddBrand(true);
+                            }}
+                            style={{ fontSize: "0.8rem", color: "var(--accent-color)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+                          >
+                            + Set up
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Add Another Brand — compact modal. Uploads a logo (optional) via
+              /api/brand-kits/upload, then creates the active BrandKit row.
+              Advanced fields stay on /admin/brand-kits. */}
+          {showAddBrand && (
+            <div
+              onClick={() => !addBrandSaving && setShowAddBrand(false)}
+              style={{
+                position: "fixed",
+                inset: 0,
+                background: "rgba(0,0,0,0.5)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                zIndex: 1000,
+              }}
+            >
+              <form
+                onClick={(e) => e.stopPropagation()}
+                onSubmit={handleAddBrandSubmit}
+                className="card"
+                style={{ width: "min(94vw, 420px)", padding: "1.5rem" }}
+              >
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1rem" }}>
+                  <h3 style={{ margin: 0, fontSize: "1.1rem", fontWeight: 600 }}>
+                    {editingKit ? `Edit ${subBrandShortLabel(editingKit.subBrand)} branding` : "Add Another Brand"}
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => setShowAddBrand(false)}
+                    disabled={addBrandSaving}
+                    style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-secondary)" }}
+                  >
+                    <X size={18} />
+                  </button>
+                </div>
+
+                <label style={{ display: "block", marginBottom: "0.4rem", fontSize: "0.85rem", fontWeight: 500 }}>
+                  Brand Name *
+                </label>
+                {editingKit ? (
+                  <input
+                    className="input-field"
+                    disabled
+                    value={subBrandShortLabel(editingKit.subBrand)}
+                    style={{ width: "100%", marginBottom: "1rem" }}
+                  />
+                ) : (
+                  <select
+                    className="input-field"
+                    required
+                    value={addBrandForm.subBrand}
+                    onChange={(e) => setAddBrandForm({ ...addBrandForm, subBrand: e.target.value })}
+                    style={{ width: "100%", marginBottom: "1rem" }}
+                  >
+                    {availableSubBrands.map((id) => (
+                      <option key={id} value={id}>{subBrandShortLabel(id)}</option>
+                    ))}
+                  </select>
+                )}
+
+                <label style={{ display: "block", marginBottom: "0.4rem", fontSize: "0.85rem", fontWeight: 500 }}>
+                  Brand Logo {editingKit ? "" : "(optional)"}
+                </label>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "1rem" }}>
+                  {addBrandFilePreviewUrl ? (
+                    <img
+                      src={addBrandFilePreviewUrl}
+                      alt="New logo preview"
+                      style={{ width: 44, height: 44, borderRadius: 6, objectFit: "cover", border: "1px solid var(--accent-color)" }}
+                    />
+                  ) : addBrandForm.logoUrl ? (
+                    <img
+                      src={addBrandForm.logoUrl}
+                      alt="Current logo"
+                      style={{ width: 44, height: 44, borderRadius: 6, objectFit: "cover", border: "1px solid var(--border-color)" }}
+                    />
+                  ) : (
+                    <div
+                      style={{
+                        width: 44, height: 44, borderRadius: 6, border: "1px dashed var(--border-color)",
+                        display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-secondary)",
+                      }}
+                    >
+                      <ImageIcon size={16} />
+                    </div>
+                  )}
+                  <input
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/svg+xml"
+                    onChange={(e) => pickAddBrandFile(e.target.files?.[0] || null)}
+                    style={{ flex: 1, minWidth: 0, fontSize: "0.85rem" }}
+                  />
+                </div>
+
+                <label style={{ display: "block", marginBottom: "0.4rem", fontSize: "0.85rem", fontWeight: 500 }}>
+                  Brand Color (optional)
+                </label>
+                <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+                  <input
+                    type="color"
+                    value={/^#[0-9a-fA-F]{6}$/.test(addBrandForm.primaryColor) ? addBrandForm.primaryColor : DEFAULT_BRAND_COLOR}
+                    onChange={(e) => setAddBrandForm({ ...addBrandForm, primaryColor: e.target.value })}
+                    style={{ width: 44, height: 38, border: "1px solid var(--border-color)", borderRadius: 6, cursor: "pointer", padding: 2 }}
+                  />
+                  <input
+                    type="text"
+                    className="input-field"
+                    placeholder={DEFAULT_BRAND_COLOR}
+                    value={addBrandForm.primaryColor}
+                    onChange={(e) => setAddBrandForm({ ...addBrandForm, primaryColor: e.target.value })}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                </div>
+
+                {addBrandError && (
+                  <p style={{ color: "var(--danger-color, #ef4444)", fontSize: "0.8rem", marginBottom: "1rem" }}>
+                    {addBrandError}
+                  </p>
+                )}
+
+                <div style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
+                  <button
+                    type="button"
+                    onClick={() => setShowAddBrand(false)}
+                    disabled={addBrandSaving}
+                    style={{ padding: "0.5rem 1rem", background: "transparent", border: "1px solid var(--border-color)", borderRadius: 6, color: "var(--text-primary)", cursor: "pointer" }}
+                  >
+                    Cancel
+                  </button>
+                  <button type="submit" className="btn-primary" disabled={addBrandSaving}>
+                    {addBrandSaving ? "Saving…" : editingKit ? "Save changes" : "Save Brand"}
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
 
           {/* Role Recovery — secondary entry point for the version-history /
               restore flow. Reuses the same backend endpoints the Roles &

--- a/frontend/src/pages/travel/WhatsAppChat.jsx
+++ b/frontend/src/pages/travel/WhatsAppChat.jsx
@@ -373,6 +373,7 @@ export default function TravelWhatsAppChat() {
     try {
       const data = await fetchApi('/api/travel/whatsapp/status');
       setWatiStatus(data || { enabled: false, connected: false, state: 'DISCONNECTED' });
+      const wasConnected = waConnectedRef.current;
       waConnectedRef.current = !!data?.connected;
       if (data?.qr) setQrImage(data.qr);
       // If a background reconnect brought us online while the modal is open,
@@ -380,6 +381,16 @@ export default function TravelWhatsAppChat() {
       if (data?.connected) {
         setShowQrModal(false);
         setConnecting(false);
+      }
+      // Reconcile the thread list against the just-learned connection state.
+      // waConnectedRef starts optimistically `true` (see its declaration) so
+      // the mount-time loadList() race can populate the list with real chats
+      // BEFORE this status check resolves `connected: false` — the live-mirror
+      // rule inside loadList() only clears the list on its NEXT call, so
+      // without this the stale thread list sits visible next to a "not
+      // connected" status pill until the next 10s poll tick.
+      if (wasConnected !== waConnectedRef.current) {
+        loadList();
       }
       return data;
     } catch {
@@ -389,6 +400,7 @@ export default function TravelWhatsAppChat() {
   };
   useEffect(() => {
     refreshWaStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ─── QR connect lifecycle (admin) ───────────────────────────

--- a/frontend/src/pages/travel/WhatsAppLog.jsx
+++ b/frontend/src/pages/travel/WhatsAppLog.jsx
@@ -8,13 +8,17 @@
 // tenants never reach it (their WhatsApp surfaces are separate and
 // untouched).
 //
-// Endpoint consumed (existing, tenant-scoped via verifyToken — no new
-// backend surface):
-//   GET /api/whatsapp/messages?status=&direction=&page=&limit=
+// Endpoints consumed (tenant-scoped via verifyToken):
+//   GET /api/whatsapp/messages?status=&direction=&page=&limit= (existing)
 //     → { messages: [{ id, to, from, body, direction, status,
 //          templateName, errorMessage, createdAt,
 //          contact?: { id, name, phone } }],
 //         pagination: { total, page, limit, pages } }
+//   DELETE /api/whatsapp/messages/dispatch-log (2026-07-08, ADMIN only)
+//     → { success, deletedCount } — permanently clears every logged
+//       dispatch with no linked chat thread (threadId=null). Live customer
+//       chat conversations (WhatsAppMessage rows with a threadId) are never
+//       touched by this action.
 //
 // Status semantics (watiClient contract):
 //   QUEUED  — stub mode (WATI_API_ENDPOINT / WATI_ACCESS_TOKEN not set):
@@ -24,8 +28,9 @@
 //   FAILED  — Wati rejected; errorMessage carries the reason.
 
 import { useEffect, useState } from "react";
-import { MessageSquare, RefreshCw, AlertTriangle } from "lucide-react";
+import { MessageSquare, RefreshCw, AlertTriangle, Trash2 } from "lucide-react";
 import { fetchApi } from "../../utils/api";
+import { useNotify } from "../../utils/notify";
 
 const STATUS_FILTERS = [
   { value: "", label: "All statuses" },
@@ -60,6 +65,7 @@ function fmtDateTime(iso) {
 }
 
 export default function TravelWhatsAppLog() {
+  const notify = useNotify();
   const [messages, setMessages] = useState([]);
   const [total, setTotal] = useState(0);
   const [pages, setPages] = useState(1);
@@ -99,6 +105,34 @@ export default function TravelWhatsAppLog() {
   const onDirectionChange = (v) => { setDirectionFilter(v); setPage(1); };
 
   const anyQueued = messages.some((m) => m.status === "QUEUED");
+
+  // "Clear dispatch log" (2026-07-08) — permanently deletes every logged
+  // dispatch (OTPs, cron reminders, itinerary/boarding-pass pushes) for
+  // this tenant. Backend scopes the delete to threadId=null rows only, so
+  // messages that are part of a live customer chat thread are never
+  // touched — see routes/whatsapp.js's DELETE /messages/dispatch-log.
+  const [clearing, setClearing] = useState(false);
+  const handleClearLog = async () => {
+    const ok = await notify.confirm({
+      title: "Clear dispatch log",
+      message: "This permanently deletes all WhatsApp dispatch log entries for this tenant (OTPs, reminders, itinerary/boarding-pass pushes). This cannot be undone. Live chat conversations are not affected.",
+      confirmText: "Clear log",
+      cancelText: "Cancel",
+      destructive: true,
+    });
+    if (!ok) return;
+    setClearing(true);
+    try {
+      const res = await fetchApi("/api/whatsapp/messages/dispatch-log", { method: "DELETE" });
+      notify.success(`Dispatch log cleared (${res?.deletedCount ?? 0} message${res?.deletedCount === 1 ? "" : "s"} deleted).`);
+      setPage(1);
+      load();
+    } catch (err) {
+      notify.error(err?.body?.error || err?.message || "Failed to clear dispatch log.");
+    } finally {
+      setClearing(false);
+    }
+  };
 
   return (
     <div
@@ -144,14 +178,29 @@ export default function TravelWhatsAppLog() {
             message{total === 1 ? "" : "s"}.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={load}
-          style={secondaryBtn}
-          aria-label="Refresh messages"
-        >
-          <RefreshCw size={14} aria-hidden /> Refresh
-        </button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            onClick={load}
+            style={secondaryBtn}
+            aria-label="Refresh messages"
+          >
+            <RefreshCw size={14} aria-hidden /> Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleClearLog}
+            disabled={clearing || total === 0}
+            style={{
+              ...secondaryBtn,
+              color: "var(--danger-color, #f43f5e)",
+              opacity: clearing || total === 0 ? 0.5 : 1,
+            }}
+            aria-label="Clear dispatch log"
+          >
+            <Trash2 size={14} aria-hidden /> {clearing ? "Clearing…" : "Clear dispatch log"}
+          </button>
+        </div>
       </header>
 
       {anyQueued && (


### PR DESCRIPTION
1. WhatsApp dispatch log — add a "Clear dispatch log" action

New DELETE /api/whatsapp/messages/dispatch-log (ADMIN only) deletes every WhatsAppMessage row with no linked thread (threadId: null) — automated one-off sends (OTPs, cron reminders, itinerary shares, boarding-pass pushes). Live chat-thread messages are never touched.
Audit-logged (CLEAR_DISPATCH_LOG with deleted count).
WhatsAppLog.jsx gets a "Clear dispatch log" button behind a destructive confirmation modal, disabled while empty/in-flight.
WhatsAppChat.jsx: thread list now reconciles immediately on WhatsApp connection-state change (previously could show a stale populated list next to a "not connected" pill for up to 10s).
Contacts.jsx: delete-contact confirmation now explicitly says "This action cannot be undone."
2. Multi-brand branding refactor

New backend/lib/brandResolver.js: single fallback chain — sub-brand's BrandKit → tenant's default-brand BrandKit → Tenant.logoUrl/brandColor → system default.
New useEffectiveBrand.js hook with a shared cache + invalidation so Sidebar/Settings stay in sync without a reload.
brand_kits.js: GET /effective/:subBrand, POST /:id/set-default (writes the previously-unused Tenant.defaultSubBrand), DELETE /:id/logo; PUT now cleans up orphaned S3/disk files on replace.
wellness.js: companion DELETE /branding/logo for non-sub-brand tenants.
Sidebar.jsx: switched to useEffectiveBrand — one logo, fully fallback-resolved.
Settings.jsx (~650 lines): Branding card is sub-brand-aware for travel tenants; new "Your Brands" management section (add/edit/delete/set-default per sub-brand).