### PR TITLE
Add browser-extension lead capture API with AI summarization; fix ext…

### DIFF
--- a/backend/middleware/originCheck.js
+++ b/backend/middleware/originCheck.js
@@ -204,6 +204,20 @@ function originCheck(req, res, next) {
     });
   }
 
+  // GlobusCRM browser extension (Gmail/WhatsApp Web lead capture, 2026-07-09)
+  // — chrome-extension://<32-char-id> origins. The id is regenerated on
+  // every unpacked reload/reinstall and will be a THIRD id again once
+  // published to the Chrome Web Store, so an exact-match allowlist entry
+  // breaks the moment anyone reloads it. This route's real trust boundary
+  // is verifyToken's JWT bearer check (backend/routes/leads_extension_capture.js),
+  // not the Origin header — Origin here is just the CSRF defense-in-depth
+  // this middleware provides for browser-driven state changes, and a
+  // chrome-extension: page is not a web origin an attacker's site can
+  // forge (extension pages don't load third-party HTML into this context).
+  if (claimedOrigin.startsWith("chrome-extension://")) {
+    return next();
+  }
+
   if (!allowedSet.has(claimedOrigin)) {
     return res.status(403).json({
       error: "Request origin not in allowlist",

--- a/backend/routes/leads_extension_capture.js
+++ b/backend/routes/leads_extension_capture.js
@@ -1,0 +1,259 @@
+// POST /api/leads/extension-capture — browser-extension lead ingestion
+// (2026-07-09).
+//
+// A browser extension (built by the senior team) scrapes Gmail + WhatsApp
+// Web and POSTs whatever it captures here. The extension authenticates as a
+// normal logged-in staff user (POST /api/auth/login → JWT), so this route
+// sits behind the same verifyToken every other authenticated route uses —
+// NOT the X-API-Key middleware/externalAuth.js (that's for server-to-server
+// sister products with no human session, e.g. Callified.ai/AdsGPT).
+//
+// Two payload shapes, keyed by `source`:
+//   Gmail:    { source: "gmail", capturedAt, subject, sender, date, to, cc,
+//               body, attachments, links }
+//   WhatsApp: { source: "whatsapp", capturedAt, chatName,
+//               messages: [{ direction: "in"|"out", sender, text, timestamp }] }
+//
+// Both shapes get normalized into the SAME internal message list and handed
+// to lib/leadConversationSummary.js's summarizeMessages() — the exact
+// Gemini-backed (OpenAI-fallback) summarizer already shipped for the
+// WhatsApp "Sync Lead" feature (PR #1203). No new LLM plumbing here.
+//
+// Dedup: Contact.email / Contact.phone (via findDuplicateContact, same
+// helper contacts.js's POST / uses) is tried first — if the sender/chat
+// already has a Contact, this APPENDS a summary block to their existing
+// description instead of creating a duplicate. If genuinely new, a Contact
+// is created with source="gmail"/"whatsapp-extension" and the idempotencyKey
+// set from a hash of the capture (Contact.idempotencyKey +
+// @@unique([tenantId, source, idempotencyKey]) already exists in schema for
+// exactly this "external producer retries the same POST" case — see
+// PRD_TRAVEL_MULTICHANNEL_LEADS G002). A retried POST with the same
+// idempotencyKey returns the existing contact instead of creating a second
+// one, even when there's no email/phone to key off (e.g. a WhatsApp chat
+// with an unresolved contact name).
+
+const express = require("express");
+const crypto = require("crypto");
+const router = express.Router();
+const { verifyToken } = require("../middleware/auth");
+const prisma = require("../lib/prisma");
+const { writeAudit } = require("../lib/audit");
+const { findDuplicateContact } = require("../utils/deduplication");
+const {
+  summarizeMessages,
+  renderBlock,
+} = require("../lib/leadConversationSummary");
+
+const VALID_SOURCES = new Set(["gmail", "whatsapp"]);
+
+function isNonEmptyString(v) {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+// Stable idempotency key so a retried POST (extension retry, double-click,
+// network blip) never creates a second Contact for the same capture. Hashed
+// (not stored raw) so arbitrary subject lines / chat names don't leak into
+// an index value verbatim.
+function computeIdempotencySeed(body) {
+  const seed =
+    body.source === "gmail"
+      ? `${body.capturedAt || ""}|${body.subject || ""}|${body.sender || ""}`
+      : `${body.capturedAt || ""}|${body.chatName || ""}`;
+  return crypto.createHash("sha256").update(seed).digest("hex").slice(0, 40);
+}
+
+// Extract a usable email/phone/name from either payload shape so dedup +
+// Contact creation can stay source-agnostic below this point.
+function extractContactHints(body) {
+  if (body.source === "gmail") {
+    const senderRaw = String(body.sender || "").trim();
+    // "Name <email@x.com>" or a bare email address.
+    const m = senderRaw.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+    const email = (m ? m[2] : senderRaw).trim() || null;
+    const name = (m && m[1].trim()) || (email ? email.split("@")[0] : null);
+    return { name, email, phone: null };
+  }
+  // whatsapp — chatName is the closest thing to a display name; no
+  // structured phone field in the scraped payload, so phone stays null and
+  // dedup falls back to the idempotency key.
+  return { name: body.chatName || null, email: null, phone: null };
+}
+
+// Normalize either payload shape into the { direction, body, createdAt }[]
+// shape lib/leadConversationSummary.js's summarizeMessages() expects
+// (direction "INBOUND"|"OUTBOUND", mirroring WhatsAppMessage rows).
+function normalizeMessages(body) {
+  const capturedAt = body.capturedAt ? new Date(body.capturedAt) : new Date();
+  const validCapturedAt = Number.isNaN(capturedAt.getTime()) ? new Date() : capturedAt;
+
+  if (body.source === "gmail") {
+    return [
+      {
+        direction: "INBOUND",
+        body: [body.subject ? `Subject: ${body.subject}` : null, body.body || ""]
+          .filter(Boolean)
+          .join("\n\n"),
+        createdAt: validCapturedAt,
+      },
+    ];
+  }
+  // whatsapp
+  return (Array.isArray(body.messages) ? body.messages : [])
+    .filter((m) => m && isNonEmptyString(m.text))
+    .map((m) => ({
+      direction: m.direction === "out" ? "OUTBOUND" : "INBOUND",
+      body: m.text,
+      // Per-message timestamps in the scraped payload are wall-clock strings
+      // ("10:01 am") with no date part, so they aren't reliably parseable —
+      // the capture's own capturedAt is the only trustworthy instant we
+      // have. Message ORDER (as scraped, oldest-first per the extension's
+      // contract) is preserved; only the absolute timestamp is collapsed.
+      createdAt: validCapturedAt,
+    }));
+}
+
+/**
+ * POST /api/leads/extension-capture
+ *
+ * Body: see file header for the two accepted shapes.
+ *
+ * Responses:
+ *   201 { created: true, contactId, summary: {purpose, highlights, leadStage} }
+ *   200 { created: false, contactId, appended: true, summary: {...} }  — existing contact, summary appended
+ *   200 { created: false, contactId, duplicate: true }                — idempotent retry, no new work done
+ *   400 { error, code: "INVALID_SOURCE" | "MISSING_PAYLOAD" | "EMPTY_CAPTURE" }
+ */
+router.post("/extension-capture", verifyToken, async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (!isNonEmptyString(body.source) || !VALID_SOURCES.has(body.source)) {
+      return res.status(400).json({
+        error: `source must be one of: ${Array.from(VALID_SOURCES).join(", ")}`,
+        code: "INVALID_SOURCE",
+      });
+    }
+    if (body.source === "gmail" && !isNonEmptyString(body.body) && !isNonEmptyString(body.subject)) {
+      return res.status(400).json({
+        error: "gmail capture requires at least a subject or a body",
+        code: "MISSING_PAYLOAD",
+      });
+    }
+    if (body.source === "whatsapp" && !Array.isArray(body.messages)) {
+      return res.status(400).json({
+        error: "whatsapp capture requires a messages array",
+        code: "MISSING_PAYLOAD",
+      });
+    }
+
+    const messages = normalizeMessages(body);
+    if (!messages.length) {
+      return res.status(400).json({
+        error: "Capture had no usable text content",
+        code: "EMPTY_CAPTURE",
+      });
+    }
+
+    const tenantId = req.user.tenantId;
+    const idempotencyKey = computeIdempotencySeed(body);
+    const sourceTag = body.source === "gmail" ? "gmail" : "whatsapp-extension";
+    const { name, email, phone } = extractContactHints(body);
+
+    // 1. Idempotent-retry short-circuit — same capture POSTed twice (extension
+    // retry / double-click) must not do the LLM call or create a second row.
+    const idempotent = await prisma.contact.findFirst({
+      where: { tenantId, source: sourceTag, idempotencyKey },
+      select: { id: true },
+    });
+    if (idempotent) {
+      return res.json({ created: false, contactId: idempotent.id, duplicate: true });
+    }
+
+    // 2. Real dedup — does this sender/phone already have a Contact? If so,
+    // append the summary to their existing description rather than forking
+    // a second row for the same person.
+    const existing =
+      email || phone ? await findDuplicateContact(email, phone, tenantId) : null;
+
+    const summary = await summarizeMessages({
+      tenantId,
+      customerName: name,
+      messages,
+    });
+    const block = renderBlock({
+      customerName: name,
+      date: messages[messages.length - 1].createdAt,
+      purpose: summary.purpose,
+      highlights: summary.highlights,
+      leadStage: summary.leadStage,
+    });
+
+    if (existing) {
+      const nextDescription = existing.description
+        ? `${existing.description}\n\n${block}`
+        : block;
+      await prisma.contact.update({
+        where: { id: existing.id },
+        data: { description: nextDescription },
+      });
+      await writeAudit("Contact", "EXTENSION_CAPTURE_APPEND", existing.id, req.user.userId, tenantId, {
+        source: sourceTag,
+      });
+      return res.json({
+        created: false,
+        appended: true,
+        contactId: existing.id,
+        summary,
+      });
+    }
+
+    // 3. Genuinely new lead.
+    const aiScore = Math.max(1, Math.min(100, Math.round((summary.leadStage ? 40 : 20))));
+    const contact = await prisma.contact.create({
+      data: {
+        tenantId,
+        name: name || (body.source === "gmail" ? "Unknown (Gmail)" : "Unknown (WhatsApp)"),
+        email,
+        phone,
+        source: sourceTag,
+        status: "Lead",
+        description: block,
+        idempotencyKey,
+        aiScore,
+        aiScoreLastComputedAt: new Date(),
+        assignedToId: req.user.userId,
+      },
+    });
+
+    try {
+      const { emitEvent } = require("../lib/eventBus");
+      await emitEvent(
+        "contact.created",
+        { contactId: contact.id, name: contact.name, email: contact.email, userId: req.user.userId },
+        tenantId,
+        req.io,
+      );
+    } catch (_e) {
+      /* event bus optional */
+    }
+
+    await prisma.touchpoint
+      .create({
+        data: { tenantId, contactId: contact.id, channel: sourceTag, source: `extension:${body.source}`, timestamp: new Date() },
+      })
+      .catch(() => {
+        /* best-effort attribution — never block lead creation */
+      });
+
+    await writeAudit("Contact", "CREATE", contact.id, req.user.userId, tenantId, {
+      name: contact.name,
+      source: sourceTag,
+    });
+
+    return res.status(201).json({ created: true, contactId: contact.id, summary });
+  } catch (err) {
+    console.error("[leads-extension-capture] error:", err && err.message);
+    return res.status(500).json({ error: "Failed to capture lead", code: "CAPTURE_FAILED" });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -178,6 +178,14 @@ app.use(
       // Allow requests with no origin (server-to-server, curl, Postman)
       if (!origin || ALLOWED_ORIGINS.includes(origin))
         return callback(null, true);
+      // GlobusCRM browser extension (2026-07-09) — chrome-extension://<id>
+      // origins. The id is regenerated on every unpacked reload/reinstall
+      // (and again once published to the Chrome Web Store), so an exact-
+      // match allowlist entry would break on the next reload. Mirrors the
+      // same allowance in middleware/originCheck.js — see that file's
+      // comment for the trust-boundary rationale (verifyToken's JWT bearer
+      // check is what actually gates these routes).
+      if (origin.startsWith("chrome-extension://")) return callback(null, true);
       // #657 — for unknown origins, do NOT error-out (which sends a 500
       // and breaks the originCheck layer below). Just decline to set the
       // Access-Control-Allow-Origin response header — the browser will
@@ -1301,6 +1309,10 @@ app.use("/api/travel", require("./routes/travel_search"));
 // /api/travel/inbound/leads/:channel handler so both surfaces share one
 // envelope, idempotency contract, Touchpoint write, and cooldown gate.
 app.use("/api/leads", require("./routes/leads_intake"));
+// Browser-extension lead capture (Gmail/WhatsApp Web scraping) — vertical-
+// agnostic, authenticated as a normal logged-in staff user (verifyToken),
+// distinct from the travel-specific multi-channel intake above.
+app.use("/api/leads", require("./routes/leads_extension_capture"));
 app.use(
   "/api/travel/itinerary-templates",
   require("./routes/travel_itinerary_templates"),

--- a/frontend/src/pages/ContactDetail.jsx
+++ b/frontend/src/pages/ContactDetail.jsx
@@ -173,25 +173,34 @@ const ContactDetail = () => {
                 WhatsApp thread, or fully regenerated as one narrative here.
                 Shown whenever the contact already has a summary OR came in
                 through any WhatsApp-flavoured source (direct auto-capture
-                "whatsapp" or multichannel intake "inbound:whatsapp") — the
-                Summarize button itself 404/409s harmlessly if there's no
-                WhatsApp history to read yet. */}
+                "whatsapp" or multichannel intake "inbound:whatsapp").
+                The manual "Summarize" (re-summarize-from-scratch) button is
+                WhatsApp-specific — POST /:id/summarize-chat only ever reads
+                WhatsAppMessage rows (lib/leadConversationSummary.js), so it
+                404/409s with a WhatsApp-flavoured error message for any other
+                source (gmail, whatsapp-extension, etc). Those sources already
+                got their one-time summary written into description at
+                capture time (routes/leads_extension_capture.js) — there's no
+                raw message log behind them to re-summarize from, so the
+                button is hidden rather than shown-and-broken. */}
             {(contact.description || /whatsapp/i.test(contact.source || '')) && (
               <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: '1rem', marginTop: '1rem' }}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem', gap: '0.5rem' }}>
                   <h4 style={{ fontSize: '0.85rem', fontWeight: '600', margin: 0, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
                     <MessageSquareText size={14} /> Chat Summary
                   </h4>
-                  <button
-                    type="button"
-                    onClick={handleSummarizeChat}
-                    disabled={summarizing}
-                    className="btn-secondary"
-                    title="Regenerate a full narrative summary from the entire WhatsApp history"
-                    style={{ fontSize: '0.75rem', padding: '0.3rem 0.65rem', display: 'flex', alignItems: 'center', gap: 4 }}
-                  >
-                    <Sparkles size={13} /> {summarizing ? 'Summarizing…' : 'Summarize'}
-                  </button>
+                  {/^whatsapp$/i.test(contact.source || '') || contact.source === 'inbound:whatsapp' ? (
+                    <button
+                      type="button"
+                      onClick={handleSummarizeChat}
+                      disabled={summarizing}
+                      className="btn-secondary"
+                      title="Regenerate a full narrative summary from the entire WhatsApp history"
+                      style={{ fontSize: '0.75rem', padding: '0.3rem 0.65rem', display: 'flex', alignItems: 'center', gap: 4 }}
+                    >
+                      <Sparkles size={13} /> {summarizing ? 'Summarizing…' : 'Summarize'}
+                    </button>
+                  ) : null}
                 </div>
                 {summarizeError && (
                   <p style={{ color: '#ef4444', fontSize: '0.75rem', margin: '0 0 0.5rem' }}>{summarizeError}</p>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -244,6 +244,7 @@ export const fetchApi = async (url, options = {}) => {
     // toast at this level means even pages that don't .catch() see feedback.
     const errData = await response.json().catch(() => ({}));
     const serverMsg = errData.error || errData.message;
+    const errorCode = errData.code || `HTTP_${response.status}`;
     let userMsg;
     if (response.status === 403) {
       // RBAC errors return a technical "requires module.action" string that's
@@ -259,15 +260,31 @@ export const fetchApi = async (url, options = {}) => {
     } else if (response.status === 404) {
       userMsg = serverMsg || 'Not found.';
     } else if (response.status >= 500) {
-      userMsg = serverMsg || 'Server error — please try again.';
+      // Never surface the raw server error text for a 5xx — it can be a raw
+      // Prisma/driver message (column names, table names, connection
+      // strings) that leaks internals to whoever's looking at the screen.
+      // The error CODE is safe (an enum-like string, no data) and is what a
+      // developer needs to correlate this toast with the matching backend
+      // log line — so it rides along in small print / the console, not the
+      // headline message.
+      userMsg = 'Something went wrong on our end. Please try again — if it keeps happening, contact support.';
+      console.error(`[api] ${response.status} ${errorCode} on ${url}:`, serverMsg || '(no server message)');
     } else {
       userMsg = serverMsg || `Request failed (${response.status}).`;
     }
 
-    if (!silent && _globalNotify) _globalNotify.error(userMsg);
+    if (!silent && _globalNotify) {
+      // Append the error code in the toast for 5xx so a dev (or a user
+      // screenshotting for support) can see it without opening DevTools —
+      // it's a stable enum string, safe to show, and short enough to not
+      // clutter the toast.
+      const toastMsg = response.status >= 500 ? `${userMsg} (${errorCode})` : userMsg;
+      _globalNotify.error(toastMsg);
+    }
     const err = new Error(userMsg);
     err.status = response.status;
     err.code = errData.code || null;
+    err.serverMessage = serverMsg || null;
     err.data = errData;
     throw err;
   }


### PR DESCRIPTION
Adds POST /api/leads/extension-capture so the GlobusCRM browser extension (Gmail + WhatsApp Web scraper) can send captured content into the CRM as a lead, reusing the existing Gemini-backed summarizer from WhatsApp's "Sync Lead" feature. Plus three fixes surfaced by testing the extension live end-to-end.

New endpoint — accepts both extension payload shapes, auths via the extension's existing login JWT (no new auth), summarizes via the shared leadConversationSummary.js, dedupes by email/idempotency key (appends a new dated block to an existing lead's description on repeat captures instead of duplicating), creates a Contact otherwise.

CORS/CSRF fix — chrome-extension://<id> origins were 403ing (ORIGIN_NOT_ALLOWED) because the id changes on every reload; both allowlists now pass any chrome-extension:// origin through, same treatment as curl/Postman. Trust boundary stays the JWT check.

Error-message fix — fetchApi no longer shows raw backend 500 text to end users; shows a calm message + safe error code, logs the real message to console.

UI fix — the Contact page's "Summarize" button (WhatsApp-only, reads WhatsAppMessage rows) was showing and 409ing on Gmail-sourced leads with a misleading error. Now scoped to only render for source === "whatsapp" / "inbound:whatsapp" — the two pre-existing values that actually have WhatsApp history. Verified this doesn't touch any existing WhatsApp lead's behavior.

Full test plan and follow-ups (no gate spec yet) are in the file at pr-extension-lead-capture.md in the scratchpad if you want to paste it directly into gh pr create or your PR tool of choice.