### PR TITLE
added WhatsApp device session governanc & protection guidelines

### DIFF
--- a/backend/lib/whatsappSessionGuard.js
+++ b/backend/lib/whatsappSessionGuard.js
@@ -1,0 +1,244 @@
+/**
+ * whatsappSessionGuard.js — device-session governance for the WhatsApp Web
+ * (QR-scan) transport used by the Travel vertical.
+ *
+ * WHY THIS EXISTS — the actual WhatsApp connection is a single tenant-scoped
+ * in-memory session + LocalAuth store owned by services/whatsappWebClient.js
+ * (one number per tenant). This module does NOT touch that engine; it only
+ * records WHICH CRM user, on WHICH device, currently controls the connect/QR
+ * action, and gates the /connect route accordingly. Two independent protections:
+ *
+ *   1. Per-user device lock — a given user may hold the control claim on only
+ *      ONE device at a time. A 2nd device for the SAME user is refused (the UI
+ *      shows a "controlled from another device" warning). DIFFERENT users are
+ *      never blocked by each other — they share the one inbox as before.
+ *
+ *   2. Per-tenant relink cooldown — because the number is shared, generating a
+ *      fresh QR / relink on it is throttled for a cooldown window after a
+ *      disconnect, regardless of who clicks. This is the Meta-suspension safety
+ *      layer (frequent relinks on one account are what trip Meta). It is skipped
+ *      when the shared session is already CONNECTED (an idempotent connect
+ *      generates no QR, so there is no relink to throttle).
+ *
+ * Stale claims (a browser tab that stopped heart-beating) are expired LAZILY on
+ * every claim()/heartbeat() call — no cron needed — so a closed tab frees the
+ * lock after WA_DEVICE_HEARTBEAT_TTL_MS.
+ *
+ * Login/logout/reconnect/blocked attempts are written to the audit log via the
+ * shared writeAudit() helper (entity "WhatsAppWebSession").
+ *
+ * CJS self-mocking seam (CLAUDE.md standing pattern): inter-function calls go
+ * through module.exports.fn(...) so vitest vi.spyOn interception works.
+ *
+ * Config (env, read at call-time so tests can override):
+ *   WA_DEVICE_LOCK               "off" disables the whole layer (default: on)
+ *   WA_DEVICE_HEARTBEAT_TTL_MS   claim goes stale after this (default 120000 = 2m)
+ *   WA_RELINK_COOLDOWN_MS        relink cooldown after a disconnect (default 900000 = 15m)
+ */
+
+const prisma = require("./prisma");
+const { writeAudit } = require("./audit");
+
+const ACTIVE = "ACTIVE";
+const LOGGED_OUT = "LOGGED_OUT";
+const EXPIRED = "EXPIRED";
+
+// Read env at call-time (not module-load) so tests can flip config per-case.
+function cfg() {
+  const raw = process.env.WA_DEVICE_LOCK;
+  const enabled = String(raw == null ? "on" : raw).toLowerCase() !== "off";
+  return {
+    enabled,
+    heartbeatTtlMs: Number(process.env.WA_DEVICE_HEARTBEAT_TTL_MS) || 120000,
+    cooldownMs: Number(process.env.WA_RELINK_COOLDOWN_MS) || 900000,
+  };
+}
+
+// writeAudit is already fail-soft (never throws), but wrap defensively so a
+// governance-audit hiccup can never break a connect/disconnect request.
+async function audit(action, entityId, userId, tenantId, details) {
+  try {
+    await writeAudit("WhatsAppWebSession", action, entityId, userId, tenantId, details);
+  } catch (e) {
+    console.warn(`[waGuard] audit ${action} failed (non-fatal): ${e.message}`);
+  }
+}
+
+// Expire ACTIVE claims whose heartbeat lapsed — frees a lock left by a closed
+// tab. Best-effort; returns the count expired.
+async function expireStale(tenantId) {
+  const { heartbeatTtlMs } = cfg();
+  const cutoff = new Date(Date.now() - heartbeatTtlMs);
+  try {
+    const r = await prisma.whatsAppWebSession.updateMany({
+      where: { tenantId: Number(tenantId), status: ACTIVE, lastHeartbeat: { lt: cutoff } },
+      data: { status: EXPIRED },
+    });
+    return r.count || 0;
+  } catch (e) {
+    console.warn(`[waGuard] expireStale failed (non-fatal): ${e.message}`);
+    return 0;
+  }
+}
+
+/**
+ * Decide whether (userId, deviceId) may drive a connect on this tenant, and —
+ * if so — record/refresh the control claim.
+ *
+ * opts: { deviceLabel, ip, reset, isConnected }
+ * Returns { allowed:true, session, reconnect } OR
+ *         { allowed:false, code, message, activeDevice?, cooldownRemainingMs? }.
+ */
+async function claim(tenantId, userId, deviceId, opts = {}) {
+  tenantId = Number(tenantId);
+  userId = Number(userId);
+  const { deviceLabel = null, ip = null, reset = false, isConnected = false } = opts;
+  const { enabled, cooldownMs } = cfg();
+
+  // Layer disabled, or a legacy/other caller with no device identity — we
+  // cannot enforce a per-device lock without a deviceId, so allow (backward
+  // compatible) and audit it as a bypass so the trail stays complete.
+  if (!enabled || !deviceId) {
+    await audit("LOGIN", null, userId, tenantId, {
+      deviceId: deviceId || null,
+      ip,
+      bypass: true,
+      reason: !enabled ? "lock-disabled" : "no-device-id",
+    });
+    return { allowed: true, bypass: true };
+  }
+
+  const dev = String(deviceId);
+  await module.exports.expireStale(tenantId);
+
+  // (1) Per-user device lock — is THIS user already ACTIVE on a different device?
+  const others = await prisma.whatsAppWebSession.findMany({
+    where: { tenantId, userId, status: ACTIVE, deviceId: { not: dev } },
+    orderBy: { lastHeartbeat: "desc" },
+  });
+  if (others.length) {
+    const a = others[0];
+    await audit("DEVICE_LOCKED", a.id, userId, tenantId, {
+      attemptedDeviceId: dev,
+      heldDeviceId: a.deviceId,
+      heldDeviceLabel: a.deviceLabel,
+    });
+    const since = a.loginAt ? new Date(a.loginAt).toISOString() : null;
+    return {
+      allowed: false,
+      code: "WA_DEVICE_LOCKED",
+      message:
+        `WhatsApp is already being controlled from another device` +
+        (a.deviceLabel ? ` (${a.deviceLabel})` : "") +
+        (since ? `, connected ${since}` : "") +
+        `. Disconnect there — or wait for it to go idle — before connecting from this device.`,
+      activeDevice: { deviceLabel: a.deviceLabel, ip: a.ip, loginAt: a.loginAt },
+    };
+  }
+
+  // (2) Per-tenant relink cooldown — only bites when a fresh QR would actually
+  // be generated (session not already CONNECTED, or an explicit reset which
+  // wipes + relinks). A resume of a still-live link generates no QR → no relink.
+  if (!isConnected || reset) {
+    const lastLogout = await prisma.whatsAppWebSession.findFirst({
+      where: { tenantId, logoutAt: { not: null } },
+      orderBy: { logoutAt: "desc" },
+      select: { logoutAt: true },
+    });
+    if (lastLogout && lastLogout.logoutAt) {
+      const remaining = cooldownMs - (Date.now() - new Date(lastLogout.logoutAt).getTime());
+      if (remaining > 0) {
+        await audit("RELINK_COOLDOWN", null, userId, tenantId, { deviceId: dev, cooldownRemainingMs: remaining, reset });
+        return {
+          allowed: false,
+          code: "WA_RELINK_COOLDOWN",
+          message:
+            `WhatsApp was recently disconnected. To protect the number from suspension, ` +
+            `please wait ${Math.ceil(remaining / 60000)} more minute(s) before reconnecting.`,
+          cooldownRemainingMs: remaining,
+        };
+      }
+    }
+  }
+
+  // (3) Allowed — upsert this device's claim (reused on reconnect, no dupes).
+  const now = new Date();
+  const existing = await prisma.whatsAppWebSession.findUnique({
+    where: { tenantId_userId_deviceId: { tenantId, userId, deviceId: dev } },
+  });
+  const reconnect = !!(existing && existing.status === ACTIVE);
+  const base = { status: ACTIVE, ip, deviceLabel, lastHeartbeat: now, logoutAt: null };
+  let row;
+  if (existing) {
+    // Reactivating a LOGGED_OUT/EXPIRED row resets loginAt; a live reconnect keeps it.
+    row = await prisma.whatsAppWebSession.update({
+      where: { id: existing.id },
+      data: reconnect ? base : { ...base, loginAt: now },
+    });
+  } else {
+    row = await prisma.whatsAppWebSession.create({
+      data: { tenantId, userId, deviceId: dev, loginAt: now, ...base },
+    });
+  }
+  await audit(reconnect ? "RECONNECT" : "LOGIN", row.id, userId, tenantId, { deviceId: dev, deviceLabel, ip, reset });
+  return { allowed: true, session: row, reconnect };
+}
+
+/**
+ * Refresh a device's heartbeat. Returns { ok, lost } — lost:true when the claim
+ * no longer exists / is no longer ACTIVE (expired or taken), so the UI can tell
+ * the operator it lost control of the session.
+ */
+async function heartbeat(tenantId, userId, deviceId) {
+  tenantId = Number(tenantId);
+  userId = Number(userId);
+  if (!deviceId) return { ok: false, lost: false };
+  const dev = String(deviceId);
+  await module.exports.expireStale(tenantId);
+  try {
+    const row = await prisma.whatsAppWebSession.findUnique({
+      where: { tenantId_userId_deviceId: { tenantId, userId, deviceId: dev } },
+    });
+    if (!row || row.status !== ACTIVE) return { ok: false, lost: true };
+    await prisma.whatsAppWebSession.update({ where: { id: row.id }, data: { lastHeartbeat: new Date() } });
+    return { ok: true, lost: false };
+  } catch (e) {
+    console.warn(`[waGuard] heartbeat failed (non-fatal): ${e.message}`);
+    return { ok: false, lost: false };
+  }
+}
+
+/**
+ * Release a user's control claim on disconnect/logout. Sets logoutAt (which
+ * starts the tenant relink cooldown) + marks the row LOGGED_OUT. When deviceId
+ * is omitted, releases all of this user's active claims for the tenant.
+ */
+async function release(tenantId, userId, deviceId, opts = {}) {
+  tenantId = Number(tenantId);
+  userId = Number(userId);
+  const { logout = false } = opts;
+  const now = new Date();
+  try {
+    const where = deviceId
+      ? { tenantId, userId, deviceId: String(deviceId) }
+      : { tenantId, userId, status: ACTIVE };
+    const r = await prisma.whatsAppWebSession.updateMany({
+      where,
+      data: { status: LOGGED_OUT, logoutAt: now },
+    });
+    await audit("LOGOUT", null, userId, tenantId, { deviceId: deviceId || null, logout, released: r.count || 0 });
+    return { released: r.count || 0 };
+  } catch (e) {
+    console.warn(`[waGuard] release failed (non-fatal): ${e.message}`);
+    return { released: 0 };
+  }
+}
+
+module.exports = {
+  claim,
+  heartbeat,
+  release,
+  expireStale,
+  cfg,
+  STATUS: { ACTIVE, LOGGED_OUT, EXPIRED },
+};

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2029,6 +2029,36 @@ model WhatsAppOptOut {
   @@index([tenantId, capturedAt])
 }
 
+// Device-session governance for the WhatsApp Web (QR-scan) transport. This is
+// NOT the WhatsApp connection itself — that stays a single tenant-scoped
+// in-memory session + LocalAuth store in services/whatsappWebClient.js. This
+// table only records WHICH CRM user, on WHICH device, currently controls the
+// connect/QR action, so we can (1) stop one user driving the same shared number
+// from two devices at once (per-user device lock) and (2) throttle fresh QR
+// relinks on the shared number (per-tenant cooldown) — both to reduce the
+// frequent-relink churn that gets Meta accounts suspended. Rows are reused on
+// reconnect (unique per tenant+user+device) so a device never accumulates dupes.
+// Stale rows (heartbeat lost) are expired lazily by whatsappSessionGuard — no cron.
+model WhatsAppWebSession {
+  id            Int       @id @default(autoincrement())
+  userId        Int // CRM user who owns this control claim
+  deviceId      String // stable browser fingerprint (localStorage uuid)
+  deviceLabel   String? // parsed user-agent + user name, for the "controlled elsewhere" warning
+  ip            String?
+  status        String    @default("ACTIVE") // ACTIVE | LOGGED_OUT | EXPIRED
+  loginAt       DateTime  @default(now())
+  logoutAt      DateTime?
+  lastHeartbeat DateTime  @default(now())
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  tenantId Int @default(1)
+
+  @@unique([tenantId, userId, deviceId])
+  @@index([tenantId, userId, status])
+  @@index([tenantId, status])
+}
+
 model WhatsAppTemplate {
   id             Int       @id @default(autoincrement())
   name           String

--- a/backend/routes/travel_whatsapp.js
+++ b/backend/routes/travel_whatsapp.js
@@ -78,6 +78,29 @@ const prisma = require("../lib/prisma");
 // const watiClient = require("../services/watiClient"); // legacy Wati REST (disabled)
 const watiClient = require("../services/whatsappWebClient");
 const { toE164 } = require("../utils/deduplication");
+// Per-user device-session governance (device lock + relink cooldown). This is a
+// thin claim layer over the SHARED tenant session — it never touches the
+// whatsappWebClient connection engine. See lib/whatsappSessionGuard.js.
+const waGuard = require("../lib/whatsappSessionGuard");
+
+// Human-friendly label for the "controlled from another device" warning:
+// the operator's name/email + a coarse browser/OS hint from the user-agent.
+function deviceLabelFor(req) {
+  const who = (req.user && (req.user.name || req.user.email)) || `user#${req.user && req.user.userId}`;
+  const ua = String(req.headers["user-agent"] || "");
+  let browser = "browser";
+  if (/edg/i.test(ua)) browser = "Edge";
+  else if (/chrome|crios/i.test(ua)) browser = "Chrome";
+  else if (/firefox|fxios/i.test(ua)) browser = "Firefox";
+  else if (/safari/i.test(ua)) browser = "Safari";
+  let os = "";
+  if (/windows/i.test(ua)) os = "Windows";
+  else if (/android/i.test(ua)) os = "Android";
+  else if (/iphone|ipad|ios/i.test(ua)) os = "iOS";
+  else if (/mac os|macintosh/i.test(ua)) os = "macOS";
+  else if (/linux/i.test(ua)) os = "Linux";
+  return `${who} · ${browser}${os ? ` on ${os}` : ""}`;
+}
 
 // Outbound media upload (paperclip in the travel chat) — memory storage,
 // 16MB cap (WhatsApp's own media ceiling, mirroring the Meta-track
@@ -240,6 +263,32 @@ router.post(
       // { reset:true } wipes any saved/stale session + kills a stuck Chromium
       // before relaunching — the escape hatch for a wedged "Generating QR…".
       const reset = Boolean(req.body && (req.body.reset === true || req.body.reset === "true"));
+
+      // ── Device-session gate (per-user device lock + per-tenant relink
+      // cooldown). Runs BEFORE any purge/connect so a blocked attempt neither
+      // wipes chats nor generates a QR. deviceId rides in the body (NOT stripped
+      // by stripDangerous); userId comes from the token. A caller with no
+      // deviceId degrades to allow (backward compatible).
+      const claim = await waGuard.claim(
+        req.travelTenant.id,
+        req.user.userId,
+        req.body && req.body.deviceId,
+        {
+          deviceLabel: deviceLabelFor(req),
+          ip: req.ip,
+          reset,
+          isConnected: watiClient.isConnected(req.travelTenant.id),
+        },
+      );
+      if (!claim.allowed) {
+        return res.status(409).json({
+          error: claim.message,
+          code: claim.code,
+          activeDevice: claim.activeDevice || null,
+          cooldownRemainingMs: claim.cooldownRemainingMs || null,
+        });
+      }
+
       // Only purge the mirror on an explicit RESET (fresh QR / new number). The
       // old `!connected` guard wiped ALL imported threads whenever the panel was
       // opened while the saved session was still resuming on boot (state is
@@ -266,6 +315,25 @@ router.get(
   async (req, res) => {
     const st = watiClient.getState(req.travelTenant.id);
     res.json({ state: st.state, connected: st.connected, qr: st.qr || null, phone: maskNumber(st.phone), lastError: st.lastError || null });
+  },
+);
+
+// POST /whatsapp/heartbeat — the device currently holding the control claim
+// pings this (~every 45s) so its lock doesn't go stale. NOT admin-gated (any
+// claim holder pings). Returns { ok, lost }: lost=true means the claim expired
+// or was taken by the user's other device, so the UI should stop pinging.
+router.post(
+  "/whatsapp/heartbeat",
+  verifyToken,
+  requireTravelTenant,
+  async (req, res) => {
+    try {
+      const out = await waGuard.heartbeat(req.travelTenant.id, req.user.userId, req.body && req.body.deviceId);
+      res.json(out);
+    } catch (e) {
+      console.error("[travel-whatsapp] heartbeat error:", e.message);
+      res.status(500).json({ error: "Heartbeat failed", code: "WA_HEARTBEAT_FAILED" });
+    }
   },
 );
 
@@ -351,6 +419,9 @@ router.post(
     try {
       const logout = (req.body && (req.body.logout === true || req.body.logout === "true")) || false;
       const st = await watiClient.disconnect(req.travelTenant.id, { logout });
+      // Release this user's control claim + stamp logoutAt (starts the tenant
+      // relink cooldown). Best-effort — never blocks the disconnect response.
+      await waGuard.release(req.travelTenant.id, req.user.userId, req.body && req.body.deviceId, { logout });
       // The linked account is a live mirror — disconnecting clears the imported
       // chats so a fresh connect re-fetches from scratch (no stale threads).
       const purged = await watiClient.purgeChats(req.travelTenant.id);

--- a/backend/routes/travel_whatsapp.js
+++ b/backend/routes/travel_whatsapp.js
@@ -324,12 +324,10 @@ router.post(
       res.json({ ...st, phone: maskNumber(st.phone) });
     } catch (e) {
       console.error("[travel-whatsapp] connect error:", e.message);
-      res
-        .status(500)
-        .json({
-          error: "Failed to start WhatsApp Web session",
-          code: "WA_CONNECT_FAILED",
-        });
+      res.status(500).json({
+        error: "Failed to start WhatsApp Web session",
+        code: "WA_CONNECT_FAILED",
+      });
     }
   },
 );
@@ -465,12 +463,10 @@ router.post(
       res.json(result);
     } catch (e) {
       console.error("[travel-whatsapp] backfill-history error:", e.message);
-      res
-        .status(500)
-        .json({
-          error: "Failed to backfill history",
-          code: "WA_BACKFILL_FAILED",
-        });
+      res.status(500).json({
+        error: "Failed to backfill history",
+        code: "WA_BACKFILL_FAILED",
+      });
     }
   },
 );
@@ -503,12 +499,10 @@ router.post(
       res.json({ ...st, purged });
     } catch (e) {
       console.error("[travel-whatsapp] disconnect error:", e.message);
-      res
-        .status(500)
-        .json({
-          error: "Failed to disconnect WhatsApp Web session",
-          code: "WA_DISCONNECT_FAILED",
-        });
+      res.status(500).json({
+        error: "Failed to disconnect WhatsApp Web session",
+        code: "WA_DISCONNECT_FAILED",
+      });
     }
   },
 );
@@ -530,12 +524,10 @@ router.get(
       res.json(me);
     } catch (e) {
       console.error("[travel-whatsapp] me error:", e.message);
-      res
-        .status(500)
-        .json({
-          error: "Failed to load WhatsApp profile",
-          code: "WA_ME_FAILED",
-        });
+      res.status(500).json({
+        error: "Failed to load WhatsApp profile",
+        code: "WA_ME_FAILED",
+      });
     }
   },
 );
@@ -558,12 +550,10 @@ router.put(
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me update error:", e.message);
-      res
-        .status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({
-          error: e.message || "Failed to update WhatsApp profile",
-          code: "WA_ME_UPDATE_FAILED",
-        });
+      res.status(e.message === "WhatsApp not connected" ? 409 : 500).json({
+        error: e.message || "Failed to update WhatsApp profile",
+        code: "WA_ME_UPDATE_FAILED",
+      });
     }
   },
 );
@@ -589,12 +579,10 @@ router.post(
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me avatar error:", e.message);
-      res
-        .status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({
-          error: e.message || "Failed to set profile picture",
-          code: "WA_ME_AVATAR_FAILED",
-        });
+      res.status(e.message === "WhatsApp not connected" ? 409 : 500).json({
+        error: e.message || "Failed to set profile picture",
+        code: "WA_ME_AVATAR_FAILED",
+      });
     }
   },
 );
@@ -610,12 +598,10 @@ router.delete(
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me avatar delete error:", e.message);
-      res
-        .status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({
-          error: e.message || "Failed to remove profile picture",
-          code: "WA_ME_AVATAR_DEL_FAILED",
-        });
+      res.status(e.message === "WhatsApp not connected" ? 409 : 500).json({
+        error: e.message || "Failed to remove profile picture",
+        code: "WA_ME_AVATAR_DEL_FAILED",
+      });
     }
   },
 );
@@ -767,12 +753,10 @@ router.get(
       res.json({ templates, stub: out.stub === true });
     } catch (e) {
       console.error("[travel-whatsapp] templates error:", e.message);
-      res
-        .status(502)
-        .json({
-          error: "Failed to load Wati templates",
-          code: "WATI_TEMPLATES_FAILED",
-        });
+      res.status(502).json({
+        error: "Failed to load Wati templates",
+        code: "WATI_TEMPLATES_FAILED",
+      });
     }
   },
 );
@@ -795,12 +779,10 @@ router.post(
       }
       const text = typeof body === "string" ? body.trim() : "";
       if (!templateName && !text) {
-        return res
-          .status(400)
-          .json({
-            error: "body or templateName required",
-            code: "MISSING_BODY",
-          });
+        return res.status(400).json({
+          error: "body or templateName required",
+          code: "MISSING_BODY",
+        });
       }
 
       // Opt-out gate — same semantics (and code) as the Meta-track send so
@@ -895,12 +877,10 @@ router.post(
       });
     } catch (e) {
       console.error("[travel-whatsapp] send error:", e.message);
-      return res
-        .status(500)
-        .json({
-          error: "Failed to send WhatsApp message",
-          code: "SEND_FAILED",
-        });
+      return res.status(500).json({
+        error: "Failed to send WhatsApp message",
+        code: "SEND_FAILED",
+      });
     }
   },
 );

--- a/backend/routes/travel_whatsapp.js
+++ b/backend/routes/travel_whatsapp.js
@@ -86,7 +86,9 @@ const waGuard = require("../lib/whatsappSessionGuard");
 // Human-friendly label for the "controlled from another device" warning:
 // the operator's name/email + a coarse browser/OS hint from the user-agent.
 function deviceLabelFor(req) {
-  const who = (req.user && (req.user.name || req.user.email)) || `user#${req.user && req.user.userId}`;
+  const who =
+    (req.user && (req.user.name || req.user.email)) ||
+    `user#${req.user && req.user.userId}`;
   const ua = String(req.headers["user-agent"] || "");
   let browser = "browser";
   if (/edg/i.test(ua)) browser = "Edge";
@@ -94,6 +96,7 @@ function deviceLabelFor(req) {
   else if (/firefox|fxios/i.test(ua)) browser = "Firefox";
   else if (/safari/i.test(ua)) browser = "Safari";
   let os = "";
+
   if (/windows/i.test(ua)) os = "Windows";
   else if (/android/i.test(ua)) os = "Android";
   else if (/iphone|ipad|ios/i.test(ua)) os = "iOS";
@@ -132,11 +135,7 @@ async function matchContact(tenantId, phoneE164) {
     return await prisma.contact.findFirst({
       where: {
         tenantId,
-        OR: [
-          { phone: phoneE164 },
-          { phone: digits },
-          { phone: `+${digits}` },
-        ],
+        OR: [{ phone: phoneE164 }, { phone: digits }, { phone: `+${digits}` }],
       },
       select: { id: true, name: true },
     });
@@ -151,9 +150,14 @@ async function matchContact(tenantId, phoneE164) {
 // the chat's reaction pills render unchanged. Empty emoji = removal.
 async function applyReaction({ tenantId, phone, item, io }) {
   try {
-    const targetRef = item.replyContextId || item.contextId || item.reactionMessageId
-      || (item.reaction && item.reaction.message_id) || null;
-    const emoji = (item.reaction && item.reaction.emoji) || item.text || item.emoji || "";
+    const targetRef =
+      item.replyContextId ||
+      item.contextId ||
+      item.reactionMessageId ||
+      (item.reaction && item.reaction.message_id) ||
+      null;
+    const emoji =
+      (item.reaction && item.reaction.emoji) || item.text || item.emoji || "";
     if (!targetRef) return;
     const target = await prisma.whatsAppMessage.findFirst({
       where: { tenantId, providerMsgId: String(targetRef) },
@@ -161,9 +165,18 @@ async function applyReaction({ tenantId, phone, item, io }) {
     });
     if (!target) return;
     let reactions = [];
-    try { reactions = JSON.parse(target.reactionsJson || "[]"); } catch { reactions = []; }
+    try {
+      reactions = JSON.parse(target.reactionsJson || "[]");
+    } catch {
+      reactions = [];
+    }
     reactions = reactions.filter((r) => r.fromPhone !== phone);
-    if (emoji) reactions.push({ emoji, fromPhone: phone, addedAt: new Date().toISOString() });
+    if (emoji)
+      reactions.push({
+        emoji,
+        fromPhone: phone,
+        addedAt: new Date().toISOString(),
+      });
     await prisma.whatsAppMessage.update({
       where: { id: target.id },
       data: { reactionsJson: JSON.stringify(reactions) },
@@ -178,7 +191,9 @@ async function applyReaction({ tenantId, phone, item, io }) {
       });
     }
   } catch (e) {
-    console.error(`[travel-whatsapp] reaction apply failed (non-fatal): ${e.message}`);
+    console.error(
+      `[travel-whatsapp] reaction apply failed (non-fatal): ${e.message}`,
+    );
   }
 }
 
@@ -198,9 +213,14 @@ router.get("/whatsapp/media", async (req, res) => {
     }
     const upstream = await watiClient.getMediaResponse(fileName);
     if (!upstream) {
-      return res.status(404).json({ error: "media unavailable (stub mode or not found)" });
+      return res
+        .status(404)
+        .json({ error: "media unavailable (stub mode or not found)" });
     }
-    res.set("Content-Type", upstream.headers.get("content-type") || "application/octet-stream");
+    res.set(
+      "Content-Type",
+      upstream.headers.get("content-type") || "application/octet-stream",
+    );
     res.set("Cache-Control", "private, max-age=86400");
     const buf = Buffer.from(await upstream.arrayBuffer());
     res.send(buf);
@@ -262,7 +282,9 @@ router.post(
     try {
       // { reset:true } wipes any saved/stale session + kills a stuck Chromium
       // before relaunching — the escape hatch for a wedged "Generating QR…".
-      const reset = Boolean(req.body && (req.body.reset === true || req.body.reset === "true"));
+      const reset = Boolean(
+        req.body && (req.body.reset === true || req.body.reset === "true"),
+      );
 
       // ── Device-session gate (per-user device lock + per-tenant relink
       // cooldown). Runs BEFORE any purge/connect so a blocked attempt neither
@@ -302,7 +324,12 @@ router.post(
       res.json({ ...st, phone: maskNumber(st.phone) });
     } catch (e) {
       console.error("[travel-whatsapp] connect error:", e.message);
-      res.status(500).json({ error: "Failed to start WhatsApp Web session", code: "WA_CONNECT_FAILED" });
+      res
+        .status(500)
+        .json({
+          error: "Failed to start WhatsApp Web session",
+          code: "WA_CONNECT_FAILED",
+        });
     }
   },
 );
@@ -314,7 +341,13 @@ router.get(
   requireTravelTenant,
   async (req, res) => {
     const st = watiClient.getState(req.travelTenant.id);
-    res.json({ state: st.state, connected: st.connected, qr: st.qr || null, phone: maskNumber(st.phone), lastError: st.lastError || null });
+    res.json({
+      state: st.state,
+      connected: st.connected,
+      qr: st.qr || null,
+      phone: maskNumber(st.phone),
+      lastError: st.lastError || null,
+    });
   },
 );
 
@@ -328,11 +361,17 @@ router.post(
   requireTravelTenant,
   async (req, res) => {
     try {
-      const out = await waGuard.heartbeat(req.travelTenant.id, req.user.userId, req.body && req.body.deviceId);
+      const out = await waGuard.heartbeat(
+        req.travelTenant.id,
+        req.user.userId,
+        req.body && req.body.deviceId,
+      );
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] heartbeat error:", e.message);
-      res.status(500).json({ error: "Heartbeat failed", code: "WA_HEARTBEAT_FAILED" });
+      res
+        .status(500)
+        .json({ error: "Heartbeat failed", code: "WA_HEARTBEAT_FAILED" });
     }
   },
 );
@@ -348,12 +387,29 @@ router.post(
 function notReadyResponse(tenantId) {
   const st = watiClient.getState(tenantId) || {};
   if (st.state === "INITIALIZING" || st.state === "AUTHENTICATED") {
-    return { status: 409, body: { error: "WhatsApp is reconnecting after a restart — please wait a few seconds and try again.", code: "WA_RECONNECTING" } };
+    return {
+      status: 409,
+      body: {
+        error:
+          "WhatsApp is reconnecting after a restart — please wait a few seconds and try again.",
+        code: "WA_RECONNECTING",
+      },
+    };
   }
   if (st.state === "QR" || st.qr) {
-    return { status: 409, body: { error: "Scan the WhatsApp QR to connect.", code: "WA_NEEDS_QR" } };
+    return {
+      status: 409,
+      body: { error: "Scan the WhatsApp QR to connect.", code: "WA_NEEDS_QR" },
+    };
   }
-  return { status: 409, body: { error: "WhatsApp is not connected — open the WhatsApp panel and scan the QR.", code: "WA_NOT_CONNECTED" } };
+  return {
+    status: 409,
+    body: {
+      error:
+        "WhatsApp is not connected — open the WhatsApp panel and scan the QR.",
+      code: "WA_NOT_CONNECTED",
+    },
+  };
 }
 
 router.post(
@@ -371,7 +427,9 @@ router.post(
       res.json(result);
     } catch (e) {
       console.error("[travel-whatsapp] import error:", e.message);
-      res.status(500).json({ error: "Failed to import chats", code: "WA_IMPORT_FAILED" });
+      res
+        .status(500)
+        .json({ error: "Failed to import chats", code: "WA_IMPORT_FAILED" });
     }
   },
 );
@@ -389,7 +447,8 @@ router.post(
   async (req, res) => {
     try {
       const id = parseInt(req.params.id);
-      if (!Number.isFinite(id)) return res.status(400).json({ error: "invalid id" });
+      if (!Number.isFinite(id))
+        return res.status(400).json({ error: "invalid id" });
       const thread = await prisma.whatsAppThread.findFirst({
         where: { id, tenantId: req.travelTenant.id },
         select: { id: true },
@@ -399,11 +458,19 @@ router.post(
         const nr = notReadyResponse(req.travelTenant.id);
         return res.status(nr.status).json(nr.body);
       }
-      const result = await watiClient.backfillThreadHistory(req.travelTenant.id, id);
+      const result = await watiClient.backfillThreadHistory(
+        req.travelTenant.id,
+        id,
+      );
       res.json(result);
     } catch (e) {
       console.error("[travel-whatsapp] backfill-history error:", e.message);
-      res.status(500).json({ error: "Failed to backfill history", code: "WA_BACKFILL_FAILED" });
+      res
+        .status(500)
+        .json({
+          error: "Failed to backfill history",
+          code: "WA_BACKFILL_FAILED",
+        });
     }
   },
 );
@@ -417,18 +484,31 @@ router.post(
   verifyRole(["ADMIN"]),
   async (req, res) => {
     try {
-      const logout = (req.body && (req.body.logout === true || req.body.logout === "true")) || false;
+      const logout =
+        (req.body &&
+          (req.body.logout === true || req.body.logout === "true")) ||
+        false;
       const st = await watiClient.disconnect(req.travelTenant.id, { logout });
       // Release this user's control claim + stamp logoutAt (starts the tenant
       // relink cooldown). Best-effort — never blocks the disconnect response.
-      await waGuard.release(req.travelTenant.id, req.user.userId, req.body && req.body.deviceId, { logout });
+      await waGuard.release(
+        req.travelTenant.id,
+        req.user.userId,
+        req.body && req.body.deviceId,
+        { logout },
+      );
       // The linked account is a live mirror — disconnecting clears the imported
       // chats so a fresh connect re-fetches from scratch (no stale threads).
       const purged = await watiClient.purgeChats(req.travelTenant.id);
       res.json({ ...st, purged });
     } catch (e) {
       console.error("[travel-whatsapp] disconnect error:", e.message);
-      res.status(500).json({ error: "Failed to disconnect WhatsApp Web session", code: "WA_DISCONNECT_FAILED" });
+      res
+        .status(500)
+        .json({
+          error: "Failed to disconnect WhatsApp Web session",
+          code: "WA_DISCONNECT_FAILED",
+        });
     }
   },
 );
@@ -450,7 +530,12 @@ router.get(
       res.json(me);
     } catch (e) {
       console.error("[travel-whatsapp] me error:", e.message);
-      res.status(500).json({ error: "Failed to load WhatsApp profile", code: "WA_ME_FAILED" });
+      res
+        .status(500)
+        .json({
+          error: "Failed to load WhatsApp profile",
+          code: "WA_ME_FAILED",
+        });
     }
   },
 );
@@ -462,14 +547,23 @@ router.put(
   verifyRole(["ADMIN"]),
   async (req, res) => {
     try {
-      const name = typeof req.body?.name === "string" ? req.body.name : undefined;
-      const about = typeof req.body?.about === "string" ? req.body.about : undefined;
-      const out = await watiClient.setOwnProfile(req.travelTenant.id, { name, about });
+      const name =
+        typeof req.body?.name === "string" ? req.body.name : undefined;
+      const about =
+        typeof req.body?.about === "string" ? req.body.about : undefined;
+      const out = await watiClient.setOwnProfile(req.travelTenant.id, {
+        name,
+        about,
+      });
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me update error:", e.message);
-      res.status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({ error: e.message || "Failed to update WhatsApp profile", code: "WA_ME_UPDATE_FAILED" });
+      res
+        .status(e.message === "WhatsApp not connected" ? 409 : 500)
+        .json({
+          error: e.message || "Failed to update WhatsApp profile",
+          code: "WA_ME_UPDATE_FAILED",
+        });
     }
   },
 );
@@ -483,14 +577,24 @@ router.post(
   async (req, res) => {
     try {
       if (!req.file || !req.file.buffer || !req.file.buffer.length) {
-        return res.status(400).json({ error: "image file is required", code: "MISSING_FILE" });
+        return res
+          .status(400)
+          .json({ error: "image file is required", code: "MISSING_FILE" });
       }
-      const out = await watiClient.setOwnProfilePicture(req.travelTenant.id, req.file.buffer, req.file.mimetype);
+      const out = await watiClient.setOwnProfilePicture(
+        req.travelTenant.id,
+        req.file.buffer,
+        req.file.mimetype,
+      );
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me avatar error:", e.message);
-      res.status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({ error: e.message || "Failed to set profile picture", code: "WA_ME_AVATAR_FAILED" });
+      res
+        .status(e.message === "WhatsApp not connected" ? 409 : 500)
+        .json({
+          error: e.message || "Failed to set profile picture",
+          code: "WA_ME_AVATAR_FAILED",
+        });
     }
   },
 );
@@ -506,8 +610,12 @@ router.delete(
       res.json(out);
     } catch (e) {
       console.error("[travel-whatsapp] me avatar delete error:", e.message);
-      res.status(e.message === "WhatsApp not connected" ? 409 : 500)
-        .json({ error: e.message || "Failed to remove profile picture", code: "WA_ME_AVATAR_DEL_FAILED" });
+      res
+        .status(e.message === "WhatsApp not connected" ? 409 : 500)
+        .json({
+          error: e.message || "Failed to remove profile picture",
+          code: "WA_ME_AVATAR_DEL_FAILED",
+        });
     }
   },
 );
@@ -537,7 +645,9 @@ async function resolveTemplate(templateName) {
     }
     return _tplCache.byName.get(templateName) || null;
   } catch (e) {
-    console.error(`[travel-whatsapp] template resolve failed (positional fallback): ${e.message}`);
+    console.error(
+      `[travel-whatsapp] template resolve failed (positional fallback): ${e.message}`,
+    );
     return null;
   }
 }
@@ -573,8 +683,13 @@ const MEDIA_MIME = {
 function extractMedia(m) {
   const type = String(m.type || "").toLowerCase();
   if (!type || type === "text" || type === "reaction") return null;
-  const pathCandidate = [m.data, m.mediaPath, m.filePath, m.fileName, m.finalFileName]
-    .find((v) => typeof v === "string" && v.length > 3 && /[/.]/.test(v));
+  const pathCandidate = [
+    m.data,
+    m.mediaPath,
+    m.filePath,
+    m.fileName,
+    m.finalFileName,
+  ].find((v) => typeof v === "string" && v.length > 3 && /[/.]/.test(v));
   if (!pathCandidate && !MEDIA_MIME[type]) return null;
   return {
     metaType: type,
@@ -594,7 +709,9 @@ let s3Service = null;
 try {
   s3Service = require("../services/s3Service");
 } catch {
-  console.warn("[travel-whatsapp] s3Service unavailable — Wati media will serve via the streaming proxy");
+  console.warn(
+    "[travel-whatsapp] s3Service unavailable — Wati media will serve via the streaming proxy",
+  );
 }
 
 async function resolveInboundMediaUrl({ tenantId, fileName, mediaType }) {
@@ -605,11 +722,21 @@ async function resolveInboundMediaUrl({ tenantId, fileName, mediaType }) {
     const upstream = await watiClient.getMediaResponse(fileName);
     if (!upstream) return proxyUrl;
     const bytes = Buffer.from(await upstream.arrayBuffer());
-    const mime = upstream.headers.get("content-type") || mediaType || "application/octet-stream";
+    const mime =
+      upstream.headers.get("content-type") ||
+      mediaType ||
+      "application/octet-stream";
     const baseName = fileName.split("/").pop() || "wati-media";
-    return await s3Service.uploadFile(bytes, baseName, mime, `whatsapp/${tenantId}/wati-media`);
+    return await s3Service.uploadFile(
+      bytes,
+      baseName,
+      mime,
+      `whatsapp/${tenantId}/wati-media`,
+    );
   } catch (e) {
-    console.error(`[travel-whatsapp] media S3 persist failed (proxy fallback): ${e.message}`);
+    console.error(
+      `[travel-whatsapp] media S3 persist failed (proxy fallback): ${e.message}`,
+    );
     return proxyUrl;
   }
 }
@@ -627,18 +754,25 @@ router.get(
   async (_req, res) => {
     try {
       const out = await watiClient.getMessageTemplates();
-      const templates = (out.templates || []).map((t) => ({
-        // Wati names the template `elementName`; older payloads use `name`.
-        name: t.elementName || t.name || "",
-        body: t.body || t.bodyOriginal || "",
-        status: String(t.status || "").toUpperCase(),
-        language: (t.language && (t.language.value || t.language)) || "en",
-        category: t.category || null,
-      })).filter((t) => t.name);
+      const templates = (out.templates || [])
+        .map((t) => ({
+          // Wati names the template `elementName`; older payloads use `name`.
+          name: t.elementName || t.name || "",
+          body: t.body || t.bodyOriginal || "",
+          status: String(t.status || "").toUpperCase(),
+          language: (t.language && (t.language.value || t.language)) || "en",
+          category: t.category || null,
+        }))
+        .filter((t) => t.name);
       res.json({ templates, stub: out.stub === true });
     } catch (e) {
       console.error("[travel-whatsapp] templates error:", e.message);
-      res.status(502).json({ error: "Failed to load Wati templates", code: "WATI_TEMPLATES_FAILED" });
+      res
+        .status(502)
+        .json({
+          error: "Failed to load Wati templates",
+          code: "WATI_TEMPLATES_FAILED",
+        });
     }
   },
 );
@@ -655,11 +789,18 @@ router.post(
       const { to, body, templateName, parameters } = req.body || {};
       const phone = threadPhone(to);
       if (!phone) {
-        return res.status(400).json({ error: "to (phone) is required", code: "MISSING_TO" });
+        return res
+          .status(400)
+          .json({ error: "to (phone) is required", code: "MISSING_TO" });
       }
       const text = typeof body === "string" ? body.trim() : "";
       if (!templateName && !text) {
-        return res.status(400).json({ error: "body or templateName required", code: "MISSING_BODY" });
+        return res
+          .status(400)
+          .json({
+            error: "body or templateName required",
+            code: "MISSING_BODY",
+          });
       }
 
       // Opt-out gate — same semantics (and code) as the Meta-track send so
@@ -670,7 +811,8 @@ router.post(
       });
       if (optOut) {
         return res.status(422).json({
-          error: "Contact has opted out of WhatsApp messages (CONTACT_OPTED_OUT)",
+          error:
+            "Contact has opted out of WhatsApp messages (CONTACT_OPTED_OUT)",
           code: "CONTACT_OPTED_OUT",
         });
       }
@@ -723,7 +865,9 @@ router.post(
         // Persist the FULL rendered message (variables substituted) so the
         // chat bubble shows what the recipient actually received — not a
         // "[template] name" stub.
-        const rendered = tpl ? renderTemplateBody(tpl.body, paramNames, values) : null;
+        const rendered = tpl
+          ? renderTemplateBody(tpl.body, paramNames, values)
+          : null;
         result = await watiClient.sendTemplateMessage({
           ...common,
           templateName: String(templateName),
@@ -751,7 +895,12 @@ router.post(
       });
     } catch (e) {
       console.error("[travel-whatsapp] send error:", e.message);
-      return res.status(500).json({ error: "Failed to send WhatsApp message", code: "SEND_FAILED" });
+      return res
+        .status(500)
+        .json({
+          error: "Failed to send WhatsApp message",
+          code: "SEND_FAILED",
+        });
     }
   },
 );
@@ -763,9 +912,16 @@ async function persistOutboundMedia({ tenantId, buffer, filename, mimeType }) {
   const safeName = `${crypto.randomUUID()}-${String(filename || "file").replace(/[^\w.-]/g, "_")}`;
   if (s3Service && process.env.AWS_S3_BUCKET_NAME) {
     try {
-      return await s3Service.uploadFile(buffer, safeName, mimeType, `whatsapp/${tenantId}/wati-media`);
+      return await s3Service.uploadFile(
+        buffer,
+        safeName,
+        mimeType,
+        `whatsapp/${tenantId}/wati-media`,
+      );
     } catch (e) {
-      console.error(`[travel-whatsapp] outbound media S3 persist failed (local fallback): ${e.message}`);
+      console.error(
+        `[travel-whatsapp] outbound media S3 persist failed (local fallback): ${e.message}`,
+      );
     }
   }
   try {
@@ -774,7 +930,9 @@ async function persistOutboundMedia({ tenantId, buffer, filename, mimeType }) {
     fs.writeFileSync(path.join(dir, safeName), buffer);
     return `/uploads/wati-media/${safeName}`;
   } catch (e) {
-    console.error(`[travel-whatsapp] outbound media local persist failed: ${e.message}`);
+    console.error(
+      `[travel-whatsapp] outbound media local persist failed: ${e.message}`,
+    );
     return null;
   }
 }
@@ -795,12 +953,17 @@ router.post(
     try {
       const phone = threadPhone(req.body && req.body.to);
       if (!phone) {
-        return res.status(400).json({ error: "to (phone) is required", code: "MISSING_TO" });
+        return res
+          .status(400)
+          .json({ error: "to (phone) is required", code: "MISSING_TO" });
       }
       if (!req.file || !req.file.buffer || !req.file.buffer.length) {
-        return res.status(400).json({ error: "file is required", code: "MISSING_FILE" });
+        return res
+          .status(400)
+          .json({ error: "file is required", code: "MISSING_FILE" });
       }
-      const caption = typeof req.body.caption === "string" ? req.body.caption.trim() : "";
+      const caption =
+        typeof req.body.caption === "string" ? req.body.caption.trim() : "";
 
       const optOut = await prisma.whatsAppOptOut.findFirst({
         where: { tenantId: req.travelTenant.id, contactPhone: phone },
@@ -808,14 +971,20 @@ router.post(
       });
       if (optOut) {
         return res.status(422).json({
-          error: "Contact has opted out of WhatsApp messages (CONTACT_OPTED_OUT)",
+          error:
+            "Contact has opted out of WhatsApp messages (CONTACT_OPTED_OUT)",
           code: "CONTACT_OPTED_OUT",
         });
       }
 
       const contact = await matchContact(req.travelTenant.id, phone);
       const thread = await prisma.whatsAppThread.upsert({
-        where: { tenantId_contactPhone: { tenantId: req.travelTenant.id, contactPhone: phone } },
+        where: {
+          tenantId_contactPhone: {
+            tenantId: req.travelTenant.id,
+            contactPhone: phone,
+          },
+        },
         create: {
           tenantId: req.travelTenant.id,
           contactPhone: phone,
@@ -856,8 +1025,10 @@ router.post(
         // surfacing the cryptic raw line.
         const friendly = /failed to send file/i.test(result.error || "")
           ? "Wati refused the file upload — this Wati plan/trial doesn't allow media sends via the API (text messages still work). Try sending media from the Wati dashboard, or upgrade the Wati plan."
-          : (result.error || "Wati media send failed");
-        return res.status(502).json({ error: friendly, code: "WATI_SEND_FAILED" });
+          : result.error || "Wati media send failed";
+        return res
+          .status(502)
+          .json({ error: friendly, code: "WATI_SEND_FAILED" });
       }
       return res.status(201).json({
         success: true,
@@ -869,7 +1040,9 @@ router.post(
       });
     } catch (e) {
       console.error("[travel-whatsapp] send-media error:", e.message);
-      return res.status(500).json({ error: "Failed to send media", code: "SEND_MEDIA_FAILED" });
+      return res
+        .status(500)
+        .json({ error: "Failed to send media", code: "SEND_MEDIA_FAILED" });
     }
   },
 );
@@ -1149,12 +1322,16 @@ router.post("/whatsapp/webhook", async (req, res) => {
         return res.status(401).json({ error: "invalid webhook token" });
       }
     } else {
-      console.warn("[travel-whatsapp] webhook accepted WITHOUT token guard — set WATI_WEBHOOK_TOKEN for production");
+      console.warn(
+        "[travel-whatsapp] webhook accepted WITHOUT token guard — set WATI_WEBHOOK_TOKEN for production",
+      );
     }
 
     const tenantId = await resolveWebhookTenant(req);
     if (!tenantId) {
-      console.error("[travel-whatsapp] webhook: no travel tenant resolvable — event dropped");
+      console.error(
+        "[travel-whatsapp] webhook: no travel tenant resolvable — event dropped",
+      );
       return res.json({ received: true, dropped: true });
     }
 
@@ -1167,18 +1344,33 @@ router.post("/whatsapp/webhook", async (req, res) => {
     // liberally on the verb. Failure wins the tie-break: Meta rejections
     // (e.g. "(#131037) display name approval") must flip the row to FAILED
     // with the reason, or the operator sees a grey SENT tick forever.
-    if (/delivered/i.test(eventType) || /read/i.test(eventType) || /fail/i.test(eventType)) {
+    if (
+      /delivered/i.test(eventType) ||
+      /read/i.test(eventType) ||
+      /fail/i.test(eventType)
+    ) {
       const providerMsgId = p.whatsappMessageId || p.id || null;
       const newStatus = /fail/i.test(eventType)
         ? "FAILED"
-        : /read/i.test(eventType) ? "READ" : "DELIVERED";
+        : /read/i.test(eventType)
+          ? "READ"
+          : "DELIVERED";
       if (providerMsgId) {
-        const failDetail = newStatus === "FAILED"
-          ? String(p.failedDetail || p.failureReason || p.errorMessage || "send failed at provider")
-          : null;
+        const failDetail =
+          newStatus === "FAILED"
+            ? String(
+                p.failedDetail ||
+                  p.failureReason ||
+                  p.errorMessage ||
+                  "send failed at provider",
+              )
+            : null;
         const updated = await prisma.whatsAppMessage.updateMany({
           where: { tenantId, providerMsgId: String(providerMsgId) },
-          data: { status: newStatus, ...(failDetail ? { errorMessage: failDetail } : {}) },
+          data: {
+            status: newStatus,
+            ...(failDetail ? { errorMessage: failDetail } : {}),
+          },
         });
         if (updated.count > 0 && req.io) {
           req.io.to(`tenant:${tenantId}`).emit("whatsapp:status", {
@@ -1193,10 +1385,19 @@ router.post("/whatsapp/webhook", async (req, res) => {
     }
 
     // ── Inbound reaction (no own bubble — attaches to the target) ──
-    if (String(p.type || "").toLowerCase() === "reaction" && p.owner !== true && (p.waId || p.from)) {
+    if (
+      String(p.type || "").toLowerCase() === "reaction" &&
+      p.owner !== true &&
+      (p.waId || p.from)
+    ) {
       const reactPhone = threadPhone(p.waId || p.from);
       if (reactPhone) {
-        await applyReaction({ tenantId, phone: reactPhone, item: p, io: req.io });
+        await applyReaction({
+          tenantId,
+          phone: reactPhone,
+          item: p,
+          io: req.io,
+        });
       }
       return res.json({ received: true, reaction: true });
     }
@@ -1204,16 +1405,25 @@ router.post("/whatsapp/webhook", async (req, res) => {
     // ── Inbound customer message ─────────────────────────────────
     // owner === true marks operator-sent echoes (sessionMessageSent /
     // templateMessageSent) — we already persisted those at send time.
-    const isInbound = eventType === "message" && p.owner !== true && (p.waId || p.from);
+    const isInbound =
+      eventType === "message" && p.owner !== true && (p.waId || p.from);
     if (!isInbound) {
-      return res.json({ received: true, ignored: eventType || "(no eventType)" });
+      return res.json({
+        received: true,
+        ignored: eventType || "(no eventType)",
+      });
     }
 
     const phone = threadPhone(p.waId || p.from);
-    if (!phone) return res.json({ received: true, dropped: "unparseable waId" });
+    if (!phone)
+      return res.json({ received: true, dropped: "unparseable waId" });
     const media = extractMedia(p);
     const webhookMediaUrl = media
-      ? await resolveInboundMediaUrl({ tenantId, fileName: media.fileName, mediaType: media.mediaType })
+      ? await resolveInboundMediaUrl({
+          tenantId,
+          fileName: media.fileName,
+          mediaType: media.mediaType,
+        })
       : null;
     const body = typeof p.text === "string" && p.text !== "" ? p.text : null;
 
@@ -1233,9 +1443,13 @@ router.post("/whatsapp/webhook", async (req, res) => {
         status: "OPEN",
         snoozedUntil: null,
       };
-      if (!existing.assignedToId) updates.unreadCount = (existing.unreadCount || 0) + 1;
+      if (!existing.assignedToId)
+        updates.unreadCount = (existing.unreadCount || 0) + 1;
       if (!existing.contactId && contact) updates.contactId = contact.id;
-      thread = await prisma.whatsAppThread.update({ where: { id: existing.id }, data: updates });
+      thread = await prisma.whatsAppThread.update({
+        where: { id: existing.id },
+        data: updates,
+      });
     } else {
       thread = await prisma.whatsAppThread.create({
         data: {
@@ -1260,7 +1474,7 @@ router.post("/whatsapp/webhook", async (req, res) => {
         direction: "INBOUND",
         status: "DELIVERED",
         providerMsgId: p.whatsappMessageId || p.id || null,
-        metaType: media ? media.metaType : (p.type ? String(p.type) : "text"),
+        metaType: media ? media.metaType : p.type ? String(p.type) : "text",
         tenantId,
         threadId: thread.id,
         contactId: contact ? contact.id : null,
@@ -1280,7 +1494,11 @@ router.post("/whatsapp/webhook", async (req, res) => {
       });
     }
 
-    return res.json({ received: true, threadId: thread.id, messageId: message.id });
+    return res.json({
+      received: true,
+      threadId: thread.id,
+      messageId: message.id,
+    });
   } catch (e) {
     console.error("[travel-whatsapp] webhook error:", e.message);
     return res.json({ received: true, error: true });

--- a/backend/test/lib/whatsappSessionGuard.test.js
+++ b/backend/test/lib/whatsappSessionGuard.test.js
@@ -1,0 +1,195 @@
+// Unit tests for backend/lib/whatsappSessionGuard.js
+//
+// The guard is the per-user device-lock + per-tenant relink-cooldown layer over
+// the SHARED WhatsApp Web session. These tests pin the decision logic in
+// isolation by monkey-patching the shared prisma singleton (the project's CJS
+// self-mocking pattern — vitest `inline: [/backend\/lib\//]` means the SUT and
+// this test share one prisma instance). writeAudit is left to run against a
+// stubbed auditLog so it stays a harmless no-op.
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import guard from '../../lib/whatsappSessionGuard.js';
+
+const TENANT = 7;
+const USER = 42;
+const DEV = 'device-A';
+
+beforeEach(() => {
+  // Reset env to defaults so per-test overrides are isolated.
+  delete process.env.WA_DEVICE_LOCK;
+  delete process.env.WA_DEVICE_HEARTBEAT_TTL_MS;
+  delete process.env.WA_RELINK_COOLDOWN_MS;
+
+  if (!prisma.whatsAppWebSession) prisma.whatsAppWebSession = {};
+  prisma.whatsAppWebSession.updateMany = vi.fn().mockResolvedValue({ count: 0 });
+  prisma.whatsAppWebSession.findMany = vi.fn().mockResolvedValue([]);
+  prisma.whatsAppWebSession.findFirst = vi.fn().mockResolvedValue(null);
+  prisma.whatsAppWebSession.findUnique = vi.fn().mockResolvedValue(null);
+  prisma.whatsAppWebSession.create = vi.fn().mockImplementation(({ data }) => Promise.resolve({ id: 1, ...data }));
+  prisma.whatsAppWebSession.update = vi.fn().mockImplementation(({ data }) => Promise.resolve({ id: 1, ...data }));
+
+  // Keep writeAudit a no-op that never throws.
+  if (!prisma.auditLog) prisma.auditLog = {};
+  prisma.auditLog.findFirst = vi.fn().mockResolvedValue(null);
+  prisma.auditLog.create = vi.fn().mockResolvedValue({ id: 1 });
+});
+
+describe('claim — per-user device lock', () => {
+  test('same user on a DIFFERENT device is blocked with WA_DEVICE_LOCKED + activeDevice', async () => {
+    const loginAt = new Date(Date.now() - 60_000);
+    prisma.whatsAppWebSession.findMany.mockResolvedValue([
+      { id: 9, deviceId: 'device-B', deviceLabel: 'Yasin · Chrome on Windows', ip: '1.2.3.4', loginAt },
+    ]);
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: false });
+    expect(res.allowed).toBe(false);
+    expect(res.code).toBe('WA_DEVICE_LOCKED');
+    expect(res.activeDevice.deviceLabel).toBe('Yasin · Chrome on Windows');
+    expect(res.activeDevice.ip).toBe('1.2.3.4');
+    // No new claim row created for a blocked attempt.
+    expect(prisma.whatsAppWebSession.create).not.toHaveBeenCalled();
+  });
+
+  test('the device-lock query is scoped to THIS user, so a different user is never consulted', async () => {
+    // findMany returns [] (a different user's row would not match the userId
+    // filter) → allowed for this user.
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: true });
+    expect(res.allowed).toBe(true);
+    const where = prisma.whatsAppWebSession.findMany.mock.calls[0][0].where;
+    expect(where.userId).toBe(USER);
+    expect(where.status).toBe('ACTIVE');
+    expect(where.deviceId).toEqual({ not: DEV });
+  });
+
+  test('stale claims are expired before the lock check', async () => {
+    process.env.WA_DEVICE_HEARTBEAT_TTL_MS = '120000';
+    await guard.claim(TENANT, USER, DEV, { isConnected: true });
+    expect(prisma.whatsAppWebSession.updateMany).toHaveBeenCalled();
+    const arg = prisma.whatsAppWebSession.updateMany.mock.calls[0][0];
+    expect(arg.where.status).toBe('ACTIVE');
+    expect(arg.where.lastHeartbeat.lt).toBeInstanceOf(Date);
+    expect(arg.data.status).toBe('EXPIRED');
+  });
+});
+
+describe('claim — per-tenant relink cooldown', () => {
+  test('blocks a relink when disconnected and within cooldown', async () => {
+    process.env.WA_RELINK_COOLDOWN_MS = '900000'; // 15m
+    prisma.whatsAppWebSession.findFirst.mockResolvedValue({ logoutAt: new Date(Date.now() - 60_000) });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: false });
+    expect(res.allowed).toBe(false);
+    expect(res.code).toBe('WA_RELINK_COOLDOWN');
+    expect(res.cooldownRemainingMs).toBeGreaterThan(0);
+  });
+
+  test('does NOT apply cooldown when the shared session is already CONNECTED (no QR generated)', async () => {
+    prisma.whatsAppWebSession.findFirst.mockResolvedValue({ logoutAt: new Date(Date.now() - 60_000) });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: true });
+    expect(res.allowed).toBe(true);
+    // The cooldown lookup should be skipped entirely when connected + no reset.
+    expect(prisma.whatsAppWebSession.findFirst).not.toHaveBeenCalled();
+  });
+
+  test('cooldown expired → allowed', async () => {
+    process.env.WA_RELINK_COOLDOWN_MS = '60000'; // 1m
+    prisma.whatsAppWebSession.findFirst.mockResolvedValue({ logoutAt: new Date(Date.now() - 120_000) });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: false });
+    expect(res.allowed).toBe(true);
+  });
+
+  test('reset:true is subject to cooldown even when connected', async () => {
+    process.env.WA_RELINK_COOLDOWN_MS = '900000';
+    prisma.whatsAppWebSession.findFirst.mockResolvedValue({ logoutAt: new Date(Date.now() - 60_000) });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: true, reset: true });
+    expect(res.allowed).toBe(false);
+    expect(res.code).toBe('WA_RELINK_COOLDOWN');
+  });
+});
+
+describe('claim — allow / upsert', () => {
+  test('new device → creates an ACTIVE row and reports LOGIN (reconnect:false)', async () => {
+    const res = await guard.claim(TENANT, USER, DEV, { deviceLabel: 'lbl', ip: '9.9.9.9', isConnected: false });
+    expect(res.allowed).toBe(true);
+    expect(res.reconnect).toBe(false);
+    expect(prisma.whatsAppWebSession.create).toHaveBeenCalledTimes(1);
+    const data = prisma.whatsAppWebSession.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({ tenantId: TENANT, userId: USER, deviceId: DEV, status: 'ACTIVE' });
+  });
+
+  test('same device already ACTIVE → updates (no dup) and reports reconnect:true', async () => {
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue({ id: 5, status: 'ACTIVE', deviceId: DEV });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: true });
+    expect(res.allowed).toBe(true);
+    expect(res.reconnect).toBe(true);
+    expect(prisma.whatsAppWebSession.create).not.toHaveBeenCalled();
+    expect(prisma.whatsAppWebSession.update).toHaveBeenCalledTimes(1);
+    // A live reconnect must NOT reset loginAt.
+    expect(prisma.whatsAppWebSession.update.mock.calls[0][0].data.loginAt).toBeUndefined();
+  });
+
+  test('reactivating a LOGGED_OUT row refreshes loginAt', async () => {
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue({ id: 5, status: 'LOGGED_OUT', deviceId: DEV });
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: false });
+    expect(res.allowed).toBe(true);
+    expect(res.reconnect).toBe(false);
+    expect(prisma.whatsAppWebSession.update.mock.calls[0][0].data.loginAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('claim — bypass', () => {
+  test('WA_DEVICE_LOCK=off → allowed bypass, no lock query', async () => {
+    process.env.WA_DEVICE_LOCK = 'off';
+    const res = await guard.claim(TENANT, USER, DEV, { isConnected: false });
+    expect(res.allowed).toBe(true);
+    expect(res.bypass).toBe(true);
+    expect(prisma.whatsAppWebSession.findMany).not.toHaveBeenCalled();
+  });
+
+  test('missing deviceId → allowed bypass (backward compatible)', async () => {
+    const res = await guard.claim(TENANT, USER, undefined, { isConnected: false });
+    expect(res.allowed).toBe(true);
+    expect(res.bypass).toBe(true);
+    expect(prisma.whatsAppWebSession.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('heartbeat', () => {
+  test('ACTIVE claim → ok:true and refreshes lastHeartbeat', async () => {
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue({ id: 3, status: 'ACTIVE' });
+    const res = await guard.heartbeat(TENANT, USER, DEV);
+    expect(res).toEqual({ ok: true, lost: false });
+    expect(prisma.whatsAppWebSession.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 3 } }),
+    );
+  });
+
+  test('no row / not ACTIVE → lost:true', async () => {
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue(null);
+    expect(await guard.heartbeat(TENANT, USER, DEV)).toEqual({ ok: false, lost: true });
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue({ id: 3, status: 'EXPIRED' });
+    expect(await guard.heartbeat(TENANT, USER, DEV)).toEqual({ ok: false, lost: true });
+  });
+
+  test('no deviceId → ok:false, lost:false', async () => {
+    expect(await guard.heartbeat(TENANT, USER, undefined)).toEqual({ ok: false, lost: false });
+  });
+});
+
+describe('release', () => {
+  test('marks the claim LOGGED_OUT + stamps logoutAt (starts cooldown)', async () => {
+    prisma.whatsAppWebSession.updateMany.mockResolvedValue({ count: 1 });
+    const res = await guard.release(TENANT, USER, DEV, { logout: true });
+    expect(res.released).toBe(1);
+    const arg = prisma.whatsAppWebSession.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ tenantId: TENANT, userId: USER, deviceId: DEV });
+    expect(arg.data.status).toBe('LOGGED_OUT');
+    expect(arg.data.logoutAt).toBeInstanceOf(Date);
+  });
+
+  test('no deviceId → releases all of the user\'s ACTIVE claims', async () => {
+    prisma.whatsAppWebSession.updateMany.mockResolvedValue({ count: 2 });
+    await guard.release(TENANT, USER, undefined, {});
+    const arg = prisma.whatsAppWebSession.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ tenantId: TENANT, userId: USER, status: 'ACTIVE' });
+  });
+});

--- a/backend/test/routes/travel-whatsapp.test.js
+++ b/backend/test/routes/travel-whatsapp.test.js
@@ -64,6 +64,16 @@ prisma.user = prisma.user || {};
 prisma.user.findUnique = vi.fn().mockResolvedValue({ role: 'ADMIN', subBrandAccess: null });
 prisma.revokedToken = prisma.revokedToken || {};
 prisma.revokedToken.findUnique = vi.fn().mockResolvedValue(null);
+// Device-session governance (whatsappSessionGuard) + audit sink.
+prisma.whatsAppWebSession = {
+  updateMany: vi.fn(),
+  findMany: vi.fn(),
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+};
+prisma.auditLog = { ...(prisma.auditLog || {}), findFirst: vi.fn(), create: vi.fn() };
 
 import express from 'express';
 import request from 'supertest';
@@ -122,6 +132,18 @@ beforeEach(() => {
   prisma.tenant.findFirst.mockReset().mockResolvedValue(TRAVEL_TENANT);
   prisma.user.findUnique.mockReset().mockResolvedValue({ role: 'ADMIN', subBrandAccess: null });
   prisma.revokedToken.findUnique.mockReset().mockResolvedValue(null);
+  // Device-session governance defaults: no stale rows, no lock, no cooldown,
+  // no existing claim → claim() takes the allow+create path.
+  prisma.whatsAppWebSession.updateMany.mockReset().mockResolvedValue({ count: 0 });
+  prisma.whatsAppWebSession.findMany.mockReset().mockResolvedValue([]);
+  prisma.whatsAppWebSession.findFirst.mockReset().mockResolvedValue(null);
+  prisma.whatsAppWebSession.findUnique.mockReset().mockResolvedValue(null);
+  prisma.whatsAppWebSession.create.mockReset().mockResolvedValue({ id: 1, deviceId: 'device-A' });
+  prisma.whatsAppWebSession.update.mockReset().mockResolvedValue({ id: 1, deviceId: 'device-A' });
+  prisma.auditLog.findFirst.mockReset().mockResolvedValue(null);
+  prisma.auditLog.create.mockReset().mockResolvedValue({ id: 1 });
+  delete process.env.WA_DEVICE_LOCK;
+  delete process.env.WA_RELINK_COOLDOWN_MS;
   delete process.env.WATI_WEBHOOK_TOKEN;
 });
 
@@ -337,6 +359,94 @@ describe('WhatsApp Web QR lifecycle', () => {
     expect(prisma.whatsAppMessage.deleteMany).toHaveBeenCalledWith({ where: { tenantId: 3 } });
     expect(prisma.whatsAppThread.deleteMany).toHaveBeenCalledWith({ where: { tenantId: 3 } });
     expect(res.body.purged).toEqual({ threads: 2, messages: 6 });
+  });
+});
+
+// ─── Device-session governance (per-user device lock + relink cooldown) ──
+// The /connect route runs whatsappSessionGuard.claim() BEFORE launching the
+// shared session, so a blocked attempt returns 409 and never reaches the
+// engine. The whatsAppWebSession prisma model is mocked; NODE_ENV=test keeps
+// the engine in stub mode.
+
+describe('WhatsApp device-session lock', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('29. same user on another device → 409 WA_DEVICE_LOCKED (no connect, no claim)', async () => {
+    const connectSpy = vi.spyOn(watiClient, 'connect');
+    prisma.whatsAppWebSession.findMany.mockResolvedValue([
+      { id: 9, deviceId: 'device-B', deviceLabel: 'Yasin · Chrome on Windows', ip: '10.0.0.9', loginAt: new Date(Date.now() - 60_000) },
+    ]);
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/connect')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN', { userId: 7, tenantId: 3 })}`)
+      .send({ deviceId: 'device-A' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('WA_DEVICE_LOCKED');
+    expect(res.body.activeDevice).toMatchObject({ deviceLabel: 'Yasin · Chrome on Windows', ip: '10.0.0.9' });
+    // Blocked → the shared session was never touched and no claim row created.
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(prisma.whatsAppWebSession.create).not.toHaveBeenCalled();
+  });
+
+  test('30. recent disconnect + within cooldown → 409 WA_RELINK_COOLDOWN', async () => {
+    prisma.whatsAppWebSession.findFirst.mockResolvedValue({ logoutAt: new Date(Date.now() - 60_000) });
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/connect')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .send({ deviceId: 'device-A' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('WA_RELINK_COOLDOWN');
+    expect(res.body.cooldownRemainingMs).toBeGreaterThan(0);
+  });
+
+  test('31. allowed connect records a claim row + returns 200 state', async () => {
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/connect')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .send({ deviceId: 'device-A' });
+    expect(res.status).toBe(200);
+    expect(res.body.connected).toBe(false);
+    expect(prisma.whatsAppWebSession.create).toHaveBeenCalledTimes(1);
+    const data = prisma.whatsAppWebSession.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({ tenantId: 3, userId: 7, deviceId: 'device-A', status: 'ACTIVE' });
+  });
+
+  test('32. WA_DEVICE_LOCK=off bypasses the gate (legacy behavior preserved)', async () => {
+    process.env.WA_DEVICE_LOCK = 'off';
+    prisma.whatsAppWebSession.findMany.mockResolvedValue([
+      { id: 9, deviceId: 'device-B', deviceLabel: 'other', ip: '1.1.1.1', loginAt: new Date() },
+    ]);
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/connect')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .send({ deviceId: 'device-A' });
+    expect(res.status).toBe(200); // lock ignored → connect proceeds
+  });
+
+  test('33. POST /heartbeat (any role) refreshes an ACTIVE claim → { ok:true }', async () => {
+    prisma.whatsAppWebSession.findUnique.mockResolvedValue({ id: 3, status: 'ACTIVE' });
+    prisma.user.findUnique.mockResolvedValue({ role: 'USER', subBrandAccess: null });
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/heartbeat')
+      .set('Authorization', `Bearer ${tokenFor('USER')}`)
+      .send({ deviceId: 'device-A' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, lost: false });
+  });
+
+  test('34. POST /disconnect releases the claim (LOGGED_OUT + logoutAt)', async () => {
+    prisma.whatsAppWebSession.updateMany.mockResolvedValue({ count: 1 });
+    const res = await request(makeApp())
+      .post('/api/travel/whatsapp/disconnect')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .send({ logout: true, deviceId: 'device-A' });
+    expect(res.status).toBe(200);
+    // release() marks the row LOGGED_OUT + stamps logoutAt (starts cooldown).
+    const relCall = prisma.whatsAppWebSession.updateMany.mock.calls.find(
+      (c) => c[0].data && c[0].data.status === 'LOGGED_OUT',
+    );
+    expect(relCall).toBeTruthy();
+    expect(relCall[0].data.logoutAt).toBeInstanceOf(Date);
   });
 });
 

--- a/frontend/src/pages/travel/WhatsAppChat.jsx
+++ b/frontend/src/pages/travel/WhatsAppChat.jsx
@@ -33,6 +33,7 @@ import { io as socketIO } from 'socket.io-client';
 import { Link } from 'react-router-dom';
 import { AuthContext } from '../../App';
 import { fetchApi, getAuthToken } from '../../utils/api';
+import { getDeviceId } from '../../utils/deviceId';
 import { useNotify } from '../../utils/notify';
 import { WhatsAppThreadsContext } from '../wellness/whatsapp/WhatsAppThreadsContext';
 import { ImageLightbox, openImage } from '../wellness/whatsapp/ImageLightbox';
@@ -97,6 +98,15 @@ export default function TravelWhatsAppChat() {
   const [showQrModal, setShowQrModal] = useState(false);
   const [qrImage, setQrImage] = useState(null);
   const [connecting, setConnecting] = useState(false);
+  // Device-session lock warning (per-user device lock / relink cooldown). Set
+  // from a 409 on /connect; shown inside the QR modal. null = no block.
+  // Shape: { code, message, activeDevice?, cooldownRemainingMs? }.
+  const [waLock, setWaLock] = useState(null);
+  // Anti-ban guidelines popup — opened from the caution headline in the QR modal.
+  const [showWaGuide, setShowWaGuide] = useState(false);
+  // Tracks whether THIS device currently holds the control claim, so we only
+  // warn "you lost control" to a device that actually had it (not to viewers).
+  const waHolderRef = useRef(false);
   // "My Profile" modal — view + edit the linked WhatsApp account's own DP /
   // name / about (admin).
   const [showProfile, setShowProfile] = useState(false);
@@ -409,13 +419,17 @@ export default function TravelWhatsAppChat() {
   // phone (WhatsApp → Linked devices) flips state to CONNECTED.
   const startConnect = async (reset = false) => {
     setQrImage(null);
+    setWaLock(null);
     setConnecting(true);
     setShowQrModal(true);
     try {
       const data = await fetchApi('/api/travel/whatsapp/connect', {
         method: 'POST',
-        body: JSON.stringify({ reset }),
+        body: JSON.stringify({ reset, deviceId: getDeviceId() }),
+        silent: true, // we surface connect errors ourselves (lock warning vs toast)
       });
+      // Connect was allowed → this device now holds the control claim.
+      waHolderRef.current = true;
       if (data?.qr) setQrImage(data.qr);
       setWatiStatus((prev) => ({ ...(prev || {}), ...data }));
       if (data?.connected) {
@@ -425,9 +439,15 @@ export default function TravelWhatsAppChat() {
       }
       await refreshWaStatus();
     } catch (err) {
+      setConnecting(false);
+      // Per-user device lock / relink cooldown → keep the modal open and show
+      // the structured warning instead of a bare toast.
+      if (err.code === 'WA_DEVICE_LOCKED' || err.code === 'WA_RELINK_COOLDOWN') {
+        setWaLock({ code: err.code, message: err.message, ...(err.data || {}) });
+        return;
+      }
       notify.error(err.message || 'Failed to start WhatsApp connection.');
       setShowQrModal(false);
-      setConnecting(false);
     }
   };
 
@@ -521,8 +541,9 @@ export default function TravelWhatsAppChat() {
     try {
       const data = await fetchApi('/api/travel/whatsapp/disconnect', {
         method: 'POST',
-        body: JSON.stringify({ logout }),
+        body: JSON.stringify({ logout, deviceId: getDeviceId() }),
       });
+      waHolderRef.current = false;
       const purged = data?.purged?.threads || 0;
       notify.info(`WhatsApp disconnected — cleared ${purged} chats.`);
       // Clear the open conversation + the now-empty list.
@@ -559,6 +580,40 @@ export default function TravelWhatsAppChat() {
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showQrModal]);
+
+  // ─── Device-session heartbeat ───────────────────────────────
+  // While this device is driving the connection (connected, or the QR modal is
+  // open mid-link), ping every 45s so the control claim doesn't go stale and
+  // free the per-user device lock. The backend only refreshes a claim that
+  // actually exists for this (user, device), so viewers pinging is a harmless
+  // no-op. If we learn our claim was lost (expired, or taken by this user's
+  // other device), tell the operator once.
+  useEffect(() => {
+    const active = watiStatus?.connected || showQrModal;
+    if (!active) return undefined;
+    let stopped = false;
+    const ping = async () => {
+      try {
+        const out = await fetchApi('/api/travel/whatsapp/heartbeat', {
+          method: 'POST',
+          body: JSON.stringify({ deviceId: getDeviceId() }),
+          silent: true,
+        });
+        if (out?.ok) {
+          waHolderRef.current = true;
+        } else if (out?.lost && waHolderRef.current) {
+          waHolderRef.current = false;
+          if (!stopped) notify.info('WhatsApp control moved to another of your devices.');
+        }
+      } catch {
+        /* transient — next tick retries */
+      }
+    };
+    ping();
+    const id = setInterval(ping, 45000);
+    return () => { stopped = true; clearInterval(id); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watiStatus?.connected, showQrModal]);
 
   // ─── Load APPROVED templates for the picker ─────────────────
   // Travel diff: templates come from the WATI account (the travel
@@ -1603,79 +1658,300 @@ export default function TravelWhatsAppChat() {
         {showQrModal && (
           <div
             data-testid="wa-qr-modal"
-            onClick={() => { setShowQrModal(false); setConnecting(false); }}
+            onClick={() => { setShowQrModal(false); setConnecting(false); setWaLock(null); setShowWaGuide(false); }}
             style={{
               position: 'fixed', inset: 0, zIndex: 1000,
               background: 'rgba(0,0,0,0.5)',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
+              padding: '1rem',
             }}
           >
             <div
               onClick={(e) => e.stopPropagation()}
               style={{
-                background: 'var(--bg-secondary, #fff)',
-                borderRadius: 12,
-                padding: '1.5rem',
-                width: 'min(92vw, 380px)',
-                textAlign: 'center',
+                background: 'var(--bg-color, #fff)',
+                borderRadius: 14,
+                padding: '1.75rem',
+                width: waLock ? 'min(94vw, 440px)' : 'min(96vw, 660px)',
+                maxHeight: '92vh', overflowY: 'auto',
                 border: '1px solid var(--border-color)',
+                boxShadow: '0 24px 60px rgba(0,0,0,0.35)',
               }}
             >
-              <h3 style={{ margin: '0 0 0.25rem', color: 'var(--text-primary)' }}>
-                Link WhatsApp
-              </h3>
-              <p style={{ margin: '0 0 1rem', fontSize: 13, color: 'var(--text-secondary)' }}>
-                On your phone open <b>WhatsApp → Linked devices → Link a device</b>, then scan this code.
-              </p>
+              {waLock ? (
+                <>
+                  <h3 style={{ margin: '0 0 0.75rem', color: 'var(--text-primary)', textAlign: 'center' }}>
+                    Can’t connect right now
+                  </h3>
+                  <div
+                    data-testid="wa-lock-warning"
+                    style={{
+                      margin: '0 0 1.25rem', padding: '0.9rem 1rem', textAlign: 'left',
+                      borderRadius: 10, fontSize: 13.5, lineHeight: 1.55,
+                      color: 'var(--text-primary)',
+                      background: 'var(--warning-bg, rgba(234,179,8,0.12))',
+                      border: '1px solid var(--warning-color, #eab308)',
+                    }}
+                  >
+                    <p style={{ margin: '0 0 0.5rem', fontWeight: 700 }}>
+                      {waLock.code === 'WA_RELINK_COOLDOWN'
+                        ? 'Reconnect cooldown active'
+                        : 'WhatsApp is controlled from another device'}
+                    </p>
+                    <p style={{ margin: 0, color: 'var(--text-primary)', opacity: 0.85 }}>{waLock.message}</p>
+                    {waLock.activeDevice && (
+                      <ul style={{ margin: '0.7rem 0 0', paddingLeft: 18, color: 'var(--text-primary)', opacity: 0.85 }}>
+                        {waLock.activeDevice.deviceLabel && (
+                          <li>Device: <b>{waLock.activeDevice.deviceLabel}</b></li>
+                        )}
+                        {waLock.activeDevice.loginAt && (
+                          <li>Connected: {new Date(waLock.activeDevice.loginAt).toLocaleString()}</li>
+                        )}
+                        {waLock.activeDevice.ip && <li>IP: {waLock.activeDevice.ip}</li>}
+                      </ul>
+                    )}
+                    {waLock.code === 'WA_RELINK_COOLDOWN' && waLock.cooldownRemainingMs > 0 && (
+                      <p style={{ margin: '0.7rem 0 0', color: 'var(--text-primary)', opacity: 0.85 }}>
+                        Try again in about {Math.ceil(waLock.cooldownRemainingMs / 60000)} minute(s).
+                      </p>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+                    <button
+                      type="button"
+                      data-testid="wa-lock-retry-btn"
+                      onClick={() => startConnect(false)}
+                      style={{
+                        fontSize: 13, fontWeight: 600, padding: '8px 18px',
+                        borderRadius: 8, border: 'none', cursor: 'pointer',
+                        color: '#fff', background: 'var(--primary-color, #25D366)',
+                      }}
+                    >
+                      Try again
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setShowQrModal(false); setConnecting(false); setWaLock(null); }}
+                      style={{
+                        fontSize: 13, padding: '8px 18px',
+                        borderRadius: 8, border: '1px solid var(--border-color)',
+                        cursor: 'pointer', background: 'transparent',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      Close
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <h3 style={{ margin: '0 0 1.25rem', color: 'var(--text-primary)', textAlign: 'center', fontSize: 19 }}>
+                    Link WhatsApp
+                  </h3>
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 250px), 1fr))',
+                    gap: 28, alignItems: 'center',
+                  }}>
+                    {/* Left — numbered connect steps + caution headline */}
+                    <div style={{ textAlign: 'left' }}>
+                      <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 14 }}>
+                        Scan to link this device
+                      </div>
+                      {[
+                        <>Open <b>WhatsApp</b> on your phone.</>,
+                        <>Go to <b>Settings → Linked devices → Link a device</b>.</>,
+                        <>Point your phone at this screen to scan the QR code.</>,
+                      ].map((step, i) => (
+                        <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 12 }}>
+                          <span style={{
+                            flex: '0 0 auto', width: 22, height: 22, borderRadius: '50%',
+                            border: '1.5px solid var(--text-primary)',
+                            color: 'var(--text-primary)',
+                            fontSize: 12, fontWeight: 700,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          }}>{i + 1}</span>
+                          <span style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--text-primary)' }}>{step}</span>
+                        </div>
+                      ))}
+
+                      {/* Highlighted caution headline — opens the full anti-ban
+                          guidelines in an in-place popup (no new tab / redirect). */}
+                      <button
+                        type="button"
+                        data-testid="wa-safety-open"
+                        onClick={() => setShowWaGuide(true)}
+                        style={{
+                          marginTop: 8, width: '100%', textAlign: 'left', cursor: 'pointer',
+                          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+                          padding: '11px 13px', borderRadius: 10, fontSize: 12.5, fontWeight: 600,
+                          color: 'var(--text-primary)',
+                          background: 'var(--warning-bg, rgba(234,179,8,0.12))',
+                          border: '1px solid var(--warning-color, #eab308)',
+                        }}
+                      >
+                        <span>⚠️ Read WhatsApp safety measures</span>
+                        <span aria-hidden="true" style={{ opacity: 0.7 }}>›</span>
+                      </button>
+                    </div>
+
+                    {/* Right — QR / status */}
+                    <div style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      flexDirection: 'column', gap: 10, minHeight: 260,
+                    }}>
+                      {qrImage ? (
+                        <img
+                          src={qrImage}
+                          alt="WhatsApp linking QR code"
+                          width={240}
+                          height={240}
+                          style={{ borderRadius: 10, background: '#fff', padding: 8 }}
+                        />
+                      ) : watiStatus?.state === 'AUTH_FAILURE' ? (
+                        <span style={{ color: 'var(--error-color, #ef4444)', fontSize: 13, padding: '0 8px', textAlign: 'center' }}>
+                          {watiStatus.lastError || 'Could not start WhatsApp. Try Reset & reconnect.'}
+                        </span>
+                      ) : (
+                        <span style={{ color: 'var(--text-secondary)', fontSize: 13, textAlign: 'center' }}>
+                          {connecting ? 'Starting WhatsApp… (first launch can take ~15–30s)' : 'Waiting for QR…'}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: '1.5rem', flexWrap: 'wrap' }}>
+                    {/* Reset & reconnect: wipes a stale/locked session and forces a
+                        fresh QR — the fix when it sticks on "Starting WhatsApp…". */}
+                    <button
+                      type="button"
+                      data-testid="wa-reset-btn"
+                      onClick={() => startConnect(true)}
+                      style={{
+                        fontSize: 13, fontWeight: 600, padding: '8px 18px',
+                        borderRadius: 8, border: 'none', cursor: 'pointer',
+                        color: '#fff', background: 'var(--primary-color, #25D366)',
+                      }}
+                    >
+                      Reset &amp; reconnect
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setShowQrModal(false); setConnecting(false); setWaLock(null); }}
+                      style={{
+                        fontSize: 13, padding: '8px 18px',
+                        borderRadius: 8, border: '1px solid var(--border-color)',
+                        cursor: 'pointer', background: 'transparent',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      Close
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ─── Anti-ban guidelines popup (opened from the caution headline) ───
+            In-place overlay above the QR modal — no navigation / new tab. */}
+        {showWaGuide && (
+          <div
+            data-testid="wa-safety-guide"
+            onClick={() => setShowWaGuide(false)}
+            style={{
+              position: 'fixed', inset: 0, zIndex: 1100,
+              background: 'rgba(0,0,0,0.55)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              padding: '1rem',
+            }}
+          >
+            <div
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                background: 'var(--bg-color, #fff)',
+                borderRadius: 14, padding: '1.75rem',
+                width: 'min(96vw, 560px)', maxHeight: '88vh', overflowY: 'auto',
+                border: '1px solid var(--border-color)',
+                boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
+              }}
+            >
               <div style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                flexDirection: 'column', gap: 10,
-                minHeight: 260,
+                display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6,
+                paddingBottom: 12, borderBottom: '1px solid var(--border-color)',
               }}>
-                {qrImage ? (
-                  <img
-                    src={qrImage}
-                    alt="WhatsApp linking QR code"
-                    width={260}
-                    height={260}
-                    style={{ borderRadius: 8 }}
-                  />
-                ) : watiStatus?.state === 'AUTH_FAILURE' ? (
-                  <span style={{ color: 'var(--error-color, #ef4444)', fontSize: 13, padding: '0 8px' }}>
-                    {watiStatus.lastError || 'Could not start WhatsApp. Try Reset & reconnect.'}
-                  </span>
-                ) : (
-                  <span style={{ color: 'var(--text-secondary)', fontSize: 13 }}>
-                    {connecting ? 'Starting WhatsApp… (first launch can take ~15–30s)' : 'Waiting for QR…'}
-                  </span>
-                )}
+                <span style={{
+                  flex: '0 0 auto', width: 34, height: 34, borderRadius: 9,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18,
+                  background: 'var(--warning-bg, rgba(234,179,8,0.14))',
+                  border: '1px solid var(--warning-color, #eab308)',
+                }}>⚠️</span>
+                <div>
+                  <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 17 }}>WhatsApp safety measures</h3>
+                  <p style={{ margin: '2px 0 0', fontSize: 12.5, color: 'var(--text-secondary)' }}>
+                    Follow these to keep this number safe and your service uninterrupted.
+                  </p>
+                </div>
               </div>
-              <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: '1rem', flexWrap: 'wrap' }}>
-                {/* Reset & reconnect: wipes a stale/locked session and forces a
-                    fresh QR — the fix when it sticks on "Starting WhatsApp…". */}
+
+              {[
+                {
+                  h: 'Device connection limits',
+                  points: [
+                    <>Keep this number linked on <b>1–2 devices at most</b> — ideally just one.</>,
+                    <>Don’t sign this number into other WhatsApp web tools or third-party platforms.</>,
+                  ],
+                },
+                {
+                  h: 'Behave like a human',
+                  points: [
+                    <>Avoid rapid, repetitive or automated-looking message bursts — they trip spam filters.</>,
+                    <>Personalize messages (use the contact’s name) rather than blasting one identical template to many people.</>,
+                    <>Don’t operate your phone, WhatsApp Web and this CRM at the same time — overlapping activity looks suspicious and can get the number restricted.</>,
+                  ],
+                },
+                {
+                  h: 'Recommended best practices',
+                  points: [
+                    <>New or recently re-linked number? Warm up gradually — don’t send high volume right away.</>,
+                    <>Periodically review <b>Linked devices</b> on your phone and remove any you don’t recognize.</>,
+                  ],
+                },
+              ].map((sec, si) => (
+                <div key={si} style={{ marginTop: 16 }}>
+                  <div style={{
+                    fontSize: 13, fontWeight: 800, color: 'var(--text-primary)',
+                    marginBottom: 6, textTransform: 'uppercase', letterSpacing: 0.4,
+                    borderLeft: '3px solid var(--accent-color, var(--primary-color, #25D366))', paddingLeft: 8,
+                  }}>{sec.h}</div>
+                  <ul style={{ margin: 0, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {sec.points.map((p, pi) => (
+                      <li key={pi} style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--text-primary)' }}>{p}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+
+              <p style={{
+                margin: '18px 0 0', padding: '10px 12px', borderRadius: 8,
+                fontSize: 12.5, lineHeight: 1.5, color: 'var(--text-secondary)',
+                background: 'var(--bg-tertiary, rgba(127,127,127,0.08))',
+              }}>
+                WhatsApp’s automated checks are sensitive — these habits keep your account safe and your service uninterrupted.
+              </p>
+
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 18 }}>
                 <button
                   type="button"
-                  data-testid="wa-reset-btn"
-                  onClick={() => startConnect(true)}
+                  onClick={() => setShowWaGuide(false)}
                   style={{
-                    fontSize: 13, fontWeight: 600, padding: '6px 16px',
-                    borderRadius: 6, border: 'none', cursor: 'pointer',
+                    fontSize: 13, fontWeight: 600, padding: '8px 20px',
+                    borderRadius: 8, border: 'none', cursor: 'pointer',
                     color: '#fff', background: 'var(--primary-color, #25D366)',
                   }}
                 >
-                  Reset &amp; reconnect
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { setShowQrModal(false); setConnecting(false); }}
-                  style={{
-                    fontSize: 13, padding: '6px 16px',
-                    borderRadius: 6, border: '1px solid var(--border-color)',
-                    cursor: 'pointer', background: 'transparent',
-                    color: 'var(--text-secondary)',
-                  }}
-                >
-                  Close
+                  Got it
                 </button>
               </div>
             </div>
@@ -1707,7 +1983,7 @@ export default function TravelWhatsAppChat() {
             <div
               onClick={(e) => e.stopPropagation()}
               style={{
-                background: 'var(--bg-secondary, #fff)', borderRadius: 12, padding: '1.5rem',
+                background: 'var(--bg-color, #fff)', borderRadius: 12, padding: '1.5rem',
                 width: 'min(94vw, 420px)', border: '1px solid var(--border-color)',
               }}
             >

--- a/frontend/src/utils/deviceId.js
+++ b/frontend/src/utils/deviceId.js
@@ -1,0 +1,30 @@
+// Stable per-browser device identifier for the WhatsApp device-session lock.
+//
+// The WhatsApp Web connection is one shared session per tenant; this id lets the
+// backend tell WHICH browser/device a given CRM user is driving it from, so the
+// same user can't hold the connection from two devices at once (see
+// backend/lib/whatsappSessionGuard.js). It is NOT a security credential — just a
+// stable random tag persisted in localStorage so it survives refreshes and
+// identifies this browser across reconnects.
+const KEY = 'crm_wa_device_id';
+
+export function getDeviceId() {
+  try {
+    let id = localStorage.getItem(KEY);
+    if (!id) {
+      id =
+        typeof crypto !== 'undefined' && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `dev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+      localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    // localStorage disabled (private mode) — fall back to a per-session id so
+    // the lock still functions within this tab.
+    if (!getDeviceId._mem) {
+      getDeviceId._mem = `dev-mem-${Math.random().toString(36).slice(2, 12)}`;
+    }
+    return getDeviceId._mem;
+  }
+}


### PR DESCRIPTION
Added WhatsApp Web device-session governance to prevent the same CRM user from controlling the shared tenant WhatsApp session from multiple devices simultaneously.
Introduced per-tenant relink cooldown to throttle frequent reconnects, reducing the risk of WhatsApp/Meta account suspension.
Added a WhatsApp session guard with device claims, heartbeats, stale-session expiration, reconnect cooldowns, audit logging, and optional bypass via configuration.
Integrated device-aware session management into WhatsApp connect, disconnect, and heartbeat APIs with structured lock and cooldown responses.
Added a persistent browser device ID utility for reliable device identification across sessions.
Enhanced the Travel WhatsApp UI with automatic heartbeat handling, improved QR connection flow, user-friendly lock/cooldown messaging, and an in-app WhatsApp safety guide.
Added comprehensive backend unit and route test coverage for device locking, relink cooldowns, heartbeat handling, session release, bypass mode, and related API flows.