### PR TITLE
Super Admin Portal — Cron Management + Analytics (new)

### DIFF
--- a/backend/config/secrets.js
+++ b/backend/config/secrets.js
@@ -32,4 +32,13 @@ const JWT_SECRET = process.env.JWT_SECRET || DEV_FALLBACK_SECRET;
 const PORTAL_JWT_SECRET =
   process.env.PORTAL_JWT_SECRET || process.env.JWT_SECRET || DEV_FALLBACK_SECRET;
 
-module.exports = { JWT_SECRET, PORTAL_JWT_SECRET };
+// Super Admin Portal JWTs (/super-admin). Deliberately its OWN secret, never
+// falling back to JWT_SECRET — Super Admin auth doesn't use the app User
+// table at all (env-based credentials only), so its tokens must not be
+// forgeable with a leaked regular-user JWT_SECRET and vice versa. No dev
+// fallback either: an unset SUPER_ADMIN_JWT_SECRET disables the portal
+// entirely (see middleware/superAdminAuth.js) rather than silently running
+// on a guessable shared default.
+const SUPER_ADMIN_JWT_SECRET = process.env.SUPER_ADMIN_JWT_SECRET || null;
+
+module.exports = { JWT_SECRET, PORTAL_JWT_SECRET, SUPER_ADMIN_JWT_SECRET };

--- a/backend/cron/apiCallLogRetentionEngine.js
+++ b/backend/cron/apiCallLogRetentionEngine.js
@@ -1,0 +1,55 @@
+/**
+ * apiCallLogRetentionEngine.js — Super Admin Portal / API Analytics.
+ *
+ * Deletes LlmCallLog + ApiCallLog rows older than the configured retention
+ * window (SystemSetting key "api_call_log_retention_days", default 30) —
+ * same pattern as cron/cronLogRetentionEngine.js, applied to the API
+ * Analytics tables instead of CronExecutionLog.
+ *
+ * Registered cron, daily 03:20 — 5 minutes after cronLogRetentionEngine
+ * (03:15) so the two retention sweeps don't contend with each other.
+ */
+
+'use strict';
+
+const cronRegistry = require('../lib/cronRegistry');
+const prisma = require('../lib/prisma');
+
+const RETENTION_SETTING_KEY = 'api_call_log_retention_days';
+const DEFAULT_RETENTION_DAYS = 30;
+
+async function runApiCallLogRetentionSweep() {
+  const setting = await prisma.systemSetting.findUnique({ where: { key: RETENTION_SETTING_KEY } });
+  const retainDays = setting ? parseInt(setting.value, 10) : DEFAULT_RETENTION_DAYS;
+  const days = Number.isFinite(retainDays) && retainDays > 0 ? retainDays : DEFAULT_RETENTION_DAYS;
+
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const [llmResult, apiResult] = await Promise.all([
+    prisma.llmCallLog.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+    prisma.apiCallLog.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+  ]);
+
+  const totalDeleted = llmResult.count + apiResult.count;
+  if (totalDeleted > 0) {
+    console.log(
+      `[apiCallLogRetention] purged ${llmResult.count} LlmCallLog + ${apiResult.count} ApiCallLog row(s) older than ${days}d (cutoff ${cutoff.toISOString()})`,
+    );
+  }
+  return { deletedLlmCallLog: llmResult.count, deletedApiCallLog: apiResult.count, retainDays: days, cutoff };
+}
+
+function initApiCallLogRetentionCron() {
+  cronRegistry.register({
+    name: 'apiCallLogRetentionEngine',
+    description: 'Purges LlmCallLog + ApiCallLog rows past the configured retention window (daily 03:20)',
+    defaultSchedule: '20 3 * * *',
+    tickFn: runApiCallLogRetentionSweep,
+  }).catch((e) => console.error('[apiCallLogRetention] cronRegistry registration failed:', e.message));
+}
+
+module.exports = {
+  runApiCallLogRetentionSweep,
+  initApiCallLogRetentionCron,
+  RETENTION_SETTING_KEY,
+  DEFAULT_RETENTION_DAYS,
+};

--- a/backend/cron/appointmentRemindersEngine.js
+++ b/backend/cron/appointmentRemindersEngine.js
@@ -23,7 +23,7 @@
  *      can drop the visible markers entirely.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
 
@@ -210,14 +210,12 @@ async function tickAppointmentReminders() {
 }
 
 function initAppointmentRemindersCron() {
-  cron.schedule("*/15 * * * *", () => {
-    tickAppointmentReminders().catch((e) =>
-      console.error("[AppointmentReminders] tick crashed:", e.message),
-    );
-  });
-  console.log(
-    "Appointment Reminders Engine initialized (cron: */15 * * * *)",
-  );
+  cronRegistry.register({
+    name: "appointmentRemindersEngine",
+    description: "Queues SMS reminders for wellness visits at T-24h/T-1h windows",
+    defaultSchedule: "*/15 * * * *",
+    tickFn: tickAppointmentReminders,
+  }).catch((e) => console.error("[AppointmentReminders] cronRegistry registration failed:", e.message));
 }
 
 // ── PRD Gap §12 #4e — No-show risk Notification fan-out ──────────────
@@ -417,16 +415,13 @@ async function runNoShowRiskForAllWellnessTenants() {
 function initNoShowRiskCron() {
   // Daily 08:30 IST — early enough for owners to act on the day's risks
   // before patients leave for work.
-  cron.schedule(
-    "30 8 * * *",
-    () => {
-      runNoShowRiskForAllWellnessTenants().catch((e) =>
-        console.error("[NoShowRisk] cron fail:", e.message),
-      );
-    },
-    { timezone: process.env.CRON_TIMEZONE || "Asia/Kolkata" },
-  );
-  console.log("[NoShowRisk] cron initialized (daily 08:30 IST)");
+  cronRegistry.register({
+    name: "noShowRiskEngine",
+    description: "Flags high no-show-risk wellness visits with an owner/doctor Notification",
+    defaultSchedule: "30 8 * * *",
+    cronOptions: { timezone: process.env.CRON_TIMEZONE || "Asia/Kolkata" },
+    tickFn: runNoShowRiskForAllWellnessTenants,
+  }).catch((e) => console.error("[NoShowRisk] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/auditIntegrityEngine.js
+++ b/backend/cron/auditIntegrityEngine.js
@@ -1,4 +1,4 @@
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const prisma = require('../lib/prisma');
 const { computeHash, genesisFor } = require('../lib/audit');
 
@@ -128,13 +128,12 @@ async function runAuditIntegritySweep() {
 function initAuditIntegrityCron() {
   // Daily at 04:00 server time (after the 03:00 retention sweep has finished
   // so we record the post-retention chain head).
-  cron.schedule('0 4 * * *', () => {
-    console.log('[AuditIntegrity] Cron tick — running daily integrity sweep...');
-    runAuditIntegritySweep().catch((err) =>
-      console.error('[AuditIntegrity] Cron failure:', err)
-    );
-  });
-  console.log('[AuditIntegrity] Cron scheduled: daily at 04:00.');
+  cronRegistry.register({
+    name: 'auditIntegrityEngine',
+    description: 'Daily audit hash-chain integrity sweep',
+    defaultSchedule: '0 4 * * *',
+    tickFn: runAuditIntegritySweep,
+  }).catch((e) => console.error('[AuditIntegrity] cronRegistry registration failed:', e.message));
 }
 
 module.exports = { initAuditIntegrityCron, runAuditIntegritySweep };

--- a/backend/cron/backupEngine.js
+++ b/backend/cron/backupEngine.js
@@ -60,7 +60,7 @@
  *   getBackupDir()    — returns the absolute backup dir path (for the
  *                       file-path sanitizer in the route).
  */
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
@@ -556,16 +556,15 @@ function listBackups({ limit = 20 } = {}) {
 }
 
 function initBackupCron() {
-  // Run daily at 2 AM. runBackup() became async with #417 — we attach a
-  // .catch so an unexpected internal rejection (none should escape; the
-  // implementation always resolves) doesn't surface as an unhandled
-  // promise rejection on the process.
-  cron.schedule('0 2 * * *', () => {
-    runBackup().catch((err) => {
-      console.error('[Backup] cron tick crashed:', err && err.message ? err.message : err);
-    });
-  });
-  console.log('[Backup] Cron scheduled: daily at 02:00');
+  // Run daily at 2 AM. runBackup() always resolves internally; the registry's
+  // own runTick() wraps every tickFn call so an unexpected rejection is
+  // caught + logged as a failed CronExecutionLog row rather than escaping.
+  cronRegistry.register({
+    name: 'backupEngine',
+    description: 'Daily mysqldump + gzip backup with retention cleanup',
+    defaultSchedule: '0 2 * * *',
+    tickFn: runBackup,
+  }).catch((e) => console.error('[Backup] cronRegistry registration failed:', e.message));
 }
 
 module.exports = {

--- a/backend/cron/campaignEngine.js
+++ b/backend/cron/campaignEngine.js
@@ -1,4 +1,4 @@
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 
 /**
@@ -133,22 +133,23 @@ async function processDueCampaigns(options = {}) {
   return result;
 }
 
-function initCampaignCron() {
-  // Run every minute
-  cron.schedule("* * * * *", async () => {
-    try {
-      const r = await processDueCampaigns();
-      if (r.processed > 0) {
-        console.log(
-          `[CampaignEngine] tick: processed=${r.processed} dispatched=${r.dispatched} errors=${r.errors.length}`,
-        );
-      }
-    } catch (err) {
-      console.error("[CampaignEngine] Cron error:", err.message);
-    }
-  });
+async function tick() {
+  const r = await processDueCampaigns();
+  if (r.processed > 0) {
+    console.log(
+      `[CampaignEngine] tick: processed=${r.processed} dispatched=${r.dispatched} errors=${r.errors.length}`,
+    );
+  }
+  return r;
+}
 
-  console.log("[CampaignEngine] Campaign scheduling cron initialized (runs every minute)");
+function initCampaignCron() {
+  cronRegistry.register({
+    name: "campaignEngine",
+    description: "Dispatches scheduled Campaign rows once scheduledAt has passed",
+    defaultSchedule: "* * * * *",
+    tickFn: tick,
+  }).catch((e) => console.error("[CampaignEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { initCampaignCron, processDueCampaigns };

--- a/backend/cron/contactGreetingsEngine.js
+++ b/backend/cron/contactGreetingsEngine.js
@@ -19,7 +19,7 @@
 // verticals (wellness, generic) can adopt this engine by widening the
 // tenant query in a follow-up commit.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -238,12 +238,12 @@ function initContactGreetingsCron() {
   // Daily 08:13 IST — :13 minute offset per the standing rule (avoid
   // :00 / :30 cluster). PRD §4.8 says "1-2d plug-in"; the cron itself
   // is one daily fire that scans the whole tenant's contact base.
-  cron.schedule("13 8 * * *", () => {
-    runContactGreetingsForAllTravelTenants().catch((e) =>
-      console.error("[ContactGreetings] cron fail:", e.message),
-    );
-  });
-  console.log("[ContactGreetings] cron initialized (daily 08:13 IST)");
+  cronRegistry.register({
+    name: "contactGreetingsEngine",
+    description: "Daily birthday/anniversary greeting Notifications for travel tenants",
+    defaultSchedule: "13 8 * * *",
+    tickFn: runContactGreetingsForAllTravelTenants,
+  }).catch((e) => console.error("[ContactGreetings] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/cronLogRetentionEngine.js
+++ b/backend/cron/cronLogRetentionEngine.js
@@ -1,0 +1,50 @@
+/**
+ * cronLogRetentionEngine.js — Super Admin Portal / Cron Maintenance.
+ *
+ * Deletes CronExecutionLog rows older than the configured retention window
+ * (SystemSetting key "cron_log_retention_days", default 30 — same default
+ * the Super Admin UI shows when no setting row exists yet, see
+ * routes/super_admin_cron.js's GET /settings/log-retention).
+ *
+ * This is itself a registered cron engine (via cronRegistry, like the other
+ * 46) — daily 03:15, off the :00/:03:00 cluster and 15 minutes after the
+ * GDPR retention sweep so it doesn't contend with that sweep's DB load.
+ */
+
+'use strict';
+
+const cronRegistry = require('../lib/cronRegistry');
+const prisma = require('../lib/prisma');
+
+const RETENTION_SETTING_KEY = 'cron_log_retention_days';
+const DEFAULT_RETENTION_DAYS = 30;
+
+async function runCronLogRetentionSweep() {
+  const setting = await prisma.systemSetting.findUnique({ where: { key: RETENTION_SETTING_KEY } });
+  const retainDays = setting ? parseInt(setting.value, 10) : DEFAULT_RETENTION_DAYS;
+  const days = Number.isFinite(retainDays) && retainDays > 0 ? retainDays : DEFAULT_RETENTION_DAYS;
+
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const result = await prisma.cronExecutionLog.deleteMany({ where: { startedAt: { lt: cutoff } } });
+
+  if (result.count > 0) {
+    console.log(`[cronLogRetention] purged ${result.count} log row(s) older than ${days}d (cutoff ${cutoff.toISOString()})`);
+  }
+  return { deleted: result.count, retainDays: days, cutoff };
+}
+
+function initCronLogRetentionCron() {
+  cronRegistry.register({
+    name: 'cronLogRetentionEngine',
+    description: 'Purges CronExecutionLog rows past the configured retention window (daily 03:15)',
+    defaultSchedule: '15 3 * * *',
+    tickFn: runCronLogRetentionSweep,
+  }).catch((e) => console.error('[cronLogRetention] cronRegistry registration failed:', e.message));
+}
+
+module.exports = {
+  runCronLogRetentionSweep,
+  initCronLogRetentionCron,
+  RETENTION_SETTING_KEY,
+  DEFAULT_RETENTION_DAYS,
+};

--- a/backend/cron/dealInsightsEngine.js
+++ b/backend/cron/dealInsightsEngine.js
@@ -1,4 +1,4 @@
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../../.env"), override: true });
 
@@ -84,11 +84,15 @@ async function tickDealInsightsEngine(io) {
  * Wire this from server.js — orchestrator passes the socket.io instance.
  */
 function initDealInsightsCron(io) {
-  cron.schedule("0 */6 * * *", () => {
-    console.log("[DealInsightsEngine] Cron tick — scanning open deals...");
-    tickDealInsightsEngine(io).catch(err => console.error("[DealInsightsEngine] Cron error:", err));
-  });
-  console.log("[DealInsightsEngine] Cron initialized (every 6 hours).");
+  cronRegistry.register({
+    name: "dealInsightsEngine",
+    description: "Scans open deals every 6h and persists heuristic-rule DealInsight rows",
+    defaultSchedule: "0 */6 * * *",
+    tickFn: () => {
+      console.log("[DealInsightsEngine] Cron tick — scanning open deals...");
+      return tickDealInsightsEngine(io);
+    },
+  }).catch((e) => console.error("[DealInsightsEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { initDealInsightsCron, tickDealInsightsEngine };

--- a/backend/cron/demoHygieneEngine.js
+++ b/backend/cron/demoHygieneEngine.js
@@ -89,7 +89,7 @@
  *                            for one-shot cleanup without waiting for
  *                            the next tick.
  */
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 
 // Canonical QA / pen-test markers. Anchor at start-of-string only — these
@@ -446,12 +446,12 @@ function initDemoHygieneCron() {
   }
   // Hourly at :17. Off-the-hour timing keeps it out of the default
   // top-of-hour cron storm (backup, retention, etc. all schedule on :00).
-  cron.schedule("17 * * * *", () => {
-    runDemoHygiene().catch((err) => {
-      console.error("[demoHygiene] cron tick crashed:", err && err.message ? err.message : err);
-    });
-  });
-  console.log("[demoHygiene] Cron scheduled: hourly at :17");
+  cronRegistry.register({
+    name: "demoHygieneEngine",
+    description: "Hourly purge of QA/pen-test data pollution from the demo box",
+    defaultSchedule: "17 * * * *",
+    tickFn: runDemoHygiene,
+  }).catch((e) => console.error("[demoHygiene] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/forecastSnapshotEngine.js
+++ b/backend/cron/forecastSnapshotEngine.js
@@ -1,4 +1,4 @@
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -204,12 +204,12 @@ async function upsertWeeklyForecast({ tenantId, userId, period, metrics, weekSta
 
 function initForecastSnapshotCron() {
   // Every Monday at 1 AM
-  cron.schedule("0 1 * * 1", () => {
-    runForecastSnapshot().catch((err) =>
-      console.error("[ForecastSnapshot] Scheduled run failed:", err.message)
-    );
-  });
-  console.log("[ForecastSnapshot] cron initialized");
+  cronRegistry.register({
+    name: "forecastSnapshotEngine",
+    description: "Weekly revenue forecast snapshot (Mondays 01:00)",
+    defaultSchedule: "0 1 * * 1",
+    tickFn: runForecastSnapshot,
+  }).catch((e) => console.error("[ForecastSnapshot] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/fxRateEngine.js
+++ b/backend/cron/fxRateEngine.js
@@ -23,7 +23,7 @@
  *   5. initCron() is idempotent — DISABLE_CRONS=1 path skips schedule.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const realPrisma = require("../lib/prisma");
 const fxRates = require("../lib/fxRates");
 
@@ -66,21 +66,22 @@ async function tick({
   return { fetched, errors };
 }
 
+async function loggedTick() {
+  const r = await tick();
+  if (r.fetched > 0 || r.errors.length > 0) {
+    console.log("[fxRateEngine]", r);
+  }
+  return r;
+}
+
 function initCron() {
   if (process.env.DISABLE_CRONS === "1") return;
-  cron.schedule(
-    "0 * * * *",
-    () => {
-      tick()
-        .then((r) => {
-          if (r.fetched > 0 || r.errors.length > 0) {
-            console.log("[fxRateEngine]", r);
-          }
-        })
-        .catch((e) => console.error("[fxRateEngine] fail:", e && e.message));
-    },
-  );
-  console.log("[fxRateEngine] cron initialized (hourly, top-of-the-hour UTC)");
+  cronRegistry.register({
+    name: "fxRateEngine",
+    description: "Hourly FxRate cache refresh from frankfurter.dev",
+    defaultSchedule: "0 * * * *",
+    tickFn: loggedTick,
+  }).catch((e) => console.error("[fxRateEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/gstrFilingReminderEngine.js
+++ b/backend/cron/gstrFilingReminderEngine.js
@@ -65,6 +65,7 @@
  * Refs #902. PRD: docs/PRD_TRAVEL_GST_COMPLIANCE.md.
  */
 
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { writeAudit } = require("../lib/audit");
 
@@ -222,6 +223,20 @@ async function runGstrFilingReminderEngine({ notify, now = new Date() } = {}) {
   return { processed, tier, daysToDeadline, errors };
 }
 
+// Super Admin Portal / Cron Maintenance — was previously wired via a raw
+// _cron.schedule("0 5 * * *", ...) call inline in server.js instead of an
+// init*Cron() function like every other engine. Moved to the same
+// cronRegistry.register() pattern so it's enable/disable/reschedule-able
+// from the Super Admin UI like the other 45 engines.
+function initCron() {
+  cronRegistry.register({
+    name: "gstrFilingReminderEngine",
+    description: "Tiered GSTR-1 filing deadline reminders for travel tenants (daily 05:00 UTC / 10:30 IST)",
+    defaultSchedule: "0 5 * * *",
+    tickFn: runGstrFilingReminderEngine,
+  }).catch((e) => console.error("[gstr-filing-reminder] cronRegistry registration failed:", e.message));
+}
+
 module.exports = {
   runGstrFilingReminderEngine,
   reminderTier,
@@ -230,4 +245,5 @@ module.exports = {
   defaultStubNotifier,
   writeAuditSafe,
   FILING_DEADLINE_DAY,
+  initCron,
 };

--- a/backend/cron/leadScoringEngine.js
+++ b/backend/cron/leadScoringEngine.js
@@ -1,8 +1,25 @@
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const prisma = require("../lib/prisma");
 const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../../.env"), override: true });
 const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { estimateLlmCost } = require("../lib/apiPricing");
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// lead-score recomputation, hence the nested try/catch and the un-awaited
+// .catch() on the create.
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("../lib/prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[LeadScoringEngine] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[LeadScoringEngine] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 let aiModel = null;
@@ -60,12 +77,46 @@ Provide ONLY a single integer score from 1-99. No explanation.`;
     const result = await aiModel.generateContent(prompt);
     const scoreText = result.response.text().trim();
     const score = parseInt(scoreText);
+    const usage = result.response.usageMetadata || {};
+    const promptTokens = usage.promptTokenCount || 0;
+    const completionTokens = usage.candidatesTokenCount || 0;
+    persistLlmCallLog({
+      tenantId: contact.tenantId || 1,
+      task: "lead-scoring",
+      model: "gemini-2.5-flash",
+      provider: "gemini",
+      reason: null,
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+      costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+      stub: false,
+      userId: null,
+      surface: "leadScoringEngine",
+      status: "success",
+    });
 
     if (!isNaN(score) && score >= 1 && score <= 99) {
       console.log(`[LeadScoringEngine] Gemini scored ${contact.name}: ${score}`);
       return score;
     }
   } catch (err) {
+    persistLlmCallLog({
+      tenantId: (contact && contact.tenantId) || 1,
+      task: "lead-scoring",
+      model: "gemini-2.5-flash",
+      provider: "gemini",
+      reason: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      costEstimate: 0,
+      stub: false,
+      userId: null,
+      surface: "leadScoringEngine",
+      status: "failed",
+      errorMessage: err.message,
+    });
     console.warn("[LeadScoringEngine] Gemini scoring failed:", err.message);
   }
 
@@ -456,17 +507,25 @@ async function tickLeadScoringEngine(io) {
 /**
  * Initialise the cron job (every 10 minutes).
  * Call this from server.js, passing the socket.io `io` instance.
+ *
+ * Super Admin Portal / Cron Maintenance — scheduling now goes through the
+ * central registry (lib/cronRegistry.js) instead of a local cron.schedule()
+ * call, so this engine's enabled state + schedule are admin-editable and
+ * take effect without a server restart. `io` is captured by closure since
+ * cronRegistry's tickFn contract takes no arguments. runImmediately
+ * reproduces the historical "run once at startup" behavior.
  */
 function initLeadScoringCron(io) {
-  // Run once at startup to immediately populate scores
-  tickLeadScoringEngine(io).catch(console.error);
-
-  cron.schedule('*/10 * * * *', () => {
-    console.log('[LeadScoring] Cron tick — rescoring all contacts...');
-    tickLeadScoringEngine(io).catch(console.error);
-  });
-
-  console.log('[LeadScoring] Cron initialized (every 10 minutes).');
+  cronRegistry.register({
+    name: 'leadScoringEngine',
+    description: 'Recomputes Contact.aiScore for stale/unscored contacts (multi-factor formula + Gemini)',
+    defaultSchedule: '*/10 * * * *',
+    runImmediately: true,
+    tickFn: () => {
+      console.log('[LeadScoring] Cron tick — rescoring all contacts...');
+      return tickLeadScoringEngine(io);
+    },
+  }).catch((e) => console.error('[LeadScoring] cronRegistry registration failed:', e.message));
 }
 
 module.exports = { initLeadScoringCron, tickLeadScoringEngine, computeScore };

--- a/backend/cron/leadSlaEngine.js
+++ b/backend/cron/leadSlaEngine.js
@@ -20,7 +20,7 @@
  * idempotency gate: once flipped, the cron will never re-fire for that lead.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { emitEvent } = require("../lib/eventBus");
 
@@ -134,12 +134,12 @@ async function tickLeadSlaBreaches() {
 }
 
 function initLeadSlaCron() {
-  cron.schedule("*/2 * * * *", () => {
-    tickLeadSlaBreaches().catch((e) =>
-      console.error("[LeadSLABreach] tick crashed:", e.message),
-    );
-  });
-  console.log("Lead SLA Breach Engine initialized (cron: */2 * * * *)");
+  cronRegistry.register({
+    name: "leadSlaEngine",
+    description: "Flips Contact.slaBreached + emits lead.sla_breached (every 2 min)",
+    defaultSchedule: "*/2 * * * *",
+    tickFn: tickLeadSlaBreaches,
+  }).catch((e) => console.error("[LeadSLABreach] cronRegistry registration failed:", e.message));
 }
 
 // Convenience runner for the manual-trigger endpoint and tests: scopes to a

--- a/backend/cron/leavePolicyEngine.js
+++ b/backend/cron/leavePolicyEngine.js
@@ -77,7 +77,7 @@
  *     .runForTenant(<id>)"` directly. If a UI ask lands, the right place
  *     is /api/cron/leave-policy/run not a fresh route here.
  */
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 
 // Default fiscal year-end — month is 0-indexed in JS Date ergonomics.
@@ -325,10 +325,13 @@ async function tick() {
  */
 function initLeavePolicyCron() {
   // 02:30 IST = 21:00 UTC previous day. The cron runs in IST per server.
-  cron.schedule("30 2 * * *", () => {
-    tick().catch((e) => console.error("[LeavePolicy] tick crashed:", e.message));
-  }, { timezone: "Asia/Kolkata" });
-  console.log("[LeavePolicy] cron scheduled: 02:30 IST daily");
+  cronRegistry.register({
+    name: "leavePolicyEngine",
+    description: "Fiscal year-end leave carry-forward + encashment payouts",
+    defaultSchedule: "30 2 * * *",
+    cronOptions: { timezone: "Asia/Kolkata" },
+    tickFn: tick,
+  }).catch((e) => console.error("[LeavePolicy] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/lowStockEngine.js
+++ b/backend/cron/lowStockEngine.js
@@ -14,7 +14,7 @@
  * Schedule: 09:00 IST daily (cron runs in server local time — use 03:30 UTC
  * if you need strict IST; for now we just say "daily morning" in cron syntax).
  */
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
 
@@ -131,16 +131,13 @@ async function runLowStockForAllWellnessTenants() {
 function initLowStockCron() {
   // 09:00 IST = 03:30 UTC. node-cron uses server time by default; pass an
   // explicit IST timezone so behaviour is consistent across environments.
-  cron.schedule(
-    "0 9 * * *",
-    () => {
-      runLowStockForAllWellnessTenants().catch((e) =>
-        console.error("[LowStock] cron fail:", e.message)
-      );
-    },
-    { timezone: "Asia/Kolkata" }
-  );
-  console.log("[LowStock] cron initialized (daily 09:00 IST)");
+  cronRegistry.register({
+    name: "lowStockEngine",
+    description: "Daily wellness inventory low-stock Notification alerts",
+    defaultSchedule: "0 9 * * *",
+    cronOptions: { timezone: "Asia/Kolkata" },
+    tickFn: runLowStockForAllWellnessTenants,
+  }).catch((e) => console.error("[LowStock] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/marketplaceEngine.js
+++ b/backend/cron/marketplaceEngine.js
@@ -1,5 +1,4 @@
-const cron = require("node-cron");
-
+const cronRegistry = require("../lib/cronRegistry");
 
 const prisma = require("../lib/prisma");
 
@@ -238,26 +237,30 @@ function formatIndiaMARTDate(date) {
  * Initialize the marketplace sync cron job.
  * Runs every 5 minutes, syncs all active providers.
  */
-function initMarketplaceCron(io) {
-  cron.schedule("*/5 * * * *", async () => {
-    // Wrap the tick body in try/catch so a partner-API throw or a Prisma blip
-    // doesn't surface as an unhandledPromiseRejection (strict Node settings
-    // could kill the process). Mirrors every other engine in backend/cron/.
+async function tick(io) {
+  console.log("[MarketplaceEngine] Running sync cycle...");
+  const configs = await prisma.marketplaceConfig.findMany({ where: { isActive: true } });
+  for (const config of configs) {
     try {
-      console.log("[MarketplaceEngine] Running sync cycle...");
-      const configs = await prisma.marketplaceConfig.findMany({ where: { isActive: true } });
-      for (const config of configs) {
-        try {
-          await syncMarketplace(config.tenantId, config.provider, io);
-        } catch (perProviderErr) {
-          console.error(`[MarketplaceEngine] tenantId=${config.tenantId} provider=${config.provider} sync error:`, perProviderErr && perProviderErr.message);
-        }
-      }
-    } catch (tickErr) {
-      console.error("[MarketplaceEngine] tick error:", tickErr && tickErr.message);
+      await syncMarketplace(config.tenantId, config.provider, io);
+    } catch (perProviderErr) {
+      console.error(`[MarketplaceEngine] tenantId=${config.tenantId} provider=${config.provider} sync error:`, perProviderErr && perProviderErr.message);
     }
-  });
-  console.log("[MarketplaceEngine] Cron scheduled: every 5 minutes");
+  }
+}
+
+// defaultEnabled:false — no tenant currently has an active MarketplaceConfig,
+// so this ships DISABLED by default (visible + one-click enable in the
+// Super Admin Cron Maintenance table, but not burning a tick every 5 min
+// until an admin actually needs it).
+function initMarketplaceCron(io) {
+  cronRegistry.register({
+    name: "marketplaceEngine",
+    description: "Syncs IndiaMART/JustDial/TradeIndia leads for active MarketplaceConfig rows",
+    defaultSchedule: "*/5 * * * *",
+    defaultEnabled: false,
+    tickFn: () => tick(io),
+  }).catch((e) => console.error("[MarketplaceEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { initMarketplaceCron, syncMarketplace };

--- a/backend/cron/orchestratorEngine.js
+++ b/backend/cron/orchestratorEngine.js
@@ -18,13 +18,30 @@
  * Failure mode: if Gemini is unavailable, falls back to rule-based proposals
  * so Rishu always sees something useful in the morning.
  */
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const crypto = require("crypto");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
+const { estimateLlmCost } = require("../lib/apiPricing");
 
 let GoogleGenerativeAI;
 try { ({ GoogleGenerativeAI } = require("@google/generative-ai")); } catch (_) { /* optional */ }
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// the orchestrator's recommendation generation, hence the nested try/catch
+// and the un-awaited .catch() on the create.
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("../lib/prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[Orchestrator] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[Orchestrator] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 // ── Dedup helpers (issues #261, #285) ──────────────────────────────
 // Cron used to spam the same "Today's occupancy only 1%" card on every
@@ -404,9 +421,10 @@ async function readContext(tenantId) {
 
 async function generateProposals(ctx) {
   if (!GoogleGenerativeAI || !process.env.GEMINI_API_KEY) return null;
+  const modelId = process.env.GEMINI_MODEL || "gemini-2.0-flash";
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: process.env.GEMINI_MODEL || "gemini-2.0-flash" });
+    const model = genAI.getGenerativeModel({ model: modelId });
     const prompt = `You are an AI orchestrator for a hair/skin/aesthetics clinic. Today's reality:
 ${ctx.summary}
 Top performing services this week: ${ctx.topServices.map((s) => s.name).join(", ") || "none"}
@@ -426,9 +444,43 @@ Output a JSON array of 1-3 recommendation cards. Each card MUST have:
 Return ONLY the JSON array, no commentary.`;
     const r = await model.generateContent(prompt);
     const txt = r.response.text().replace(/```json|```/g, "").trim();
+    const usage = r.response.usageMetadata || {};
+    const promptTokens = usage.promptTokenCount || 0;
+    const completionTokens = usage.candidatesTokenCount || 0;
+    persistLlmCallLog({
+      tenantId: (ctx && ctx.tenantId) || 1,
+      task: "orchestrator-recommendation",
+      model: modelId,
+      provider: "gemini",
+      reason: null,
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+      costEstimate: estimateLlmCost(modelId, promptTokens, completionTokens),
+      stub: false,
+      userId: null,
+      surface: "orchestratorEngine",
+      status: "success",
+    });
     const parsed = JSON.parse(txt);
     return Array.isArray(parsed) ? parsed : null;
   } catch (e) {
+    persistLlmCallLog({
+      tenantId: (ctx && ctx.tenantId) || 1,
+      task: "orchestrator-recommendation",
+      model: modelId,
+      provider: "gemini",
+      reason: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      costEstimate: 0,
+      stub: false,
+      userId: null,
+      surface: "orchestratorEngine",
+      status: "failed",
+      errorMessage: e.message,
+    });
     console.warn("[Orchestrator] Gemini failed, using fallback rules:", e.message);
     return null;
   }
@@ -671,10 +723,13 @@ async function runForAllWellnessTenants() {
 
 function initOrchestratorCron() {
   // 07:00 IST every day = 01:30 UTC
-  cron.schedule("30 1 * * *", () => {
-    runForAllWellnessTenants().catch((e) => console.error("[Orchestrator] cron fail:", e.message));
-  }, { timezone: "Asia/Kolkata" });
-  console.log("[Orchestrator] cron initialized (daily 07:00 IST)");
+  cronRegistry.register({
+    name: "orchestratorEngine",
+    description: "Daily wellness AI orchestration — Owner Dashboard recommendation cards",
+    defaultSchedule: "30 1 * * *",
+    cronOptions: { timezone: "Asia/Kolkata" },
+    tickFn: runForAllWellnessTenants,
+  }).catch((e) => console.error("[Orchestrator] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { initOrchestratorCron, runForTenant, runForAllWellnessTenants, executeApproved, cleanupExistingDupes, ruleBasedProposals };

--- a/backend/cron/paymentDeadlineEngine.js
+++ b/backend/cron/paymentDeadlineEngine.js
@@ -24,7 +24,7 @@
 // BEFORE sending so an hourly re-tick can't double-send. dayTag ∈
 // {d10,d9,d8,d7,overdue}.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const emailSender = require("../lib/emailSender");
 const content = require("../lib/paymentDeadlineContent");
@@ -227,10 +227,12 @@ async function runPaymentDeadlineTick(now = new Date()) {
 // contend). Day-bucket idempotency means the first tick that sees a new bucket
 // sends; later ticks that day are no-ops.
 function initPaymentDeadlineCron() {
-  cron.schedule("37 * * * *", () => {
-    runPaymentDeadlineTick().catch((e) => console.error("[PaymentDeadline] tick error:", e.message));
-  });
-  console.log("[PaymentDeadline] cron scheduled (hourly :37)");
+  cronRegistry.register({
+    name: "paymentDeadlineEngine",
+    description: "Pay-or-cancel deposit-deadline chase for accepted-unpaid travel bookings (hourly :37)",
+    defaultSchedule: "37 * * * *",
+    tickFn: runPaymentDeadlineTick,
+  }).catch((e) => console.error("[PaymentDeadline] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { runPaymentDeadlineTick, initPaymentDeadlineCron, daysToGo, formatDeadline, userCanAccess };

--- a/backend/cron/paymentScheduleReminderEngine.js
+++ b/backend/cron/paymentScheduleReminderEngine.js
@@ -54,7 +54,7 @@
  *   convention spreads the daily cron herd across the wall clock.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { writeAudit } = require("../lib/audit");
 
@@ -395,23 +395,32 @@ async function processEscalations({ notify, now = new Date(), prisma: prismaOver
   };
 }
 
+// One tick runs BOTH the T-7/T-3/T-1 pre-due reminders AND the T+3/T+7/T+14
+// post-due escalation chain. allSettled (not a plain await sequence) so a
+// failure on one side can never stop the other from running — matches the
+// original two-independent-.catch()-chains isolation exactly.
+async function tick() {
+  const results = await Promise.allSettled([processReminders(), processEscalations()]);
+  const [reminders, escalations] = results;
+  if (reminders.status === "rejected") {
+    console.error("[payment-schedule-reminder] unhandled tick error:", reminders.reason);
+  }
+  if (escalations.status === "rejected") {
+    console.error("[payment-schedule-escalation] unhandled tick error:", escalations.reason);
+  }
+}
+
 /**
  * Register the cron schedule. Wired into backend/server.js cron init block.
  */
 function initCron() {
   // Daily 09:13 IST (off-minute per the standing-rule herd-spread).
-  // One tick runs BOTH the T-7/T-3/T-1 pre-due reminders AND the T+3/T+7/T+14
-  // post-due escalation chain. Each guarded by its own try/catch so a failure
-  // on one side doesn't stop the other.
-  cron.schedule("13 9 * * *", () => {
-    processReminders().catch((err) => {
-      console.error("[payment-schedule-reminder] unhandled tick error:", err);
-    });
-    processEscalations().catch((err) => {
-      console.error("[payment-schedule-escalation] unhandled tick error:", err);
-    });
-  });
-  console.log("[payment-schedule-reminder] cron initialized (daily 09:13 IST, reminders + escalation)");
+  cronRegistry.register({
+    name: "paymentScheduleReminderEngine",
+    description: "TravelPaymentSchedule T-7/T-3/T-1 reminders + T+3/T+7/T+14 escalation (daily 09:13 IST)",
+    defaultSchedule: "13 9 * * *",
+    tickFn: tick,
+  }).catch((e) => console.error("[payment-schedule-reminder] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/quoteExpirySweep.js
+++ b/backend/cron/quoteExpirySweep.js
@@ -34,7 +34,7 @@
  *      same quote (because pass 2 sees status='Expired' and skips).
  */
 
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const realPrisma = require('../lib/prisma');
 const { writeAudit } = require('../lib/audit');
 
@@ -167,22 +167,27 @@ async function sweep({ now = new Date(), prisma = realPrisma } = {}) {
   return { quotesSwept, errors };
 }
 
+async function tick() {
+  const r = await sweep();
+  if (r.quotesSwept > 0 || r.errors.length > 0) {
+    console.log('[quoteExpirySweep]', r);
+  }
+}
+
+// Super Admin Portal / Cron Maintenance — scheduling now goes through the
+// central registry (lib/cronRegistry.js) instead of a local cron.schedule()
+// call, so this engine's enabled state + schedule are admin-editable and
+// take effect without a server restart. defaultSchedule/cronOptions below
+// are exactly what this engine hardcoded historically (09:00 IST daily) —
+// they're only USED as a fallback until (or unless) a CronConfig row exists.
 function initCron() {
-  // 09:00 IST = 03:30 UTC. node-cron uses server time by default; the
-  // explicit Asia/Kolkata timezone keeps behaviour consistent across
-  // demo (UTC-host) and operator-local-time deploys.
-  cron.schedule(
-    '0 9 * * *',
-    () => {
-      sweep().then((r) => {
-        if (r.quotesSwept > 0 || r.errors.length > 0) {
-          console.log('[quoteExpirySweep]', r);
-        }
-      }).catch((e) => console.error('[quoteExpirySweep] fail:', e.message));
-    },
-    { timezone: 'Asia/Kolkata' },
-  );
-  console.log('[quoteExpirySweep] cron initialized (daily 09:00 IST)');
+  cronRegistry.register({
+    name: 'quoteExpirySweep',
+    description: 'Daily sweep — flips Draft/Sent TravelQuotes past validUntil to Expired',
+    defaultSchedule: '0 9 * * *',
+    cronOptions: { timezone: 'Asia/Kolkata' },
+    tickFn: tick,
+  }).catch((e) => console.error('[quoteExpirySweep] cronRegistry registration failed:', e.message));
 }
 
 module.exports = {

--- a/backend/cron/recurringInvoiceEngine.js
+++ b/backend/cron/recurringInvoiceEngine.js
@@ -1,4 +1,4 @@
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const crypto = require("crypto");
 const prisma = require("../lib/prisma");
 
@@ -112,9 +112,12 @@ async function processRecurringInvoices(io) {
 }
 
 function initRecurringInvoiceCron(io) {
-  // Run daily at 6 AM
-  cron.schedule("0 6 * * *", () => processRecurringInvoices(io));
-  console.log("[RecurringInvoice] Cron scheduled: daily at 6 AM");
+  cronRegistry.register({
+    name: "recurringInvoiceEngine",
+    description: "Generates due recurring invoices (daily 06:00)",
+    defaultSchedule: "0 6 * * *",
+    tickFn: () => processRecurringInvoices(io),
+  }).catch((e) => console.error("[RecurringInvoice] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { initRecurringInvoiceCron, processRecurringInvoices };

--- a/backend/cron/religiousGuidanceEngine.js
+++ b/backend/cron/religiousGuidanceEngine.js
@@ -25,7 +25,7 @@
 // Scoped to vertical=travel tenants per PRD; other verticals can
 // adopt the engine by widening the tenant query in a follow-up.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -248,12 +248,12 @@ function initReligiousGuidanceCron() {
   // Daily 09:13 IST — :13 minute offset per the standing rule (avoid
   // :00 / :30 cluster). One daily fire scans the whole tenant's
   // upcoming-14d RFU window.
-  cron.schedule("13 9 * * *", () => {
-    runReligiousGuidanceForAllTravelTenants().catch((e) =>
-      console.error("[ReligiousGuidance] cron fail:", e.message),
-    );
-  });
-  console.log("[ReligiousGuidance] cron initialized (daily 09:13 IST)");
+  cronRegistry.register({
+    name: "religiousGuidanceEngine",
+    description: "Daily RFU religious-guidance packet delivery for upcoming-14d itineraries",
+    defaultSchedule: "13 9 * * *",
+    tickFn: runReligiousGuidanceForAllTravelTenants,
+  }).catch((e) => console.error("[ReligiousGuidance] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/reportEngine.js
+++ b/backend/cron/reportEngine.js
@@ -1,4 +1,4 @@
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const nodemailer = require('nodemailer');
 const PDFDocument = require('pdfkit');
 
@@ -257,27 +257,28 @@ async function processSchedule(schedule) {
   }
 }
 
+async function tick() {
+  console.log('[Report Engine] Checking for due scheduled reports...');
+  const schedules = await prisma.reportSchedule.findMany({ where: { enabled: true } });
+  const now = new Date();
+
+  for (const schedule of schedules) {
+    // Use node-cron to check if this schedule should have run by now
+    const shouldRun = shouldScheduleRun(schedule, now);
+    if (shouldRun) {
+      await processSchedule(schedule);
+    }
+  }
+}
+
 function initReportCron() {
   // Check every hour for due report schedules
-  cron.schedule('0 * * * *', async () => {
-    console.log('[Report Engine] Checking for due scheduled reports...');
-    try {
-      const schedules = await prisma.reportSchedule.findMany({ where: { enabled: true } });
-      const now = new Date();
-
-      for (const schedule of schedules) {
-        // Use node-cron to check if this schedule should have run by now
-        const shouldRun = shouldScheduleRun(schedule, now);
-        if (shouldRun) {
-          await processSchedule(schedule);
-        }
-      }
-    } catch (err) {
-      console.error('[Report Engine] Cron tick error:', err);
-    }
-  });
-
-  console.log('[Report Engine] Initialized — checking every hour for due reports.');
+  cronRegistry.register({
+    name: 'reportEngine',
+    description: 'Hourly check for due ReportSchedule rows + email dispatch',
+    defaultSchedule: '0 * * * *',
+    tickFn: tick,
+  }).catch((e) => console.error('[Report Engine] cronRegistry registration failed:', e.message));
 }
 
 function shouldScheduleRun(schedule, now) {

--- a/backend/cron/retentionEngine.js
+++ b/backend/cron/retentionEngine.js
@@ -1,4 +1,4 @@
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const prisma = require("../lib/prisma");
 
 // Map RetentionPolicy.entity → prisma model property name. Resolved
@@ -178,12 +178,18 @@ async function runRetentionSweep() {
  * Initialize the retention cron job (daily at 03:00 server time).
  * Wire this in server.js: `require('./cron/retentionEngine').initRetentionCron()`.
  */
+async function tick() {
+  console.log('[Retention] Cron tick — running daily retention sweep...');
+  return runRetentionSweep();
+}
+
 function initRetentionCron() {
-  cron.schedule('0 3 * * *', () => {
-    console.log('[Retention] Cron tick — running daily retention sweep...');
-    runRetentionSweep().catch(err => console.error('[Retention] Cron failure:', err));
-  });
-  console.log('[Retention] Cron scheduled: daily at 03:00.');
+  cronRegistry.register({
+    name: 'retentionEngine',
+    description: 'Daily GDPR/DPDP retention sweep — purges rows past their RetentionPolicy window',
+    defaultSchedule: '0 3 * * *',
+    tickFn: tick,
+  }).catch((e) => console.error('[Retention] cronRegistry registration failed:', e.message));
 }
 
 // #576 — default retention windows for new wellness tenants. Matches

--- a/backend/cron/scheduledEmailEngine.js
+++ b/backend/cron/scheduledEmailEngine.js
@@ -1,4 +1,4 @@
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const crypto = require("crypto");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
@@ -137,12 +137,12 @@ async function processScheduledEmails() {
 }
 
 function initScheduledEmailCron() {
-  cron.schedule("* * * * *", () => {
-    processScheduledEmails().catch((err) => {
-      console.error("[scheduledEmailEngine] unhandled tick error:", err);
-    });
-  });
-  console.log("Scheduled Email Engine initialized (cron: * * * * *)");
+  cronRegistry.register({
+    name: "scheduledEmailEngine",
+    description: "Dispatches ScheduledEmail rows whose sendAt has passed (every minute)",
+    defaultSchedule: "* * * * *",
+    tickFn: processScheduledEmails,
+  }).catch((e) => console.error("[scheduledEmailEngine] cronRegistry registration failed:", e.message));
 }
 
 // G097 sub-brand anchor resolution. Reads Contact.subBrand → Tenant.defaultSubBrand

--- a/backend/cron/sentimentEngine.js
+++ b/backend/cron/sentimentEngine.js
@@ -16,8 +16,24 @@
 const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../../.env"), override: true });
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
+const { estimateLlmCost } = require("../lib/apiPricing");
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// sentiment scoring, hence the nested try/catch and the un-awaited .catch().
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("../lib/prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[Sentiment] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[Sentiment] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 let genAI = null;
 let geminiModel = null;
@@ -109,9 +125,43 @@ async function analyzeMessage(text) {
         `Text: "${safeText.slice(0, 4000)}"`;
       const result = await geminiModel.generateContent(prompt);
       const raw = result.response.text();
+      const usage = result.response.usageMetadata || {};
+      const promptTokens = usage.promptTokenCount || 0;
+      const completionTokens = usage.candidatesTokenCount || 0;
+      persistLlmCallLog({
+        tenantId: 1,
+        task: "sentiment",
+        model: "gemini-2.5-flash",
+        provider: "gemini",
+        reason: null,
+        promptTokens,
+        completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+        stub: false,
+        userId: null,
+        surface: "sentimentEngine",
+        status: "success",
+      });
       const parsed = parseGeminiResponse(raw);
       if (parsed) return parsed;
     } catch (err) {
+      persistLlmCallLog({
+        tenantId: 1,
+        task: "sentiment",
+        model: "gemini-2.5-flash",
+        provider: "gemini",
+        reason: null,
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        costEstimate: 0,
+        stub: false,
+        userId: null,
+        surface: "sentimentEngine",
+        status: "failed",
+        errorMessage: err.message,
+      });
       console.warn("[Sentiment] Gemini call failed, falling back to rules:", err.message);
     }
   }
@@ -162,16 +212,20 @@ async function tickSentimentEngine() {
  * Initialise the cron job (every 15 minutes). Safe to call once at boot.
  */
 function initSentimentCron() {
-  // Run shortly after boot so fresh deploys catch up immediately.
+  cronRegistry.register({
+    name: "sentimentEngine",
+    description: "Customer sentiment analysis over recent inbound messages (every 15 min)",
+    defaultSchedule: "*/15 * * * *",
+    tickFn: tickSentimentEngine,
+  }).catch((e) => console.error("[Sentiment] cronRegistry registration failed:", e.message));
+
+  // Run shortly after boot so fresh deploys catch up immediately — routed
+  // through cronRegistry.runTick (not a bare tickSentimentEngine() call) so
+  // this startup pass is also captured as a CronExecutionLog row.
   setTimeout(() => {
-    tickSentimentEngine().catch(err => console.error("[Sentiment] Initial tick error:", err));
+    cronRegistry.runTick("sentimentEngine", "startup").catch((err) =>
+      console.error("[Sentiment] Initial tick error:", err));
   }, 15_000);
-
-  cron.schedule("*/15 * * * *", () => {
-    tickSentimentEngine().catch(err => console.error("[Sentiment] Cron tick error:", err));
-  });
-
-  console.log("[Sentiment] Cron initialized (every 15 minutes).");
 }
 
 module.exports = {

--- a/backend/cron/sequenceEngine.js
+++ b/backend/cron/sequenceEngine.js
@@ -23,7 +23,7 @@
  *   the step it is parked on has pauseOnReply=true — flips status='Paused'
  *   and clears nextRun. Idempotent via the sequenceReplyHandled timestamp.
  */
-const cron = require('node-cron');
+const cronRegistry = require('../lib/cronRegistry');
 const prisma = require('../lib/prisma');
 const { getSetting, KEYS } = require('../lib/tenantSettings');
 const { evaluateCondition, renderTemplate } = require('../lib/eventBus');
@@ -982,12 +982,12 @@ const tickSequenceEngine = async () => {
 };
 
 const initSequenceCron = () => {
-  cron.schedule('* * * * *', () => {
-    tickSequenceEngine().catch((err) => {
-      console.error('[sequenceEngine] unhandled tick error:', err);
-    });
-  });
-  console.log('Sequence Execution Engine initialized (cron: * * * * *)');
+  cronRegistry.register({
+    name: 'sequenceEngine',
+    description: 'Drip-sequence step execution — sends due SequenceEnrollment steps (every minute)',
+    defaultSchedule: '* * * * *',
+    tickFn: tickSequenceEngine,
+  }).catch((e) => console.error('[sequenceEngine] cronRegistry registration failed:', e.message));
 };
 
 module.exports = {

--- a/backend/cron/slaBreachEngine.js
+++ b/backend/cron/slaBreachEngine.js
@@ -17,7 +17,7 @@
  * cron will never re-fire for that ticket — so we don't spam the bus.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
 const { emitEvent } = require("../lib/eventBus");
@@ -177,12 +177,12 @@ async function tickSlaBreaches() {
 }
 
 function initSlaBreachCron() {
-  cron.schedule("*/5 * * * *", () => {
-    tickSlaBreaches().catch((e) =>
-      console.error("[SLABreach] tick crashed:", e.message),
-    );
-  });
-  console.log("SLA Breach Engine initialized (cron: */5 * * * *)");
+  cronRegistry.register({
+    name: "slaBreachEngine",
+    description: "Flips Ticket.breached + emits sla.breached (every 5 min)",
+    defaultSchedule: "*/5 * * * *",
+    tickFn: tickSlaBreaches,
+  }).catch((e) => console.error("[SLABreach] cronRegistry registration failed:", e.message));
 }
 
 // Convenience runner for the manual-trigger endpoint: scopes to a single

--- a/backend/cron/travelDiagnosticAdvisorAlerts.js
+++ b/backend/cron/travelDiagnosticAdvisorAlerts.js
@@ -18,7 +18,7 @@
 // type='warning'). Each diagnostic gets at most ONE escalation alert
 // across its lifecycle.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -222,14 +222,13 @@ async function runDiagnosticAlertsForAllTravelTenants() {
 }
 
 function initTravelDiagnosticAlertsCron() {
-  // Every 5 minutes — :07 offset per the standing rule (avoid the :00 /
-  // :05 cluster). PRD §6.3 specifies "every 5 min."
-  cron.schedule("*/5 * * * *", () => {
-    runDiagnosticAlertsForAllTravelTenants().catch((e) =>
-      console.error("[TravelDiagnosticAlerts] cron fail:", e.message),
-    );
-  });
-  console.log("[TravelDiagnosticAlerts] cron initialized (every 5 min)");
+  // Every 5 minutes. PRD §6.3 specifies "every 5 min."
+  cronRegistry.register({
+    name: "travelDiagnosticAdvisorAlerts",
+    description: "Flags stalled (>30 min, no advisor outreach) travel diagnostics (every 5 min)",
+    defaultSchedule: "*/5 * * * *",
+    tickFn: runDiagnosticAlertsForAllTravelTenants,
+  }).catch((e) => console.error("[TravelDiagnosticAlerts] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/travelJourneyReminders.js
+++ b/backend/cron/travelJourneyReminders.js
@@ -26,7 +26,7 @@
 // library. This cron triggers the EVENT; the actual message body comes
 // from per-tenant templates in a follow-up commit.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -214,14 +214,13 @@ async function runJourneyRemindersForAllTravelTenants() {
 }
 
 function initTravelJourneyRemindersCron() {
-  // Every 30 minutes — :13 offset per the standing rule. PRD §6.3
-  // specifies "every 30 min."
-  cron.schedule("13,43 * * * *", () => {
-    runJourneyRemindersForAllTravelTenants().catch((e) =>
-      console.error("[TravelJourneyReminders] cron fail:", e.message),
-    );
-  });
-  console.log("[TravelJourneyReminders] cron initialized (every 30 min)");
+  // Every 30 minutes. PRD §6.3 specifies "every 30 min."
+  cronRegistry.register({
+    name: "travelJourneyReminders",
+    description: "RFU journey milestone reminders (T-7d/T-3d/T-1d/T-0/T+2d/T+7d), every 30 min",
+    defaultSchedule: "13,43 * * * *",
+    tickFn: runJourneyRemindersForAllTravelTenants,
+  }).catch((e) => console.error("[TravelJourneyReminders] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/travelReviewEngine.js
+++ b/backend/cron/travelReviewEngine.js
@@ -20,7 +20,7 @@
 // Travel-only: scans the Itinerary model (travel-only) — no-ops for
 // wellness/generic.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const crypto = require("crypto");
 const prisma = require("../lib/prisma");
 const emailSender = require("../lib/emailSender");
@@ -112,10 +112,12 @@ async function runTravelReviewTick(now = new Date()) {
 // Daily tick at 09:07 — reviews aren't time-critical; the 4-day lookback covers
 // any missed day. Idempotency (one row per itinerary) makes re-runs safe.
 function initTravelReviewCron() {
-  cron.schedule("7 9 * * *", () => {
-    runTravelReviewTick().catch((e) => console.error("[TravelReview] tick error:", e.message));
-  });
-  console.log("[TravelReview] cron scheduled (daily 09:07)");
+  cronRegistry.register({
+    name: "travelReviewEngine",
+    description: "Post-trip customer review request emails (daily 09:07)",
+    defaultSchedule: "7 9 * * *",
+    tickFn: runTravelReviewTick,
+  }).catch((e) => console.error("[TravelReview] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { runTravelReviewTick, initTravelReviewCron, REVIEW_STATUSES, reviewUrl };

--- a/backend/cron/tripCountdownEngine.js
+++ b/backend/cron/tripCountdownEngine.js
@@ -27,7 +27,7 @@
 // travelJourneyReminders.js, which only writes Notification rows — no email —
 // so the two don't double-send.)
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const emailSender = require("../lib/emailSender");
 const content = require("../lib/tripCountdownContent");
@@ -142,10 +142,12 @@ async function runTripCountdownTick(now = new Date()) {
 // Hourly tick (at :17). Daily-bucket idempotency means the first tick of each
 // day that sees a new days-to-go sends; later ticks that day are no-ops.
 function initTripCountdownCron() {
-  cron.schedule("17 * * * *", () => {
-    runTripCountdownTick().catch((e) => console.error("[TripCountdown] tick error:", e.message));
-  });
-  console.log("[TripCountdown] cron scheduled (hourly :17)");
+  cronRegistry.register({
+    name: "tripCountdownEngine",
+    description: "Pre-trip countdown nudge emails for PAID travel customers (hourly :17)",
+    defaultSchedule: "17 * * * *",
+    tickFn: runTripCountdownTick,
+  }).catch((e) => console.error("[TripCountdown] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { runTripCountdownTick, initTripCountdownCron, daysToGo, PAID_STATUSES, AGREEMENT_SECURED };

--- a/backend/cron/tripPaymentReminders.js
+++ b/backend/cron/tripPaymentReminders.js
@@ -23,7 +23,7 @@
 // dispatch line. WhatsApp/email send slots in once Wati BSP creds (Q9)
 // land — the WhatsAppMessage row creation goes in the same loop.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -223,15 +223,14 @@ async function runPaymentRemindersForAllTravelTenants() {
 }
 
 function initTripPaymentRemindersCron() {
-  // Daily 07:13 IST (off-minute per the standing rule). PRD §6.3 says
-  // "daily 09:00 IST" — running earlier so the reminders are queued by
-  // the time school finance teams open the system.
-  cron.schedule("13 7 * * *", () => {
-    runPaymentRemindersForAllTravelTenants().catch((e) =>
-      console.error("[TripPaymentReminders] cron fail:", e.message),
-    );
-  });
-  console.log("[TripPaymentReminders] cron initialized (daily 07:13 IST)");
+  // Daily 07:13 IST. PRD §6.3 says "daily 09:00 IST" — running earlier so
+  // the reminders are queued by the time school finance teams open the system.
+  cronRegistry.register({
+    name: "tripPaymentReminders",
+    description: "TripInstalmentPayment pre-due/overdue reminder notifications (daily 07:13 IST)",
+    defaultSchedule: "13 7 * * *",
+    tickFn: runPaymentRemindersForAllTravelTenants,
+  }).catch((e) => console.error("[TripPaymentReminders] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/tripPostTripFeedback.js
+++ b/backend/cron/tripPostTripFeedback.js
@@ -19,7 +19,7 @@
 // reuse here). When Wati creds land, the dispatch loop adds a
 // WhatsAppMessage row keyed to schoolContact.phone with the survey link.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -169,15 +169,13 @@ async function runPostTripFeedbackForAllTravelTenants() {
 }
 
 function initTripPostTripFeedbackCron() {
-  // 06:13 IST — :13 minute jitter per the standing rule (avoid :00 / :30
-  // clustering across the cron fleet). The actual time of day matches the
-  // PRD §6.3 "daily 06:00 IST" specification approximately.
-  cron.schedule("13 6 * * *", () => {
-    runPostTripFeedbackForAllTravelTenants().catch((e) =>
-      console.error("[TripPostTripFeedback] cron fail:", e.message),
-    );
-  });
-  console.log("[TripPostTripFeedback] cron initialized (daily 06:13 IST)");
+  // 06:13 IST — matches the PRD §6.3 "daily 06:00 IST" specification approximately.
+  cronRegistry.register({
+    name: "tripPostTripFeedback",
+    description: "Creates a post-trip feedback Survey for recently-returned TmcTrips (daily 06:13 IST)",
+    defaultSchedule: "13 6 * * *",
+    tickFn: runPostTripFeedbackForAllTravelTenants,
+  }).catch((e) => console.error("[TripPostTripFeedback] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/visaRiskFlagEngine.js
+++ b/backend/cron/visaRiskFlagEngine.js
@@ -65,7 +65,7 @@
 // The Notification row is the visible SHELL output; advisor dashboard
 // surfaces them under the Visa Sure queue.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 
 const PORTAL_BASE = process.env.PUBLIC_BASE_URL || "https://crm.globusdemos.com";
@@ -537,12 +537,12 @@ async function runRiskFlaggingForAllTravelTenants() {
 function initVisaRiskFlagCron() {
   // Every 6 hours per the SHELL dispatch contract. Real engine cadence
   // tightens to 15 min once PC-1..PC-5 resolve (PRD §4 latency target).
-  cron.schedule("0 */6 * * *", () => {
-    runRiskFlaggingForAllTravelTenants().catch((e) =>
-      console.error("[VisaRiskFlag] cron fail:", e.message),
-    );
-  });
-  console.log("[VisaRiskFlag] cron initialized (every 6 hours)");
+  cronRegistry.register({
+    name: "visaRiskFlagEngine",
+    description: "Flags at-risk VisaApplication rows (complex-case/rejection-history/stale) — every 6h",
+    defaultSchedule: "0 */6 * * *",
+    tickFn: runRiskFlaggingForAllTravelTenants,
+  }).catch((e) => console.error("[VisaRiskFlag] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/walletExpiryEngine.js
+++ b/backend/cron/walletExpiryEngine.js
@@ -58,7 +58,7 @@
  *   env var per PRD §4.
  */
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { writeAudit } = require("../lib/audit");
 
@@ -283,16 +283,13 @@ async function run() {
  * server's local TZ.
  */
 function initWalletExpiryCron() {
-  cron.schedule(
-    DEFAULT_SCHEDULE,
-    () => {
-      module.exports.run().catch((e) =>
-        console.error(`[walletExpiry] cron tick failed: ${e.message}`),
-      );
-    },
-    { timezone: "Asia/Kolkata" },
-  );
-  console.log("[walletExpiry] cron initialized (daily 03:30 IST)");
+  cronRegistry.register({
+    name: "walletExpiryEngine",
+    description: "Expires ACTIVE WalletCreditBatch rows past expiresAt + debits balance (daily 03:30 IST)",
+    defaultSchedule: DEFAULT_SCHEDULE,
+    cronOptions: { timezone: "Asia/Kolkata" },
+    tickFn: () => module.exports.run(),
+  }).catch((e) => console.error("[walletExpiry] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/webCheckinAutomation.js
+++ b/backend/cron/webCheckinAutomation.js
@@ -31,7 +31,7 @@
 //
 // Travel-only: WebCheckin rows exist only in the travel vertical.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { writeAudit } = require("../lib/audit");
 const { resolveAdapter: defaultResolveAdapter } = require("../services/airlineAdapters");
@@ -355,12 +355,12 @@ function initWebCheckinAutomationCron() {
   // Every 15 min, off-cluster (mirrors scheduler's jitter but offset by a few
   // minutes so automation claims `reminded` rows before the scheduler's
   // +30-min stall sweep can flip them to fallback-agent).
-  cron.schedule("8,23,38,53 * * * *", () => {
-    runWebCheckinAutomationTick().catch((e) =>
-      console.error("[WebCheckinAutomation] cron fail:", e.message),
-    );
-  });
-  console.log("[WebCheckinAutomation] cron initialized (every 15 min, off-minute jitter)");
+  cronRegistry.register({
+    name: "webCheckinAutomation",
+    description: "Performs airline web check-in for reminded/retry-eligible bookings (every 15 min)",
+    defaultSchedule: "8,23,38,53 * * * *",
+    tickFn: runWebCheckinAutomationTick,
+  }).catch((e) => console.error("[WebCheckinAutomation] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/webCheckinEngine.js
+++ b/backend/cron/webCheckinEngine.js
@@ -23,7 +23,7 @@
 // Travel-only: WebCheckin rows exist only in the travel vertical, so this
 // no-ops for wellness/generic tenants.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const emailSender = require("../lib/emailSender");
 const content = require("../lib/webCheckinContent");
@@ -134,10 +134,12 @@ async function runWebCheckinTick(now = new Date()) {
 // and the existing webCheckinScheduler's :13/:28/:43/:58). The 12h milestone
 // windows mean an hourly tick reliably fires each of T-36/24/12h once.
 function initWebCheckinCron() {
-  cron.schedule("47 * * * *", () => {
-    runWebCheckinTick().catch((e) => console.error("[WebCheckinEmail] tick error:", e.message));
-  });
-  console.log("[WebCheckinEmail] cron scheduled (hourly :47)");
+  cronRegistry.register({
+    name: "webCheckinEngine",
+    description: "Web check-in reminder emails at T-36h/T-24h/T-12h before departure (hourly :47)",
+    defaultSchedule: "47 * * * *",
+    tickFn: runWebCheckinTick,
+  }).catch((e) => console.error("[WebCheckinEmail] cronRegistry registration failed:", e.message));
 }
 
 module.exports = { runWebCheckinTick, initWebCheckinCron, PAID_STATUSES };

--- a/backend/cron/webCheckinScheduler.js
+++ b/backend/cron/webCheckinScheduler.js
@@ -26,7 +26,7 @@
 // pending Wati BSP creds (Q9). The Notification + status transition
 // are the visible Phase 1 outputs.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
@@ -247,14 +247,13 @@ async function runWebCheckinSchedulerForAllTravelTenants() {
 }
 
 function initWebCheckinSchedulerCron() {
-  // Every 15 minutes — off the :00/:15/:30/:45 cluster per the standing
-  // rule. PRD §6.3 row 1 specifies "every 15 min."
-  cron.schedule("13,28,43,58 * * * *", () => {
-    runWebCheckinSchedulerForAllTravelTenants().catch((e) =>
-      console.error("[WebCheckinScheduler] cron fail:", e.message),
-    );
-  });
-  console.log("[WebCheckinScheduler] cron initialized (every 15 min, off-minute jitter)");
+  // Every 15 minutes. PRD §6.3 row 1 specifies "every 15 min."
+  cronRegistry.register({
+    name: "webCheckinScheduler",
+    description: "Flips WebCheckin status pending→reminded→fallback-agent on window/stall triggers (every 15 min)",
+    defaultSchedule: "13,28,43,58 * * * *",
+    tickFn: runWebCheckinSchedulerForAllTravelTenants,
+  }).catch((e) => console.error("[WebCheckinScheduler] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/wellnessOpsEngine.js
+++ b/backend/cron/wellnessOpsEngine.js
@@ -8,7 +8,7 @@
  * SMS provider here — we just queue an SmsMessage row that the existing
  * provider worker will pick up.
  */
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { getSetting, KEYS } = require("../lib/tenantSettings");
 
@@ -305,10 +305,12 @@ async function runOpsForAllWellnessTenants() {
 
 function initWellnessOpsCron() {
   // Hourly — NPS sends are time-sensitive (catch the 72h window cleanly)
-  cron.schedule("17 * * * *", () => {
-    runOpsForAllWellnessTenants().catch((e) => console.error("[WellnessOps] cron fail:", e.message));
-  });
-  console.log("[WellnessOps] cron initialized (hourly NPS + retention)");
+  cronRegistry.register({
+    name: "wellnessOpsEngine",
+    description: "Hourly wellness NPS survey (72h post-visit) + 90-day junk-lead retention purge",
+    defaultSchedule: "17 * * * *",
+    tickFn: runOpsForAllWellnessTenants,
+  }).catch((e) => console.error("[WellnessOps] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/whatsappMediaEngine.js
+++ b/backend/cron/whatsappMediaEngine.js
@@ -17,7 +17,7 @@
 // days after upload. The first download attempt should happen within seconds
 // of the inbound webhook; if it doesn't, we re-resolve the URL each retry.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { decryptCredential } = require("../lib/credentialMasking");
 const { downloadMediaUrl, downloadMediaBytes } = require("../services/whatsappProvider");
@@ -160,12 +160,12 @@ async function tick() {
 }
 
 function initWhatsappMediaCron() {
-  cron.schedule(TICK_CRON, () => {
-    tick().catch((err) => {
-      console.error("[whatsappMediaEngine] unhandled tick error:", err);
-    });
-  });
-  console.log(`[whatsappMediaEngine] initialized (cron: ${TICK_CRON})`);
+  cronRegistry.register({
+    name: "whatsappMediaEngine",
+    description: "Downloads pending WhatsApp inbound media (60s tick)",
+    defaultSchedule: TICK_CRON,
+    tickFn: tick,
+  }).catch((e) => console.error("[whatsappMediaEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/whatsappOutboundEngine.js
+++ b/backend/cron/whatsappOutboundEngine.js
@@ -32,7 +32,7 @@
 //   or has no accessToken, the engine marks the row FAILED with a clear
 //   `lastError` rather than spinning indefinitely.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { decryptCredential } = require("../lib/credentialMasking");
 const { sendText, sendTemplate } = require("../services/whatsappProvider");
@@ -509,12 +509,19 @@ async function tick() {
   }
 }
 
+// Super Admin Portal / Cron Maintenance — scheduling now goes through the
+// central registry (lib/cronRegistry.js) instead of a local cron.schedule()
+// call, so this engine's enabled state + schedule are admin-editable and
+// take effect without a server restart.
 function initWhatsappOutboundCron(io) {
   if (io) socketIo = io;
-  cron.schedule(TICK_CRON, () => {
-    tick();
-  });
-  console.log(`[whatsappOutboundEngine] initialized (cron: ${TICK_CRON})`);
+  cronRegistry.register({
+    name: 'whatsappOutboundEngine',
+    description: 'Claims + sends PENDING WaOutboundJob rows via Meta Cloud API (30s tick)',
+    defaultSchedule: TICK_CRON,
+    tickFn: tick,
+  }).catch((e) => console.error('[whatsappOutboundEngine] cronRegistry registration failed:', e.message));
+  console.log(`[whatsappOutboundEngine] registered (default tick: ${TICK_CRON})`);
 }
 
 module.exports = {

--- a/backend/cron/whatsappTemplateSyncEngine.js
+++ b/backend/cron/whatsappTemplateSyncEngine.js
@@ -12,7 +12,7 @@
 // Also exposed as an on-demand POST /api/whatsapp/templates/sync route in
 // routes/whatsapp.js — see the helper `syncTemplatesForTenant` below.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { decryptCredential } = require("../lib/credentialMasking");
 const provider = require("../services/whatsappProvider");
@@ -113,12 +113,12 @@ async function tick() {
 }
 
 function initWhatsappTemplateSyncCron() {
-  cron.schedule(TICK_CRON, () => {
-    tick().catch((err) => {
-      console.error("[whatsappTemplateSyncEngine] unhandled tick error:", err);
-    });
-  });
-  console.log(`[whatsappTemplateSyncEngine] initialized (cron: ${TICK_CRON})`);
+  cronRegistry.register({
+    name: "whatsappTemplateSyncEngine",
+    description: "Nightly sync of approved WhatsApp templates from Meta (daily 03:30)",
+    defaultSchedule: TICK_CRON,
+    tickFn: tick,
+  }).catch((e) => console.error("[whatsappTemplateSyncEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/cron/whatsappTokenRefreshEngine.js
+++ b/backend/cron/whatsappTokenRefreshEngine.js
@@ -16,7 +16,7 @@
 // fails repeatedly until the token actually expires, the expired-branch
 // catches it.
 
-const cron = require("node-cron");
+const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
 const { encryptCredential, decryptCredential } = require("../lib/credentialMasking");
 const provider = require("../services/whatsappProvider");
@@ -162,8 +162,12 @@ async function tick() {
 }
 
 function initWhatsappTokenRefreshCron() {
-  cron.schedule(TICK_CRON, () => { tick(); });
-  console.log(`[whatsappTokenRefreshEngine] initialized (cron: ${TICK_CRON})`);
+  cronRegistry.register({
+    name: "whatsappTokenRefreshEngine",
+    description: "Proactive WhatsApp token refresh (7d before expiry) + expiry Notification (daily 04:30)",
+    defaultSchedule: TICK_CRON,
+    tickFn: tick,
+  }).catch((e) => console.error("[whatsappTokenRefreshEngine] cronRegistry registration failed:", e.message));
 }
 
 module.exports = {

--- a/backend/lib/apiPricing.js
+++ b/backend/lib/apiPricing.js
@@ -1,0 +1,109 @@
+/**
+ * apiPricing.js — static $-per-unit pricing table for external API cost
+ * estimation, powering the Super Admin "API Analytics" dashboard.
+ *
+ * Deliberately a maintained constants table, not a live pricing API call —
+ * the whole point is estimating cost WITHOUT hitting the provider (their
+ * billing APIs are typically delayed/aggregated, not per-call). Prices are
+ * list-price-as-of-authoring and WILL drift; there is no automatic refresh.
+ * Update PRICING_PER_1K below when a provider changes list pricing.
+ *
+ * Two shapes:
+ *   - LLM/token-based (Gemini, OpenAI, Anthropic, Perplexity, Groq):
+ *     estimateLlmCost(model, promptTokens, completionTokens) -> Decimal-safe number
+ *   - Flat-rate APIs (SerpApi — no token concept, priced per search):
+ *     estimateFlatCost(provider) -> number | null (null = unknown, don't guess)
+ */
+
+'use strict';
+
+// $ per 1,000 tokens, input/output split where the provider prices them
+// differently (most do). Source: each provider's public pricing page,
+// captured at authoring time (2026-07). Model-name keys mirror the `model`
+// strings already used in llmRouter.js's MODEL_ROUTING / ENV_FOR_MODEL maps.
+const PRICING_PER_1K = {
+  // Gemini
+  'gemini-flash': { in: 0.000075, out: 0.0003 }, // gemini-2.5-flash-ish tier
+  'gemini-2.5-flash': { in: 0.000075, out: 0.0003 },
+  'gemini-2.5-flash-lite': { in: 0.00002, out: 0.00008 },
+  'gemini-2.0-flash': { in: 0.00005, out: 0.0002 },
+  'gemini-pro': { in: 0.00125, out: 0.005 },
+
+  // OpenAI
+  'gpt-4': { in: 0.03, out: 0.06 },
+  'gpt-4o': { in: 0.0025, out: 0.01 },
+  'gpt-4o-mini': { in: 0.00015, out: 0.0006 },
+  'gpt-4o-search-preview': { in: 0.0025, out: 0.01 },
+
+  // Anthropic
+  'claude-opus-4-7': { in: 0.015, out: 0.075 },
+  'claude-opus-4-8': { in: 0.015, out: 0.075 },
+  'claude-haiku': { in: 0.0008, out: 0.004 },
+  'claude-haiku-4-5': { in: 0.001, out: 0.005 },
+
+  // Perplexity
+  'perplexity-sonar': { in: 0.001, out: 0.001 },
+
+  // Groq (Llama models — Groq's own hosted pricing)
+  'groq-llama': { in: 0.00005, out: 0.00008 },
+};
+
+// Flat $/request pricing for non-token APIs. Providers absent from this
+// table (or explicitly set to null) are "don't estimate, we don't know the
+// plan's real per-call rate" — surfaced as "unknown" in the UI rather than a
+// silently-wrong number. TripGo/Zoom have no public flat per-call price (both
+// are typically negotiated/tiered plans); Razorpay is a % of the transaction
+// amount, not a per-API-call cost — all three are tracked as request COUNTS
+// only, never a fabricated $ figure.
+const FLAT_RATE_PER_REQUEST = {
+  serpapi: 0.015, // SerpApi's pay-as-you-go list rate ($75/5000 searches)
+  tripgo: null,
+  zoom: null,
+  razorpay: null,
+};
+
+// provider inference from a model-name string — mirrors llmRouter.js's own
+// providerForModel() so this module has zero import-cycle risk (llmRouter.js
+// requires apiPricing.js, not the reverse) and can be reused by call sites
+// that never touch llmRouter.js (routes/ai.js, sentimentEngine.js, etc.).
+function inferProvider(model) {
+  const m = String(model || '').toLowerCase();
+  if (m.includes('gemini')) return 'gemini';
+  if (m.includes('gpt') || m.includes('openai')) return 'openai';
+  if (m.includes('claude')) return 'anthropic';
+  if (m.includes('perplexity') || m.includes('sonar')) return 'perplexity';
+  if (m.includes('groq') || m.includes('llama')) return 'groq';
+  return 'unknown';
+}
+
+/**
+ * Returns a plain number (USD), never throws. Falls back to 0 for unknown
+ * models — callers should treat 0 as "unpriced", same convention llmRouter.js
+ * already uses for costEstimate.
+ */
+function estimateLlmCost(model, promptTokens, completionTokens) {
+  const key = String(model || '').toLowerCase();
+  const rate = PRICING_PER_1K[key];
+  if (!rate) return 0;
+  const inCost = ((promptTokens || 0) / 1000) * rate.in;
+  const outCost = ((completionTokens || 0) / 1000) * rate.out;
+  return Math.round((inCost + outCost) * 1e6) / 1e6; // 6dp, matches Decimal(12,6)
+}
+
+/**
+ * Returns a number for a known flat-rate provider, or null when the rate is
+ * unknown — callers must NOT coerce null to 0 (that would silently claim
+ * "free" instead of "unpriced").
+ */
+function estimateFlatCost(provider) {
+  const rate = FLAT_RATE_PER_REQUEST[String(provider || '').toLowerCase()];
+  return typeof rate === 'number' ? rate : null;
+}
+
+module.exports = {
+  PRICING_PER_1K,
+  FLAT_RATE_PER_REQUEST,
+  inferProvider,
+  estimateLlmCost,
+  estimateFlatCost,
+};

--- a/backend/lib/cronDynamicHandlers.js
+++ b/backend/lib/cronDynamicHandlers.js
@@ -1,0 +1,148 @@
+/**
+ * cronDynamicHandlers.js — Super Admin Portal / Cron Maintenance.
+ *
+ * Fixed, safe handler types for admin-created dynamic crons (CronConfig
+ * rows with isSystem:false). There is NO arbitrary-code-execution path —
+ * an admin picks a handlerKey from this fixed list and supplies JSON
+ * metadata; the handler interprets that data, it never evals/requires it.
+ *
+ * Adding a new handler type = add one entry here + one UI option. This is
+ * the intentional ceiling on "what a dynamic cron can do" — anything
+ * requiring real business logic should become a proper cron/*.js engine
+ * registered via cronRegistry.register() instead (see docs at the top of
+ * lib/cronRegistry.js), not a dynamic handler.
+ */
+
+'use strict';
+
+const HANDLERS = {
+  // Pings an arbitrary URL on schedule. Useful for keep-alive pings,
+  // triggering an external system's own cron via webhook, etc.
+  // metadata: { url: string, method?: 'GET'|'POST', bodyJson?: string, headersJson?: string }
+  http_webhook_ping: {
+    label: "HTTP Webhook Ping",
+    description: "Pings an arbitrary URL on schedule. Useful for keep-alive pings or triggering external webhooks.",
+    metadataSchema: { url: "string (required)", method: "'GET'|'POST' (default POST)", bodyJson: "string", headersJson: "string" },
+    fn: async function httpWebhookPing(metadata) {
+      const { url, method = 'POST', bodyJson, headersJson } = metadata || {};
+    if (!url || typeof url !== 'string') {
+      throw new Error('http_webhook_ping requires metadata.url');
+    }
+    // Guard against pinging internal/private infra from a public-facing
+    // "Create Cron" form — same class of concern as an SSRF guard.
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`http_webhook_ping: metadata.url is not a valid URL: ${url}`);
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error(`http_webhook_ping: unsupported protocol ${parsed.protocol}`);
+    }
+    // URL.hostname KEEPS the brackets for an IPv6 literal (e.g. "[::1]"),
+    // unlike most other hostname APIs — both forms are listed so a bracketed
+    // or unbracketed literal is caught either way.
+    const blockedHosts = ['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'];
+    if (blockedHosts.includes(parsed.hostname)) {
+      throw new Error(`http_webhook_ping: refusing to ping internal host ${parsed.hostname}`);
+    }
+
+    let headers = { 'content-type': 'application/json' };
+    if (headersJson) {
+      try {
+        headers = { ...headers, ...JSON.parse(headersJson) };
+      } catch {
+        throw new Error('http_webhook_ping: metadata.headersJson is not valid JSON');
+      }
+    }
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 15000);
+    try {
+      const resp = await fetch(url, {
+        method,
+        headers,
+        body: method === 'GET' ? undefined : (bodyJson || '{}'),
+        signal: ctrl.signal,
+      });
+      if (!resp.ok) {
+        throw new Error(`http_webhook_ping: ${url} responded ${resp.status}`);
+      }
+      return { ok: true, status: resp.status };
+    } finally {
+      clearTimeout(timer);
+    }
+    },
+  },
+
+  // No-op handler that just logs — useful for verifying the scheduler
+  // itself works (create one, watch it fire, check the Cron Logs screen)
+  // without needing any external dependency.
+  // metadata: { message?: string }
+  log_note: {
+    label: "Log Note (test/no-op)",
+    description: "Logs a message to the console on every tick. Useful for verifying the scheduler without external dependencies.",
+    metadataSchema: { message: "string (optional)" },
+    fn: async function logNote(metadata) {
+      const message = (metadata && metadata.message) || '(no message)';
+      console.log(`[cronDynamicHandlers:log_note] ${message}`);
+      return { ok: true, message };
+    },
+  },
+};
+
+const VALID_HANDLER_KEYS = Object.keys(HANDLERS);
+
+function isValidHandlerKey(key) {
+  return VALID_HANDLER_KEYS.includes(key);
+}
+
+function getHandler(key) {
+  return HANDLERS[key] || null;
+}
+
+function getHandlerCatalog() {
+  return VALID_HANDLER_KEYS.map((key) => {
+    const h = HANDLERS[key];
+    return {
+      key,
+      label: h.label || key,
+      description: h.description || "",
+      metadataSchema: h.metadataSchema || {},
+    };
+  });
+}
+
+/**
+ * Build a tickFn for a dynamic CronConfig row — parses metadataJson once
+ * (at build time, not per-tick) so a malformed JSON fails fast at
+ * registration instead of silently no-op-ing on every tick.
+ */
+function buildDynamicTickFn(handlerKey, metadataJson) {
+  const handlerEntry = HANDLERS[handlerKey];
+  if (!handlerEntry) {
+    throw new Error(`Unknown handlerKey: ${handlerKey}`);
+  }
+  const handler = handlerEntry.fn;
+  if (typeof handler !== 'function') {
+    throw new Error(`Handler ${handlerKey} does not expose a callable fn`);
+  }
+  let metadata = {};
+  if (metadataJson) {
+    try {
+      metadata = JSON.parse(metadataJson);
+    } catch {
+      throw new Error('metadataJson is not valid JSON');
+    }
+  }
+  return () => handler(metadata);
+}
+
+module.exports = {
+  HANDLERS,
+  VALID_HANDLER_KEYS,
+  isValidHandlerKey,
+  getHandler,
+  getHandlerCatalog,
+  buildDynamicTickFn,
+};

--- a/backend/lib/cronRegistry.js
+++ b/backend/lib/cronRegistry.js
@@ -1,0 +1,358 @@
+/**
+ * cronRegistry.js — Super Admin Portal / Cron Maintenance.
+ *
+ * Central owner of every real node-cron ScheduledTask in the process. The
+ * 46 existing cron/*.js engines stop calling node-cron's cron.schedule()
+ * themselves; instead each engine's init function calls
+ * register({name, tickFn, defaultSchedule, ...}) once at boot. This module
+ * is the ONLY place that ever calls node-cron's schedule/stop/destroy, so
+ * it's the single seam the Super Admin UI's Enable/Disable and
+ * Edit-Schedule actions need to hook into.
+ *
+ * Self-healing by design: on first registration for a given engine name,
+ * if no CronConfig row exists yet, one is upserted using the engine's own
+ * hardcoded defaultSchedule + enabled=true. This means:
+ *   - A totally fresh DB (first boot ever) behaves EXACTLY like the old
+ *     hardcoded cron.schedule() calls — same schedule, always enabled.
+ *   - Adding a 47th engine later needs zero manual DB setup; it just
+ *     shows up in the Super Admin table on next boot.
+ *   - An admin's edits (schedule/enabled) in CronConfig are authoritative
+ *     from then on; register() never overwrites an EXISTING row.
+ *
+ * Every tick (whether fired by node-cron on schedule or by the manual
+ * "Run now" trigger) is wrapped so a CronExecutionLog row is written with
+ * start/finish/duration/status/error — this is what powers the Cron Logs
+ * screen's pass/fail history and rate.
+ *
+ * Live reschedule: applyConfig(name) tears down the current node-cron task
+ * (if any) and recreates it from the CURRENT CronConfig row — called right
+ * after any admin edit, so changes take effect immediately, no restart.
+ *
+ * CJS self-mocking seam (CLAUDE.md standing pattern): inter-function calls
+ * go through module.exports.fn(...) so vitest vi.spyOn interception works,
+ * and the real `node-cron` module is reached only via the exported `_cron`
+ * reference (never a bare local closure over `require('node-cron')`) so
+ * tests can vi.spyOn(module.exports._cron, 'schedule'/'validate') instead
+ * of fighting vitest's ESM-import-only vi.mock() hoisting against a
+ * top-level CJS require — the same constraint documented in
+ * test/services/flyer-render-engine.test.js for `require('puppeteer')`.
+ */
+
+'use strict';
+
+const _cron = require('node-cron');
+const prisma = require('./prisma');
+const { buildDynamicTickFn } = require('./cronDynamicHandlers');
+
+// name -> { task, defaultSchedule, tickFn, options, running }
+// `task` is null when the engine is currently disabled (no live node-cron
+// ScheduledTask exists for it).
+const registry = new Map();
+
+function isValidExpression(expr) {
+  try {
+    return module.exports._cron.validate(String(expr || ''));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register a cron engine. Called once per engine, from that engine's own
+ * init*Cron() function, in place of the engine's former direct
+ * cron.schedule(...) call.
+ *
+ * @param {Object} opts
+ * @param {string}   opts.name             Stable machine key, e.g. "leadScoringEngine". Must be unique.
+ * @param {string}   opts.defaultSchedule  Cron expression this engine shipped with historically — the fallback
+ *                                         used when no CronConfig row exists yet (fresh DB) or the row's
+ *                                         schedule is somehow invalid.
+ * @param {Function} opts.tickFn           The engine's existing tick callback — called with NO arguments,
+ *                                         exactly as node-cron would have called it. May return a Promise.
+ * @param {string}   [opts.description]    Human-readable description shown in the Super Admin table.
+ * @param {Object}   [opts.cronOptions]    Extra node-cron schedule options (e.g. { timezone: 'Asia/Kolkata' }).
+ * @param {boolean}  [opts.runImmediately] If true, calls tickFn once synchronously-fired (fire-and-forget)
+ *                                         right after registration — mirrors engines that historically ran
+ *                                         an immediate first tick at boot (e.g. leadScoringEngine).
+ * @param {boolean}  [opts.defaultEnabled] Enabled state used ONLY on first-ever registration (fresh
+ *                                         CronConfig row). Default true — matches every engine's historical
+ *                                         always-on behavior. An engine that's currently disconnected from
+ *                                         production traffic (e.g. no tenant has an active config for it
+ *                                         yet) can register with defaultEnabled:false so it's VISIBLE in the
+ *                                         Super Admin table for future one-click enable, without actually
+ *                                         running until an admin flips it on.
+ */
+async function register({
+  name,
+  defaultSchedule,
+  tickFn,
+  description = null,
+  cronOptions = {},
+  runImmediately = false,
+  defaultEnabled = true,
+}) {
+  if (!name || typeof name !== 'string') {
+    throw new Error('cronRegistry.register: name is required');
+  }
+  if (typeof tickFn !== 'function') {
+    throw new Error(`cronRegistry.register(${name}): tickFn must be a function`);
+  }
+  if (!module.exports.isValidExpression(defaultSchedule)) {
+    throw new Error(`cronRegistry.register(${name}): defaultSchedule "${defaultSchedule}" is not a valid cron expression`);
+  }
+
+  // Self-healing upsert — NEVER overwrites an existing row's schedule/enabled
+  // (those are admin-owned once created). Only creates the row if it's truly
+  // the engine's first-ever boot against this DB.
+  try {
+    await prisma.cronConfig.upsert({
+      where: { name },
+      update: description != null ? { description } : {},
+      create: {
+        name,
+        description,
+        schedule: defaultSchedule,
+        enabled: defaultEnabled,
+        isSystem: true,
+        createdBy: 'system',
+      },
+    });
+  } catch (e) {
+    console.error(`[cronRegistry] ${name}: failed to upsert CronConfig row (non-fatal, using in-memory default): ${e.message}`);
+  }
+
+  registry.set(name, {
+    task: null,
+    defaultSchedule,
+    tickFn,
+    cronOptions,
+    running: false,
+  });
+
+  await module.exports.applyConfig(name);
+
+  if (runImmediately) {
+    module.exports.runTick(name, 'startup').catch((e) =>
+      console.error(`[cronRegistry] ${name}: immediate startup tick failed: ${e.message}`));
+  }
+
+  return { name };
+}
+
+/**
+ * (Re)apply the CURRENT CronConfig row for `name` to the live node-cron
+ * task: stop/destroy whatever's running, then — if enabled — create a
+ * fresh task on the configured schedule. Called by register() at boot and
+ * by the Super Admin routes right after any Create/Update/Enable/Disable
+ * edit, so changes are live immediately.
+ */
+async function applyConfig(name) {
+  const entry = registry.get(name);
+  if (!entry) return { ok: false, reason: 'not-registered' };
+
+  // Tear down whatever's currently scheduled.
+  if (entry.task) {
+    try {
+      entry.task.stop();
+      entry.task.destroy();
+    } catch (e) {
+      console.warn(`[cronRegistry] ${name}: error stopping previous task (non-fatal): ${e.message}`);
+    }
+    entry.task = null;
+  }
+
+  let config = null;
+  try {
+    config = await prisma.cronConfig.findUnique({ where: { name } });
+  } catch (e) {
+    console.error(`[cronRegistry] ${name}: failed to read CronConfig (falling back to default schedule, enabled): ${e.message}`);
+  }
+
+  const enabled = config ? config.enabled : true;
+  const scheduleExpr = config && module.exports.isValidExpression(config.schedule) ? config.schedule : entry.defaultSchedule;
+
+  if (!enabled) {
+    console.log(`[cronRegistry] ${name}: disabled — no task scheduled`);
+    return { ok: true, enabled: false };
+  }
+
+  entry.task = module.exports._cron.schedule(
+    scheduleExpr,
+    () => {
+      module.exports.runTick(name, 'scheduled').catch((e) =>
+        console.error(`[cronRegistry] ${name}: tick error escaped runTick (this should not happen): ${e.message}`));
+    },
+    entry.cronOptions,
+  );
+
+  console.log(`[cronRegistry] ${name}: scheduled "${scheduleExpr}"${config ? '' : ' (default — no CronConfig row yet)'}`);
+  return { ok: true, enabled: true, schedule: scheduleExpr };
+}
+
+/**
+ * Execute one tick for `name` NOW, regardless of schedule — used by both
+ * the real node-cron firing (triggerType: "scheduled") and the Super
+ * Admin "Run now" manual-trigger button (triggerType: "manual"). Always
+ * writes a CronExecutionLog row bracketing the run, so the Cron Logs
+ * screen has a complete pass/fail history no matter how the tick fired.
+ *
+ * Guards against overlapping runs of the SAME engine (a slow tick + a
+ * manual trigger firing concurrently) by skipping (not queuing) — matches
+ * the historical behavior of the underlying engines, none of which were
+ * reentrant-safe.
+ */
+async function runTick(name, triggerType = 'scheduled') {
+  const entry = registry.get(name);
+  if (!entry) throw new Error(`cronRegistry.runTick: "${name}" is not registered`);
+  if (entry.running) {
+    console.warn(`[cronRegistry] ${name}: tick already in progress — skipping this ${triggerType} trigger`);
+    return { skipped: true, reason: 'already-running' };
+  }
+
+  entry.running = true;
+  const startedAt = new Date();
+  let logId = null;
+  try {
+    const config = await prisma.cronConfig.findUnique({ where: { name }, select: { id: true } });
+    if (config) {
+      const row = await prisma.cronExecutionLog.create({
+        data: {
+          cronConfigId: config.id,
+          cronName: name,
+          startedAt,
+          status: 'running',
+          triggerType,
+          instance: process.env.HOSTNAME || process.env.COMPUTERNAME || null,
+        },
+      });
+      logId = row.id;
+    }
+  } catch (e) {
+    console.warn(`[cronRegistry] ${name}: failed to write start log (non-fatal): ${e.message}`);
+  }
+
+  let status = 'success';
+  let errorMessage = null;
+  try {
+    await entry.tickFn();
+  } catch (e) {
+    status = 'failed';
+    errorMessage = String(e && e.message || e).slice(0, 4000);
+    console.error(`[cronRegistry] ${name}: tick threw: ${errorMessage}`);
+  } finally {
+    entry.running = false;
+  }
+
+  const finishedAt = new Date();
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  if (logId != null) {
+    try {
+      await prisma.cronExecutionLog.update({
+        where: { id: logId },
+        data: { finishedAt, durationMs, status, errorMessage },
+      });
+    } catch (e) {
+      console.warn(`[cronRegistry] ${name}: failed to write finish log (non-fatal): ${e.message}`);
+    }
+  }
+
+  return { status, durationMs, errorMessage };
+}
+
+/** List every registered engine's live in-memory state (for the API layer). */
+function listRegistered() {
+  return Array.from(registry.entries()).map(([name, entry]) => ({
+    name,
+    defaultSchedule: entry.defaultSchedule,
+    running: entry.running,
+    scheduled: !!entry.task,
+  }));
+}
+
+function isRegistered(name) {
+  return registry.has(name);
+}
+
+/**
+ * Fully remove a cron from the live registry — stops/destroys its node-cron
+ * task (if any) and drops it from the in-memory Map. Used when an admin
+ * deletes a DYNAMIC (isSystem:false) cron; system engines are never
+ * unregistered (they're recreated on the next boot from their init*Cron()
+ * call regardless), so this is only meaningful for admin-created crons.
+ * Does NOT touch the CronConfig DB row — the caller deletes that separately.
+ */
+function unregister(name) {
+  const entry = registry.get(name);
+  if (!entry) return { ok: false, reason: "not-registered" };
+  if (entry.task) {
+    try { entry.task.stop(); entry.task.destroy(); } catch { /* best-effort */ }
+  }
+  registry.delete(name);
+  return { ok: true };
+}
+
+/** Test/shutdown helper — stop every live task without clearing the registry map. */
+function stopAll() {
+  for (const [, entry] of registry) {
+    if (entry.task) {
+      try { entry.task.stop(); entry.task.destroy(); } catch { /* best-effort */ }
+      entry.task = null;
+    }
+  }
+}
+
+/** Test-only — fully reset registry state between test files. */
+function _resetForTests() {
+  stopAll();
+  registry.clear();
+}
+
+/**
+ * Load all admin-created dynamic crons (CronConfig rows with isSystem:false)
+ * from the DB and register them in the live registry. Called once at boot
+ * after every system engine has registered itself, so dynamic crons survive
+ * server restarts without requiring an admin to re-save them.
+ *
+ * Disabled dynamic crons are still registered (so they appear in the Super
+ * Admin table and can be enabled on demand), but applyConfig() will not
+ * create a live node-cron task for them.
+ */
+async function loadDynamicCrons() {
+  try {
+    const dynamicCrons = await prisma.cronConfig.findMany({ where: { isSystem: false } });
+    for (const config of dynamicCrons) {
+      try {
+        const tickFn = buildDynamicTickFn(config.handlerKey, config.metadataJson);
+        await register({
+          name: config.name,
+          description: config.description,
+          defaultSchedule: config.schedule,
+          defaultEnabled: config.enabled,
+          tickFn,
+        });
+        console.log(`[cronRegistry] loaded dynamic cron "${config.name}" (enabled=${config.enabled}, schedule="${config.schedule}")`);
+      } catch (e) {
+        console.error(`[cronRegistry] failed to load dynamic cron "${config.name}": ${e.message}`);
+      }
+    }
+    return { loaded: dynamicCrons.length };
+  } catch (e) {
+    console.error('[cronRegistry] failed to load dynamic crons:', e.message);
+    return { loaded: 0, error: e.message };
+  }
+}
+
+module.exports = {
+  register,
+  applyConfig,
+  runTick,
+  loadDynamicCrons,
+  listRegistered,
+  isRegistered,
+  unregister,
+  isValidExpression,
+  stopAll,
+  _resetForTests,
+  _cron,
+};

--- a/backend/lib/leadJunkFilter.js
+++ b/backend/lib/leadJunkFilter.js
@@ -17,6 +17,22 @@
  * Returns: { isJunk: boolean, score: 0..100, reasons: string[] }
  */
 const prisma = require("./prisma");
+const { estimateLlmCost } = require("./apiPricing");
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// lead ingestion, hence the nested try/catch and the un-awaited .catch().
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("./prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[leadJunkFilter] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[leadJunkFilter] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 // India mobile: 10 digits, starts with 6/7/8/9. We accept "+91" prefix or
 // the bare 10-digit local form.
@@ -115,7 +131,7 @@ async function classifyLead({ tenantId, name, phone, email, source }) {
   //   LEAD_JUNK_AI=1 in env. Uses Gemini to decide on borderline cases.
   if (!isJunk && score >= 26 && score <= 50 && process.env.LEAD_JUNK_AI === "1") {
     try {
-      const gemini = await aiClassify({ name, phone, email, source, reasons });
+      const gemini = await aiClassify({ tenantId, name, phone, email, source, reasons });
       if (gemini && typeof gemini.confidence === "number") {
         if (gemini.verdict === "junk" && gemini.confidence > 0.7) {
           reasons.push(`AI: ${gemini.reason || "classified as junk"}`);
@@ -132,18 +148,58 @@ async function classifyLead({ tenantId, name, phone, email, source }) {
 }
 
 // Light-weight Gemini wrapper — only loaded when LEAD_JUNK_AI=1
-async function aiClassify({ name, phone, email, source, reasons }) {
+async function aiClassify({ tenantId, name, phone, email, source, reasons }) {
   const { GoogleGenerativeAI } = require("@google/generative-ai");
   if (!process.env.GEMINI_API_KEY) return null;
+  const modelId = process.env.GEMINI_MODEL || "gemini-2.0-flash";
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-  const model = genAI.getGenerativeModel({ model: process.env.GEMINI_MODEL || "gemini-2.0-flash" });
+  const model = genAI.getGenerativeModel({ model: modelId });
   const prompt = `Classify the following inbound CRM lead as either "junk" or "good".
 Return ONLY a JSON object: {"verdict":"junk"|"good","confidence":0.0-1.0,"reason":"short string"}.
 
 Lead: name="${name || ""}", phone="${phone || ""}", email="${email || ""}", source="${source || ""}"
 Pre-flagged signals: ${reasons.join("; ") || "none"}`;
-  const r = await model.generateContent(prompt);
+  let r;
+  try {
+    r = await model.generateContent(prompt);
+  } catch (e) {
+    persistLlmCallLog({
+      tenantId: tenantId || 1,
+      task: "junk-classification",
+      model: modelId,
+      provider: "gemini",
+      reason: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      costEstimate: 0,
+      stub: false,
+      userId: null,
+      surface: "leadJunkFilter",
+      status: "failed",
+      errorMessage: e.message,
+    });
+    throw e;
+  }
   const txt = r.response.text().replace(/```json|```/g, "").trim();
+  const usage = r.response.usageMetadata || {};
+  const promptTokens = usage.promptTokenCount || 0;
+  const completionTokens = usage.candidatesTokenCount || 0;
+  persistLlmCallLog({
+    tenantId: tenantId || 1,
+    task: "junk-classification",
+    model: modelId,
+    provider: "gemini",
+    reason: null,
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    costEstimate: estimateLlmCost(modelId, promptTokens, completionTokens),
+    stub: false,
+    userId: null,
+    surface: "leadJunkFilter",
+    status: "success",
+  });
   return JSON.parse(txt);
 }
 

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -66,9 +66,9 @@ const { getBudgetCap, evaluateCap } = require("./tenantSettings");
 const TASK_ROUTING = {
   search: { primary: "perplexity-sonar", fallback: null },
   citation: { primary: "perplexity-sonar", fallback: null },
-  reasoning: { primary: "claude-opus-4-7", fallback: "gpt-4" },
-  "talking-points": { primary: "claude-opus-4-7", fallback: "gpt-4" },
-  "form-vs-call": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+  reasoning: { primary: "gemini-flash", fallback: "gpt-4" },
+  "talking-points": { primary: "gemini-flash", fallback: "gpt-4" },
+  "form-vs-call": { primary: "gemini-flash", fallback: "gpt-4" },
   "bulk-text": { primary: "gemini-flash", fallback: "groq-llama" },
   "call-summary": { primary: "gemini-flash", fallback: null },
   // Itinerary-suggest (PRD_TRAVEL_ITINERARY_UPGRADES FR-3.6 + AI_SURFACES §3
@@ -318,10 +318,10 @@ async function llmEnabled(task, tenantId) {
 
 function pickModel(task) {
   if (!TASK_ROUTING[task]) {
-    // Unknown task → reasoning catch-all (Claude). PRD prefers a
-    // high-quality default for unknown classes — talking-points/
-    // form-vs-call quality matters more than bulk-text/call-summary.
-    return { task, model: "claude-opus-4-7", reason: "unknown-task-fallback" };
+    // Unknown task → reasoning catch-all (Gemini Flash). Matches the
+    // "reasoning"/"talking-points"/"form-vs-call" primary (2026-07-14 —
+    // Claude Opus removed as a cost-saving swap, see TASK_ROUTING above).
+    return { task, model: "gemini-flash", reason: "unknown-task-fallback" };
   }
   return { task, model: TASK_ROUTING[task].primary, reason: "primary" };
 }
@@ -475,18 +475,21 @@ async function routeRequest({ task, payload, tenantId } = {}) {
   // own PrismaClient don't trigger a circular-import bomb.
   try {
     const prisma = require("./prisma");
+    const { inferProvider } = require("./apiPricing");
     prisma.llmCallLog
       .create({
         data: {
           tenantId: tenantId || 1,
           task,
           model,
+          provider: inferProvider(model),
           reason,
           promptTokens: tokensIn,
           completionTokens: tokensOut,
           totalTokens: tokensIn + tokensOut,
-          costEstimate: 0, // stub mode = $0; real-mode wire-in adds per-token pricing
+          costEstimate: 0, // stub mode = $0 — no real API call was made, so no real cost
           stub: true,
+          status: "success",
           userId: (payload && payload.__userId) || null,
           surface: (payload && payload.__surface) || null,
         },
@@ -525,7 +528,7 @@ function buildStubText(task, _payload) {
   const tag = `[STUB-${task.toUpperCase()}]`;
   switch (task) {
     case "talking-points":
-      return `${tag} Lead profile suggests: (1) confirm budget tier, (2) ask about prior travel, (3) probe destination flexibility. Synthetic content — real Claude reasoning lands when Q11 keys arrive.`;
+      return `${tag} Lead profile suggests: (1) confirm budget tier, (2) ask about prior travel, (3) probe destination flexibility. Synthetic content — real Gemini Flash reasoning lands when Q11 keys arrive.`;
     case "call-summary":
       return `${tag} Call summary: customer expressed interest in trip, advisor walked through options, follow-up scheduled. Synthetic content — real Gemini summary lands when Q11 keys arrive.`;
     case "lead-conversation-summary":
@@ -547,7 +550,7 @@ function buildStubText(task, _payload) {
         leadStage: "New Enquiry",
       });
     case "form-vs-call":
-      return `${tag} Form-vs-call comparison: 85% match (synthetic). Real Claude comparison lands when Q11 keys arrive.`;
+      return `${tag} Form-vs-call comparison: 85% match (synthetic). Real Gemini Flash comparison lands when Q11 keys arrive.`;
     case "search":
     case "citation":
       return `${tag} Cited search result: "Synthetic citation pending Q11 Perplexity key." (https://example.invalid/q11-stub)`;
@@ -596,12 +599,12 @@ function buildStubText(task, _payload) {
         { lineType: "service", description: "Travel insurance per person", quantity: 2, unitPrice: 1200, currency: "INR" },
       ]);
     case "reasoning":
-      return `${tag} Reasoning output (synthetic). Real Claude/GPT lands when Q11 keys arrive.`;
+      return `${tag} Reasoning output (synthetic). Real Gemini Flash/GPT lands when Q11 keys arrive.`;
     default:
       // Unknown task → still produce SOMETHING so the consumer
       // doesn't bomb on a null/empty response. Tag uses the
       // raw task name so the operator can spot config drift.
-      return `${tag} Reasoning output (synthetic). Real Claude/GPT lands when Q11 keys arrive.`;
+      return `${tag} Reasoning output (synthetic). Real Gemini Flash/GPT lands when Q11 keys arrive.`;
   }
 }
 
@@ -851,68 +854,100 @@ async function callGemini(modelId, system, user, apiKey, maxTokens) {
   throw lastErr || new Error("gemini call failed");
 }
 
+// Fire-and-forget LlmCallLog write shared by the success + failure paths
+// below — a DB-write failure must never mask the real call's outcome.
+function persistLlmCallLog(data) {
+  try {
+    const prisma = require("./prisma");
+    prisma.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[llm-router] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[llm-router] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
+
 async function realProviderCall({ task, model, payload, tenantId }) {
   const provider = providerForModel(model);
-  const envVar = ENV_FOR_MODEL[model];
-  const apiKey = envVar && process.env[envVar];
-  if (!apiKey) throw new Error(`no API key for ${model}`);
-  const modelId = resolveRealModelId(model);
-  const { system, user } = buildPrompt(task, payload);
-  const maxTokens = 4096;
+  const { estimateLlmCost } = require("./apiPricing");
+  const baseLogFields = {
+    tenantId: tenantId || 1,
+    task,
+    model,
+    provider,
+    stub: false,
+    userId: (payload && payload.__userId) || null,
+    surface: (payload && payload.__surface) || null,
+  };
 
-  let out;
-  if (provider === "anthropic") out = await callAnthropic(modelId, system, user, apiKey, maxTokens);
-  else if (provider === "openai") {
-    // gpt-4o-search-preview browses the live web when web_search_options is set;
-    // regular gpt-4o has no web access, so only enable it for the search model.
-    const extra = /search/.test(modelId) ? { web_search_options: {} } : {};
-    out = await callOpenAICompatible("https://api.openai.com/v1", modelId, system, user, apiKey, maxTokens, extra);
+  let apiKey, modelId, system, user;
+  try {
+    const envVar = ENV_FOR_MODEL[model];
+    apiKey = envVar && process.env[envVar];
+    if (!apiKey) throw new Error(`no API key for ${model}`);
+    modelId = resolveRealModelId(model);
+    ({ system, user } = buildPrompt(task, payload));
+  } catch (e) {
+    persistLlmCallLog({
+      ...baseLogFields,
+      reason: "real",
+      costEstimate: 0,
+      status: "failed",
+      errorMessage: e.message,
+    });
+    throw e;
   }
-  else if (provider === "perplexity") out = await callOpenAICompatible("https://api.perplexity.ai", modelId, system, user, apiKey, maxTokens);
-  else if (provider === "gemini") out = await callGemini(modelId, system, user, apiKey, maxTokens);
-  else if (provider === "groq") out = await callOpenAICompatible("https://api.groq.com/openai/v1", modelId, system, user, apiKey, maxTokens);
-  else throw new Error(`unknown provider for ${model}`);
+
+  const maxTokens = 4096;
+  let out;
+  try {
+    if (provider === "anthropic") out = await callAnthropic(modelId, system, user, apiKey, maxTokens);
+    else if (provider === "openai") {
+      // gpt-4o-search-preview browses the live web when web_search_options is set;
+      // regular gpt-4o has no web access, so only enable it for the search model.
+      const extra = /search/.test(modelId) ? { web_search_options: {} } : {};
+      out = await callOpenAICompatible("https://api.openai.com/v1", modelId, system, user, apiKey, maxTokens, extra);
+    }
+    else if (provider === "perplexity") out = await callOpenAICompatible("https://api.perplexity.ai", modelId, system, user, apiKey, maxTokens);
+    else if (provider === "gemini") out = await callGemini(modelId, system, user, apiKey, maxTokens);
+    else if (provider === "groq") out = await callOpenAICompatible("https://api.groq.com/openai/v1", modelId, system, user, apiKey, maxTokens);
+    else throw new Error(`unknown provider for ${model}`);
+  } catch (e) {
+    // Failure path — log WHY (errorMessage), no tokens/cost since no
+    // successful response came back. Powers the API Analytics "failures"
+    // view: every failed external call is visible with its real error text.
+    persistLlmCallLog({
+      ...baseLogFields,
+      reason: "real",
+      costEstimate: 0,
+      status: "failed",
+      errorMessage: e.message,
+    });
+    throw e;
+  }
 
   const tokensIn =
     out.tokensIn || estimateTokens(JSON.stringify(payload || {}));
   const tokensOut = out.tokensOut || estimateTokens(out.text);
+  const costEstimate = estimateLlmCost(model, tokensIn, tokensOut);
 
   // Token-only telemetry — NEVER log payload content (PII discipline).
   console.log(
     `[llm-router] task=${task} model=${model} (${modelId}) tenant=${tenantId || "?"} ` +
-    `tokens_in=${tokensIn} tokens_out=${tokensOut} cost_estimate=$0.0000 stub=false reason=real`,
+    `tokens_in=${tokensIn} tokens_out=${tokensOut} cost_estimate=$${costEstimate.toFixed(6)} stub=false reason=real`,
   );
 
   // Persist one LlmCallLog row (best-effort, fire-and-forget) — mirrors the
   // stub path so the admin spend dashboard counts real calls too.
-  try {
-    const prisma = require("./prisma");
-    prisma.llmCallLog
-      .create({
-        data: {
-          tenantId: tenantId || 1,
-          task,
-          model,
-          reason: "real",
-          promptTokens: tokensIn,
-          completionTokens: tokensOut,
-          totalTokens: tokensIn + tokensOut,
-          costEstimate: 0, // real per-token pricing is a follow-up; tokens are real
-          stub: false,
-          userId: (payload && payload.__userId) || null,
-          surface: (payload && payload.__surface) || null,
-        },
-      })
-      .catch((e) =>
-        console.error(
-          `[llm-router] LlmCallLog persist failed (non-fatal): ${e.message}`,
-        ),
-      );
-  } catch (e) {
-    console.error(
-      `[llm-router] LlmCallLog require failed (non-fatal): ${e.message}`,
-    );
-  }
+  persistLlmCallLog({
+    ...baseLogFields,
+    reason: "real",
+    promptTokens: tokensIn,
+    completionTokens: tokensOut,
+    totalTokens: tokensIn + tokensOut,
+    costEstimate,
+    status: "success",
+  });
 
   return {
     text: out.text || "",

--- a/backend/middleware/superAdminAuth.js
+++ b/backend/middleware/superAdminAuth.js
@@ -1,0 +1,198 @@
+/**
+ * superAdminAuth.js — Super Admin Portal authentication middleware.
+ *
+ * Completely separate from the regular User/JWT auth system
+ * (middleware/auth.js). Credentials are NOT stored in the app User/tenant
+ * tables — only in environment variables + one auto-managed SystemSetting
+ * row (never a full DB table of admins):
+ *
+ *   SUPER_ADMIN_USERNAME            — plain username, compared verbatim.
+ *   SUPER_ADMIN_PASSWORD_HASH       — bcrypt hash of the password (preferred
+ *                                     path). Generate once via
+ *                                     scripts/hash-super-admin-password.js
+ *                                     and paste only the hash into .env —
+ *                                     the plaintext password is never
+ *                                     written to disk at any point.
+ *   SUPER_ADMIN_PASSWORD_PLAINTEXT  — convenience alternative to the above:
+ *                                     a PLAIN password typed directly into
+ *                                     .env. On the FIRST successful login
+ *                                     (or ANY time it's set to a real value
+ *                                     again later — see "password change"
+ *                                     below) the server bcrypt-hashes it and
+ *                                     persists the hash to the SystemSetting
+ *                                     table (key "super_admin_password_hash").
+ *                                     Immediately after hashing, the server
+ *                                     rewrites .env in place, replacing the
+ *                                     real password with the sentinel
+ *                                     PLAINTEXT_PLACEHOLDER below — so the
+ *                                     plaintext never sits on disk longer
+ *                                     than one login cycle, and no one has
+ *                                     to remember to remove it by hand.
+ *
+ *                                     PASSWORD CHANGE: to change the
+ *                                     password later, just edit .env and set
+ *                                     SUPER_ADMIN_PASSWORD_PLAINTEXT to the
+ *                                     NEW password (overwriting the
+ *                                     placeholder), then log in with that
+ *                                     new password. Any value that isn't the
+ *                                     exact placeholder sentinel is treated
+ *                                     as "operator wants to set this as the
+ *                                     new password" — it gets hashed,
+ *                                     persisted, and .env is rewritten back
+ *                                     to the placeholder again. This works
+ *                                     any number of times.
+ *   SUPER_ADMIN_JWT_SECRET          — dedicated JWT signing secret
+ *                                     (config/secrets.js). No dev fallback:
+ *                                     unset disables the whole portal.
+ *
+ * Token shape: { role: 'SUPER_ADMIN', username }, signed with
+ * SUPER_ADMIN_JWT_SECRET, 8h expiry. Sent back as a normal Bearer token
+ * (frontend stores it separately from the regular app JWT — different
+ * localStorage key — so a Super Admin session and a regular staff session
+ * can coexist in the same browser without clobbering each other).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const jwt = require("jsonwebtoken");
+const { SUPER_ADMIN_JWT_SECRET } = require("../config/secrets");
+const prisma = require("../lib/prisma");
+
+const TOKEN_EXPIRY = "8h";
+const PASSWORD_HASH_SETTING_KEY = "super_admin_password_hash";
+const ENV_PATH = path.join(__dirname, "..", ".env");
+const ENV_VAR_NAME = "SUPER_ADMIN_PASSWORD_PLAINTEXT";
+// The sentinel .env is rewritten to after a plaintext password is hashed +
+// persisted. NOT a real password — isPlaintextPlaceholder() below is the
+// single source of truth for "is this the placeholder or a real value?".
+const PLAINTEXT_PLACEHOLDER = "<hashed — edit this value to change the password>";
+
+function isSuperAdminConfigured() {
+  const hasCredential = Boolean(
+    process.env.SUPER_ADMIN_PASSWORD_HASH || process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT,
+  );
+  return Boolean(process.env.SUPER_ADMIN_USERNAME && hasCredential && SUPER_ADMIN_JWT_SECRET);
+}
+
+// True for both "unset" and "already the placeholder" — both mean "no
+// pending password change here", so callers treat them identically.
+function isPlaintextPlaceholder(value) {
+  return !value || value === PLAINTEXT_PLACEHOLDER;
+}
+
+/**
+ * Resolve the bcrypt hash to verify a login attempt against, in priority
+ * order: (1) a hash already promoted to SystemSetting from a prior
+ * plaintext-env login, (2) SUPER_ADMIN_PASSWORD_HASH from env, (3) null —
+ * caller falls back to the plaintext-promotion path in routes/super_admin_auth.js.
+ */
+async function getPersistedPasswordHash() {
+  try {
+    const row = await prisma.systemSetting.findUnique({ where: { key: PASSWORD_HASH_SETTING_KEY } });
+    return row ? row.value : null;
+  } catch (e) {
+    console.warn("[superAdminAuth] failed to read persisted password hash (non-fatal):", e.message);
+    return null;
+  }
+}
+
+async function persistPromotedPasswordHash(hash) {
+  await prisma.systemSetting.upsert({
+    where: { key: PASSWORD_HASH_SETTING_KEY },
+    update: { value: hash, updatedBy: "system (auto-promoted from SUPER_ADMIN_PASSWORD_PLAINTEXT)" },
+    create: {
+      key: PASSWORD_HASH_SETTING_KEY,
+      value: hash,
+      category: "super-admin-auth",
+      updatedBy: "system (auto-promoted from SUPER_ADMIN_PASSWORD_PLAINTEXT)",
+    },
+  });
+}
+
+/**
+ * Rewrites .env in place, replacing the SUPER_ADMIN_PASSWORD_PLAINTEXT line's
+ * value with the placeholder sentinel — called immediately after a real
+ * plaintext password has been hashed + persisted, so the plaintext never
+ * sits on disk longer than one login cycle. Also updates process.env in the
+ * running process (a file edit alone wouldn't affect the already-running
+ * server until a restart).
+ *
+ * Best-effort: if the file can't be read/written (permissions, missing
+ * file, unexpected format), this logs a warning and returns false — it
+ * NEVER throws, because a disk-write failure must not break the login that
+ * already succeeded and already persisted the real hash to the DB.
+ */
+function redactPlaintextInEnvFile() {
+  try {
+    if (!fs.existsSync(ENV_PATH)) {
+      console.warn(`[superAdminAuth] .env not found at ${ENV_PATH} — skipping plaintext redaction (non-fatal)`);
+      return false;
+    }
+    const content = fs.readFileSync(ENV_PATH, "utf8");
+    const lineRe = new RegExp(`^${ENV_VAR_NAME}=.*$`, "m");
+    if (!lineRe.test(content)) {
+      // Nothing to redact — the var isn't set as its own line (e.g. only
+      // exported some other way). Not an error; just nothing to do.
+      return false;
+    }
+    const updated = content.replace(lineRe, `${ENV_VAR_NAME}=${PLAINTEXT_PLACEHOLDER}`);
+    fs.writeFileSync(ENV_PATH, updated, "utf8");
+    process.env[ENV_VAR_NAME] = PLAINTEXT_PLACEHOLDER;
+    return true;
+  } catch (e) {
+    console.warn(`[superAdminAuth] failed to redact ${ENV_VAR_NAME} in .env (non-fatal): ${e.message}`);
+    return false;
+  }
+}
+
+function issueSuperAdminToken(username) {
+  return jwt.sign({ role: "SUPER_ADMIN", username }, SUPER_ADMIN_JWT_SECRET, {
+    expiresIn: TOKEN_EXPIRY,
+  });
+}
+
+const WWW_AUTH = "Bearer";
+function unauthorized(res, error) {
+  res.set("WWW-Authenticate", WWW_AUTH);
+  return res.status(401).json({ error });
+}
+
+/**
+ * Protects every /api/super-admin/* route except /login. Header-only
+ * (no cookie fallback — this is a separate, deliberately narrower auth
+ * surface than the main app's).
+ */
+function requireSuperAdmin(req, res, next) {
+  if (!isSuperAdminConfigured()) {
+    return res.status(503).json({
+      error: "Super Admin Portal is not configured on this server (missing env vars)",
+      code: "SUPER_ADMIN_NOT_CONFIGURED",
+    });
+  }
+
+  const authHeader = req.headers.authorization || "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  if (!token) return unauthorized(res, "No Super Admin token provided");
+
+  try {
+    const decoded = jwt.verify(token, SUPER_ADMIN_JWT_SECRET);
+    if (decoded.role !== "SUPER_ADMIN") {
+      return unauthorized(res, "Invalid Super Admin token");
+    }
+    req.superAdmin = { username: decoded.username };
+    next();
+  } catch (e) {
+    return unauthorized(res, "Invalid or expired Super Admin token: " + e.message);
+  }
+}
+
+module.exports = {
+  requireSuperAdmin,
+  issueSuperAdminToken,
+  isSuperAdminConfigured,
+  getPersistedPasswordHash,
+  persistPromotedPasswordHash,
+  isPlaintextPlaceholder,
+  redactPlaintextInEnvFile,
+  PLAINTEXT_PLACEHOLDER,
+};

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1682,17 +1682,23 @@ model LlmCallLog {
   // class is a code-only change — no schema migration.
   task             String // search | citation | reasoning | talking-points | form-vs-call | bulk-text | call-summary | <unknown>
   model            String // claude-opus-4-7 | gemini-flash | perplexity-sonar | gpt-4 | claude-haiku
+  // Provider family, independent of the specific model string above — lets
+  // the API Analytics dashboard group/filter by "Gemini" vs "OpenAI" vs
+  // "Anthropic" without re-deriving it from `model` on every query. Backfilled
+  // via providerForModel()/inferProvider() at write time (lib/apiPricing.js).
+  provider         String   @default("unknown") // gemini | openai | anthropic | perplexity | groq | unknown
   reason           String? // primary | unknown-task-fallback | <future: fallback-after-primary-failure>
   promptTokens     Int      @default(0)
   completionTokens Int      @default(0)
   totalTokens      Int      @default(0)
-  costEstimate     Decimal  @default(0) @db.Decimal(12, 6) // up to 6dp; USD by convention
+  costEstimate     Decimal  @default(0) @db.Decimal(12, 6) // up to 6dp; USD by convention; from lib/apiPricing.js static table
   stub             Boolean  @default(true)
   // Optional caller context — useful for "which user / which surface burned
   // the most tokens". Both nullable so public-endpoint callers (no req.user)
   // just leave them null.
   userId           Int?
   surface          String? // free-form caller tag, e.g. "talking-points-regen", "form-vs-call-comparison"
+  status           String   @default("success") // success | failed — mirrors CronExecutionLog's status column
   errorMessage     String?  @db.Text // populated only when the call failed
   createdAt        DateTime @default(now())
 
@@ -1701,6 +1707,30 @@ model LlmCallLog {
   @@index([tenantId, createdAt])
   @@index([tenantId, task, createdAt])
   @@index([tenantId, model, createdAt])
+  @@index([provider, createdAt])
+  @@index([status, createdAt])
+}
+
+// Generic non-LLM external API call log — first consumer is SerpApi
+// (Google Flights/Hotels search, no token concept). Deliberately separate
+// from LlmCallLog rather than shoehorning token-shaped columns onto a
+// non-token API; the Super Admin API Analytics dashboard reads BOTH tables
+// and merges them into one combined view by provider.
+model ApiCallLog {
+  id           Int      @id @default(autoincrement())
+  tenantId     Int      @default(1)
+  provider     String // serpapi | <future providers>
+  endpoint     String? // e.g. "google_flights", "google_hotels"
+  status       String   @default("success") // success | failed
+  costEstimate Decimal  @default(0) @db.Decimal(12, 6) // flat $/request from lib/apiPricing.js, when known
+  durationMs   Int?
+  surface      String? // free-form caller tag, e.g. "tboClient-flight-search"
+  errorMessage String?  @db.Text
+  createdAt    DateTime @default(now())
+
+  @@index([tenantId, createdAt])
+  @@index([provider, createdAt])
+  @@index([status, createdAt])
 }
 
 model PipelineStage {
@@ -2557,11 +2587,11 @@ model CalendarIntegration {
 
   tenantId Int    @default(1)
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  // @@index([tenantId]) removed — the FK relation already creates an implicit index on tenantId
 
   /// One calendar connection per (tenant, user, provider). Multi-tenancy isolation: a user's calendar
   /// connection in Wellness tenant is independent from their connection in Travel tenant.
   @@unique([tenantId, userId, provider])
-  // @@index([tenantId]) removed — the FK relation already creates an implicit index on tenantId
 }
 
 /// Per-user Gmail connection (OAuth2 via the Gmail API). Mirrors
@@ -2588,11 +2618,11 @@ model GmailIntegration {
 
   tenantId Int    @default(1)
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  // @@index([tenantId]) removed — the FK relation already creates an implicit index on tenantId
 
   /// One Gmail connection per (tenant, user, provider). Multi-tenancy isolation: each tenant's
   /// users have independent Gmail connections.
   @@unique([tenantId, userId, provider])
-  // @@index([tenantId]) removed — the FK relation already creates an implicit index on tenantId
 }
 
 model CalendarEvent {
@@ -8675,4 +8705,72 @@ model FxRate {
 
   @@unique([baseCurrency, quoteCurrency, fetchedAt])
   @@index([baseCurrency, quoteCurrency])
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Super Admin Portal — Cron Maintenance (system-wide, NOT tenant-scoped;
+// crons run once per process across all tenants, so config/logs live at
+// the platform level, unlike TenantSetting).
+// ─────────────────────────────────────────────────────────────────────────
+
+// One row per registered cron engine. `name` is the stable machine key each
+// engine passes to lib/cronRegistry.register({name, ...}) — e.g.
+// "leadScoringEngine", "quoteExpirySweep". A row is upserted lazily the
+// first time an engine registers (self-healing: a fresh DB or a newly
+// added engine needs zero manual setup — see cronRegistry.js). `schedule`
+// and `enabled` are the live, admin-editable override; when null/unset the
+// registry falls back to the engine's own hardcoded defaultSchedule so
+// nothing breaks before an admin ever visits the portal.
+model CronConfig {
+  id           Int      @id @default(autoincrement())
+  name         String   @unique // engine's stable key, e.g. "leadScoringEngine"
+  description  String?  @db.Text
+  schedule     String // live cron expression (node-cron syntax)
+  enabled      Boolean  @default(true)
+  isSystem     Boolean  @default(true) // true = one of the 46 built-in engines (cannot be deleted, only disabled); false = admin-created dynamic cron
+  handlerKey   String? // for isSystem=false rows: which registered generic handler to invoke
+  metadataJson String?  @db.Text // free-form JSON for dynamic-cron config (isSystem=false)
+  createdBy    String? // super-admin username, or "system" for auto-registered engine rows
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  logs CronExecutionLog[]
+
+  @@index([enabled])
+}
+
+// One row per cron TICK (not per schedule) — a full execution history.
+model CronExecutionLog {
+  id           Int        @id @default(autoincrement())
+  cronConfigId Int
+  cronConfig   CronConfig @relation(fields: [cronConfigId], references: [id], onDelete: Cascade)
+  cronName     String // denormalized copy of CronConfig.name so logs survive a cron being renamed/deleted-then-recreated
+  startedAt    DateTime   @default(now())
+  finishedAt   DateTime?
+  durationMs   Int?
+  status       String     @default("running") // running, success, failed
+  errorMessage String?    @db.Text
+  triggerType  String     @default("scheduled") // scheduled, manual, startup
+  instance     String? // hostname/PID — useful once this runs on >1 server
+  metadataJson String?    @db.Text
+
+  @@index([cronConfigId, startedAt])
+  @@index([cronName, startedAt])
+  @@index([status])
+  @@index([startedAt])
+}
+
+// Global (non-tenant) key/value settings for the Super Admin portal.
+// First consumer: cron log retention window. Mirrors TenantSetting's
+// freeform-value + category shape but at the platform level.
+model SystemSetting {
+  id        Int      @id @default(autoincrement())
+  key       String   @unique // e.g. "cron_log_retention_days"
+  value     String   @db.Text // freeform; caller parses
+  category  String?  @db.VarChar(50)
+  updatedBy String? // super-admin username
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([category])
 }

--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -4,6 +4,7 @@ require("dotenv").config({ path: path.resolve(__dirname, "../../.env"), override
 const { verifyToken } = require("../middleware/auth");
 const { llmLimiter } = require("../middleware/apiRateLimiters");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { estimateLlmCost } = require("../lib/apiPricing");
 
 const router = express.Router();
 const prisma = require("../lib/prisma");
@@ -73,8 +74,47 @@ Requirements:
 - Sign off as the sender (don't include a specific name, just "Best regards,")
 - Do not include a subject line in the output`;
 
-      const result = await model.generateContent(prompt);
+      let result;
+      try {
+        result = await model.generateContent(prompt);
+      } catch (genErr) {
+        persistLlmCallLog({
+          tenantId: (req.user && req.user.tenantId) || 1,
+          task: "email-draft",
+          model: "gemini-2.5-flash",
+          provider: "gemini",
+          reason: null,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          costEstimate: 0,
+          stub: false,
+          userId: null,
+          surface: "ai-email-draft",
+          status: "failed",
+          errorMessage: genErr.message,
+        });
+        throw genErr;
+      }
       const draft = result.response.text();
+      const usage = result.response.usageMetadata || {};
+      const promptTokens = usage.promptTokenCount || 0;
+      const completionTokens = usage.candidatesTokenCount || 0;
+      persistLlmCallLog({
+        tenantId: (req.user && req.user.tenantId) || 1,
+        task: "email-draft",
+        model: "gemini-2.5-flash",
+        provider: "gemini",
+        reason: null,
+        promptTokens,
+        completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+        stub: false,
+        userId: null,
+        surface: "ai-email-draft",
+        status: "success",
+      });
       return res.json({ draft, model: "gemini-2.5-flash" });
     }
 
@@ -110,8 +150,48 @@ Requirements:
 - Be concise and actionable
 - End with appropriate sign-off`;
 
-      const result = await model.generateContent(prompt);
-      return res.json({ draft: result.response.text(), model: "gemini-2.5-flash" });
+      let result;
+      try {
+        result = await model.generateContent(prompt);
+      } catch (genErr) {
+        persistLlmCallLog({
+          tenantId: (req.user && req.user.tenantId) || 1,
+          task: "email-draft",
+          model: "gemini-2.5-flash",
+          provider: "gemini",
+          reason: null,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          costEstimate: 0,
+          stub: false,
+          userId: null,
+          surface: "ai-email-draft",
+          status: "failed",
+          errorMessage: genErr.message,
+        });
+        throw genErr;
+      }
+      const draft = result.response.text();
+      const usage = result.response.usageMetadata || {};
+      const promptTokens = usage.promptTokenCount || 0;
+      const completionTokens = usage.candidatesTokenCount || 0;
+      persistLlmCallLog({
+        tenantId: (req.user && req.user.tenantId) || 1,
+        task: "email-draft",
+        model: "gemini-2.5-flash",
+        provider: "gemini",
+        reason: null,
+        promptTokens,
+        completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+        stub: false,
+        userId: null,
+        surface: "ai-email-draft",
+        status: "success",
+      });
+      return res.json({ draft, model: "gemini-2.5-flash" });
     }
 
     res.json({ draft: "Thank you for your email. I've reviewed your message and will follow up with a detailed response shortly.\n\nBest regards,", model: "fallback" });
@@ -132,8 +212,47 @@ router.post("/subject-lines", verifyToken, llmLimiter, async (req, res) => {
 
 Context: "${context}"`;
 
-      const result = await model.generateContent(prompt);
+      let result;
+      try {
+        result = await model.generateContent(prompt);
+      } catch (genErr) {
+        persistLlmCallLog({
+          tenantId: (req.user && req.user.tenantId) || 1,
+          task: "email-draft",
+          model: "gemini-2.5-flash",
+          provider: "gemini",
+          reason: null,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          costEstimate: 0,
+          stub: false,
+          userId: null,
+          surface: "ai-email-draft",
+          status: "failed",
+          errorMessage: genErr.message,
+        });
+        throw genErr;
+      }
       const lines = result.response.text().split("\n").filter(l => l.trim()).slice(0, count || 5);
+      const usage = result.response.usageMetadata || {};
+      const promptTokens = usage.promptTokenCount || 0;
+      const completionTokens = usage.candidatesTokenCount || 0;
+      persistLlmCallLog({
+        tenantId: (req.user && req.user.tenantId) || 1,
+        task: "email-draft",
+        model: "gemini-2.5-flash",
+        provider: "gemini",
+        reason: null,
+        promptTokens,
+        completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+        stub: false,
+        userId: null,
+        surface: "ai-email-draft",
+        status: "success",
+      });
       return res.json({ subjects: lines });
     }
 
@@ -142,6 +261,22 @@ Context: "${context}"`;
     res.json({ subjects: [`Follow up: ${req.body.context}`, `RE: ${req.body.context}`] });
   }
 });
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so direct Gemini calls from this route are
+// visible to the Super Admin "API Analytics" dashboard. A DB hiccup here
+// must NEVER break email-draft generation, hence the nested try/catch and
+// the un-awaited .catch() on the create.
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("../lib/prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[AI] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[AI] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 // Resolve the SENDER's own organisation so AI-written emails represent the
 // tenant (e.g. "Travel Stall"), NOT the platform vendor that built the CRM.

--- a/backend/routes/deal_insights.js
+++ b/backend/routes/deal_insights.js
@@ -6,9 +6,26 @@ const prisma = require("../lib/prisma");
 const { verifyToken, verifyRole } = require("../middleware/auth");
 const { llmLimiter } = require("../middleware/apiRateLimiters");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { estimateLlmCost } = require("../lib/apiPricing");
 
 const router = express.Router();
 const { formatMoney } = require("../utils/formatMoney");
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// deal-insight generation, hence the nested try/catch and the un-awaited
+// .catch() on the create.
+function persistLlmCallLog(data) {
+  try {
+    const prismaClient = require("../lib/prisma");
+    prismaClient.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[DealInsights] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[DealInsights] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 let aiModel = null;
@@ -398,6 +415,24 @@ Recent activities: ${(deal.contact?.activities || []).slice(0, 3).map(a => `${a.
 
         const result = await aiModel.generateContent(prompt);
         const aiText = (result.response.text() || "").trim().replace(/^["']|["']$/g, "");
+        const usage = result.response.usageMetadata || {};
+        const promptTokens = usage.promptTokenCount || 0;
+        const completionTokens = usage.candidatesTokenCount || 0;
+        persistLlmCallLog({
+          tenantId: req.user.tenantId || 1,
+          task: "deal-insights",
+          model: "gemini-2.5-flash",
+          provider: "gemini",
+          reason: null,
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+          costEstimate: estimateLlmCost("gemini-2.5-flash", promptTokens, completionTokens),
+          stub: false,
+          userId: req.user.userId || null,
+          surface: "deal-insights",
+          status: "success",
+        });
         if (aiText) {
           candidates.push({
             type: "NEXT_BEST_ACTION",
@@ -406,6 +441,22 @@ Recent activities: ${(deal.contact?.activities || []).slice(0, 3).map(a => `${a.
           });
         }
       } catch (aiErr) {
+        persistLlmCallLog({
+          tenantId: (req.user && req.user.tenantId) || 1,
+          task: "deal-insights",
+          model: "gemini-2.5-flash",
+          provider: "gemini",
+          reason: null,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          costEstimate: 0,
+          stub: false,
+          userId: (req.user && req.user.userId) || null,
+          surface: "deal-insights",
+          status: "failed",
+          errorMessage: aiErr.message,
+        });
         console.warn("[DealInsights] AI insight skipped:", aiErr.message);
       }
     }

--- a/backend/routes/super_admin_api_analytics.js
+++ b/backend/routes/super_admin_api_analytics.js
@@ -1,0 +1,444 @@
+/**
+ * routes/super_admin_api_analytics.js — API Analytics module (Super Admin
+ * Portal). Read-only aggregation + browsing over the two API-call log
+ * tables: LlmCallLog (Gemini/OpenAI/Anthropic/Perplexity/Groq — token +
+ * cost based) and ApiCallLog (SerpApi + future flat-rate providers).
+ *
+ * All routes require requireSuperAdmin (mounted with that middleware in
+ * server.js), same as routes/super_admin_cron.js.
+ *
+ * Endpoint groups:
+ *   GET /overview?days=<1-90, default 14> — totals, byDay, byProvider,
+ *     byModel, top failures, all merged across BOTH tables. Optionally
+ *     accepts ?from=<ISO date>&to=<ISO date> for an exact date/range instead
+ *     of the day-count preset — when either is present, days/DEFAULT_DAYS
+ *     is ignored entirely (from/to always wins, matching the UI's "custom
+ *     range replaces the preset dropdown" behavior). A single ?from= with
+ *     no ?to= is treated as "that one day" (to defaults to end-of-from-day).
+ *   GET /calls?page&pageSize&provider&status&search&from&to — paginated
+ *     browse of individual call rows (merged + tagged with `source`:
+ *     "llm" | "api" so the UI can render provider-specific columns).
+ *   GET/PUT /settings/log-retention — shares the SAME retention window as
+ *     cron/apiCallLogRetentionEngine.js (SystemSetting key
+ *     "api_call_log_retention_days").
+ */
+
+const express = require("express");
+const router = express.Router();
+const prisma = require("../lib/prisma");
+
+const MAX_DAYS = 90;
+const DEFAULT_DAYS = 14;
+const RETENTION_SETTING_KEY = "api_call_log_retention_days";
+const DEFAULT_RETENTION_DAYS = 30;
+
+function dayKey(d) {
+  return new Date(d).toISOString().slice(0, 10);
+}
+
+function toNum(dec) {
+  // Prisma Decimal fields deserialize as a Decimal.js-like object with
+  // .toNumber(), or occasionally a plain string/number depending on driver
+  // config — handle all three so the route never throws on a shape surprise.
+  if (dec == null) return 0;
+  if (typeof dec === "number") return dec;
+  if (typeof dec.toNumber === "function") return dec.toNumber();
+  return Number(dec) || 0;
+}
+
+// ── Overview (charts) ───────────────────────────────────────────────────
+
+router.get("/overview", async (req, res) => {
+  try {
+    const { provider, model, from, to } = req.query;
+
+    // An explicit ?from/?to date (or single-date) always overrides the
+    // day-count preset — the UI's custom date picker replaces the dropdown
+    // rather than combining with it.
+    //
+    // A bare date string ("2026-07-14") parses as UTC MIDNIGHT per the ES
+    // spec (new Date("2026-07-14") -> 2026-07-14T00:00:00.000Z), but
+    // Date#setHours mutates in LOCAL time — on a server running IST
+    // (UTC+5:30) that shifted "end of day" back by 5.5 hours
+    // (...T18:29:59.999Z instead of ...T23:59:59.999Z), silently clipping
+    // the last few hours of real data from a "single day" filter. Using
+    // setUTCHours keeps the whole boundary in UTC, matching how the date
+    // string itself was parsed.
+    let since, until, days;
+    if (from || to) {
+      if (from) {
+        const fromDate = new Date(from);
+        if (Number.isNaN(fromDate.getTime())) return res.status(400).json({ error: "invalid `from` date", code: "INVALID_DATE" });
+        since = fromDate;
+      }
+      if (to) {
+        const toDate = new Date(to);
+        if (Number.isNaN(toDate.getTime())) return res.status(400).json({ error: "invalid `to` date", code: "INVALID_DATE" });
+        // Bump to the end of that UTC calendar day so a single-day filter
+        // actually includes every row from that day, not just midnight-exact.
+        toDate.setUTCHours(23, 59, 59, 999);
+        until = toDate;
+      } else {
+        // ?from with no ?to → "just that one day".
+        until = new Date(since);
+        until.setUTCHours(23, 59, 59, 999);
+      }
+      if (!since) {
+        // ?to with no ?from → everything up to that date, uncapped at the start.
+        since = new Date(0);
+      }
+      days = Math.max(1, Math.ceil((until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000)));
+    } else {
+      const daysRaw = parseInt(req.query.days, 10);
+      days = Number.isFinite(daysRaw) && daysRaw > 0 ? Math.min(daysRaw, MAX_DAYS) : DEFAULT_DAYS;
+      since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    }
+
+    const llmWhere = { createdAt: until ? { gte: since, lte: until } : { gte: since } };
+    if (provider) llmWhere.provider = provider;
+    if (model) llmWhere.model = model;
+
+    const apiWhere = { createdAt: until ? { gte: since, lte: until } : { gte: since } };
+    if (provider) apiWhere.provider = provider;
+    // ApiCallLog has no `model` column (endpoint is its nearest analog) — a
+    // ?model= filter narrows to LLM-only results, matching the "by model"
+    // chart's own LLM-only scope rather than silently ignoring the filter.
+    if (model) apiWhere.id = -1; // unsatisfiable — excludes all ApiCallLog rows
+
+    const [llmLogs, apiLogs] = await Promise.all([
+      prisma.llmCallLog.findMany({
+        where: llmWhere,
+        select: {
+          provider: true,
+          model: true,
+          task: true,
+          status: true,
+          promptTokens: true,
+          completionTokens: true,
+          totalTokens: true,
+          costEstimate: true,
+          stub: true,
+          errorMessage: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+      }),
+      prisma.apiCallLog.findMany({
+        where: apiWhere,
+        select: {
+          provider: true,
+          endpoint: true,
+          status: true,
+          costEstimate: true,
+          errorMessage: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+      }),
+    ]);
+
+    // Normalize both tables into one shape for aggregation.
+    const mergedAll = [
+      ...llmLogs.map((l) => ({
+        provider: l.provider || "unknown",
+        model: l.model,
+        status: l.status,
+        tokens: l.totalTokens || 0,
+        cost: toNum(l.costEstimate),
+        stub: l.stub,
+        errorMessage: l.errorMessage,
+        createdAt: l.createdAt,
+        source: "llm",
+      })),
+      ...apiLogs.map((a) => ({
+        provider: a.provider || "unknown",
+        model: a.endpoint || null,
+        status: a.status,
+        tokens: 0,
+        cost: toNum(a.costEstimate),
+        stub: false,
+        errorMessage: a.errorMessage,
+        createdAt: a.createdAt,
+        source: "api",
+      })),
+    ];
+
+    // Stub calls never hit a real API (no key configured — llmRouter.js's
+    // synthetic-response fallback) and always cost $0 with heuristic
+    // character-count "tokens", not real ones. Excluded entirely from this
+    // dashboard — a provider with no configured key (e.g. anthropic/
+    // perplexity) should never appear here at all, and there's no
+    // "stub calls" concept surfaced to the operator.
+    const merged = mergedAll.filter((c) => !c.stub);
+
+    // Runs-over-time by day — call count + cost, split success/failed.
+    const byDayMap = new Map();
+    for (const c of merged) {
+      const key = dayKey(c.createdAt);
+      if (!byDayMap.has(key)) {
+        byDayMap.set(key, { date: key, success: 0, failed: 0, total: 0, cost: 0, tokens: 0 });
+      }
+      const bucket = byDayMap.get(key);
+      bucket.total += 1;
+      bucket.cost += c.cost;
+      bucket.tokens += c.tokens;
+      if (c.status === "failed") bucket.failed += 1;
+      else bucket.success += 1;
+    }
+    const byDay = [...byDayMap.values()]
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((b) => ({ ...b, cost: Math.round(b.cost * 1e6) / 1e6 }));
+
+    // Per-provider breakdown — calls, tokens, cost, failure count.
+    const byProviderMap = new Map();
+    for (const c of merged) {
+      if (!byProviderMap.has(c.provider)) {
+        byProviderMap.set(c.provider, { provider: c.provider, calls: 0, failures: 0, tokens: 0, cost: 0 });
+      }
+      const p = byProviderMap.get(c.provider);
+      p.calls += 1;
+      p.tokens += c.tokens;
+      p.cost += c.cost;
+      if (c.status === "failed") p.failures += 1;
+    }
+    const byProvider = [...byProviderMap.values()]
+      .map((p) => ({ ...p, cost: Math.round(p.cost * 1e6) / 1e6 }))
+      .sort((a, b) => b.calls - a.calls);
+
+    // Per-model breakdown (LLM only — ApiCallLog has no model concept).
+    // Built from `merged` (stub rows already excluded), not the raw llmLogs.
+    const byModelMap = new Map();
+    for (const c of merged) {
+      if (c.source !== "llm") continue;
+      const key = c.model || "unknown";
+      if (!byModelMap.has(key)) {
+        byModelMap.set(key, { model: key, provider: c.provider, calls: 0, tokens: 0, cost: 0, failures: 0 });
+      }
+      const m = byModelMap.get(key);
+      m.calls += 1;
+      m.tokens += c.tokens;
+      m.cost += c.cost;
+      if (c.status === "failed") m.failures += 1;
+    }
+    const byModel = [...byModelMap.values()]
+      .map((m) => ({ ...m, cost: Math.round(m.cost * 1e6) / 1e6 }))
+      .sort((a, b) => b.calls - a.calls);
+
+    // Recent failures — the "if failure then why" surface, newest first.
+    const recentFailures = merged
+      .filter((c) => c.status === "failed")
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .slice(0, 25)
+      .map((c) => ({
+        provider: c.provider,
+        model: c.model,
+        source: c.source,
+        errorMessage: c.errorMessage,
+        createdAt: c.createdAt,
+      }));
+
+    const totals = merged.reduce(
+      (acc, c) => {
+        acc.calls += 1;
+        acc.tokens += c.tokens;
+        acc.cost += c.cost;
+        if (c.status === "failed") acc.failures += 1;
+        else acc.success += 1;
+        return acc;
+      },
+      { calls: 0, success: 0, failures: 0, tokens: 0, cost: 0 },
+    );
+    totals.cost = Math.round(totals.cost * 1e6) / 1e6;
+
+    res.json({
+      days,
+      since: since.toISOString(),
+      until: until ? until.toISOString() : null,
+      totals,
+      byDay,
+      byProvider,
+      byModel,
+      recentFailures,
+    });
+  } catch (e) {
+    console.error("[super-admin-api-analytics] GET /overview failed:", e.message);
+    res.status(500).json({ error: "Failed to load API analytics" });
+  }
+});
+
+// ── Filter option lists ──────────────────────────────────────────────────
+// Distinct provider/model values across ALL history (not scoped to the
+// overview's ?days window) so the filter dropdowns stay stable and don't
+// shrink to just whatever the current window happens to contain.
+
+router.get("/filters", async (req, res) => {
+  try {
+    // stub:false — a provider/model with ONLY stub-mode rows (no API key ever
+    // configured, llmRouter.js's synthetic fallback) shouldn't appear as a
+    // filterable option; it's never actually been called for real.
+    // ?provider= optionally scopes the model list to that provider's models
+    // only, so picking "openai" never leaves a gemini model selected in the
+    // second dropdown (which would silently return zero results).
+    const { provider } = req.query;
+    const modelWhere = { stub: false };
+    if (provider) modelWhere.provider = provider;
+
+    const [llmProviders, apiProviders, models] = await Promise.all([
+      prisma.llmCallLog.findMany({ where: { stub: false }, distinct: ["provider"], select: { provider: true } }),
+      prisma.apiCallLog.findMany({ distinct: ["provider"], select: { provider: true } }),
+      prisma.llmCallLog.findMany({ where: modelWhere, distinct: ["model"], select: { model: true } }),
+    ]);
+    const providers = [...new Set([...llmProviders, ...apiProviders].map((r) => r.provider))].sort();
+    const modelList = [...new Set(models.map((r) => r.model))].sort();
+    res.json({ providers, models: modelList });
+  } catch (e) {
+    console.error("[super-admin-api-analytics] GET /filters failed:", e.message);
+    res.status(500).json({ error: "Failed to load filter options" });
+  }
+});
+
+// ── Individual call browsing ────────────────────────────────────────────
+
+router.get("/calls", async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const pageSize = Math.min(100, Math.max(1, parseInt(req.query.pageSize, 10) || 25));
+    const { provider, model, status, search, from, to } = req.query;
+
+    const where = {};
+    if (provider) where.provider = provider;
+    if (model) where.model = model;
+    if (status) where.status = status;
+    if (from || to) {
+      where.createdAt = {};
+      if (from) {
+        const fromDate = new Date(from);
+        if (Number.isNaN(fromDate.getTime())) return res.status(400).json({ error: "invalid `from` date", code: "INVALID_DATE" });
+        where.createdAt.gte = fromDate;
+      }
+      if (to) {
+        const toDate = new Date(to);
+        if (Number.isNaN(toDate.getTime())) return res.status(400).json({ error: "invalid `to` date", code: "INVALID_DATE" });
+        // Bump to end-of-UTC-day (see /overview's matching comment) so
+        // ?to=2026-07-13 includes ALL of that day's rows, not just up to
+        // its opening midnight.
+        toDate.setUTCHours(23, 59, 59, 999);
+        where.createdAt.lte = toDate;
+      }
+    }
+    if (search) {
+      where.OR = [
+        { model: { contains: search } },
+        { task: { contains: search } },
+        { errorMessage: { contains: search } },
+      ];
+    }
+
+    // LlmCallLog and ApiCallLog are separate tables with no shared PK space,
+    // so true cross-table pagination would require a UNION the ORM doesn't
+    // expose cleanly. Pragmatic approach: fetch both filtered sets bounded
+    // to a sane cap, merge + sort by createdAt, then paginate in memory.
+    // Acceptable at this data volume (observability logs, not transactional
+    // data) — same tradeoff the cron logs endpoint doesn't have to make
+    // because it only reads one table.
+    const FETCH_CAP = 2000;
+    const apiWhere = { ...where };
+    // ApiCallLog has no `model`/`task` columns — a ?model= filter should
+    // exclude ApiCallLog entirely (it's an LLM-only concept here), and a
+    // search's OR narrows to the fields ApiCallLog actually has.
+    delete apiWhere.model;
+    if (model) apiWhere.id = -1; // unsatisfiable — excludes all ApiCallLog rows
+    if (apiWhere.OR) {
+      apiWhere.OR = [
+        { endpoint: { contains: search } },
+        { errorMessage: { contains: search } },
+      ];
+    }
+
+    const [llmRows, apiRows] = await Promise.all([
+      prisma.llmCallLog.findMany({ where, orderBy: { createdAt: "desc" }, take: FETCH_CAP }),
+      prisma.apiCallLog.findMany({ where: apiWhere, orderBy: { createdAt: "desc" }, take: FETCH_CAP }),
+    ]);
+
+    const merged = [
+      ...llmRows.map((l) => ({
+        id: `llm-${l.id}`,
+        source: "llm",
+        provider: l.provider,
+        model: l.model,
+        task: l.task,
+        status: l.status,
+        promptTokens: l.promptTokens,
+        completionTokens: l.completionTokens,
+        totalTokens: l.totalTokens,
+        cost: toNum(l.costEstimate),
+        stub: l.stub,
+        errorMessage: l.errorMessage,
+        createdAt: l.createdAt,
+      })),
+      ...apiRows.map((a) => ({
+        id: `api-${a.id}`,
+        source: "api",
+        provider: a.provider,
+        model: a.endpoint,
+        task: null,
+        status: a.status,
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        cost: toNum(a.costEstimate),
+        stub: false,
+        errorMessage: a.errorMessage,
+        createdAt: a.createdAt,
+      })),
+    ].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+    const total = merged.length;
+    const startIdx = (page - 1) * pageSize;
+    const pageRows = merged.slice(startIdx, startIdx + pageSize);
+
+    res.json({ calls: pageRows, total, page, pageSize, truncated: total >= FETCH_CAP * 2 });
+  } catch (e) {
+    console.error("[super-admin-api-analytics] GET /calls failed:", e.message);
+    res.status(500).json({ error: "Failed to list API calls" });
+  }
+});
+
+// ── Settings (retention) ────────────────────────────────────────────────
+
+router.get("/settings/log-retention", async (req, res) => {
+  try {
+    const setting = await prisma.systemSetting.findUnique({ where: { key: RETENTION_SETTING_KEY } });
+    const retainDays = setting ? parseInt(setting.value, 10) : DEFAULT_RETENTION_DAYS;
+    res.json({ retainDays: Number.isFinite(retainDays) && retainDays > 0 ? retainDays : DEFAULT_RETENTION_DAYS });
+  } catch (e) {
+    console.error("[super-admin-api-analytics] GET /settings/log-retention failed:", e.message);
+    res.status(500).json({ error: "Failed to load retention setting" });
+  }
+});
+
+router.put("/settings/log-retention", async (req, res) => {
+  try {
+    const { retainDays } = req.body || {};
+    const days = parseInt(retainDays, 10);
+    if (!Number.isFinite(days) || days < 1 || days > 3650) {
+      return res.status(400).json({ error: "retainDays must be between 1 and 3650", code: "INVALID_RETENTION" });
+    }
+    await prisma.systemSetting.upsert({
+      where: { key: RETENTION_SETTING_KEY },
+      update: { value: String(days), updatedBy: (req.superAdmin && req.superAdmin.username) || null },
+      create: {
+        key: RETENTION_SETTING_KEY,
+        value: String(days),
+        category: "api-analytics",
+        updatedBy: (req.superAdmin && req.superAdmin.username) || null,
+      },
+    });
+    res.json({ retainDays: days });
+  } catch (e) {
+    console.error("[super-admin-api-analytics] PUT /settings/log-retention failed:", e.message);
+    res.status(500).json({ error: "Failed to update retention setting" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/super_admin_auth.js
+++ b/backend/routes/super_admin_auth.js
@@ -1,0 +1,121 @@
+/**
+ * routes/super_admin_auth.js — Super Admin Portal authentication.
+ *
+ * Deliberately separate from routes/auth.js. Credentials are environment-
+ * based only (see middleware/superAdminAuth.js for the full contract) —
+ * there is no SuperAdmin database table and no self-registration.
+ *
+ * Password flow (see middleware/superAdminAuth.js docblock for the full
+ * design rationale):
+ *   1. If SUPER_ADMIN_PASSWORD_PLAINTEXT is set to something other than the
+ *      placeholder sentinel AND it matches the SUBMITTED password exactly
+ *      (proving the caller actually knows the new value, not just that
+ *      .env happens to hold one) — treat this as the operator setting/
+ *      changing the password: hash it, OVERWRITE the persisted SystemSetting
+ *      hash (upsert — there is only ever one row, so the old hash can never
+ *      linger and be checked against by mistake), redact .env back to the
+ *      placeholder, and log in successfully with a notice. This makes "edit
+ *      .env, restart, log in with the new password" work every time, not
+ *      just on first bootstrap — and a wrong-password guess never triggers
+ *      a re-hash cycle, since it can't match the plaintext either.
+ *   2. Otherwise, verify the submitted password against whatever hash is
+ *      already current (the previously-persisted one, or
+ *      SUPER_ADMIN_PASSWORD_HASH from env as a fallback).
+ *
+ * Endpoints:
+ *   POST /api/super-admin/auth/login   — { username, password } -> { token, username }
+ *   GET  /api/super-admin/auth/me      — current Super Admin session (requireSuperAdmin)
+ *   POST /api/super-admin/auth/logout  — stateless (JWT-based); client just discards the token
+ */
+
+const express = require("express");
+const bcrypt = require("bcryptjs");
+const router = express.Router();
+const {
+  requireSuperAdmin,
+  issueSuperAdminToken,
+  isSuperAdminConfigured,
+  getPersistedPasswordHash,
+  persistPromotedPasswordHash,
+  isPlaintextPlaceholder,
+  redactPlaintextInEnvFile,
+} = require("../middleware/superAdminAuth");
+
+const DUMMY_HASH = "$2a$10$invalidinvalidinvalidinvalidinvalidinvalidinvalidinva";
+
+router.post("/login", async (req, res) => {
+  if (!isSuperAdminConfigured()) {
+    return res.status(503).json({
+      error: "Super Admin Portal is not configured on this server",
+      code: "SUPER_ADMIN_NOT_CONFIGURED",
+    });
+  }
+
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: "username and password are required" });
+  }
+
+  // Constant-shape response for both "wrong username" and "wrong password"
+  // so the endpoint doesn't leak which one was incorrect (username
+  // enumeration hardening) — mirrors routes/auth.js's login contract.
+  const expectedUsername = process.env.SUPER_ADMIN_USERNAME;
+
+  if (username !== expectedUsername) {
+    // Still run a bcrypt.compare against a dummy hash so the response
+    // timing doesn't reveal "the username didn't even match" vs "the
+    // password was wrong" via a fast-path short-circuit.
+    const decoyHash = (await getPersistedPasswordHash()) || process.env.SUPER_ADMIN_PASSWORD_HASH || DUMMY_HASH;
+    await bcrypt.compare(password, decoyHash);
+    return res.status(401).json({ error: "Invalid Super Admin credentials" });
+  }
+
+  // A real (non-placeholder) plaintext value in .env that matches the
+  // SUBMITTED password is treated as "apply this as the current password
+  // now" — whether or not a hash already exists. This is what makes
+  // password CHANGE work (not just first-login bootstrap): edit .env,
+  // restart, log in with the new password. Requiring the submission to
+  // match (not just checking .env in isolation) means a wrong-password
+  // guess never triggers a re-hash, and the caller has to actually know the
+  // new value to swap it in.
+  const envPlaintext = process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT || null;
+  if (!isPlaintextPlaceholder(envPlaintext) && password === envPlaintext) {
+    const newHash = await bcrypt.hash(envPlaintext, 10);
+    await persistPromotedPasswordHash(newHash); // upsert — fully replaces the old hash, never leaves both live
+    redactPlaintextInEnvFile();
+    const token = issueSuperAdminToken(username);
+    return res.json({
+      token,
+      username,
+      notice: "Password updated from .env and hashed. The plaintext has been cleared from .env automatically.",
+    });
+  }
+
+  const hashToCheck = (await getPersistedPasswordHash()) || process.env.SUPER_ADMIN_PASSWORD_HASH || null;
+  if (!hashToCheck) {
+    // isSuperAdminConfigured() guarantees a credential is set, so this is
+    // unreachable in practice — kept as a safe fallback.
+    return res.status(401).json({ error: "Invalid Super Admin credentials" });
+  }
+
+  const match = await bcrypt.compare(password, hashToCheck);
+  if (!match) {
+    return res.status(401).json({ error: "Invalid Super Admin credentials" });
+  }
+
+  const token = issueSuperAdminToken(username);
+  return res.json({ token, username });
+});
+
+router.get("/me", requireSuperAdmin, (req, res) => {
+  res.json({ username: req.superAdmin.username, role: "SUPER_ADMIN" });
+});
+
+// Stateless JWT — nothing to invalidate server-side. Kept as a real
+// endpoint (not just a frontend no-op) so the client always has something
+// to call, and so a future move to a token-blocklist has a landing spot.
+router.post("/logout", requireSuperAdmin, (req, res) => {
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/backend/routes/super_admin_cron.js
+++ b/backend/routes/super_admin_cron.js
@@ -1,0 +1,422 @@
+/**
+ * routes/super_admin_cron.js — Cron Maintenance module (Super Admin Portal).
+ *
+ * All routes here require requireSuperAdmin (mounted with that middleware
+ * in server.js). None of this touches the regular User/tenant auth system.
+ *
+ * Endpoint groups:
+ *   Cron Management: GET /crons, GET /crons/:name, POST /crons,
+ *     PUT /crons/:name, DELETE /crons/:name, POST /crons/:name/enable,
+ *     POST /crons/:name/disable, PUT /crons/:name/schedule,
+ *     POST /crons/:name/run-now
+ *   Cron Logs: GET /logs (paginated + filterable), GET /logs/:id,
+ *     DELETE /logs/:id, POST /logs/clear
+ *   Settings: GET /settings/log-retention, PUT /settings/log-retention
+ */
+
+const express = require("express");
+const router = express.Router();
+const prisma = require("../lib/prisma");
+const cronRegistry = require("../lib/cronRegistry");
+const { isValidHandlerKey, VALID_HANDLER_KEYS, getHandlerCatalog, buildDynamicTickFn } = require("../lib/cronDynamicHandlers");
+
+const RETENTION_SETTING_KEY = "cron_log_retention_days";
+const DEFAULT_RETENTION_DAYS = 30;
+
+// ── Cron Management ─────────────────────────────────────────────────────
+
+router.get("/crons", async (req, res) => {
+  try {
+    const crons = await prisma.cronConfig.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        logs: { orderBy: { startedAt: "desc" }, take: 1 },
+      },
+    });
+    const registered = new Set(cronRegistry.listRegistered().map((r) => r.name));
+    const decorated = crons.map((c) => {
+      const lastLog = c.logs[0] || null;
+      const { logs, ...rest } = c;
+      return {
+        ...rest,
+        isRegisteredInProcess: registered.has(c.name),
+        lastExecutionAt: lastLog ? lastLog.startedAt : null,
+        lastStatus: lastLog ? lastLog.status : null,
+      };
+    });
+    res.json({ crons: decorated });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /crons failed:", e.message);
+    res.status(500).json({ error: "Failed to list crons" });
+  }
+});
+
+// Catalog of dynamic-cron handler types. The UI consumes this so adding a
+// new handler in lib/cronDynamicHandlers.js does not require a frontend
+// code change to show up in the "Create Cron" form.
+router.get("/cron-handlers", async (req, res) => {
+  try {
+    res.json({ handlers: getHandlerCatalog() });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /cron-handlers failed:", e.message);
+    res.status(500).json({ error: "Failed to load handler catalog" });
+  }
+});
+
+router.get("/crons/:name", async (req, res) => {
+  try {
+    const cron = await prisma.cronConfig.findUnique({ where: { name: req.params.name } });
+    if (!cron) return res.status(404).json({ error: "Cron not found", code: "CRON_NOT_FOUND" });
+    res.json({ cron });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /crons/:name failed:", e.message);
+    res.status(500).json({ error: "Failed to load cron" });
+  }
+});
+
+// Create a NEW dynamic cron (isSystem:false). System engines (isSystem:true)
+// are only ever created by cronRegistry.register() at boot — this route
+// can't create or overwrite one of those.
+router.post("/crons", async (req, res) => {
+  try {
+    const { name, description, schedule, handlerKey, metadataJson, enabled } = req.body || {};
+    if (!name || typeof name !== "string" || !/^[a-zA-Z0-9_-]{1,100}$/.test(name)) {
+      return res.status(400).json({
+        error: "name is required and must be alphanumeric/dash/underscore, 1-100 chars",
+        code: "INVALID_NAME",
+      });
+    }
+    if (!schedule || !cronRegistry.isValidExpression(schedule)) {
+      return res.status(400).json({ error: "schedule is not a valid cron expression", code: "INVALID_SCHEDULE" });
+    }
+    if (!handlerKey || !isValidHandlerKey(handlerKey)) {
+      return res.status(400).json({
+        error: `handlerKey must be one of: ${VALID_HANDLER_KEYS.join(", ")}`,
+        code: "INVALID_HANDLER_KEY",
+      });
+    }
+    if (metadataJson) {
+      try {
+        JSON.parse(metadataJson);
+      } catch {
+        return res.status(400).json({ error: "metadataJson is not valid JSON", code: "INVALID_METADATA_JSON" });
+      }
+    }
+
+    const existing = await prisma.cronConfig.findUnique({ where: { name } });
+    if (existing) {
+      return res.status(409).json({ error: "A cron with this name already exists", code: "CRON_NAME_TAKEN" });
+    }
+
+    const created = await prisma.cronConfig.create({
+      data: {
+        name,
+        description: description || null,
+        schedule,
+        enabled: enabled !== false,
+        isSystem: false,
+        handlerKey,
+        metadataJson: metadataJson || null,
+        createdBy: req.superAdmin.username,
+      },
+    });
+
+    // Register it live immediately — no restart needed.
+    const tickFn = buildDynamicTickFn(handlerKey, metadataJson);
+    await cronRegistry.register({
+      name,
+      description,
+      defaultSchedule: schedule,
+      defaultEnabled: enabled !== false,
+      tickFn,
+    });
+
+    res.status(201).json({ cron: created });
+  } catch (e) {
+    console.error("[super-admin-cron] POST /crons failed:", e.message);
+    res.status(500).json({ error: "Failed to create cron" });
+  }
+});
+
+// Update a dynamic cron's description/handlerKey/metadata (schedule/enabled
+// have their own dedicated routes below so the UI's distinct actions map
+// 1:1 to distinct endpoints, matching the PRD's separate "Edit Schedule" /
+// "Enable/Disable" affordances).
+router.put("/crons/:name", async (req, res) => {
+  try {
+    const existing = await prisma.cronConfig.findUnique({ where: { name: req.params.name } });
+    if (!existing) return res.status(404).json({ error: "Cron not found", code: "CRON_NOT_FOUND" });
+    if (existing.isSystem) {
+      return res.status(403).json({
+        error: "System cron engines can only be enabled/disabled/rescheduled, not edited",
+        code: "SYSTEM_CRON_READONLY",
+      });
+    }
+
+    const { description, handlerKey, metadataJson } = req.body || {};
+    const data = {};
+    if (description !== undefined) data.description = description;
+    if (handlerKey !== undefined) {
+      if (!isValidHandlerKey(handlerKey)) {
+        return res.status(400).json({
+          error: `handlerKey must be one of: ${VALID_HANDLER_KEYS.join(", ")}`,
+          code: "INVALID_HANDLER_KEY",
+        });
+      }
+      data.handlerKey = handlerKey;
+    }
+    if (metadataJson !== undefined) {
+      if (metadataJson) {
+        try {
+          JSON.parse(metadataJson);
+        } catch {
+          return res.status(400).json({ error: "metadataJson is not valid JSON", code: "INVALID_METADATA_JSON" });
+        }
+      }
+      data.metadataJson = metadataJson || null;
+    }
+
+    const updated = await prisma.cronConfig.update({ where: { name: req.params.name }, data });
+
+    // Re-register with the (possibly new) handler/metadata so the change is live.
+    const tickFn = buildDynamicTickFn(updated.handlerKey, updated.metadataJson);
+    await cronRegistry.register({
+      name: updated.name,
+      description: updated.description,
+      defaultSchedule: updated.schedule,
+      tickFn,
+    });
+    await cronRegistry.applyConfig(updated.name);
+
+    res.json({ cron: updated });
+  } catch (e) {
+    console.error("[super-admin-cron] PUT /crons/:name failed:", e.message);
+    res.status(500).json({ error: "Failed to update cron" });
+  }
+});
+
+// Delete — only dynamic (isSystem:false) crons. System engines are
+// protected/critical and can only ever be disabled, never removed, since
+// they correspond to real code that still runs at every boot.
+router.delete("/crons/:name", async (req, res) => {
+  try {
+    const existing = await prisma.cronConfig.findUnique({ where: { name: req.params.name } });
+    if (!existing) return res.status(404).json({ error: "Cron not found", code: "CRON_NOT_FOUND" });
+    if (existing.isSystem) {
+      return res.status(403).json({
+        error: "System cron engines are protected and cannot be deleted — disable it instead",
+        code: "SYSTEM_CRON_PROTECTED",
+      });
+    }
+
+    cronRegistry.unregister(existing.name);
+    await prisma.cronConfig.delete({ where: { name: existing.name } });
+    res.json({ ok: true, deleted: existing.name });
+  } catch (e) {
+    console.error("[super-admin-cron] DELETE /crons/:name failed:", e.message);
+    res.status(500).json({ error: "Failed to delete cron" });
+  }
+});
+
+router.post("/crons/:name/enable", async (req, res) => {
+  await setEnabled(req, res, true);
+});
+
+router.post("/crons/:name/disable", async (req, res) => {
+  await setEnabled(req, res, false);
+});
+
+async function setEnabled(req, res, enabled) {
+  try {
+    const existing = await prisma.cronConfig.findUnique({ where: { name: req.params.name } });
+    if (!existing) return res.status(404).json({ error: "Cron not found", code: "CRON_NOT_FOUND" });
+
+    const updated = await prisma.cronConfig.update({
+      where: { name: req.params.name },
+      data: { enabled },
+    });
+    // Live effect — no restart needed.
+    await cronRegistry.applyConfig(req.params.name);
+    res.json({ cron: updated });
+  } catch (e) {
+    console.error(`[super-admin-cron] set enabled=${enabled} failed:`, e.message);
+    res.status(500).json({ error: "Failed to update cron enabled state" });
+  }
+}
+
+router.put("/crons/:name/schedule", async (req, res) => {
+  try {
+    const { schedule } = req.body || {};
+    if (!schedule || !cronRegistry.isValidExpression(schedule)) {
+      return res.status(400).json({ error: "schedule is not a valid cron expression", code: "INVALID_SCHEDULE" });
+    }
+    const existing = await prisma.cronConfig.findUnique({ where: { name: req.params.name } });
+    if (!existing) return res.status(404).json({ error: "Cron not found", code: "CRON_NOT_FOUND" });
+
+    const updated = await prisma.cronConfig.update({
+      where: { name: req.params.name },
+      data: { schedule },
+    });
+    // Live effect — tears down + recreates the node-cron task immediately.
+    await cronRegistry.applyConfig(req.params.name);
+    res.json({ cron: updated });
+  } catch (e) {
+    console.error("[super-admin-cron] PUT /crons/:name/schedule failed:", e.message);
+    res.status(500).json({ error: "Failed to update cron schedule" });
+  }
+});
+
+// Manual "Run now" trigger — fires immediately regardless of schedule,
+// logged with triggerType:"manual" so the Cron Logs screen distinguishes
+// it from a real scheduled/startup firing.
+router.post("/crons/:name/run-now", async (req, res) => {
+  try {
+    if (!cronRegistry.isRegistered(req.params.name)) {
+      return res.status(409).json({
+        error: "This cron is not currently registered in this process (server may need a restart, or it's disabled)",
+        code: "CRON_NOT_REGISTERED",
+      });
+    }
+    const result = await cronRegistry.runTick(req.params.name, "manual");
+    res.json({ result });
+  } catch (e) {
+    console.error("[super-admin-cron] POST /crons/:name/run-now failed:", e.message);
+    res.status(500).json({ error: "Failed to trigger cron" });
+  }
+});
+
+// ── Cron Logs ────────────────────────────────────────────────────────────
+
+router.get("/logs", async (req, res) => {
+  try {
+    const {
+      page = "1",
+      pageSize = "25",
+      cronName,
+      status,
+      from,
+      to,
+      search,
+    } = req.query;
+
+    const take = Math.min(Math.max(parseInt(pageSize, 10) || 25, 1), 200);
+    const skip = (Math.max(parseInt(page, 10) || 1, 1) - 1) * take;
+
+    const where = {};
+    if (cronName) where.cronName = cronName;
+    if (status) where.status = status;
+    if (from || to) {
+      where.startedAt = {};
+      if (from) {
+        const fromDate = new Date(from);
+        if (isNaN(fromDate.getTime())) return res.status(400).json({ error: "Invalid `from` date", code: "INVALID_DATE" });
+        where.startedAt.gte = fromDate;
+      }
+      if (to) {
+        const toDate = new Date(to);
+        if (isNaN(toDate.getTime())) return res.status(400).json({ error: "Invalid `to` date", code: "INVALID_DATE" });
+        where.startedAt.lte = toDate;
+      }
+    }
+    if (search) {
+      where.OR = [
+        { cronName: { contains: search } },
+        { errorMessage: { contains: search } },
+      ];
+    }
+
+    const [logs, total] = await Promise.all([
+      prisma.cronExecutionLog.findMany({
+        where,
+        orderBy: { startedAt: "desc" },
+        skip,
+        take,
+      }),
+      prisma.cronExecutionLog.count({ where }),
+    ]);
+
+    res.json({ logs, total, page: Number(page), pageSize: take });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /logs failed:", e.message);
+    res.status(500).json({ error: "Failed to list logs" });
+  }
+});
+
+router.get("/logs/:id", async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id)) return res.status(400).json({ error: "Invalid log id", code: "INVALID_ID" });
+    const log = await prisma.cronExecutionLog.findUnique({ where: { id } });
+    if (!log) return res.status(404).json({ error: "Log not found", code: "LOG_NOT_FOUND" });
+    res.json({ log });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /logs/:id failed:", e.message);
+    res.status(500).json({ error: "Failed to load log" });
+  }
+});
+
+router.delete("/logs/:id", async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id)) return res.status(400).json({ error: "Invalid log id", code: "INVALID_ID" });
+    const existing = await prisma.cronExecutionLog.findUnique({ where: { id } });
+    if (!existing) return res.status(404).json({ error: "Log not found", code: "LOG_NOT_FOUND" });
+    await prisma.cronExecutionLog.delete({ where: { id } });
+    res.json({ ok: true, deleted: id });
+  } catch (e) {
+    console.error("[super-admin-cron] DELETE /logs/:id failed:", e.message);
+    res.status(500).json({ error: "Failed to delete log" });
+  }
+});
+
+// Bulk clear — optionally scoped to a single cron name; otherwise clears ALL logs.
+router.post("/logs/clear", async (req, res) => {
+  try {
+    const { cronName } = req.body || {};
+    const where = cronName ? { cronName } : {};
+    const result = await prisma.cronExecutionLog.deleteMany({ where });
+    res.json({ ok: true, deletedCount: result.count });
+  } catch (e) {
+    console.error("[super-admin-cron] POST /logs/clear failed:", e.message);
+    res.status(500).json({ error: "Failed to clear logs" });
+  }
+});
+
+// ── Settings: log retention ─────────────────────────────────────────────
+
+router.get("/settings/log-retention", async (req, res) => {
+  try {
+    const setting = await prisma.systemSetting.findUnique({ where: { key: RETENTION_SETTING_KEY } });
+    const retainDays = setting ? parseInt(setting.value, 10) : DEFAULT_RETENTION_DAYS;
+    res.json({ retainDays: Number.isFinite(retainDays) ? retainDays : DEFAULT_RETENTION_DAYS });
+  } catch (e) {
+    console.error("[super-admin-cron] GET /settings/log-retention failed:", e.message);
+    res.status(500).json({ error: "Failed to load retention setting" });
+  }
+});
+
+router.put("/settings/log-retention", async (req, res) => {
+  try {
+    const { retainDays } = req.body || {};
+    const parsed = parseInt(retainDays, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 3650) {
+      return res.status(400).json({ error: "retainDays must be an integer between 1 and 3650", code: "INVALID_RETENTION_DAYS" });
+    }
+    const setting = await prisma.systemSetting.upsert({
+      where: { key: RETENTION_SETTING_KEY },
+      update: { value: String(parsed), updatedBy: req.superAdmin.username },
+      create: {
+        key: RETENTION_SETTING_KEY,
+        value: String(parsed),
+        category: "cron-maintenance",
+        updatedBy: req.superAdmin.username,
+      },
+    });
+    res.json({ retainDays: parseInt(setting.value, 10) });
+  } catch (e) {
+    console.error("[super-admin-cron] PUT /settings/log-retention failed:", e.message);
+    res.status(500).json({ error: "Failed to update retention setting" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/super_admin_cron_analytics.js
+++ b/backend/routes/super_admin_cron_analytics.js
@@ -1,0 +1,93 @@
+/**
+ * routes/super_admin_cron_analytics.js — Cron Analytics module (Super Admin
+ * Portal). Read-only aggregation over CronExecutionLog for the charts on
+ * the /super-admin/cron-analytics page: runs-over-time, success/fail split,
+ * average duration trend, and per-cron summary rows.
+ *
+ * All routes require requireSuperAdmin (mounted with that middleware in
+ * server.js), same as routes/super_admin_cron.js.
+ *
+ * Endpoint: GET /overview?days=<1-90, default 14>
+ */
+
+const express = require("express");
+const router = express.Router();
+const prisma = require("../lib/prisma");
+
+const MAX_DAYS = 90;
+const DEFAULT_DAYS = 14;
+
+function dayKey(d) {
+  return new Date(d).toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+router.get("/overview", async (req, res) => {
+  try {
+    const daysRaw = parseInt(req.query.days, 10);
+    const days = Number.isFinite(daysRaw) && daysRaw > 0 ? Math.min(daysRaw, MAX_DAYS) : DEFAULT_DAYS;
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    const logs = await prisma.cronExecutionLog.findMany({
+      where: { startedAt: { gte: since } },
+      select: { cronName: true, startedAt: true, durationMs: true, status: true },
+      orderBy: { startedAt: "asc" },
+    });
+
+    // Runs-over-time — one bucket per calendar day, counts by status.
+    const byDayMap = new Map();
+    for (const log of logs) {
+      const key = dayKey(log.startedAt);
+      if (!byDayMap.has(key)) byDayMap.set(key, { date: key, success: 0, failed: 0, running: 0, total: 0 });
+      const bucket = byDayMap.get(key);
+      bucket.total += 1;
+      if (log.status === "success") bucket.success += 1;
+      else if (log.status === "failed") bucket.failed += 1;
+      else bucket.running += 1;
+    }
+    const byDay = [...byDayMap.values()].sort((a, b) => a.date.localeCompare(b.date));
+
+    // Overall status split (pie/donut).
+    const statusTotals = { success: 0, failed: 0, running: 0 };
+    for (const log of logs) {
+      if (log.status === "success") statusTotals.success += 1;
+      else if (log.status === "failed") statusTotals.failed += 1;
+      else statusTotals.running += 1;
+    }
+
+    // Per-cron summary — run count, failure count, average duration.
+    const perCronMap = new Map();
+    for (const log of logs) {
+      if (!perCronMap.has(log.cronName)) {
+        perCronMap.set(log.cronName, { cronName: log.cronName, runs: 0, failures: 0, totalDurationMs: 0, durationSamples: 0 });
+      }
+      const c = perCronMap.get(log.cronName);
+      c.runs += 1;
+      if (log.status === "failed") c.failures += 1;
+      if (typeof log.durationMs === "number") {
+        c.totalDurationMs += log.durationMs;
+        c.durationSamples += 1;
+      }
+    }
+    const perCron = [...perCronMap.values()]
+      .map((c) => ({
+        cronName: c.cronName,
+        runs: c.runs,
+        failures: c.failures,
+        avgDurationMs: c.durationSamples > 0 ? Math.round(c.totalDurationMs / c.durationSamples) : null,
+      }))
+      .sort((a, b) => b.runs - a.runs);
+
+    res.json({
+      days,
+      since: since.toISOString(),
+      totals: { runs: logs.length, ...statusTotals },
+      byDay,
+      perCron,
+    });
+  } catch (e) {
+    console.error("[super-admin-cron-analytics] GET /overview failed:", e.message);
+    res.status(500).json({ error: "Failed to load cron analytics" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/travel_diagnostics.js
+++ b/backend/routes/travel_diagnostics.js
@@ -1514,8 +1514,9 @@ router.patch(
 //
 // PRD §4.2 + §6.1: generate an advisor talking-points brief for a
 // completed diagnostic via the LLM router (per PRD §9.1 this is a
-// reasoning task → Claude Opus primary, GPT-4 fallback). First consumer
-// of the lib/llmRouter.js scaffold (commit 583c06b) — until Q11 API
+// reasoning task → Gemini Flash primary, GPT-4 fallback — 2026-07-14
+// swap off Claude Opus, see backend/lib/llmRouter.js TASK_ROUTING).
+// First consumer of the lib/llmRouter.js scaffold (commit 583c06b) — until Q11 API
 // keys land the router returns deterministic [STUB-TALKING-POINTS]
 // synthetic text so the advisor UI can render SOMETHING and tests can
 // pin the contract.
@@ -1729,7 +1730,7 @@ router.post(
       });
 
       // Parse the LLM text for a confidence percentage. The stub
-      // returns "85% match (synthetic)"; real Claude output is
+      // returns "85% match (synthetic)"; real Gemini Flash output is
       // expected to surface a "\d+%" token in the prose. When
       // absent we return null + classify as "unknown" so the UI
       // can render an advisor-review prompt rather than guessing.

--- a/backend/routes/travel_personalised_destinations.js
+++ b/backend/routes/travel_personalised_destinations.js
@@ -9,12 +9,13 @@
 // Stall, lands under SupplierCredential category "llm-key").
 //
 // Cred-swap behaviour: backend/lib/llmRouter.js routes "reasoning"
-// task to claude-opus-4-7 primary / gpt-4 fallback. Until Q11 keys
-// drop, the router returns deterministic synthetic text matching
-// the envelope shape { text, finishReason, usage, model, stub:true }.
-// The MOMENT Q11 keys land in ENV or SupplierCredential, this
-// endpoint switches over to real Claude reasoning with NO code
-// change here — the swap point is inside llmRouter.routeRequest.
+// task to gemini-flash primary / gpt-4 fallback (2026-07-14 swap off
+// Claude Opus). Until Q11 keys drop, the router returns deterministic
+// synthetic text matching the envelope shape
+// { text, finishReason, usage, model, stub:true }. The MOMENT Q11 keys
+// land in ENV or SupplierCredential, this endpoint switches over to
+// real Gemini Flash reasoning with NO code change here — the swap
+// point is inside llmRouter.routeRequest.
 //
 // Endpoint: POST /api/travel-personalised-destinations/recommend
 //   Body: { customerName, budgetINR, travelMonth, partySize,

--- a/backend/scripts/backfill-llm-call-log-provider-cost.js
+++ b/backend/scripts/backfill-llm-call-log-provider-cost.js
@@ -1,0 +1,64 @@
+/**
+ * scripts/backfill-llm-call-log-provider-cost.js — one-time backfill for
+ * LlmCallLog rows written before provider/cost estimation was wired in
+ * (2026-07-14). Those rows have provider:"unknown" and costEstimate:0
+ * baked in permanently — this script infers the real provider from each
+ * row's `model` string and recomputes costEstimate from its token counts,
+ * using the exact same lib/apiPricing.js table live calls use going forward.
+ *
+ * Idempotent: only touches rows where provider = "unknown" (the column
+ * default), so re-running is safe and a no-op once everything is backfilled.
+ * Stub rows (stub:true) are intentionally left at costEstimate:0 — no real
+ * API call was made, so there's no real cost to attribute, but they DO get
+ * a real `provider` tag so "Calls by provider" reflects them correctly.
+ *
+ * Usage: node scripts/backfill-llm-call-log-provider-cost.js [--dry-run]
+ */
+
+'use strict';
+
+const prisma = require('../lib/prisma');
+const { inferProvider, estimateLlmCost } = require('../lib/apiPricing');
+
+async function run() {
+  const dryRun = process.argv.includes('--dry-run');
+  const rows = await prisma.llmCallLog.findMany({ where: { provider: 'unknown' } });
+
+  if (rows.length === 0) {
+    console.log('[backfill] no rows with provider="unknown" — nothing to do.');
+    return { updated: 0, total: 0 };
+  }
+
+  console.log(`[backfill] found ${rows.length} row(s) to backfill${dryRun ? ' (dry run — no writes)' : ''}.`);
+
+  let updated = 0;
+  for (const row of rows) {
+    const provider = inferProvider(row.model);
+    const costEstimate = row.stub ? 0 : estimateLlmCost(row.model, row.promptTokens, row.completionTokens);
+
+    if (dryRun) {
+      console.log(`  [dry-run] id=${row.id} model=${row.model} -> provider=${provider} cost=${costEstimate}`);
+      continue;
+    }
+
+    await prisma.llmCallLog.update({
+      where: { id: row.id },
+      data: { provider, costEstimate },
+    });
+    updated += 1;
+  }
+
+  console.log(`[backfill] ${dryRun ? 'would update' : 'updated'} ${dryRun ? rows.length : updated} of ${rows.length} row(s).`);
+  return { updated: dryRun ? 0 : updated, total: rows.length };
+}
+
+if (require.main === module) {
+  run()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error('[backfill] failed:', e);
+      process.exit(1);
+    });
+}
+
+module.exports = { run };

--- a/backend/scripts/hash-super-admin-password.js
+++ b/backend/scripts/hash-super-admin-password.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * hash-super-admin-password.js — one-time helper to generate the bcrypt
+ * hash for SUPER_ADMIN_PASSWORD_HASH.
+ *
+ * The Super Admin Portal never stores or compares a plaintext password —
+ * only this hash lives in .env. Run this once, paste the OUTPUT hash into
+ * .env, then forget the plaintext (or store it in your team's password
+ * manager, not in this repo).
+ *
+ * Usage:
+ *   node scripts/hash-super-admin-password.js "your-password-here"
+ *
+ * If no argument is given, prompts on stdin so the password never appears
+ * in shell history.
+ */
+
+const bcrypt = require("bcryptjs");
+const readline = require("readline");
+
+async function main() {
+  const argPassword = process.argv[2];
+  let password = argPassword;
+
+  if (!password) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    password = await new Promise((resolve) => {
+      rl.question("Enter the Super Admin password (input will be visible): ", (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    });
+  }
+
+  if (!password || password.length < 8) {
+    console.error("Password must be at least 8 characters.");
+    process.exit(1);
+  }
+
+  const hash = await bcrypt.hash(password, 10);
+  console.log("\nAdd this to your .env file:\n");
+  console.log(`SUPER_ADMIN_PASSWORD_HASH=${hash}\n`);
+}
+
+main().catch((e) => {
+  console.error("Failed to generate hash:", e.message);
+  process.exit(1);
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -49,7 +49,6 @@ const express = require("express");
 const cors = require("cors");
 const http = require("http");
 const { Server } = require("socket.io");
-const _cron = require("node-cron");
 const swaggerUi = require("swagger-ui-express");
 const YAML = require("yamljs");
 const rateLimit = require("express-rate-limit");
@@ -345,6 +344,27 @@ app.post(
   (req, res, next) => next(),
 );
 
+// Super Admin login — a single, extremely high-privilege account with no
+// account-lockout/2FA of its own, so brute-force protection matters even
+// more here than on the regular multi-user login. Tighter budget than the
+// app login (5/15min per IP is already tight; there's no legitimate-traffic
+// reason for a burst against this one specific account).
+const superAdminLoginIpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  keyGenerator: (req, res) => ipKeyGenerator(req, res),
+  message: { error: "Too many Super Admin login attempts from this IP, please try again later." },
+  validate: { trustProxy: false, xForwardedForHeader: false },
+});
+app.post(
+  "/api/super-admin/auth/login",
+  superAdminLoginIpLimiter,
+  (req, res, next) => next(),
+);
+
 // #531 (HI-02 mitigation): per-IP and per-email rate limiting on
 // /api/auth/forgot-password. Mirrors the login limiter pattern. Without
 // these, an attacker can hammer the endpoint to enumerate valid emails
@@ -563,6 +583,13 @@ io.on("connection", (socket) => {
 
 // Import Enterprise Routes
 const authRoutes = require("./routes/auth");
+// Super Admin Portal — completely separate auth + module surface from the
+// rest of the app (see middleware/superAdminAuth.js for the contract).
+const superAdminAuthRoutes = require("./routes/super_admin_auth");
+const superAdminCronRoutes = require("./routes/super_admin_cron");
+const superAdminCronAnalyticsRoutes = require("./routes/super_admin_cron_analytics");
+const superAdminApiAnalyticsRoutes = require("./routes/super_admin_api_analytics");
+const { requireSuperAdmin } = require("./middleware/superAdminAuth");
 const rolesRoutes = require("./routes/roles");
 const widgetsRoutes = require("./routes/widgets");
 const pagesRoutes = require("./routes/pages");
@@ -922,6 +949,13 @@ app.use("/api", (req, res, next) => {
     // Public landing-page submit + tracking pixels are referenced by
     // rendered pages as /api/pages/<slug>/submit and /api/pages/<slug>/track.
     "/pages/",
+    // Super Admin Portal — deliberately its OWN auth system (env-based
+    // credentials, no User/tenant table, dedicated JWT secret), so it must
+    // bypass the app's verifyToken guard entirely. Every actual route
+    // (except /super-admin/auth/login itself) is independently protected
+    // by requireSuperAdmin at the route level — same pattern as /portal/*
+    // above being globally open but individually gated by its own JWT.
+    "/super-admin",
   ];
   if (openPaths.some((p) => req.path.startsWith(p))) return next();
   // Public marketing catalog — the /pricing page hits GET /subscriptions/plans
@@ -1038,6 +1072,13 @@ app.param("id", validateNumericId);
 
 // Map API Endpoints
 app.use("/api/auth", authRoutes);
+// Super Admin Portal — /login is open (checked inside the route itself);
+// every other /api/super-admin/* route is gated by requireSuperAdmin here
+// at the mount point, so no individual route file can forget the guard.
+app.use("/api/super-admin/auth", superAdminAuthRoutes);
+app.use("/api/super-admin/cron", requireSuperAdmin, superAdminCronRoutes);
+app.use("/api/super-admin/cron-analytics", requireSuperAdmin, superAdminCronAnalyticsRoutes);
+app.use("/api/super-admin/api-analytics", requireSuperAdmin, superAdminApiAnalyticsRoutes);
 app.use("/api/roles", rolesRoutes);
 // SPEC §C3 — unified /api/me + /api/permissions endpoints. Both come
 // from the same module so the SPEC-named endpoint surface is contiguous.
@@ -2022,7 +2063,10 @@ if (process.env.DISABLE_CRONS === "1") {
   const { initRecurringInvoiceCron } = require("./cron/recurringInvoiceEngine");
   initRecurringInvoiceCron(io);
 
-  // Initialize Marketplace Sync Engine (runs every 5 min)
+  // Marketplace Sync Engine — registers via cronRegistry with
+  // defaultEnabled:false (no tenant has an active MarketplaceConfig today,
+  // so it ships OFF by default). Now visible + one-click-enable from the
+  // Super Admin Cron Maintenance table instead of being invisible.
   const { initMarketplaceCron } = require("./cron/marketplaceEngine");
   initMarketplaceCron(io);
 
@@ -2225,21 +2269,11 @@ if (process.env.DISABLE_CRONS === "1") {
   // Iterates active tenants and emits a tiered reminder (T-7d / T-3d / T-1d / T-0)
   // for each one whose prior-month GSTR filing is approaching its deadline. Notify
   // half is a console-log stub today; real WhatsApp / email dispatch lands when
-  // Q9 creds drop. Respects DISABLE_CRONS=1 via the outer guard.
-  const {
-    runGstrFilingReminderEngine,
-  } = require("./cron/gstrFilingReminderEngine");
-  _cron.schedule("0 5 * * *", async () => {
-    try {
-      const result = await runGstrFilingReminderEngine();
-      console.log("[gstr-filing-reminder]", result);
-    } catch (e) {
-      console.error("[gstr-filing-reminder] cron failed:", e.message);
-    }
-  });
-  console.log(
-    "[gstr-filing-reminder] cron initialized (daily 05:00 UTC / 10:30 IST)",
-  );
+  // Q9 creds drop. Respects DISABLE_CRONS=1 via the outer guard. Now registers
+  // via cronRegistry (Super Admin Portal / Cron Maintenance) instead of a raw
+  // _cron.schedule() call, so it's manageable from the Super Admin UI too.
+  const { initCron: initGstrFilingReminderCron } = require("./cron/gstrFilingReminderEngine");
+  initGstrFilingReminderCron();
 
   // Initialize Low-Stock Inventory Alerts (daily 09:00 IST, wellness tenants)
   const { initLowStockCron } = require("./cron/lowStockEngine");
@@ -2323,6 +2357,24 @@ if (process.env.DISABLE_CRONS === "1") {
   // Idempotent (status filter is the set-once gate).
   const { initWalletExpiryCron } = require("./cron/walletExpiryEngine");
   initWalletExpiryCron();
+
+  // Super Admin Portal / Cron Maintenance — purges CronExecutionLog rows
+  // past the configured retention window (daily 03:15, admin-configurable
+  // via PUT /api/super-admin/cron/settings/log-retention).
+  const { initCronLogRetentionCron } = require("./cron/cronLogRetentionEngine");
+  initCronLogRetentionCron();
+
+  // Super Admin Portal / API Analytics — purges LlmCallLog + ApiCallLog
+  // rows past the configured retention window (daily 03:20, admin-
+  // configurable via PUT /api/super-admin/api-analytics/settings/log-retention).
+  const { initApiCallLogRetentionCron } = require("./cron/apiCallLogRetentionEngine");
+  initApiCallLogRetentionCron();
+
+  // Super Admin Portal / Cron Maintenance — re-register any admin-created
+  // dynamic crons (isSystem:false) from CronConfig so they survive server
+  // restarts without requiring an admin to re-save each one.
+  const { loadDynamicCrons } = require("./lib/cronRegistry");
+  loadDynamicCrons().catch((e) => console.error("[server] loadDynamicCrons failed:", e.message));
 
   // Initialize Notification Rules Engine — event-driven notifications for
   // business events (SLA breaches, approvals, expenses, leave requests).

--- a/backend/services/flyerRenderEngine.js
+++ b/backend/services/flyerRenderEngine.js
@@ -145,6 +145,56 @@ function _resetPuppeteerCacheForTests() {
   _puppeteerResolution = null;
 }
 
+// ---------------------------------------------------------------------------
+// PNG render resource guards
+// ---------------------------------------------------------------------------
+
+// Each PNG render used to launch a fresh headless Chromium. Under bulk cron
+// usage that can spawn dozens of Chrome processes simultaneously and exhaust
+// RAM. We keep a small concurrency cap so at most N renders run at once.
+const PNG_MAX_CONCURRENT = (() => {
+  const v = parseInt(process.env.FLYER_RENDER_PNG_MAX_CONCURRENT, 10);
+  return Number.isFinite(v) && v >= 1 ? v : 2;
+})();
+
+// Hard ceiling on how long any single puppeteer step may hang. A stuck
+// `page.setContent` or `page.screenshot` would otherwise hold the concurrency
+// slot (and a Chrome process) forever.
+const PNG_RENDER_TIMEOUT_MS = (() => {
+  const v = parseInt(process.env.FLYER_RENDER_PNG_TIMEOUT_MS, 10);
+  return Number.isFinite(v) && v >= 5_000 ? v : 45_000;
+})();
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+const _pngConcurrency = { running: 0, queue: [] };
+
+async function _acquirePngSlot() {
+  if (_pngConcurrency.running < PNG_MAX_CONCURRENT) {
+    _pngConcurrency.running += 1;
+    return;
+  }
+  await new Promise((resolve) => _pngConcurrency.queue.push(resolve));
+  // We have been resumed into a slot; the runner that released the slot already
+  // incremented the running counter.
+}
+
+function _releasePngSlot() {
+  _pngConcurrency.running = Math.max(0, _pngConcurrency.running - 1);
+  const next = _pngConcurrency.queue.shift();
+  if (next) {
+    _pngConcurrency.running += 1;
+    next();
+  }
+}
+
 /**
  * The 5 supported `format` values + their dispatch metadata. Keyed for
  * O(1) format-validity lookup + tidy switch dispatch in renderFlyer.
@@ -273,7 +323,7 @@ function applyDataOverrides(template, data) {
  */
 const STUB_PNG_BUFFER = Buffer.from(
   "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63000100000005000100" +
-    "0d0a2db40000000049454e44ae426082",
+  "0d0a2db40000000049454e44ae426082",
   "hex",
 );
 
@@ -440,34 +490,6 @@ function buildStubPngResponse(formatMeta) {
 }
 
 /**
- * Render concurrency gate — each real PNG render spawns a full Chromium
- * (~300–500 MB transient). Uncapped bursts of flyer requests, stacked on top
- * of resident WhatsApp Web sessions, were a direct OOM contributor on small
- * VPS boxes. Extra callers queue FIFO instead of launching in parallel.
- * FLYER_RENDER_CONCURRENCY overrides the default (2); clamped to [1, 8].
- */
-const RENDER_CONCURRENCY = (() => {
-  const v = parseInt(process.env.FLYER_RENDER_CONCURRENCY, 10);
-  return Number.isFinite(v) && v >= 1 ? Math.min(v, 8) : 2;
-})();
-let _renderActive = 0;
-const _renderWaiters = [];
-function _acquireRenderSlot() {
-  if (_renderActive < RENDER_CONCURRENCY) {
-    _renderActive++;
-    return Promise.resolve();
-  }
-  return new Promise((resolve) => _renderWaiters.push(resolve)).then(() => {
-    _renderActive++;
-  });
-}
-function _releaseRenderSlot() {
-  _renderActive = Math.max(0, _renderActive - 1);
-  const next = _renderWaiters.shift();
-  if (next) next();
-}
-
-/**
  * Render the PNG path. When Puppeteer is installed AND the
  * `FLYER_RENDER_FORCE_STUB` env var is not truthy, launches headless
  * Chrome + screenshots a viewport-sized page (real render). Otherwise
@@ -501,39 +523,79 @@ async function renderPngBranch({ template, formatMeta }) {
   // Concurrency gate: each real render spawns a full Chromium (~300–500 MB).
   // An uncapped burst of flyer requests alongside resident WhatsApp sessions
   // can OOM the box — queue extra callers FIFO instead of launching in parallel.
-  await module.exports._acquireRenderSlot();
+  await module.exports._acquirePngSlot();
   try {
     return await renderPngReal(resolution.puppeteer, template, formatMeta);
   } finally {
-    module.exports._releaseRenderSlot();
+    module.exports._releasePngSlot();
   }
 }
 
 async function renderPngReal(puppeteer, template, formatMeta) {
   const html = buildHtmlShellForPng(template, formatMeta.widthPx, formatMeta.heightPx);
 
-  // Real Puppeteer branch. Wrapped in try/finally so a failed page
-  // close or a Chrome crash mid-render doesn't leak a child process.
+  // Real Puppeteer branch. The concurrency slot is already held by the
+  // caller (renderPngBranch) — do NOT acquire a second one here, that would
+  // deadlock every render past PNG_MAX_CONCURRENT (each in-flight caller
+  // holds the outer slot while waiting forever on an inner one nobody
+  // releases until the outer holder finishes, which never happens).
+  //
+  // We time-box every puppeteer step so a hung Chrome cannot hold resources
+  // forever, AND pass puppeteer's own `timeout`/`protocolTimeout` launch
+  // options — these are native puppeteer/CDP-level guards that actually
+  // terminate the underlying Chromium process on expiry, unlike a bare
+  // Promise.race (which only abandons the JS promise; the OS process can
+  // keep running). Page and browser are closed in finally; if close ALSO
+  // hangs past its own timeout, the process is left for the OS/container
+  // to reap — protocolTimeout is what keeps that case rare.
   let browser = null;
+  let page = null;
   try {
-    browser = await puppeteer.launch({
-      headless: true,
-      // --disable-dev-shm-usage: Linux/Docker /dev/shm defaults to 64 MB and
-      // Chromium crashes or wedges against it. timeout caps a hung launch;
-      // protocolTimeout caps any wedged CDP call so a stuck render can't
-      // hold the concurrency slot (and its ~400 MB) forever.
-      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-      timeout: 30000,
-      protocolTimeout: 60000,
-    });
-    const page = await browser.newPage();
-    await page.setViewport({
-      width: formatMeta.widthPx,
-      height: formatMeta.heightPx,
-      deviceScaleFactor: 1,
-    });
-    await page.setContent(html, { waitUntil: "networkidle0" });
-    const buffer = await page.screenshot({ type: "png", omitBackground: false });
+    browser = await withTimeout(
+      puppeteer.launch({
+        headless: true,
+        // Minimal, low-RAM Chromium flags. --disable-dev-shm-usage is critical
+        // in Docker / low-mem containers to avoid /dev/shm exhaustion; the
+        // others trim GPU/zygote overhead since we only screenshot a static page.
+        args: [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage",
+          "--disable-accelerated-2d-canvas",
+          "--no-first-run",
+          "--no-zygote",
+          "--disable-gpu",
+        ],
+        // Native puppeteer guards (restored from a teammate's earlier PR that
+        // a merge conflict had dropped): timeout caps a hung launch;
+        // protocolTimeout caps any wedged CDP call so a stuck render can't
+        // hold the concurrency slot (and its ~400 MB) forever.
+        timeout: 30_000,
+        protocolTimeout: 60_000,
+      }),
+      20_000,
+      "puppeteer.launch",
+    );
+    page = await browser.newPage();
+    await withTimeout(
+      page.setViewport({
+        width: formatMeta.widthPx,
+        height: formatMeta.heightPx,
+        deviceScaleFactor: 1,
+      }),
+      10_000,
+      "page.setViewport",
+    );
+    await withTimeout(
+      page.setContent(html, { waitUntil: "networkidle0" }),
+      PNG_RENDER_TIMEOUT_MS,
+      "page.setContent",
+    );
+    const buffer = await withTimeout(
+      page.screenshot({ type: "png", omitBackground: false }),
+      PNG_RENDER_TIMEOUT_MS,
+      "page.screenshot",
+    );
     return {
       buffer,
       mimeType: formatMeta.mimeType,
@@ -543,8 +605,15 @@ async function renderPngReal(puppeteer, template, formatMeta) {
       engine: "puppeteer-headless",
     };
   } finally {
+    if (page) {
+      try {
+        if (typeof page.close === "function") {
+          await withTimeout(page.close(), 5_000, "page.close");
+        }
+      } catch (_e) { /* ignore close errors */ }
+    }
     if (browser) {
-      try { await browser.close(); } catch (_e) { /* ignore close errors */ }
+      try { await withTimeout(browser.close(), 10_000, "browser.close"); } catch (_e) { /* ignore close errors */ }
     }
   }
 }
@@ -585,6 +654,6 @@ module.exports = {
   _tryRequirePuppeteer: tryRequirePuppeteer,
   // Render-concurrency gate internals (used by renderPngBranch; exposed for
   // unit-test introspection only, same convention as _tryRequirePuppeteer).
-  _acquireRenderSlot,
-  _releaseRenderSlot,
+  _acquirePngSlot,
+  _releasePngSlot,
 };

--- a/backend/services/imageProviders/aiImageFallbackProvider.js
+++ b/backend/services/imageProviders/aiImageFallbackProvider.js
@@ -5,22 +5,21 @@
  * surface a usable photo, this provider cascades through AI image
  * generators and emits the first hit:
  *
- *   1. Gemini Imagen (`GEMINI_API_KEY`) — Google AI Studio `:predict`
- *      endpoint with `imagen-3.0-generate-002`. Free-tier keys may not be
- *      entitled to Imagen; the call falls through on any non-200.
- *   2. OpenAI DALL-E (`OPENAI_API_KEY`) — via the existing
+ *   1. OpenAI DALL-E (`OPENAI_API_KEY`) — via the existing
  *      `services/marketingFlyerImageLLM.generateFlyerImage` wrapper.
- *   3. Pollinations (key-free) — guaranteed fallback so an empty card
- *      never ships. Lower fidelity than the AI providers above.
+ *   2. Pollinations (key-free) — guaranteed fallback so an empty card
+ *      never ships. Lower fidelity than the AI provider above.
  *
- * Groq is intentionally NOT in this cascade — `GROQ_API_KEY` only gates
- * text models (Llama / Mixtral on Groq's LPU); Groq exposes no image
- * generation API as of 2026-06.
+ * Gemini Imagen was removed from this cascade (2026-07-13) — the project's
+ * Gemini key is reserved for text tasks (lead scoring/summarization) and
+ * should not also absorb image-generation quota. Groq is intentionally NOT
+ * in this cascade either — `GROQ_API_KEY` only gates text models (Llama /
+ * Mixtral on Groq's LPU); Groq exposes no image generation API as of
+ * 2026-06.
  *
- * Per-call cost on the Gemini + DALL-E paths is gated by the project's
- * per-tenant LLM budget (LlmCallLog + tenantSettings). When budget is
- * exhausted the AI providers return null and the cascade lands on
- * Pollinations.
+ * Per-call cost on the DALL-E path is gated by the project's per-tenant
+ * LLM budget (LlmCallLog + tenantSettings). When budget is exhausted the
+ * AI provider returns null and the cascade lands on Pollinations.
  */
 
 'use strict';
@@ -44,8 +43,8 @@ function isAvailable() {
 // should prefer real destination photography"). Keeping it as the
 // last-resort within the LAST-RESORT provider means the page ships
 // with destination-relevant imagery instead of empty card slots when
-// none of (Unsplash, Pexels, Pixabay, DALL-E, Stability, Imagen) have
-// usable keys — which is the demo box's current state.
+// none of (Unsplash, Pexels, Pixabay, DALL-E, Stability) have usable
+// keys — which is the demo box's current state.
 function pollinationsUrl(prompt, w, h) {
   const safePrompt = encodeURIComponent(String(prompt || 'travel destination').slice(0, 280));
   const seed = Math.floor(Math.random() * 1e6);
@@ -76,79 +75,10 @@ function enrichPhotoPrompt(query) {
   return `${q}, professional travel photography, golden hour lighting, cinematic composition, high detail, no text, no watermark, photorealistic`;
 }
 
-// Try Gemini Imagen first when GEMINI_API_KEY is present. Uses the public
-// generativelanguage.googleapis.com :predict endpoint with the imagen-3
-// model. Returns a persisted /uploads/ URL on success, null on any failure
-// (key not entitled to Imagen, quota, parse error, etc.) so the caller
-// falls through to DALL-E + Pollinations. Groq is intentionally absent —
-// it ships text models only; no image-generation surface as of 2026-06.
-async function tryGeminiImagen(query, aspectRatio) {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) return null;
-  const shortQ = String(query || '').slice(0, 80);
-  const aspect = ['1:1', '3:4', '4:3', '9:16', '16:9'].includes(aspectRatio) ? aspectRatio : '4:3';
-  const prompt = enrichPhotoPrompt(query).slice(0, 480);
-  const model = process.env.LLM_MODEL_GEMINI_IMAGE || 'imagen-3.0-generate-002';
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:predict?key=${encodeURIComponent(apiKey)}`;
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), 30000);
-  let resp;
-  let body;
-  try {
-    resp = await fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        instances: [{ prompt }],
-        parameters: { sampleCount: 1, aspectRatio: aspect },
-      }),
-      signal: ctrl.signal,
-    });
-    body = await resp.json().catch(() => ({}));
-  } catch (e) {
-    clearTimeout(timer);
-    console.log(`[ai-image-fallback] Gemini Imagen threw for "${shortQ}": ${e.message || e}`);
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-  if (!resp.ok) {
-    const msg = (body && body.error && (body.error.message || body.error.status)) || resp.statusText;
-    console.log(`[ai-image-fallback] Gemini Imagen ${resp.status} for "${shortQ}": ${msg}`);
-    return null;
-  }
-  const b64 = body?.predictions?.[0]?.bytesBase64Encoded;
-  if (!b64) {
-    console.log(`[ai-image-fallback] Gemini Imagen returned no bytesBase64Encoded for "${shortQ}"`);
-    return null;
-  }
-  try {
-    const path = require('path');
-    const fs = require('fs');
-    const crypto = require('crypto');
-    const uploadsDir = path.join(__dirname, '..', '..', 'uploads', 'ai-fallback');
-    fs.mkdirSync(uploadsDir, { recursive: true });
-    const hash = crypto.createHash('sha1').update(`${prompt}${aspect}${Date.now()}`).digest('hex').slice(0, 16);
-    const filename = `gemini-${hash}.png`;
-    fs.writeFileSync(path.join(uploadsDir, filename), Buffer.from(b64, 'base64'));
-    return `/uploads/ai-fallback/${filename}`;
-  } catch (e) {
-    console.log(`[ai-image-fallback] Gemini Imagen persist failed for "${shortQ}": ${e.message || e}`);
-    return null;
-  }
-}
-
 async function search(query, { tenantId, aspectRatio, perPage = 1 } = {}) {
   const shortQ = String(query || '').slice(0, 80);
 
-  // 1. Gemini Imagen (free-tier may not be entitled — falls through silently).
-  const geminiUrl = await tryGeminiImagen(query, aspectRatio);
-  if (geminiUrl) {
-    console.log(`[ai-image-fallback] Gemini Imagen SUCCESS for "${shortQ}" → ${geminiUrl}`);
-    return [normalize({ url: geminiUrl, model: 'gemini-imagen' }, query)];
-  }
-
-  // 2. OpenAI DALL-E via the existing marketingFlyerImageLLM wrapper.
+  // 1. OpenAI DALL-E via the existing marketingFlyerImageLLM wrapper.
   let generateImage;
   try {
     ({ generateFlyerImage: generateImage } = require('../marketingFlyerImageLLM'));
@@ -208,7 +138,7 @@ function normalize(item, originalQuery) {
       providerUrl: '',
       license: 'ai-generated',
       query: originalQuery || '',
-      model: item.model || 'imagen',
+      model: item.model || 'dall-e-3',
     },
   };
 }

--- a/backend/services/landingPageGeneratorLLM.js
+++ b/backend/services/landingPageGeneratorLLM.js
@@ -43,6 +43,7 @@ if (process.env.NODE_ENV !== 'test') {
 const { getBudgetCap, evaluateCap, KEYS } = require('../lib/tenantSettings');
 const { buildDestinationLandingPagePrompt } = require('./landingPagePrompts');
 const { guardLandingPageOutput, buildDeterministicFallback } = require('../lib/landingPageGuard');
+const { estimateLlmCost } = require('../lib/apiPricing');
 
 void KEYS;
 
@@ -156,7 +157,7 @@ function parseGeminiJson(raw) {
  * than the 7-block PR-B version. 4096 truncated mid-JSON on several
  * destinations during the quality-validation sweep.
  */
-async function callGeminiAttempt({ apiKey, modelName, prompt }) {
+async function callGeminiAttempt({ apiKey, modelName, prompt }, _usageOut) {
   const { GoogleGenerativeAI } = require('@google/generative-ai');
   const ai = new GoogleGenerativeAI(apiKey);
   const model = ai.getGenerativeModel({
@@ -174,6 +175,15 @@ async function callGeminiAttempt({ apiKey, modelName, prompt }) {
   const fullPrompt = `${prompt.system}\n\n${prompt.user}`;
   const res = await model.generateContent(fullPrompt);
   const text = res?.response?.text?.();
+  // Optional out-parameter — callers that want real token usage (for
+  // LlmCallLog cost estimation) pass a plain object here; we mutate it
+  // in place so callGeminiAttempt's return contract (a bare string) stays
+  // unchanged for existing callers (callGeminiForTee et al).
+  if (_usageOut && typeof _usageOut === 'object') {
+    const usage = (res && res.response && res.response.usageMetadata) || {};
+    _usageOut.promptTokens = usage.promptTokenCount || 0;
+    _usageOut.completionTokens = usage.candidatesTokenCount || 0;
+  }
   if (!text) throw new Error('Gemini returned an empty response');
   return text;
 }
@@ -206,9 +216,10 @@ async function callGemini({ destination, durationDays, audience, subBrand, tenan
   let raw;
   let modelUsed;
   let lastError;
+  const usageOut = {};
   for (const modelName of cascade) {
     try {
-      raw = await callGeminiAttempt({ apiKey, modelName, prompt });
+      raw = await callGeminiAttempt({ apiKey, modelName, prompt }, usageOut);
       modelUsed = modelName;
       lastError = null;
       break;
@@ -231,7 +242,12 @@ async function callGemini({ destination, durationDays, audience, subBrand, tenan
   }
   if (raw === undefined) throw lastError;
 
-  return { rawJson: parseGeminiJson(raw), modelUsed };
+  return {
+    rawJson: parseGeminiJson(raw),
+    modelUsed,
+    promptTokens: usageOut.promptTokens || 0,
+    completionTokens: usageOut.completionTokens || 0,
+  };
 }
 
 /**
@@ -377,27 +393,37 @@ function groqEnabled() {
 
 /**
  * Persist one LlmCallLog row best-effort. Mirrors the lib/llmRouter
- * pattern so the admin spend dashboard sees this task class. Token
- * counts are estimates (Gemini doesn't return per-request counts on
- * every model — we use string-length heuristics).
+ * pattern so the admin spend dashboard sees this task class. When the
+ * caller has real Gemini usageMetadata (promptTokens/completionTokens
+ * params), those are used for accurate cost estimation; otherwise falls
+ * back to the pre-existing string-length heuristic (Groq/OpenAI paths,
+ * or Gemini responses that omitted usageMetadata).
  */
-function persistCallLog({ tenantId, stub, realModeError, inputSize, outputSize, model, userId, surface }) {
+function persistCallLog({
+  tenantId, stub, realModeError, inputSize, outputSize, model, userId, surface,
+  provider, status, errorMessage, promptTokens, completionTokens,
+}) {
   try {
     const prisma = require('../lib/prisma');
+    const finalPromptTokens = typeof promptTokens === 'number' ? promptTokens : Math.ceil(inputSize / 4);
+    const finalCompletionTokens = typeof completionTokens === 'number' ? completionTokens : Math.ceil(outputSize / 4);
     prisma.llmCallLog
       .create({
         data: {
           tenantId: tenantId || 1,
           task: TASK_NAME,
           model,
+          provider: provider || 'gemini',
           reason: stub ? 'stub' : 'real',
-          promptTokens: Math.ceil(inputSize / 4),
-          completionTokens: Math.ceil(outputSize / 4),
-          totalTokens: Math.ceil((inputSize + outputSize) / 4),
-          costEstimate: 0,
+          promptTokens: finalPromptTokens,
+          completionTokens: finalCompletionTokens,
+          totalTokens: finalPromptTokens + finalCompletionTokens,
+          costEstimate: estimateLlmCost(model, finalPromptTokens, finalCompletionTokens),
           stub,
           userId: userId || null,
           surface: surface || null,
+          status: status || (realModeError && !stub ? 'failed' : 'success'),
+          errorMessage: errorMessage || null,
         },
       })
       .catch((e) => console.error(`[landingPageGeneratorLLM] LlmCallLog persist failed (non-fatal): ${e.message}`));
@@ -480,7 +506,7 @@ async function generateLandingPageContent(args = {}) {
 
   if (await module.exports.realModeEnabled(tenantId)) {
     try {
-      const { rawJson, modelUsed } = await module.exports.callGemini({ ...input, tenantId });
+      const { rawJson, modelUsed, promptTokens, completionTokens } = await module.exports.callGemini({ ...input, tenantId });
       const guardResult = guardLandingPageOutput(rawJson, input);
       const outputSize = JSON.stringify(guardResult.output).length;
       persistCallLog({
@@ -492,6 +518,10 @@ async function generateLandingPageContent(args = {}) {
         model: modelUsed || MODEL_PRIMARY,
         userId: __userId,
         surface: __surface,
+        provider: 'gemini',
+        status: 'success',
+        promptTokens,
+        completionTokens,
       });
       return {
         ...guardResult.output,
@@ -503,6 +533,21 @@ async function generateLandingPageContent(args = {}) {
       };
     } catch (e) {
       geminiError = e.message || String(e);
+      persistCallLog({
+        tenantId,
+        stub: false,
+        realModeError: null,
+        inputSize,
+        outputSize: 0,
+        model: MODEL_PRIMARY,
+        userId: __userId,
+        surface: __surface,
+        provider: 'gemini',
+        status: 'failed',
+        errorMessage: geminiError,
+        promptTokens: 0,
+        completionTokens: 0,
+      });
       console.error(
         `[landingPageGeneratorLLM] Gemini cascade exhausted: ${geminiError}`,
         e.stack ? `\n${e.stack}` : '',

--- a/backend/services/marketingFlyerCopyLLM.js
+++ b/backend/services/marketingFlyerCopyLLM.js
@@ -75,6 +75,23 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 const { getBudgetCap, evaluateCap, KEYS } = require('../lib/tenantSettings');
+const { estimateLlmCost } = require('../lib/apiPricing');
+
+// Fire-and-forget LlmCallLog write — mirrors lib/llmRouter.js's
+// persistLlmCallLog helper so this direct Gemini call is visible to the
+// Super Admin "API Analytics" dashboard. A DB hiccup here must NEVER break
+// flyer-copy generation, hence the nested try/catch and the un-awaited
+// .catch() on the create.
+function persistLlmCallLog(data) {
+  try {
+    const prisma = require('../lib/prisma');
+    prisma.llmCallLog.create({ data }).catch((e) =>
+      console.error(`[marketingFlyerCopyLLM] LlmCallLog persist failed (non-fatal): ${e.message}`),
+    );
+  } catch (e) {
+    console.error(`[marketingFlyerCopyLLM] LlmCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
 
 const INTEGRATION = 'llm'; // share the LLM monthly cap envelope
 const TASK_NAME = 'marketing-flyer-copy'; // PRD §9.1 + FR-3.6.1
@@ -217,7 +234,7 @@ async function realModeEnabled(tenantId) {
  * shape (so consumers don't branch). Throws on any error — caller
  * falls through to the stub via try/catch.
  */
-async function callGemini({ destination, subBrand, themeJson, targetAudience }) {
+async function callGemini({ destination, subBrand, themeJson, targetAudience, tenantId }) {
   const apiKey = process.env[GEMINI_KEY_ENV];
   if (!apiKey) {
     throw new Error(`marketingFlyerCopyLLM: ${GEMINI_KEY_ENV} not set`);
@@ -250,7 +267,12 @@ async function callGemini({ destination, subBrand, themeJson, targetAudience }) 
       },
     });
     const res = await model.generateContent(prompt);
-    return res.response.text();
+    const usage = res.response.usageMetadata || {};
+    return {
+      text: res.response.text(),
+      promptTokens: usage.promptTokenCount || 0,
+      completionTokens: usage.candidatesTokenCount || 0,
+    };
   };
 
   // Multi-model cascade on 429 (each Gemini model on the free tier has
@@ -270,10 +292,15 @@ async function callGemini({ destination, subBrand, themeJson, targetAudience }) 
     'gemini-2.5-flash-lite',
   ]));
   let raw;
+  let modelUsed;
+  let usageResult;
   let lastError;
   for (const m of cascade) {
     try {
-      raw = await tryGemini(m);
+      const attempt = await tryGemini(m);
+      raw = attempt.text;
+      usageResult = attempt;
+      modelUsed = m;
       lastError = null;
       break;
     } catch (e) {
@@ -285,13 +312,65 @@ async function callGemini({ destination, subBrand, themeJson, targetAudience }) 
       // entry, not hard-abort. Without this, a single removed model in
       // the chain (like gemini-1.5-flash Sept 2025) blows the whole call.
       const isModelGone = /404.*Not Found|is not found for API version|is not supported for generateContent/i.test(msg);
-      if (!isQuota && !isModelGone) throw e;
+      if (!isQuota && !isModelGone) {
+        persistLlmCallLog({
+          tenantId: tenantId || 1,
+          task: 'flyer-copy',
+          model: m,
+          provider: 'gemini',
+          reason: null,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          costEstimate: 0,
+          stub: false,
+          userId: null,
+          surface: 'marketingFlyerCopyLLM',
+          status: 'failed',
+          errorMessage: e.message,
+        });
+        throw e;
+      }
       console.warn(
         `[marketingFlyerCopyLLM] '${m}' ${isQuota ? 'hit quota' : 'model unavailable'} — falling through cascade`,
       );
     }
   }
-  if (raw === undefined) throw lastError;
+  if (raw === undefined) {
+    persistLlmCallLog({
+      tenantId: tenantId || 1,
+      task: 'flyer-copy',
+      model: cascade[cascade.length - 1],
+      provider: 'gemini',
+      reason: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      costEstimate: 0,
+      stub: false,
+      userId: null,
+      surface: 'marketingFlyerCopyLLM',
+      status: 'failed',
+      errorMessage: (lastError && lastError.message) || 'gemini cascade exhausted',
+    });
+    throw lastError;
+  }
+
+  persistLlmCallLog({
+    tenantId: tenantId || 1,
+    task: 'flyer-copy',
+    model: modelUsed,
+    provider: 'gemini',
+    reason: null,
+    promptTokens: usageResult.promptTokens,
+    completionTokens: usageResult.completionTokens,
+    totalTokens: usageResult.promptTokens + usageResult.completionTokens,
+    costEstimate: estimateLlmCost(modelUsed, usageResult.promptTokens, usageResult.completionTokens),
+    stub: false,
+    userId: null,
+    surface: 'marketingFlyerCopyLLM',
+    status: 'success',
+  });
 
   const parsed = parseGeminiJson(raw);
   return { ...parsed, _source: 'gemini' };
@@ -377,6 +456,7 @@ async function generateFlyerCopy(args = {}, _ctx = {}) {
         subBrand,
         themeJson,
         targetAudience,
+        tenantId,
       });
       return {
         copyJson: { ...realJson, _source: 'gemini' },

--- a/backend/services/razorpayService.js
+++ b/backend/services/razorpayService.js
@@ -13,17 +13,52 @@ function getRazorpay() {
   return razorpayInstance;
 }
 
+// ── API Analytics logging ───────────────────────────────────────────
+// Fire-and-forget ApiCallLog row per Razorpay API call — request COUNT
+// only (per user direction: Razorpay charges a % of the transaction, not a
+// per-API-call fee, so costEstimate always stays 0 here; the value of this
+// row is purely "how many Razorpay calls, success vs failure").
+function logApiCall({ endpoint, status, durationMs, errorMessage }) {
+  if (process.env.NODE_ENV === 'test') return;
+  try {
+    const prisma = require('../lib/prisma');
+    prisma.apiCallLog
+      .create({
+        data: {
+          tenantId: 1,
+          provider: 'razorpay',
+          endpoint,
+          status,
+          costEstimate: 0,
+          durationMs,
+          surface: 'razorpayService',
+          errorMessage: errorMessage || null,
+        },
+      })
+      .catch((e) => console.error(`[razorpayService] ApiCallLog persist failed (non-fatal): ${e.message}`));
+  } catch (e) {
+    console.error(`[razorpayService] ApiCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
+
 async function createOrder(amount, planId, currency = 'INR') {
   const razorpay = getRazorpay();
-  // Razorpay expects the smallest unit of the currency (paise for INR,
-  // cents for USD). Both happen to be 1/100 of the major unit, so the
-  // *100 multiplier covers both.
-  const order = await razorpay.orders.create({
-    amount: Math.round(amount * 100),
-    currency,
-    notes: { planId: planId.toString() }
-  });
-  return order;
+  const startedAt = Date.now();
+  try {
+    // Razorpay expects the smallest unit of the currency (paise for INR,
+    // cents for USD). Both happen to be 1/100 of the major unit, so the
+    // *100 multiplier covers both.
+    const order = await razorpay.orders.create({
+      amount: Math.round(amount * 100),
+      currency,
+      notes: { planId: planId.toString() }
+    });
+    logApiCall({ endpoint: 'orders.create', status: 'success', durationMs: Date.now() - startedAt });
+    return order;
+  } catch (e) {
+    logApiCall({ endpoint: 'orders.create', status: 'failed', durationMs: Date.now() - startedAt, errorMessage: e.message });
+    throw e;
+  }
 }
 
 function verifySignature(orderId, paymentId, signature) {

--- a/backend/services/serpApiClient.js
+++ b/backend/services/serpApiClient.js
@@ -59,6 +59,36 @@ function num(v) {
   return Number.isFinite(n) ? n : null;
 }
 
+// ── API Analytics logging ───────────────────────────────────────────
+// Fire-and-forget ApiCallLog row per SerpApi search — mirrors llmRouter.js's
+// LlmCallLog pattern but for a flat-rate (non-token) provider. Must NEVER
+// throw or await-block the caller; this module's whole contract is
+// "never throws" (callers fall through to the next tier on any hiccup).
+function logApiCall({ endpoint, status, durationMs, errorMessage }) {
+  if (process.env.NODE_ENV === "test") return; // keep existing test suites deterministic
+  try {
+    const prisma = require("../lib/prisma");
+    const { estimateFlatCost } = require("../lib/apiPricing");
+    const cost = estimateFlatCost("serpapi");
+    prisma.apiCallLog
+      .create({
+        data: {
+          tenantId: 1,
+          provider: "serpapi",
+          endpoint,
+          status,
+          costEstimate: cost || 0,
+          durationMs,
+          surface: "serpApiClient",
+          errorMessage: errorMessage || null,
+        },
+      })
+      .catch((e) => console.error(`[serpApiClient] ApiCallLog persist failed (non-fatal): ${e.message}`));
+  } catch (e) {
+    console.error(`[serpApiClient] ApiCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
+
 // ── Google Flights ───────────────────────────────────────────────────
 // SerpApi groups results into `best_flights` + `other_flights`; each group has
 // a `flights` array of legs (one per hop), `total_duration` (minutes), `price`,
@@ -127,14 +157,25 @@ async function searchFlights(q = {}, ax = axios) {
   const cacheKey = `F|${q.from}|${q.to}|${q.departDate}|${q.returnDate || ""}|${q.adults}|${q.children}|${q.currency}`;
   const hit = _cacheGet(cacheKey);
   if (hit) return hit;
-  const resp = await ax.get(SERP_URL, { params, timeout: TIMEOUT_MS });
+  const startedAt = Date.now();
+  let resp;
+  try {
+    resp = await ax.get(SERP_URL, { params, timeout: TIMEOUT_MS });
+  } catch (e) {
+    logApiCall({ endpoint: "google_flights", status: "failed", durationMs: Date.now() - startedAt, errorMessage: e.message });
+    console.error(`[serpApiClient] flights request failed: ${e.message}`);
+    return null;
+  }
   const data = resp && resp.data;
   if (!data || data.error) {
+    const errMsg = (data && data.error) || "empty response";
+    logApiCall({ endpoint: "google_flights", status: "failed", durationMs: Date.now() - startedAt, errorMessage: errMsg });
     if (data && data.error) console.error(`[serpApiClient] flights error: ${data.error}`);
     return null;
   }
   const mapped = mapFlights(data, q);
   _cacheSet(cacheKey, mapped);
+  logApiCall({ endpoint: "google_flights", status: "success", durationMs: Date.now() - startedAt });
   return mapped;
 }
 
@@ -194,14 +235,25 @@ async function searchHotels(q = {}, ax = axios) {
   const cacheKey = `H|${q.city}|${q.checkIn}|${q.checkOut}|${q.adults}|${q.currency}`;
   const hit = _cacheGet(cacheKey);
   if (hit) return hit;
-  const resp = await ax.get(SERP_URL, { params, timeout: TIMEOUT_MS });
+  const startedAt = Date.now();
+  let resp;
+  try {
+    resp = await ax.get(SERP_URL, { params, timeout: TIMEOUT_MS });
+  } catch (e) {
+    logApiCall({ endpoint: "google_hotels", status: "failed", durationMs: Date.now() - startedAt, errorMessage: e.message });
+    console.error(`[serpApiClient] hotels request failed: ${e.message}`);
+    return null;
+  }
   const data = resp && resp.data;
   if (!data || data.error) {
+    const errMsg = (data && data.error) || "empty response";
+    logApiCall({ endpoint: "google_hotels", status: "failed", durationMs: Date.now() - startedAt, errorMessage: errMsg });
     if (data && data.error) console.error(`[serpApiClient] hotels error: ${data.error}`);
     return null;
   }
   const mapped = mapHotels(data, q);
   _cacheSet(cacheKey, mapped);
+  logApiCall({ endpoint: "google_hotels", status: "success", durationMs: Date.now() - startedAt });
   return mapped;
 }
 

--- a/backend/services/tripGoClient.js
+++ b/backend/services/tripGoClient.js
@@ -42,6 +42,36 @@ function num(v) {
   return Number.isFinite(n) ? n : null;
 }
 
+// ── API Analytics logging ───────────────────────────────────────────
+// Fire-and-forget ApiCallLog row per TripGo request — mirrors
+// serpApiClient.js's logApiCall. Must NEVER throw or block the caller;
+// this module's contract is "never throws" (callers fall through to the
+// LLM/stub tier on any hiccup).
+function logApiCall({ endpoint, status, durationMs, errorMessage }) {
+  if (process.env.NODE_ENV === "test") return;
+  try {
+    const prisma = require("../lib/prisma");
+    const { estimateFlatCost } = require("../lib/apiPricing");
+    const cost = estimateFlatCost("tripgo"); // null — no public flat rate; tracked as request count only
+    prisma.apiCallLog
+      .create({
+        data: {
+          tenantId: 1,
+          provider: "tripgo",
+          endpoint,
+          status,
+          costEstimate: cost || 0,
+          durationMs,
+          surface: "tripGoClient",
+          errorMessage: errorMessage || null,
+        },
+      })
+      .catch((e) => console.error(`[tripGoClient] ApiCallLog persist failed (non-fatal): ${e.message}`));
+  } catch (e) {
+    console.error(`[tripGoClient] ApiCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
+
 function headers() {
   return { "X-TripGo-Key": KEY(), Accept: "application/json" };
 }
@@ -147,6 +177,7 @@ async function searchTransfers(q = {}, ax = axios) {
     return null;
   }
   if (!q.from || !q.to) return null;
+  const startedAt = Date.now();
   console.log(`[tripGoClient] searchTransfers: geocoding "${q.from}" → "${q.to}"`);
   const [from, to] = await Promise.all([
     module.exports.geocode(q.from, ax),
@@ -154,6 +185,7 @@ async function searchTransfers(q = {}, ax = axios) {
   ]);
   if (!from || !to) {
     console.log(`[tripGoClient] searchTransfers: could not geocode ${!from ? `origin "${q.from}"` : `destination "${q.to}"`} — falling through to LLM`);
+    logApiCall({ endpoint: "searchTransfers", status: "failed", durationMs: Date.now() - startedAt, errorMessage: "geocode failed for origin or destination" });
     return null; // couldn't resolve one endpoint → fall through
   }
   const params = {
@@ -163,24 +195,33 @@ async function searchTransfers(q = {}, ax = axios) {
     bestReturnedTripOnly: "false",
     modes: MODES,
   };
-  const resp = await ax.get(`${BASE}/routing.json`, {
-    params,
-    headers: headers(),
-    timeout: TIMEOUT_MS,
-    // axios serializes array params as modes=a&modes=b (repeat key) — TripGo's
-    // expected form.
-    paramsSerializer: (p) => {
-      const parts = [];
-      for (const [k, val] of Object.entries(p)) {
-        if (Array.isArray(val)) val.forEach((v) => parts.push(`${k}=${encodeURIComponent(v)}`));
-        else parts.push(`${k}=${encodeURIComponent(val)}`);
-      }
-      return parts.join("&");
-    },
-  });
+  let resp;
+  try {
+    resp = await ax.get(`${BASE}/routing.json`, {
+      params,
+      headers: headers(),
+      timeout: TIMEOUT_MS,
+      // axios serializes array params as modes=a&modes=b (repeat key) — TripGo's
+      // expected form.
+      paramsSerializer: (p) => {
+        const parts = [];
+        for (const [k, val] of Object.entries(p)) {
+          if (Array.isArray(val)) val.forEach((v) => parts.push(`${k}=${encodeURIComponent(v)}`));
+          else parts.push(`${k}=${encodeURIComponent(val)}`);
+        }
+        return parts.join("&");
+      },
+    });
+  } catch (e) {
+    logApiCall({ endpoint: "searchTransfers", status: "failed", durationMs: Date.now() - startedAt, errorMessage: e.message });
+    console.error(`[tripGoClient] routing request failed: ${e.message}`);
+    return null;
+  }
   const data = resp && resp.data;
   if (!data || data.error) {
-    console.error(`[tripGoClient] routing error: ${data && data.error ? JSON.stringify(data.error) : "empty response"}`);
+    const errMsg = data && data.error ? JSON.stringify(data.error) : "empty response";
+    logApiCall({ endpoint: "searchTransfers", status: "failed", durationMs: Date.now() - startedAt, errorMessage: errMsg });
+    console.error(`[tripGoClient] routing error: ${errMsg}`);
     return null;
   }
   const groupCount = Array.isArray(data.groups) ? data.groups.length : 0;
@@ -189,6 +230,7 @@ async function searchTransfers(q = {}, ax = axios) {
   if (groupCount > 0 && mapped.length === 0) {
     console.log("[tripGoClient] (TripGo routed it but no option had a moneyCost — falling through to LLM for a priced estimate)");
   }
+  logApiCall({ endpoint: "searchTransfers", status: "success", durationMs: Date.now() - startedAt });
   return mapped;
 }
 

--- a/backend/services/whatsappWebClient.js
+++ b/backend/services/whatsappWebClient.js
@@ -144,13 +144,26 @@ async function restoreSessions() {
   } catch {
     return { restored: 0, reason: "no-auth-dir" }; // nothing linked yet
   }
-  const tenantIds = [];
+  let tenantIds = [];
   for (const e of entries) {
     if (!e.isDirectory()) continue;
     const m = /^session-travel-(\d+)$/.exec(e.name);
     if (m) tenantIds.push(Number(m[1]));
   }
   if (!tenantIds.length) return { restored: 0 };
+  // Cap concurrent Chrome launches on boot to avoid memory spikes / OOM on live.
+  if (RESTORE_MAX_TENANTS > 0 && tenantIds.length > RESTORE_MAX_TENANTS) {
+    tenantIds.sort((a, b) => {
+      try {
+        const da = fs.statSync(path.join(AUTH_DIR, `session-travel-${a}`)).mtimeMs;
+        const db = fs.statSync(path.join(AUTH_DIR, `session-travel-${b}`)).mtimeMs;
+        return db - da;
+      } catch { return 0; }
+    });
+    const skipped = tenantIds.slice(RESTORE_MAX_TENANTS);
+    tenantIds = tenantIds.slice(0, RESTORE_MAX_TENANTS);
+    console.warn(`[whatsappWeb] boot-restore capped at ${RESTORE_MAX_TENANTS}: restoring ${tenantIds.length} most-recent tenant(s); skipping ${skipped.length} older tenant(s) (they reconnect on demand): ${skipped.join(", ")}`);
+  }
   console.log(`[whatsappWeb] boot-restore: re-initializing ${tenantIds.length} saved session(s): ${tenantIds.join(", ")}`);
   let i = 0;
   for (const tenantId of tenantIds) {
@@ -291,6 +304,24 @@ const RECONNECT_DELAY_MS = (() => {
   return Number.isFinite(v) && v >= 2_000 ? v : 6_000;
 })();
 
+// Boot-restore cap: opening a headless Chromium for every saved tenant at once
+// can OOM a modest live server. We restore the most-recent N tenants on startup;
+// the rest reconnect on demand when an operator opens the page / a cron sends.
+const RESTORE_MAX_TENANTS = (() => {
+  const v = parseInt(process.env.WHATSAPP_WEB_RESTORE_MAX_TENANTS, 10);
+  return Number.isFinite(v) && v >= 0 ? v : 10;
+})();
+
+// How long a DISCONNECTED / AUTH_FAILURE session object stays in the in-memory
+// registry before being removed. Keeping it for a few minutes lets the UI show
+// the last error / "Reset" action and gives auto-reconnect a window, while
+// preventing an unbounded accumulation of dead tenant metadata on long-lived
+// servers with many tenants.
+const SESSION_PRUNE_MS = (() => {
+  const v = parseInt(process.env.WHATSAPP_WEB_SESSION_PRUNE_MS, 10);
+  return Number.isFinite(v) && v >= 0 ? v : 300_000; // default 5 minutes
+})();
+
 // Resolve a Chromium executable: explicit override, else fall back to the
 // top-level puppeteer's downloaded Chromium (whatsapp-web.js's own nested
 // puppeteer may not have one). Best-effort — null lets wweb use its default.
@@ -422,24 +453,57 @@ function reapDeadClient(tenantId, s, { wipe = false } = {}) {
     });
 }
 
-async function clearSession(tenantId, { wipe = true } = {}) {
+// Destroy a session's puppeteer client, clear its timers, and force-kill any
+// orphan Chromium still holding the tenant's user-data-dir. Keeps the session
+// registry entry intact (callers decide when to delete/wipe) so error state and
+// UI messaging survive the teardown.
+async function destroyClientAndOrphans(tenantId) {
   tenantId = Number(tenantId);
   const s = getSession(tenantId);
-  if (s) {
-    if (s.watchdog) { clearTimeout(s.watchdog); s.watchdog = null; }
-    if (s.client) {
-      try {
-        await Promise.race([
-          s.client.destroy(),
-          new Promise((r) => setTimeout(r, 8000)),
-        ]);
-      } catch (e) { console.warn(`[whatsappWeb] tenant ${tenantId} destroy warn: ${e.message}`); }
+  if (!s) return;
+  if (s.watchdog) { clearTimeout(s.watchdog); s.watchdog = null; }
+  // NOTE: we deliberately do NOT clear s.pruneTimer here. The callers that
+  // schedule a prune (watchdog, init failure, auth_failure, disconnected) want
+  // the timer to remain active so dead sessions are eventually removed from
+  // the registry. clearSession() deletes the session object anyway, so a
+  // pending prune timer simply no-ops when it fires.
+  if (s.client) {
+    try {
+      await Promise.race([
+        s.client.destroy(),
+        new Promise((r) => setTimeout(r, 8000)),
+      ]);
+    } catch (e) {
+      console.warn(`[whatsappWeb] tenant ${tenantId} destroy warn: ${e.message}`);
     }
+    s.client = null;
   }
-  sessions.delete(tenantId);
-  // Free any orphan Chromium still holding the dir (cross-process lock).
+  // Safety net: if destroy() didn't kill the browser (or we lost the handle),
+  // terminate any Chromium whose command line still references this tenant dir.
   module.exports.killBrowsersForDir(tenantId);
-  if (wipe) {    try {
+}
+
+// Schedule removal of a dead session object from the registry after a cooldown.
+// Called on AUTH_FAILURE / disconnected so the Map does not grow forever.
+function scheduleSessionPrune(tenantId) {
+  const s = getSession(tenantId);
+  if (!s) return;
+  if (s.pruneTimer) clearTimeout(s.pruneTimer);
+  s.pruneTimer = setTimeout(() => {
+    const cur = getSession(tenantId);
+    if (cur && (cur.state === STATE.DISCONNECTED || cur.state === STATE.AUTH_FAILURE)) {
+      sessions.delete(tenantId);
+      console.log(`[whatsappWeb] tenant ${tenantId} pruned stale ${cur.state} session from registry`);
+    }
+  }, SESSION_PRUNE_MS);
+}
+
+async function clearSession(tenantId, { wipe = true } = {}) {
+  tenantId = Number(tenantId);
+  await module.exports.destroyClientAndOrphans(tenantId);
+  sessions.delete(tenantId);
+  if (wipe) {
+    try {
       const fs = require("fs");
       const dir = path.join(AUTH_DIR, `session-travel-${tenantId}`);
       fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 });
@@ -559,7 +623,8 @@ async function _connectImpl(tenantId, { reset = false } = {}) {
   module.exports.wireEvents(client, tenantId);
 
   // Watchdog: if neither a QR nor a ready state arrives in time, the restore
-  // is stuck (almost always a stale session dir) — surface an actionable error.
+  // is stuck (almost always a stale session dir) — surface an actionable error
+  // AND tear down the browser so a stuck Chromium does not sit in memory forever.
   session.watchdog = setTimeout(() => {
     const s = getSession(tenantId);
     if (s && (s.state === STATE.INITIALIZING || s.state === STATE.AUTHENTICATED)) {
@@ -570,12 +635,17 @@ async function _connectImpl(tenantId, { reset = false } = {}) {
       // ready) — reap it instead of leaving it as an orphan.
       module.exports.reapDeadClient(tenantId, s);
       module.exports.emitState(tenantId);
+      module.exports.scheduleSessionPrune(tenantId);
+      module.exports.destroyClientAndOrphans(tenantId).catch((e) =>
+        console.warn(`[whatsappWeb] tenant ${tenantId} watchdog cleanup warn: ${e.message}`));
     }
   }, QR_WATCHDOG_MS);
 
   // initialize() resolves once the browser is up; errors here flip to
   // AUTH_FAILURE so the UI can offer a retry instead of hanging on a spinner.
-  client.initialize().catch((e) => {
+  // Crucially, we also destroy the client + kill any orphan Chromium — otherwise
+  // a failed initialization leaves a headless Chrome process alive forever.
+  client.initialize().catch(async (e) => {
     console.error(`[whatsappWeb] tenant ${tenantId} initialize failed: ${e.message}`);
     const s = getSession(tenantId);
     if (s) {
@@ -586,6 +656,8 @@ async function _connectImpl(tenantId, { reset = false } = {}) {
       module.exports.reapDeadClient(tenantId, s);
     }
     module.exports.emitState(tenantId);
+    module.exports.scheduleSessionPrune(tenantId);
+    await module.exports.destroyClientAndOrphans(tenantId).catch(() => { });
   });
 
   return module.exports.getState(tenantId);
@@ -607,7 +679,7 @@ async function disconnect(tenantId, { logout = false } = {}) {
   await module.exports.clearSession(tenantId, { wipe: logout });
   // Only a deliberate logout clears the imported chats (fresh number / clean
   // slate). A plain disconnect keeps them so they're there on reconnect.
-  if (logout) await module.exports.purgeChats(tenantId).catch(() => {});
+  if (logout) await module.exports.purgeChats(tenantId).catch(() => { });
   module.exports.emitState(tenantId);
   return { state: STATE.DISCONNECTED, connected: false, phone: null, qr: null };
 }
@@ -635,15 +707,17 @@ async function disconnect(tenantId, { logout = false } = {}) {
  */
 async function shutdown({ perClientTimeoutMs = 5000 } = {}) {
   const ids = Array.from(sessions.keys());
-  if (!ids.length) return { closed: 0 };
+  if (!ids.length) return { closed: 0, killed: 0 };
   console.log(`[whatsappWeb] graceful shutdown — destroying ${ids.length} live session(s) so their auth stores flush cleanly`);
   let closed = 0;
+  let killed = 0;
   await Promise.all(
     ids.map(async (tenantId) => {
       const s = sessions.get(tenantId);
       if (!s) return;
       s.manualClose = true; // suppress auto-reconnect during teardown
       if (s.watchdog) { clearTimeout(s.watchdog); s.watchdog = null; }
+      if (s.pruneTimer) { clearTimeout(s.pruneTimer); s.pruneTimer = null; }
       if (!s.client) return;
       try {
         await Promise.race([
@@ -653,11 +727,20 @@ async function shutdown({ perClientTimeoutMs = 5000 } = {}) {
         closed += 1;
       } catch (e) {
         console.warn(`[whatsappWeb] tenant ${tenantId} shutdown destroy warn: ${e.message}`);
+      } finally {
+        // Drop the handle and force-kill any Chromium that survived the timeout.
+        s.client = null;
+        try {
+          module.exports.killBrowsersForDir(tenantId);
+          killed += 1;
+        } catch (killErr) {
+          console.warn(`[whatsappWeb] tenant ${tenantId} shutdown orphan-kill warn: ${killErr.message}`);
+        }
       }
     }),
   );
-  console.log(`[whatsappWeb] graceful shutdown done — ${closed}/${ids.length} session(s) closed cleanly`);
-  return { closed };
+  console.log(`[whatsappWeb] graceful shutdown done — ${closed}/${ids.length} session(s) closed cleanly, ${killed} orphan Chromium process(es) killed`);
+  return { closed, killed };
 }
 
 /**
@@ -700,7 +783,7 @@ function wireEvents(client, tenantId) {
     module.exports.emitState(tenantId);
   });
 
-  client.on("auth_failure", (msg) => {
+  client.on("auth_failure", async (msg) => {
     const s = getSession(tenantId);
     if (!s) return;
     s.state = STATE.AUTH_FAILURE;
@@ -712,6 +795,8 @@ function wireEvents(client, tenantId) {
     // auth_failure during boot-restore may be transient corruption worth a retry.
     module.exports.reapDeadClient(tenantId, s);
     module.exports.emitState(tenantId);
+    module.exports.scheduleSessionPrune(tenantId);
+    await module.exports.destroyClientAndOrphans(tenantId).catch(() => { });
   });
 
   client.on("ready", () => {
@@ -738,7 +823,7 @@ function wireEvents(client, tenantId) {
     }, 4000);
   });
 
-  client.on("disconnected", (reason) => {
+  client.on("disconnected", async (reason) => {
     const s = getSession(tenantId);
     console.warn(`[whatsappWeb] tenant ${tenantId} disconnected: ${reason}`);
     const deliberate = !!(s && s.manualClose);
@@ -758,6 +843,8 @@ function wireEvents(client, tenantId) {
       }
     }
     module.exports.emitState(tenantId);
+    module.exports.scheduleSessionPrune(tenantId);
+    await module.exports.destroyClientAndOrphans(tenantId).catch(() => { });
     // NOTE: we deliberately do NOT purge the imported chats on a transient
     // drop anymore — that was wiping the operator's whole inbox on every
     // network blip / server restart (the chats reappeared only after a slow
@@ -1237,6 +1324,19 @@ async function ingestInbound(tenantId, msg) {
   if (!phone) return;
 
   const prisma = require("../lib/prisma");
+
+  // Blocked/opted-out numbers (routes/whatsapp.js /opt-outs) must not reach
+  // the inbox at all — previously this list only gated OUTBOUND sends, so a
+  // "blocked" contact's inbound messages were silently ingested anyway.
+  // Group chats aren't gated here: opt-out rows are keyed by 1:1 contactPhone,
+  // and a single opted-out participant shouldn't suppress a whole group thread.
+  if (!isGroup) {
+    const optedOut = await prisma.whatsAppOptOut.findUnique({
+      where: { tenantId_contactPhone: { tenantId, contactPhone: phone } },
+    });
+    if (optedOut) return;
+  }
+
   const providerMsgId = msg.id ? msg.id._serialized : null;
 
   // Dedup — the same id can arrive twice across reconnects.
@@ -1317,7 +1417,7 @@ async function ingestInbound(tenantId, msg) {
   if (!isGroup) {
     require("../lib/travelWhatsappLeadCapture")
       .safeMaybeCaptureLead({ tenantId, phone, name: waName, threadId: thread.id, isGroup })
-      .catch(() => {});
+      .catch(() => { });
   }
 
   return { threadId: thread.id, messageId: message.id };
@@ -1609,116 +1709,116 @@ async function importAllChats(tenantId, { perChatLimit = 25, maxChats = 300 } = 
   }
   session.importing = true;
   try {
-  const channelPhone = session && session.phone;
-  const prisma = require("../lib/prisma");
+    const channelPhone = session && session.phone;
+    const prisma = require("../lib/prisma");
 
-  let chats = [];
-  try {
-    chats = await session.client.getChats();
-  } catch (e) {
-    console.error(`[whatsappWeb] tenant ${tenantId} getChats failed: ${e.message}`);
-    return { imported: false, reason: e.message };
-  }
-
-  // Import 1:1 chats (@c.us / @lid) AND groups (@g.us). Skip channels
-  // (@newsletter) + status/broadcast.
-  const candidates = chats.filter((c) => {
-    const id = c && c.id && c.id._serialized;
-    if (!id) return false;
-    const kind = module.exports.chatAddressKind(id);
-    return module.exports.isIndividualChatId(id) || kind === "group" || c.isGroup;
-  });
-  const byKind = chats.reduce((acc, c) => {
-    const k = module.exports.chatAddressKind(c && c.id && c.id._serialized) || "other";
-    acc[k] = (acc[k] || 0) + 1; return acc;
-  }, {});
-  console.log(`[whatsappWeb] tenant ${tenantId} import: ${chats.length} chats total, ${candidates.length} importable (1:1 + groups). breakdown=${JSON.stringify(byKind)}`);
-
-  let threadsTouched = 0;
-  let messages = 0;
-  // Bounded media-download budget across the whole import so a large account
-  // can't trigger thousands of downloads; recent chats (top of the list) get
-  // their images first.
-  const mediaBudget = { remaining: 250 };
-  for (const chat of candidates) {
-    if (threadsTouched >= maxChats) break;
-    const id = chat.id._serialized;
-    const isGroup = Boolean(chat.isGroup) || module.exports.chatAddressKind(id) === "group";
-    // Groups: the thread key IS the group id (no single phone); name = subject.
-    // Individuals: resolve real phone (+ name) — @lid ids aren't numbers.
-    let phone;
-    let contact = null;
-    let waName;
-    if (isGroup) {
-      phone = id; // e.g. "<id>@g.us"
-      waName = (chat.name && chat.name.trim()) || "Group";
-    } else {
-      const resolved = await module.exports.resolveIndividual(session.client, id);
-      phone = resolved.key; // +number or lid:<digits>
-      contact = resolved.phone ? await matchContact(tenantId, resolved.phone) : null;
-      waName = module.exports.cleanName(chat.name) || module.exports.cleanName(resolved.name) || null;
-    }
-    // Profile picture (DP / group icon) — best-effort CDN URL (null if none).
-    const avatar = await module.exports.getProfilePicSafe(session.client, id);
-
-    let msgs = [];
+    let chats = [];
     try {
-      msgs = await chat.fetchMessages({ limit: perChatLimit });
+      chats = await session.client.getChats();
     } catch (e) {
-      console.warn(`[whatsappWeb] fetchMessages(${phone}) failed: ${e.message}`);
+      console.error(`[whatsappWeb] tenant ${tenantId} getChats failed: ${e.message}`);
+      return { imported: false, reason: e.message };
     }
-    // Keep real content messages; the THREAD is created regardless so the
-    // conversation shows up even if history isn't fetchable yet (parity with
-    // WhatsApp Web, which lists every chat).
-    const content = (msgs || []).filter((m) => module.exports.isContentMessage(m));
-    const latestTs = content.length ? content[content.length - 1].timestamp : (chat.timestamp || null);
-    const lastMessageAt = latestTs ? new Date(latestTs * 1000) : new Date();
 
-    // Upsert the thread (unread mirrors WhatsApp's own per-chat unread count).
-    const existing = await prisma.whatsAppThread.findUnique({
-      where: { tenantId_contactPhone: { tenantId, contactPhone: phone } },
+    // Import 1:1 chats (@c.us / @lid) AND groups (@g.us). Skip channels
+    // (@newsletter) + status/broadcast.
+    const candidates = chats.filter((c) => {
+      const id = c && c.id && c.id._serialized;
+      if (!id) return false;
+      const kind = module.exports.chatAddressKind(id);
+      return module.exports.isIndividualChatId(id) || kind === "group" || c.isGroup;
     });
-    let thread;
-    if (existing) {
-      thread = await updateThreadSafe(prisma, { id: existing.id }, {
-        lastMessageAt,
-        status: existing.status === "CLOSED" ? "CLOSED" : "OPEN",
-        ...(!existing.contactId && contact ? { contactId: contact.id } : {}),
-        ...(waName && !existing.contactName ? { contactName: waName } : {}),
-        ...(avatar ? { contactAvatar: avatar } : {}),
-      });
-    } else {
-      thread = await createThreadSafe(prisma, {
-        tenantId,
-        contactPhone: phone,
-        contactName: waName,
-        contactAvatar: avatar,
-        status: "OPEN",
-        lastMessageAt,
-        unreadCount: Number(chat.unreadCount) > 0 ? Number(chat.unreadCount) : 0,
-        contactId: contact ? contact.id : null,
-      });
-    }
-    threadsTouched += 1;
+    const byKind = chats.reduce((acc, c) => {
+      const k = module.exports.chatAddressKind(c && c.id && c.id._serialized) || "other";
+      acc[k] = (acc[k] || 0) + 1; return acc;
+    }, {});
+    console.log(`[whatsappWeb] tenant ${tenantId} import: ${chats.length} chats total, ${candidates.length} importable (1:1 + groups). breakdown=${JSON.stringify(byKind)}`);
 
-    // Oldest-first so createdAt ordering lands naturally.
-    for (const m of content.slice().reverse()) {
+    let threadsTouched = 0;
+    let messages = 0;
+    // Bounded media-download budget across the whole import so a large account
+    // can't trigger thousands of downloads; recent chats (top of the list) get
+    // their images first.
+    const mediaBudget = { remaining: 250 };
+    for (const chat of candidates) {
+      if (threadsTouched >= maxChats) break;
+      const id = chat.id._serialized;
+      const isGroup = Boolean(chat.isGroup) || module.exports.chatAddressKind(id) === "group";
+      // Groups: the thread key IS the group id (no single phone); name = subject.
+      // Individuals: resolve real phone (+ name) — @lid ids aren't numbers.
+      let phone;
+      let contact = null;
+      let waName;
+      if (isGroup) {
+        phone = id; // e.g. "<id>@g.us"
+        waName = (chat.name && chat.name.trim()) || "Group";
+      } else {
+        const resolved = await module.exports.resolveIndividual(session.client, id);
+        phone = resolved.key; // +number or lid:<digits>
+        contact = resolved.phone ? await matchContact(tenantId, resolved.phone) : null;
+        waName = module.exports.cleanName(chat.name) || module.exports.cleanName(resolved.name) || null;
+      }
+      // Profile picture (DP / group icon) — best-effort CDN URL (null if none).
+      const avatar = await module.exports.getProfilePicSafe(session.client, id);
+
+      let msgs = [];
       try {
-        const wrote = await module.exports.persistHistoryMessage(tenantId, m, {
-          phone, contactId: contact ? contact.id : null, threadId: thread.id, channelPhone, mediaBudget, isGroup,
-        });
-        if (wrote) messages += 1;
+        msgs = await chat.fetchMessages({ limit: perChatLimit });
       } catch (e) {
-        console.warn(`[whatsappWeb] history persist failed (${phone}): ${e.message}`);
+        console.warn(`[whatsappWeb] fetchMessages(${phone}) failed: ${e.message}`);
+      }
+      // Keep real content messages; the THREAD is created regardless so the
+      // conversation shows up even if history isn't fetchable yet (parity with
+      // WhatsApp Web, which lists every chat).
+      const content = (msgs || []).filter((m) => module.exports.isContentMessage(m));
+      const latestTs = content.length ? content[content.length - 1].timestamp : (chat.timestamp || null);
+      const lastMessageAt = latestTs ? new Date(latestTs * 1000) : new Date();
+
+      // Upsert the thread (unread mirrors WhatsApp's own per-chat unread count).
+      const existing = await prisma.whatsAppThread.findUnique({
+        where: { tenantId_contactPhone: { tenantId, contactPhone: phone } },
+      });
+      let thread;
+      if (existing) {
+        thread = await updateThreadSafe(prisma, { id: existing.id }, {
+          lastMessageAt,
+          status: existing.status === "CLOSED" ? "CLOSED" : "OPEN",
+          ...(!existing.contactId && contact ? { contactId: contact.id } : {}),
+          ...(waName && !existing.contactName ? { contactName: waName } : {}),
+          ...(avatar ? { contactAvatar: avatar } : {}),
+        });
+      } else {
+        thread = await createThreadSafe(prisma, {
+          tenantId,
+          contactPhone: phone,
+          contactName: waName,
+          contactAvatar: avatar,
+          status: "OPEN",
+          lastMessageAt,
+          unreadCount: Number(chat.unreadCount) > 0 ? Number(chat.unreadCount) : 0,
+          contactId: contact ? contact.id : null,
+        });
+      }
+      threadsTouched += 1;
+
+      // Oldest-first so createdAt ordering lands naturally.
+      for (const m of content.slice().reverse()) {
+        try {
+          const wrote = await module.exports.persistHistoryMessage(tenantId, m, {
+            phone, contactId: contact ? contact.id : null, threadId: thread.id, channelPhone, mediaBudget, isGroup,
+          });
+          if (wrote) messages += 1;
+        } catch (e) {
+          console.warn(`[whatsappWeb] history persist failed (${phone}): ${e.message}`);
+        }
       }
     }
-  }
 
-  console.log(`[whatsappWeb] tenant ${tenantId} chat import done — ${threadsTouched} chats, ${messages} messages`);
-  if (_io) {
-    _io.to(`tenant:${tenantId}`).emit("whatsapp:imported", { tenantId, threads: threadsTouched, messages });
-  }
-  return { imported: true, threads: threadsTouched, messages };
+    console.log(`[whatsappWeb] tenant ${tenantId} chat import done — ${threadsTouched} chats, ${messages} messages`);
+    if (_io) {
+      _io.to(`tenant:${tenantId}`).emit("whatsapp:imported", { tenantId, threads: threadsTouched, messages });
+    }
+    return { imported: true, threads: threadsTouched, messages };
   } finally {
     session.importing = false;
   }
@@ -2121,6 +2221,9 @@ module.exports = {
   ingestInboundDTO,
   persistHistoryMessageDTO,
   applyGatewayState,
+  // lifecycle helpers
+  destroyClientAndOrphans,
+  scheduleSessionPrune,
   // helpers
   normalizePhone,
   toChatId,

--- a/backend/services/zoomClient.js
+++ b/backend/services/zoomClient.js
@@ -29,6 +29,34 @@ function isEnabled() {
   return Boolean(accountId && clientId && clientSecret);
 }
 
+// ── API Analytics logging ───────────────────────────────────────────
+// Fire-and-forget ApiCallLog row per Zoom API call — mirrors
+// serpApiClient.js's logApiCall. Zoom has no publicly documented flat
+// per-call price (tiered/negotiated plans), so costEstimate stays 0 — this
+// is a request-COUNT tracker, not a cost tracker, for this provider.
+function logApiCall({ endpoint, status, durationMs, errorMessage }) {
+  if (process.env.NODE_ENV === "test") return;
+  try {
+    const prisma = require("../lib/prisma");
+    prisma.apiCallLog
+      .create({
+        data: {
+          tenantId: 1,
+          provider: "zoom",
+          endpoint,
+          status,
+          costEstimate: 0,
+          durationMs,
+          surface: "zoomClient",
+          errorMessage: errorMessage || null,
+        },
+      })
+      .catch((e) => console.error(`[zoomClient] ApiCallLog persist failed (non-fatal): ${e.message}`));
+  } catch (e) {
+    console.error(`[zoomClient] ApiCallLog require failed (non-fatal): ${e.message}`);
+  }
+}
+
 // Exchange the Server-to-Server credentials for a short-lived access token.
 async function getAccessToken() {
   const { accountId, clientId, clientSecret } = creds();
@@ -49,7 +77,14 @@ async function getAccessToken() {
 // real API error so the caller can log + fall back gracefully.
 async function createMeeting({ topic, startTime, durationMins, timezone, agenda } = {}) {
   if (!isEnabled()) return null;
-  const token = await module.exports.getAccessToken();
+  const startedAt = Date.now();
+  let token;
+  try {
+    token = await module.exports.getAccessToken();
+  } catch (e) {
+    logApiCall({ endpoint: "createMeeting", status: "failed", durationMs: Date.now() - startedAt, errorMessage: e.message });
+    throw e;
+  }
   const body = {
     topic: String(topic || "Meeting").slice(0, 200),
     type: 2, // scheduled meeting
@@ -66,9 +101,11 @@ async function createMeeting({ topic, startTime, durationMins, timezone, agenda 
   });
   if (!r.ok) {
     const t = await r.text().catch(() => "");
+    logApiCall({ endpoint: "createMeeting", status: "failed", durationMs: Date.now() - startedAt, errorMessage: `Zoom create-meeting failed (${r.status}): ${t.slice(0, 200)}` });
     throw new Error(`Zoom create-meeting failed (${r.status}): ${t.slice(0, 200)}`);
   }
   const d = await r.json();
+  logApiCall({ endpoint: "createMeeting", status: "success", durationMs: Date.now() - startedAt });
   return {
     joinUrl: d.join_url || null,
     startUrl: d.start_url || null,

--- a/backend/test/cron/apiCallLogRetentionEngine.test.js
+++ b/backend/test/cron/apiCallLogRetentionEngine.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for backend/cron/apiCallLogRetentionEngine.js — purges old
+ * LlmCallLog + ApiCallLog rows per the Super Admin-configured retention
+ * window. Mirrors test/cron/cronLogRetentionEngine.test.js's structure,
+ * applied to the two API Analytics tables instead of CronExecutionLog.
+ *
+ * Pinned:
+ *   - No SystemSetting row yet → falls back to DEFAULT_RETENTION_DAYS (30).
+ *   - A persisted setting overrides the default.
+ *   - A malformed/non-numeric setting value falls back to the default
+ *     rather than computing a garbage cutoff (e.g. NaN days).
+ *   - Both llmCallLog.deleteMany and apiCallLog.deleteMany are called with
+ *     createdAt < cutoff, where cutoff = now - retainDays.
+ *   - Returns { deletedLlmCallLog, deletedApiCallLog, retainDays, cutoff }.
+ *   - initApiCallLogRetentionCron registers via cronRegistry with the daily
+ *     03:20 default schedule.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+prisma.systemSetting = { ...(prisma.systemSetting || {}), findUnique: vi.fn() };
+prisma.llmCallLog = { ...(prisma.llmCallLog || {}), deleteMany: vi.fn() };
+prisma.apiCallLog = { ...(prisma.apiCallLog || {}), deleteMany: vi.fn() };
+
+const registerMock = vi.fn().mockResolvedValue({});
+const registryPath = requireCJS.resolve('../../lib/cronRegistry.js');
+Module._cache[registryPath] = { id: registryPath, filename: registryPath, loaded: true, exports: { register: registerMock } };
+
+const sut = requireCJS('../../cron/apiCallLogRetentionEngine.js');
+
+beforeEach(() => {
+  prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+  prisma.llmCallLog.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+  prisma.apiCallLog.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+  registerMock.mockReset().mockResolvedValue({});
+});
+
+describe('runApiCallLogRetentionSweep', () => {
+  test('falls back to the 30-day default when no SystemSetting row exists', async () => {
+    const result = await sut.runApiCallLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+    expect(prisma.llmCallLog.deleteMany).toHaveBeenCalledWith({
+      where: { createdAt: { lt: expect.any(Date) } },
+    });
+    expect(prisma.apiCallLog.deleteMany).toHaveBeenCalledWith({
+      where: { createdAt: { lt: expect.any(Date) } },
+    });
+  });
+
+  test('uses the persisted retention setting when present', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '7' });
+    prisma.llmCallLog.deleteMany.mockResolvedValue({ count: 12 });
+    prisma.apiCallLog.deleteMany.mockResolvedValue({ count: 3 });
+    const result = await sut.runApiCallLogRetentionSweep();
+    expect(result.retainDays).toBe(7);
+    expect(result.deletedLlmCallLog).toBe(12);
+    expect(result.deletedApiCallLog).toBe(3);
+  });
+
+  test('a non-numeric setting value falls back to the default (no NaN cutoff)', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: 'not-a-number' });
+    const result = await sut.runApiCallLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+    expect(result.cutoff.getTime()).not.toBeNaN();
+  });
+
+  test('a zero or negative setting value falls back to the default', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '0' });
+    const result = await sut.runApiCallLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+  });
+
+  test('cutoff is computed as now - retainDays (within a small tolerance)', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '10' });
+    const before = Date.now();
+    const result = await sut.runApiCallLogRetentionSweep();
+    const expectedCutoff = before - 10 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(result.cutoff.getTime() - expectedCutoff)).toBeLessThan(5000);
+  });
+
+  test('both deleteMany calls use the SAME cutoff instant', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '15' });
+    await sut.runApiCallLogRetentionSweep();
+    const llmCutoff = prisma.llmCallLog.deleteMany.mock.calls[0][0].where.createdAt.lt;
+    const apiCutoff = prisma.apiCallLog.deleteMany.mock.calls[0][0].where.createdAt.lt;
+    expect(llmCutoff.getTime()).toBe(apiCutoff.getTime());
+  });
+});
+
+describe('initApiCallLogRetentionCron', () => {
+  test('registers via cronRegistry with the daily 03:20 default schedule', () => {
+    sut.initApiCallLogRetentionCron();
+    expect(registerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'apiCallLogRetentionEngine',
+        defaultSchedule: '20 3 * * *',
+        tickFn: sut.runApiCallLogRetentionSweep,
+      }),
+    );
+  });
+});

--- a/backend/test/cron/cronLogRetentionEngine.test.js
+++ b/backend/test/cron/cronLogRetentionEngine.test.js
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for backend/cron/cronLogRetentionEngine.js — purges old
+ * CronExecutionLog rows per the Super Admin-configured retention window.
+ *
+ * Pinned:
+ *   - No SystemSetting row yet → falls back to DEFAULT_RETENTION_DAYS (30).
+ *   - A persisted setting overrides the default.
+ *   - A malformed/non-numeric setting value falls back to the default
+ *     rather than computing a garbage cutoff (e.g. NaN days).
+ *   - deleteMany is called with startedAt < cutoff, where cutoff = now -
+ *     retainDays (computed correctly).
+ *   - Returns { deleted, retainDays, cutoff } for the caller/log line.
+ *   - initCronLogRetentionCron registers via cronRegistry with the daily
+ *     03:15 default schedule.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+prisma.systemSetting = { ...(prisma.systemSetting || {}), findUnique: vi.fn() };
+prisma.cronExecutionLog = { ...(prisma.cronExecutionLog || {}), deleteMany: vi.fn() };
+
+const registerMock = vi.fn().mockResolvedValue({});
+const registryPath = requireCJS.resolve('../../lib/cronRegistry.js');
+Module._cache[registryPath] = { id: registryPath, filename: registryPath, loaded: true, exports: { register: registerMock } };
+
+const sut = requireCJS('../../cron/cronLogRetentionEngine.js');
+
+beforeEach(() => {
+  prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+  prisma.cronExecutionLog.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+  registerMock.mockReset().mockResolvedValue({});
+});
+
+describe('runCronLogRetentionSweep', () => {
+  test('falls back to the 30-day default when no SystemSetting row exists', async () => {
+    const result = await sut.runCronLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+    expect(prisma.cronExecutionLog.deleteMany).toHaveBeenCalledWith({
+      where: { startedAt: { lt: expect.any(Date) } },
+    });
+  });
+
+  test('uses the persisted retention setting when present', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '7' });
+    prisma.cronExecutionLog.deleteMany.mockResolvedValue({ count: 12 });
+    const result = await sut.runCronLogRetentionSweep();
+    expect(result.retainDays).toBe(7);
+    expect(result.deleted).toBe(12);
+  });
+
+  test('a non-numeric setting value falls back to the default (no NaN cutoff)', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: 'not-a-number' });
+    const result = await sut.runCronLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+    expect(result.cutoff.getTime()).not.toBeNaN();
+  });
+
+  test('a zero or negative setting value falls back to the default', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '0' });
+    const result = await sut.runCronLogRetentionSweep();
+    expect(result.retainDays).toBe(30);
+  });
+
+  test('cutoff is computed as now - retainDays (within a small tolerance)', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '10' });
+    const before = Date.now();
+    const result = await sut.runCronLogRetentionSweep();
+    const expectedCutoff = before - 10 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(result.cutoff.getTime() - expectedCutoff)).toBeLessThan(5000);
+  });
+
+  test('returns the deleteMany count as `deleted`', async () => {
+    prisma.cronExecutionLog.deleteMany.mockResolvedValue({ count: 42 });
+    const result = await sut.runCronLogRetentionSweep();
+    expect(result.deleted).toBe(42);
+  });
+});
+
+describe('initCronLogRetentionCron', () => {
+  test('registers via cronRegistry with the daily 03:15 default schedule', () => {
+    sut.initCronLogRetentionCron();
+    expect(registerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'cronLogRetentionEngine',
+        defaultSchedule: '15 3 * * *',
+        tickFn: sut.runCronLogRetentionSweep,
+      }),
+    );
+  });
+});

--- a/backend/test/cron/marketplaceEngine.test.js
+++ b/backend/test/cron/marketplaceEngine.test.js
@@ -26,20 +26,24 @@
  *   - lib/prisma — re-use the existing singleton, monkey-patch model
  *     methods (mirrors slaBreachEngine.test.js).
  *   - global.fetch — vi.fn() reset per test.
- *   - node-cron — same monkey-patch dance.
+ *   - lib/cronRegistry — the SUT registers via cronRegistry.register({...})
+ *     (Super Admin Portal / Cron Maintenance retrofit) instead of calling
+ *     node-cron directly; we mock register() and capture the tickFn option
+ *     to drive tick-behavior assertions, same role the old node-cron
+ *     scheduleMock played.
  *
  * NOT covered (intentional):
  *   - formatIndiaMARTDate is exercised indirectly through the IndiaMART
  *     happy path; its exact string format is implementation-detail. We do
  *     not pin it as a separate assertion.
- *   - The 5-min cron schedule (initMarketplaceCron) — wires one schedule;
- *     we assert it was called.
+ *   - The 5-min cron schedule (initMarketplaceCron) — wires one
+ *     registration; we assert cronRegistry.register was called with the
+ *     right name/defaultSchedule/defaultEnabled.
  */
-import { describe, test, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRequire } from 'node:module';
 
 const requireCJS = createRequire(import.meta.url);
-const nodeCron = requireCJS('node-cron');
 
 // ── Fake deduplication module in require cache ─────────────────────────
 const findDupMock = vi.fn();
@@ -66,10 +70,15 @@ prisma.marketplaceLead = {
   create: vi.fn(),
 };
 
-// ── Patch node-cron BEFORE requiring SUT ───────────────────────────────
-const originalSchedule = nodeCron.schedule;
-const scheduleMock = vi.fn();
-nodeCron.schedule = scheduleMock;
+// ── Fake cronRegistry module in require cache (BEFORE requiring SUT) ──
+const registerMock = vi.fn().mockResolvedValue({ name: 'marketplaceEngine' });
+const cronRegistryPath = requireCJS.resolve('../../lib/cronRegistry.js');
+Module._cache[cronRegistryPath] = {
+  id: cronRegistryPath,
+  filename: cronRegistryPath,
+  loaded: true,
+  exports: { register: registerMock },
+};
 
 // ── Require SUT — destructured findDup ref captured against the fake ──
 const sutPath = requireCJS.resolve('../../cron/marketplaceEngine.js');
@@ -86,7 +95,7 @@ beforeEach(() => {
   prisma.marketplaceConfig.findMany.mockReset();
   prisma.marketplaceConfig.update.mockReset();
   prisma.marketplaceLead.create.mockReset();
-  scheduleMock.mockReset();
+  registerMock.mockReset().mockResolvedValue({ name: 'marketplaceEngine' });
 
   // Defaults
   findDupMock.mockResolvedValue(null);
@@ -99,10 +108,6 @@ beforeEach(() => {
 
 afterEach(() => {
   global.fetch = originalFetch;
-});
-
-afterAll(() => {
-  nodeCron.schedule = originalSchedule;
 });
 
 /** Build a fetch Response stub. */
@@ -450,13 +455,16 @@ describe('cron/marketplaceEngine — TradeIndia sync (soft-fail)', () => {
 });
 
 describe('cron/marketplaceEngine — initMarketplaceCron registration', () => {
-  test('initMarketplaceCron registers a 5-minute schedule', () => {
+  test('initMarketplaceCron registers via cronRegistry with the 5-minute default, disabled by default', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     marketplaceEngine.initMarketplaceCron(null);
     logSpy.mockRestore();
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-    expect(scheduleMock.mock.calls[0][0]).toBe('*/5 * * * *');
-    expect(typeof scheduleMock.mock.calls[0][1]).toBe('function');
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    const opts = registerMock.mock.calls[0][0];
+    expect(opts.name).toBe('marketplaceEngine');
+    expect(opts.defaultSchedule).toBe('*/5 * * * *');
+    expect(opts.defaultEnabled).toBe(false);
+    expect(typeof opts.tickFn).toBe('function');
   });
 
   test('cron tick iterates active configs and dispatches syncMarketplace per provider', async () => {
@@ -471,7 +479,7 @@ describe('cron/marketplaceEngine — initMarketplaceCron registration', () => {
     // Each provider call will go through syncMarketplace; pre-stage findUnique
     // to return inactive so each is a fast no-op.
     prisma.marketplaceConfig.findUnique.mockResolvedValue({ isActive: false });
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     // findMany scopes to active configs only.
@@ -702,7 +710,7 @@ describe('cron/marketplaceEngine — extension: cron-tick fault isolation', () =
       return { isActive: false };
     });
 
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick(); // must not reject
     logSpy.mockRestore();
     errSpy.mockRestore();
@@ -710,28 +718,29 @@ describe('cron/marketplaceEngine — extension: cron-tick fault isolation', () =
     expect(prisma.marketplaceConfig.findUnique).toHaveBeenCalledTimes(2);
   });
 
-  test('outer-catch wrapper swallows prisma.findMany throw — tick stays alive', async () => {
-    // SUT lines 228-240: outer try/catch wraps the whole tick body. If
-    // findMany itself throws (DB connection blip), the tick MUST NOT reject —
-    // otherwise it surfaces as unhandledPromiseRejection and strict Node settings
-    // could kill the process.
+  test('a prisma.findMany throw propagates to the caller — cronRegistry.runTick (not this engine) now owns tick-level fault isolation', async () => {
+    // Since the Super Admin Portal / Cron Maintenance retrofit, the outer
+    // "never let a tick reject" guarantee moved to cronRegistry.runTick
+    // (see test/lib/cronRegistry.test.js's "thrown tickFn error is caught,
+    // logged as failed... and does not propagate" case) so every engine's
+    // failures are uniformly captured as a CronExecutionLog row instead of
+    // each engine re-implementing its own outer try/catch. This engine's
+    // tick() therefore no longer swallows a findMany throw itself — it
+    // propagates, and the registry is what contains it.
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     marketplaceEngine.initMarketplaceCron(null);
 
     prisma.marketplaceConfig.findMany.mockRejectedValue(new Error('DB_CONNECTION_LOST'));
 
-    const tick = scheduleMock.mock.calls[0][1];
-    // Tick must resolve (not reject) — guarded by outer try/catch.
-    await expect(tick()).resolves.toBeUndefined();
+    const tick = registerMock.mock.calls[0][0].tickFn;
+    await expect(tick()).rejects.toThrow('DB_CONNECTION_LOST');
     logSpy.mockRestore();
-    errSpy.mockRestore();
-    // Outer-catch path: findUnique never reached because the loop never started.
+    // Loop never started — findUnique never reached.
     expect(prisma.marketplaceConfig.findUnique).not.toHaveBeenCalled();
   });
 
   test('empty active configs list → tick is a graceful no-op (no provider work, no throw)', async () => {
-    // SUT line 230: findMany returns []. The for-loop body never runs. Pin this
+    // SUT: findMany returns []. The for-loop body never runs. Pin this
     // because a freshly-provisioned tenant with no configured marketplaces is the
     // STEADY STATE for most installs.
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -739,7 +748,7 @@ describe('cron/marketplaceEngine — extension: cron-tick fault isolation', () =
 
     prisma.marketplaceConfig.findMany.mockResolvedValue([]);
 
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await expect(tick()).resolves.toBeUndefined();
     logSpy.mockRestore();
     // No syncMarketplace work → no findUnique, no fetch, no create.

--- a/backend/test/cron/reportEngine.test.js
+++ b/backend/test/cron/reportEngine.test.js
@@ -21,17 +21,22 @@
  * Mocking strategy:
  *   - createRequire + cache delete (matches backupEngine pattern).
  *   - lib/prisma — monkey-patch model methods.
- *   - node-cron — schedule mock so initReportCron registers cleanly.
+ *   - lib/cronRegistry — the SUT registers via cronRegistry.register({...})
+ *     (Super Admin Portal / Cron Maintenance retrofit) instead of calling
+ *     node-cron directly; we mock register() and capture the tickFn option.
+ *     Note: the SUT's own outer try/catch around the tick body moved to
+ *     cronRegistry.runTick (see test/lib/cronRegistry.test.js), so tick()
+ *     now PROPAGATES a findMany rejection instead of swallowing it itself.
  *
  * NOT covered (intentional):
  *   - Real SMTP delivery (SMTP_HOST defaults to ethereal.email → mock branch).
  *   - The exact PDF bytes (assert Buffer + sane length only).
  */
-import { describe, test, expect, vi, beforeEach, afterAll } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { createRequire } from 'node:module';
 
 const requireCJS = createRequire(import.meta.url);
-const nodeCron = requireCJS('node-cron');
+const Module = requireCJS('node:module');
 
 // ── Patch prisma BEFORE requiring SUT ──────────────────────────────────
 import prisma from '../../lib/prisma.js';
@@ -52,10 +57,15 @@ prisma.reportSchedule = {
 };
 prisma.tenantSetting = { findUnique: vi.fn() };
 
-// ── Patch node-cron BEFORE requiring SUT ───────────────────────────────
-const originalSchedule = nodeCron.schedule;
-const scheduleMock = vi.fn();
-nodeCron.schedule = scheduleMock;
+// ── Fake cronRegistry module in require cache (BEFORE requiring SUT) ──
+const registerMock = vi.fn().mockResolvedValue({ name: 'reportEngine' });
+const cronRegistryPath = requireCJS.resolve('../../lib/cronRegistry.js');
+Module._cache[cronRegistryPath] = {
+  id: cronRegistryPath,
+  filename: cronRegistryPath,
+  loaded: true,
+  exports: { register: registerMock },
+};
 
 // ── Require SUT ───────────────────────────────────────────────────────
 const sutPath = requireCJS.resolve('../../cron/reportEngine.js');
@@ -76,7 +86,7 @@ beforeEach(() => {
   prisma.reportSchedule.findMany.mockReset();
   prisma.reportSchedule.update.mockReset();
   prisma.tenantSetting.findUnique.mockReset();
-  scheduleMock.mockReset();
+  registerMock.mockReset().mockResolvedValue({ name: 'reportEngine' });
 
   // Defaults
   prisma.user.findMany.mockResolvedValue([]);
@@ -95,10 +105,6 @@ beforeEach(() => {
   prisma.reportSchedule.update.mockResolvedValue({});
   prisma.reportSchedule.findMany.mockResolvedValue([]);
   prisma.tenantSetting.findUnique.mockResolvedValue(null);
-});
-
-afterAll(() => {
-  nodeCron.schedule = originalSchedule;
 });
 
 /** Build a ReportSchedule row. */
@@ -300,13 +306,15 @@ describe('cron/reportEngine — error containment + initReportCron registration'
     logSpy.mockRestore();
   });
 
-  test('initReportCron registers an hourly schedule', () => {
+  test('initReportCron registers an hourly schedule via cronRegistry', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     reportEngine.initReportCron();
     logSpy.mockRestore();
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-    expect(scheduleMock.mock.calls[0][0]).toBe('0 * * * *');
-    expect(typeof scheduleMock.mock.calls[0][1]).toBe('function');
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    const opts = registerMock.mock.calls[0][0];
+    expect(opts.name).toBe('reportEngine');
+    expect(opts.defaultSchedule).toBe('0 * * * *');
+    expect(typeof opts.tickFn).toBe('function');
   });
 
   test('cron tick fetches enabled schedules and dispatches due ones', async () => {
@@ -317,7 +325,7 @@ describe('cron/reportEngine — error containment + initReportCron registration'
       schedule({ id: 1, lastRunAt: null }),
       schedule({ id: 2, lastRunAt: new Date(Date.now() - 3600 * 1000), frequency: 'weekly' }),
     ]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     // findMany once on schedules + downstream deal.count from the one due schedule
@@ -330,16 +338,18 @@ describe('cron/reportEngine — error containment + initReportCron registration'
     expect(prisma.reportSchedule.update.mock.calls[0][0].where.id).toBe(1);
   });
 
-  test('cron tick: outer findMany rejection is logged, does not throw', async () => {
+  test('cron tick: a findMany rejection propagates — cronRegistry.runTick (not this engine) now owns tick-level fault isolation', async () => {
+    // Since the Super Admin Portal / Cron Maintenance retrofit, the outer
+    // "never let a tick reject" guarantee moved to cronRegistry.runTick
+    // (see test/lib/cronRegistry.test.js), so every engine's failures are
+    // uniformly captured as a CronExecutionLog row instead of each engine
+    // re-implementing its own outer try/catch.
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     reportEngine.initReportCron();
     prisma.reportSchedule.findMany.mockRejectedValue(new Error('DB lost'));
-    const tick = scheduleMock.mock.calls[0][1];
-    await expect(tick()).resolves.not.toThrow();
-    expect(errSpy).toHaveBeenCalled();
+    const tick = registerMock.mock.calls[0][0].tickFn;
+    await expect(tick()).rejects.toThrow('DB lost');
     logSpy.mockRestore();
-    errSpy.mockRestore();
   });
 
   test('shouldScheduleRun semantics: weekly schedule run 2h ago is NOT due (167h threshold)', async () => {
@@ -348,7 +358,7 @@ describe('cron/reportEngine — error containment + initReportCron registration'
     prisma.reportSchedule.findMany.mockResolvedValue([
       schedule({ id: 1, lastRunAt: new Date(Date.now() - 2 * 3600 * 1000), frequency: 'weekly' }),
     ]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     expect(prisma.reportSchedule.update).not.toHaveBeenCalled();
@@ -360,7 +370,7 @@ describe('cron/reportEngine — error containment + initReportCron registration'
     prisma.reportSchedule.findMany.mockResolvedValue([
       schedule({ id: 99, lastRunAt: new Date(Date.now() - 25 * 3600 * 1000), frequency: 'daily' }),
     ]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     expect(prisma.reportSchedule.update).toHaveBeenCalledTimes(1);
@@ -406,7 +416,7 @@ describe('cron/reportEngine — extended coverage (frequency windows + multi-sch
         frequency: 'monthly',
       }),
     ]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     expect(prisma.reportSchedule.update).toHaveBeenCalledTimes(1);
@@ -417,7 +427,7 @@ describe('cron/reportEngine — extended coverage (frequency windows + multi-sch
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     reportEngine.initReportCron();
     prisma.reportSchedule.findMany.mockResolvedValue([]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     expect(prisma.reportSchedule.findMany).toHaveBeenCalledTimes(1);
@@ -429,7 +439,7 @@ describe('cron/reportEngine — extended coverage (frequency windows + multi-sch
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     reportEngine.initReportCron();
     prisma.reportSchedule.findMany.mockResolvedValue([]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     // The findMany clause is the only gate against disabled rows — pin it.
@@ -450,7 +460,7 @@ describe('cron/reportEngine — extended coverage (frequency windows + multi-sch
     prisma.deal.count
       .mockRejectedValueOnce(new Error('transient DB blip'))
       .mockResolvedValue(0);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await expect(tick()).resolves.not.toThrow();
     logSpy.mockRestore();
     errSpy.mockRestore();
@@ -504,7 +514,7 @@ describe('cron/reportEngine — extended coverage (frequency windows + multi-sch
         frequency: 'fortnightly', // not in the switch
       }),
     ]);
-    const tick = scheduleMock.mock.calls[0][1];
+    const tick = registerMock.mock.calls[0][0].tickFn;
     await tick();
     logSpy.mockRestore();
     expect(prisma.reportSchedule.update).toHaveBeenCalledTimes(1);

--- a/backend/test/lib/apiPricing.test.js
+++ b/backend/test/lib/apiPricing.test.js
@@ -1,0 +1,93 @@
+// @ts-check
+/**
+ * Unit tests for backend/lib/apiPricing.js — static per-provider pricing
+ * table used to estimate external API cost WITHOUT calling the provider's
+ * own billing API. Powers the Super Admin "API Analytics" dashboard.
+ *
+ * Pinned:
+ *   - inferProvider() maps model-name substrings to provider families
+ *     (gemini/openai/anthropic/perplexity/groq), defaults to "unknown".
+ *   - estimateLlmCost() computes $ from promptTokens/completionTokens using
+ *     PRICING_PER_1K; unknown models return 0 (never throws, never guesses).
+ *   - estimateFlatCost() returns a number for known flat-rate providers
+ *     (serpapi) and null (NOT 0) for unknown ones, so callers can tell
+ *     "priced at $0" apart from "we don't know the price".
+ */
+
+import { describe, test, expect } from 'vitest';
+import { inferProvider, estimateLlmCost, estimateFlatCost, PRICING_PER_1K, FLAT_RATE_PER_REQUEST } from '../../lib/apiPricing.js';
+
+describe('inferProvider', () => {
+  test.each([
+    ['gemini-2.5-flash', 'gemini'],
+    ['gemini-pro', 'gemini'],
+    ['gpt-4o', 'openai'],
+    ['gpt-4o-mini', 'openai'],
+    ['claude-opus-4-7', 'anthropic'],
+    ['claude-haiku', 'anthropic'],
+    ['perplexity-sonar', 'perplexity'],
+    ['groq-llama', 'groq'],
+    ['some-made-up-model', 'unknown'],
+    [undefined, 'unknown'],
+    [null, 'unknown'],
+    ['', 'unknown'],
+  ])('%s -> %s', (model, expected) => {
+    expect(inferProvider(model)).toBe(expected);
+  });
+
+  test('is case-insensitive', () => {
+    expect(inferProvider('GEMINI-2.5-FLASH')).toBe('gemini');
+    expect(inferProvider('GPT-4O')).toBe('openai');
+  });
+});
+
+describe('estimateLlmCost', () => {
+  test('computes cost from promptTokens + completionTokens at the model rate', () => {
+    const rate = PRICING_PER_1K['gemini-2.5-flash'];
+    const cost = estimateLlmCost('gemini-2.5-flash', 1000, 1000);
+    expect(cost).toBeCloseTo(rate.in + rate.out, 6);
+  });
+
+  test('zero tokens -> zero cost', () => {
+    expect(estimateLlmCost('gpt-4o', 0, 0)).toBe(0);
+  });
+
+  test('unknown model -> 0, never throws', () => {
+    expect(estimateLlmCost('totally-unknown-model-xyz', 5000, 5000)).toBe(0);
+  });
+
+  test('missing/undefined token counts default to 0 rather than NaN', () => {
+    expect(estimateLlmCost('gpt-4o-mini', undefined, undefined)).toBe(0);
+  });
+
+  test('input and output tokens are priced at their own (different) rates', () => {
+    const rate = PRICING_PER_1K['gpt-4'];
+    expect(rate.in).not.toBe(rate.out); // sanity: this model's rates actually differ
+    const inputOnly = estimateLlmCost('gpt-4', 1000, 0);
+    const outputOnly = estimateLlmCost('gpt-4', 0, 1000);
+    expect(inputOnly).toBeCloseTo(rate.in, 6);
+    expect(outputOnly).toBeCloseTo(rate.out, 6);
+    expect(inputOnly).not.toBeCloseTo(outputOnly, 6);
+  });
+
+  test('rounds to 6 decimal places (matches Prisma Decimal(12,6) column)', () => {
+    const cost = estimateLlmCost('gemini-2.5-flash-lite', 333, 777);
+    const decimalPlaces = (String(cost).split('.')[1] || '').length;
+    expect(decimalPlaces).toBeLessThanOrEqual(6);
+  });
+});
+
+describe('estimateFlatCost', () => {
+  test('serpapi returns the known flat rate', () => {
+    expect(estimateFlatCost('serpapi')).toBe(FLAT_RATE_PER_REQUEST.serpapi);
+    expect(typeof estimateFlatCost('serpapi')).toBe('number');
+  });
+
+  test('unknown provider returns null, NOT 0 (unpriced vs free are different)', () => {
+    expect(estimateFlatCost('some-new-provider')).toBeNull();
+  });
+
+  test('is case-insensitive', () => {
+    expect(estimateFlatCost('SerpApi')).toBe(FLAT_RATE_PER_REQUEST.serpapi);
+  });
+});

--- a/backend/test/lib/cronDynamicHandlers.test.js
+++ b/backend/test/lib/cronDynamicHandlers.test.js
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for backend/lib/cronDynamicHandlers.js — the fixed, safe
+ * handler set for admin-created dynamic crons.
+ *
+ * Pinned:
+ *   - VALID_HANDLER_KEYS / isValidHandlerKey reflect exactly the HANDLERS map.
+ *   - http_webhook_ping: requires metadata.url; rejects non-URL strings;
+ *     rejects non-http(s) protocols; refuses localhost/127.0.0.1/0.0.0.0/::1
+ *     (SSRF guard); happy path calls fetch with the right method/headers/body;
+ *     throws on a non-ok response.
+ *   - log_note: always succeeds, echoes the message (or a default).
+ *   - buildDynamicTickFn: throws synchronously on an unknown handlerKey or
+ *     malformed metadataJson (fail-fast at registration, not per-tick);
+ *     the returned tickFn correctly delegates to the resolved handler with
+ *     the parsed metadata.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  HANDLERS,
+  VALID_HANDLER_KEYS,
+  isValidHandlerKey,
+  getHandler,
+  getHandlerCatalog,
+  buildDynamicTickFn,
+} from '../../lib/cronDynamicHandlers.js';
+
+describe('module shape', () => {
+  test('VALID_HANDLER_KEYS matches the HANDLERS map keys', () => {
+    expect(VALID_HANDLER_KEYS.sort()).toEqual(Object.keys(HANDLERS).sort());
+  });
+
+  test('isValidHandlerKey', () => {
+    expect(isValidHandlerKey('http_webhook_ping')).toBe(true);
+    expect(isValidHandlerKey('log_note')).toBe(true);
+    expect(isValidHandlerKey('rm_rf_slash')).toBe(false);
+  });
+
+  test('getHandler returns the handler entry or null', () => {
+    expect(getHandler('http_webhook_ping')).toBe(HANDLERS.http_webhook_ping);
+    expect(getHandler('log_note')).toBe(HANDLERS.log_note);
+    expect(getHandler('not_real')).toBe(null);
+  });
+
+  test('getHandlerCatalog exposes label/description/schema for each handler', () => {
+    const catalog = getHandlerCatalog();
+    expect(catalog.map((h) => h.key).sort()).toEqual(VALID_HANDLER_KEYS.sort());
+    const ping = catalog.find((h) => h.key === 'http_webhook_ping');
+    expect(ping.label).toBeTruthy();
+    expect(ping.description).toContain('URL');
+    expect(ping.metadataSchema).toBeDefined();
+  });
+});
+
+describe('http_webhook_ping', () => {
+  let fetchMock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('throws when metadata.url is missing', async () => {
+    await expect(HANDLERS.http_webhook_ping.fn({})).rejects.toThrow(/requires metadata.url/);
+  });
+
+  test('throws on a malformed URL string', async () => {
+    await expect(HANDLERS.http_webhook_ping.fn({ url: 'not a url' })).rejects.toThrow(/not a valid URL/);
+  });
+
+  test('rejects non-http(s) protocols', async () => {
+    await expect(HANDLERS.http_webhook_ping.fn({ url: 'file:///etc/passwd' })).rejects.toThrow(/unsupported protocol/);
+  });
+
+  test.each(['http://localhost/x', 'http://127.0.0.1/x', 'http://0.0.0.0/x', 'http://[::1]/x'])(
+    'refuses internal host %s (SSRF guard)',
+    async (url) => {
+      await expect(HANDLERS.http_webhook_ping.fn({ url })).rejects.toThrow(/refusing to ping internal host/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test('happy path POSTs with JSON content-type + the given body', async () => {
+    const result = await HANDLERS.http_webhook_ping.fn({
+      url: 'https://example.com/webhook',
+      bodyJson: '{"hello":"world"}',
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/webhook',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        body: '{"hello":"world"}',
+      }),
+    );
+  });
+
+  test('GET method sends no body', async () => {
+    await HANDLERS.http_webhook_ping.fn({ url: 'https://example.com/x', method: 'GET' });
+    expect(fetchMock.mock.calls[0][1].body).toBeUndefined();
+  });
+
+  test('merges custom headersJson on top of the default content-type', async () => {
+    await HANDLERS.http_webhook_ping.fn({
+      url: 'https://example.com/x',
+      headersJson: '{"authorization":"Bearer xyz"}',
+    });
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({
+      'content-type': 'application/json',
+      authorization: 'Bearer xyz',
+    });
+  });
+
+  test('malformed headersJson throws', async () => {
+    await expect(
+      HANDLERS.http_webhook_ping.fn({ url: 'https://example.com/x', headersJson: '{not json' }),
+    ).rejects.toThrow(/headersJson is not valid JSON/);
+  });
+
+  test('a non-ok response throws with the status code', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    await expect(HANDLERS.http_webhook_ping.fn({ url: 'https://example.com/x' })).rejects.toThrow(/responded 503/);
+  });
+});
+
+describe('log_note', () => {
+  test('echoes the given message', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await HANDLERS.log_note.fn({ message: 'hello from a dynamic cron' });
+    expect(result).toEqual({ ok: true, message: 'hello from a dynamic cron' });
+    logSpy.mockRestore();
+  });
+
+  test('falls back to a default message when none is given', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await HANDLERS.log_note.fn({});
+    expect(result.message).toBe('(no message)');
+    logSpy.mockRestore();
+  });
+});
+
+describe('buildDynamicTickFn', () => {
+  test('throws synchronously on an unknown handlerKey', () => {
+    expect(() => buildDynamicTickFn('not_a_real_handler', null)).toThrow(/Unknown handlerKey/);
+  });
+
+  test('throws synchronously on malformed metadataJson (fail-fast at registration)', () => {
+    expect(() => buildDynamicTickFn('log_note', '{not json')).toThrow(/metadataJson is not valid JSON/);
+  });
+
+  test('the returned tickFn delegates to the resolved handler with parsed metadata', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const tickFn = buildDynamicTickFn('log_note', '{"message":"parsed ok"}');
+    const result = await tickFn();
+    expect(result).toEqual({ ok: true, message: 'parsed ok' });
+    logSpy.mockRestore();
+  });
+
+  test('an absent metadataJson defaults to an empty object (no throw)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const tickFn = buildDynamicTickFn('log_note', null);
+    const result = await tickFn();
+    expect(result.message).toBe('(no message)');
+    logSpy.mockRestore();
+  });
+});

--- a/backend/test/lib/cronRegistry.test.js
+++ b/backend/test/lib/cronRegistry.test.js
@@ -1,0 +1,424 @@
+/**
+ * Unit tests for backend/lib/cronRegistry.js — Super Admin Portal / Cron
+ * Maintenance central scheduler.
+ *
+ * MOCK STRATEGY: two dependencies to fake — prisma (model methods
+ * monkey-patched on the shared singleton, same pattern as
+ * test/lib/eventBus.test.js) and node-cron (the SUT's real `require('node-
+ * cron')` is reached ONLY via the exported `_cron` reference — see the
+ * "CJS self-mocking seam" note atop cronRegistry.js — so we
+ * vi.spyOn(cronRegistry._cron, 'schedule'/'validate') instead of
+ * vi.mock('node-cron', ...), which cannot intercept a top-level CJS
+ * require (same constraint documented in
+ * test/services/flyer-render-engine.test.js for `require('puppeteer')`).
+ *
+ * Coverage:
+ *   - register(): validates inputs, upserts CronConfig only on first-ever
+ *     registration (never overwrites an existing row's schedule/enabled),
+ *     creates a live node-cron task by default.
+ *   - applyConfig(): disabled row -> no task scheduled; re-enabling
+ *     recreates one; schedule edits tear down + recreate with the new
+ *     expression; invalid DB schedule falls back to defaultSchedule.
+ *   - runTick(): writes a CronExecutionLog start+finish row bracketing
+ *     the call; success vs thrown-error status; overlap guard (a tick
+ *     already running skips a concurrent trigger rather than queuing);
+ *     manual vs scheduled triggerType is recorded verbatim.
+ *   - listRegistered() / isRegistered() introspection.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+
+// Patch the prisma singleton BEFORE the SUT (lazily) uses it.
+prisma.cronConfig = {
+  ...(prisma.cronConfig || {}),
+  upsert: vi.fn(),
+  findUnique: vi.fn(),
+};
+prisma.cronExecutionLog = {
+  ...(prisma.cronExecutionLog || {}),
+  create: vi.fn(),
+  update: vi.fn(),
+};
+
+const cronRegistry = requireCJS('../../lib/cronRegistry');
+
+// Fake node-cron ScheduledTask — records stop/destroy calls so tests can
+// assert the registry actually tears down + recreates tasks.
+const scheduledTasks = [];
+function makeFakeTask() {
+  return { stop: vi.fn(), destroy: vi.fn(), getStatus: vi.fn(() => 'scheduled') };
+}
+
+beforeEach(() => {
+  scheduledTasks.length = 0;
+  prisma.cronConfig.upsert.mockReset().mockResolvedValue({ id: 1, name: 'test' });
+  prisma.cronConfig.findUnique.mockReset().mockResolvedValue(null);
+  prisma.cronExecutionLog.create.mockReset().mockResolvedValue({ id: 101 });
+  prisma.cronExecutionLog.update.mockReset().mockResolvedValue({ id: 101 });
+  cronRegistry._resetForTests();
+
+  // vi.restoreAllMocks() (via vitest.config's default restoreMocks, if set)
+  // may or may not run between files — reset explicitly by re-assigning the
+  // spy's implementation + call history every test rather than re-spying
+  // (spying on an already-spied method twice with vi.spyOn returns the SAME
+  // spy without clearing its recorded calls).
+  if (cronRegistry._cron.schedule.mock) {
+    cronRegistry._cron.schedule.mockClear();
+    cronRegistry._cron.validate.mockClear();
+  } else {
+    vi.spyOn(cronRegistry._cron, 'schedule');
+    vi.spyOn(cronRegistry._cron, 'validate');
+  }
+  cronRegistry._cron.schedule.mockImplementation((expr, fn, opts) => {
+    const task = makeFakeTask();
+    scheduledTasks.push({ expr, fn, opts, task });
+    return task;
+  });
+  // Minimal real-ish validation: 5 space-separated fields, or the
+  // explicit sentinel used by "invalid expression" test cases.
+  cronRegistry._cron.validate.mockImplementation((expr) => {
+    if (expr === 'not-a-cron-expr' || expr === 'garbage') return false;
+    const parts = String(expr || '').trim().split(/\s+/);
+    return parts.length === 5;
+  });
+});
+
+describe('register()', () => {
+  test('rejects missing name / non-function tickFn / invalid defaultSchedule', async () => {
+    await expect(cronRegistry.register({ name: '', tickFn: () => {}, defaultSchedule: '* * * * *' }))
+      .rejects.toThrow(/name is required/);
+    await expect(cronRegistry.register({ name: 'x', tickFn: null, defaultSchedule: '* * * * *' }))
+      .rejects.toThrow(/tickFn must be a function/);
+    await expect(cronRegistry.register({ name: 'x', tickFn: () => {}, defaultSchedule: 'not-a-cron-expr' }))
+      .rejects.toThrow(/not a valid cron expression/);
+  });
+
+  test('first-ever registration upserts a CronConfig row with the engine default + isSystem:true', async () => {
+    await cronRegistry.register({
+      name: 'quoteExpirySweep',
+      defaultSchedule: '0 9 * * *',
+      tickFn: vi.fn(),
+      description: 'Daily quote expiry sweep',
+    });
+    expect(prisma.cronConfig.upsert).toHaveBeenCalledWith({
+      where: { name: 'quoteExpirySweep' },
+      update: { description: 'Daily quote expiry sweep' },
+      create: {
+        name: 'quoteExpirySweep',
+        description: 'Daily quote expiry sweep',
+        schedule: '0 9 * * *',
+        enabled: true,
+        isSystem: true,
+        createdBy: 'system',
+      },
+    });
+  });
+
+  test('registration with no existing CronConfig row schedules using defaultSchedule', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    await cronRegistry.register({ name: 'engineA', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(cronRegistry._cron.schedule).toHaveBeenCalledTimes(1);
+    expect(cronRegistry._cron.schedule.mock.calls[0][0]).toBe('*/5 * * * *');
+  });
+
+  test('registration with an existing ENABLED CronConfig row uses the DB schedule, not the default', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 5, name: 'engineB', schedule: '0 */2 * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineB', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(cronRegistry._cron.schedule.mock.calls[0][0]).toBe('0 */2 * * *');
+  });
+
+  test('registration with an existing DISABLED CronConfig row schedules NOTHING', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 6, name: 'engineC', schedule: '*/5 * * * *', enabled: false });
+    await cronRegistry.register({ name: 'engineC', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(cronRegistry._cron.schedule).not.toHaveBeenCalled();
+  });
+
+  test('an invalid schedule stored in the DB row falls back to defaultSchedule rather than crashing', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 7, name: 'engineD', schedule: 'garbage', enabled: true });
+    await cronRegistry.register({ name: 'engineD', defaultSchedule: '0 0 * * *', tickFn: vi.fn() });
+    expect(cronRegistry._cron.schedule.mock.calls[0][0]).toBe('0 0 * * *');
+  });
+
+  test('runImmediately fires one tick right after registration (fire-and-forget)', async () => {
+    const tickFn = vi.fn().mockResolvedValue();
+    await cronRegistry.register({ name: 'engineE', defaultSchedule: '*/10 * * * *', tickFn, runImmediately: true });
+    // runTick is fire-and-forget (not awaited by register) — flush microtasks.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(tickFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('a CronConfig upsert failure is non-fatal — registration + scheduling still proceeds', async () => {
+    prisma.cronConfig.upsert.mockRejectedValue(new Error('DB down'));
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    await expect(cronRegistry.register({ name: 'engineF', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() }))
+      .resolves.toMatchObject({ name: 'engineF' });
+    expect(cronRegistry._cron.schedule).toHaveBeenCalledTimes(1);
+  });
+
+  test('defaultEnabled:false seeds a disabled row on first-ever registration (visible in the UI, not running)', async () => {
+    // Simulates real DB read-your-own-write continuity: register()'s upsert
+    // persists enabled:false, and applyConfig()'s own findUnique (a separate
+    // round-trip) sees that same row — unlike a real DB, this mock has no
+    // memory of the upsert, so we model the post-upsert row explicitly.
+    prisma.cronConfig.findUnique.mockResolvedValue({
+      id: 40, name: 'marketplaceEngine', schedule: '*/5 * * * *', enabled: false,
+    });
+    await cronRegistry.register({
+      name: 'marketplaceEngine',
+      defaultSchedule: '*/5 * * * *',
+      tickFn: vi.fn(),
+      defaultEnabled: false,
+    });
+    expect(prisma.cronConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: expect.objectContaining({ enabled: false }) }),
+    );
+    expect(cronRegistry._cron.schedule).not.toHaveBeenCalled();
+  });
+
+  test('defaultEnabled defaults to true when omitted (matches every engine historical always-on behavior)', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    await cronRegistry.register({ name: 'engineQ', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(prisma.cronConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: expect.objectContaining({ enabled: true }) }),
+    );
+  });
+});
+
+describe('applyConfig() — live reschedule', () => {
+  test('stops + destroys the previous task before creating a new one', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 8, name: 'engineG', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineG', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    const firstTask = scheduledTasks[0].task;
+
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 8, name: 'engineG', schedule: '0 */3 * * *', enabled: true });
+    await cronRegistry.applyConfig('engineG');
+
+    expect(firstTask.stop).toHaveBeenCalledTimes(1);
+    expect(firstTask.destroy).toHaveBeenCalledTimes(1);
+    expect(scheduledTasks).toHaveLength(2);
+    expect(scheduledTasks[1].expr).toBe('0 */3 * * *');
+  });
+
+  test('disabling via applyConfig stops the task and schedules nothing new', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 9, name: 'engineH', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineH', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    const firstTask = scheduledTasks[0].task;
+
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 9, name: 'engineH', schedule: '*/5 * * * *', enabled: false });
+    const result = await cronRegistry.applyConfig('engineH');
+
+    expect(firstTask.stop).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ ok: true, enabled: false });
+    expect(scheduledTasks).toHaveLength(1); // no NEW task created
+  });
+
+  test('re-enabling a previously-disabled engine creates a fresh task', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 10, name: 'engineI', schedule: '*/5 * * * *', enabled: false });
+    await cronRegistry.register({ name: 'engineI', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(scheduledTasks).toHaveLength(0);
+
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 10, name: 'engineI', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.applyConfig('engineI');
+    expect(scheduledTasks).toHaveLength(1);
+  });
+
+  test('applyConfig on an unregistered name is a safe no-op', async () => {
+    const result = await cronRegistry.applyConfig('does-not-exist');
+    expect(result).toEqual({ ok: false, reason: 'not-registered' });
+  });
+
+  test('a CronConfig read failure during applyConfig falls back to enabled+default rather than throwing', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValueOnce({ id: 11, name: 'engineJ', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineJ', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+
+    prisma.cronConfig.findUnique.mockRejectedValueOnce(new Error('DB blip'));
+    await expect(cronRegistry.applyConfig('engineJ')).resolves.toMatchObject({ ok: true, enabled: true });
+  });
+});
+
+describe('unregister()', () => {
+  test('stops + destroys the live task and removes the engine from the registry', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 50, name: 'dynCronA', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'dynCronA', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    const task = scheduledTasks[0].task;
+
+    const result = cronRegistry.unregister('dynCronA');
+
+    expect(result).toEqual({ ok: true });
+    expect(task.stop).toHaveBeenCalledTimes(1);
+    expect(task.destroy).toHaveBeenCalledTimes(1);
+    expect(cronRegistry.isRegistered('dynCronA')).toBe(false);
+  });
+
+  test('unregistering a disabled (never-scheduled) engine is a safe no-op on the task side', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 51, name: 'dynCronB', schedule: '*/5 * * * *', enabled: false });
+    await cronRegistry.register({ name: 'dynCronB', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+
+    const result = cronRegistry.unregister('dynCronB');
+    expect(result).toEqual({ ok: true });
+    expect(cronRegistry.isRegistered('dynCronB')).toBe(false);
+  });
+
+  test('unregistering an unknown name returns not-registered', () => {
+    expect(cronRegistry.unregister('never-existed')).toEqual({ ok: false, reason: 'not-registered' });
+  });
+
+  test('a subsequent runTick against an unregistered name throws (matches pre-unregister behavior)', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 52, name: 'dynCronC', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'dynCronC', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    cronRegistry.unregister('dynCronC');
+    await expect(cronRegistry.runTick('dynCronC')).rejects.toThrow(/not registered/);
+  });
+});
+
+describe('runTick()', () => {
+  test('writes a CronExecutionLog start row then a finish row with status=success', async () => {
+    const tickFn = vi.fn().mockResolvedValue();
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 20, name: 'engineK' });
+    await cronRegistry.register({ name: 'engineK', defaultSchedule: '*/5 * * * *', tickFn });
+
+    const result = await cronRegistry.runTick('engineK', 'manual');
+
+    expect(prisma.cronExecutionLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ cronName: 'engineK', status: 'running', triggerType: 'manual' }),
+      }),
+    );
+    expect(prisma.cronExecutionLog.update).toHaveBeenCalledWith({
+      where: { id: 101 },
+      data: expect.objectContaining({ status: 'success', errorMessage: null }),
+    });
+    expect(result.status).toBe('success');
+    expect(tickFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('a thrown tickFn error is caught, logged as failed with the error message, and does not propagate', async () => {
+    const tickFn = vi.fn().mockRejectedValue(new Error('boom'));
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 21, name: 'engineL' });
+    await cronRegistry.register({ name: 'engineL', defaultSchedule: '*/5 * * * *', tickFn });
+
+    const result = await cronRegistry.runTick('engineL', 'scheduled');
+
+    expect(result.status).toBe('failed');
+    expect(result.errorMessage).toMatch(/boom/);
+    expect(prisma.cronExecutionLog.update).toHaveBeenCalledWith({
+      where: { id: 101 },
+      data: expect.objectContaining({ status: 'failed', errorMessage: expect.stringContaining('boom') }),
+    });
+  });
+
+  test('overlapping runs of the SAME engine are skipped, not queued', async () => {
+    let resolveTick;
+    const tickFn = vi.fn(() => new Promise((r) => { resolveTick = r; }));
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 22, name: 'engineM', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineM', defaultSchedule: '*/5 * * * *', tickFn });
+
+    const firstRun = cronRegistry.runTick('engineM', 'scheduled');
+    // Let firstRun's pre-tickFn awaits (CronConfig lookup + log create) flush
+    // before firing the concurrent trigger, so entry.running is definitely
+    // true and tickFn has definitely been invoked (it's what's holding the
+    // promise open) by the time we assert below.
+    await new Promise((r) => setTimeout(r, 0));
+    const secondRun = await cronRegistry.runTick('engineM', 'manual'); // fires while first is mid-flight
+    expect(secondRun).toEqual({ skipped: true, reason: 'already-running' });
+    expect(tickFn).toHaveBeenCalledTimes(1);
+
+    resolveTick();
+    await firstRun;
+  });
+
+  test('runTick on an unregistered name throws synchronously (caller/route bug, not a soft-fail case)', async () => {
+    await expect(cronRegistry.runTick('nope')).rejects.toThrow(/not registered/);
+  });
+
+  test('a missing CronConfig row (race with delete) still runs the tick, just skips logging', async () => {
+    const tickFn = vi.fn().mockResolvedValue();
+    prisma.cronConfig.findUnique.mockResolvedValueOnce({ id: 23, name: 'engineN' }); // for register()
+    await cronRegistry.register({ name: 'engineN', defaultSchedule: '*/5 * * * *', tickFn });
+
+    prisma.cronConfig.findUnique.mockResolvedValueOnce(null); // for runTick's own lookup
+    const result = await cronRegistry.runTick('engineN', 'scheduled');
+    expect(result.status).toBe('success');
+    expect(prisma.cronExecutionLog.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('introspection', () => {
+  test('listRegistered reflects registered engines with live scheduled/running flags', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 30, name: 'engineO', schedule: '*/5 * * * *', enabled: true });
+    await cronRegistry.register({ name: 'engineO', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    const list = cronRegistry.listRegistered();
+    expect(list).toContainEqual(expect.objectContaining({ name: 'engineO', scheduled: true, running: false }));
+  });
+
+  test('isRegistered is true only for engines that called register()', async () => {
+    expect(cronRegistry.isRegistered('engineP')).toBe(false);
+    await cronRegistry.register({ name: 'engineP', defaultSchedule: '*/5 * * * *', tickFn: vi.fn() });
+    expect(cronRegistry.isRegistered('engineP')).toBe(true);
+  });
+});
+
+describe('loadDynamicCrons()', () => {
+  test('re-registers every isSystem:false CronConfig row from the DB at boot', async () => {
+    const dynamicRows = [
+      { id: 40, name: 'dynBootA', schedule: '*/5 * * * *', enabled: true, isSystem: false, handlerKey: 'log_note', metadataJson: '{"message":"a"}' },
+      { id: 41, name: 'dynBootB', schedule: '0 */3 * * *', enabled: false, isSystem: false, handlerKey: 'log_note', metadataJson: null },
+    ];
+    prisma.cronConfig.findMany = vi.fn().mockResolvedValue(dynamicRows);
+    prisma.cronConfig.findUnique.mockImplementation(({ where: { name } }) => {
+      return Promise.resolve(dynamicRows.find((r) => r.name === name) || null);
+    });
+
+    const result = await cronRegistry.loadDynamicCrons();
+
+    expect(result.loaded).toBe(2);
+    expect(cronRegistry.isRegistered('dynBootA')).toBe(true);
+    expect(cronRegistry.isRegistered('dynBootB')).toBe(true);
+    // Enabled one got a live task; disabled one did not.
+    const tasks = cronRegistry.listRegistered();
+    expect(tasks.find((t) => t.name === 'dynBootA').scheduled).toBe(true);
+    expect(tasks.find((t) => t.name === 'dynBootB').scheduled).toBe(false);
+  });
+
+  test('logs and skips individual dynamic crons that fail to build, continuing with the rest', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const dynamicRows = [
+      { id: 42, name: 'dynBad', schedule: '*/5 * * * *', enabled: true, isSystem: false, handlerKey: 'unknown_handler', metadataJson: null },
+      { id: 43, name: 'dynGood', schedule: '*/10 * * * *', enabled: true, isSystem: false, handlerKey: 'log_note', metadataJson: null },
+    ];
+    prisma.cronConfig.findMany = vi.fn().mockResolvedValue(dynamicRows);
+    prisma.cronConfig.findUnique.mockImplementation(({ where: { name } }) => {
+      return Promise.resolve(dynamicRows.find((r) => r.name === name) || null);
+    });
+
+    const result = await cronRegistry.loadDynamicCrons();
+
+    expect(result.loaded).toBe(2);
+    expect(cronRegistry.isRegistered('dynBad')).toBe(false);
+    expect(cronRegistry.isRegistered('dynGood')).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('dynBad'));
+    errorSpy.mockRestore();
+  });
+
+  test('returns 0 loaded when the DB query itself fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    prisma.cronConfig.findMany = vi.fn().mockRejectedValue(new Error('DB down'));
+
+    const result = await cronRegistry.loadDynamicCrons();
+
+    expect(result.loaded).toBe(0);
+    expect(result.error).toMatch(/DB down/);
+    errorSpy.mockRestore();
+  });
+});
+
+describe('isValidExpression()', () => {
+  test('delegates to node-cron validate', () => {
+    expect(cronRegistry.isValidExpression('*/5 * * * *')).toBe(true);
+    expect(cronRegistry.isValidExpression('not-a-cron-expr')).toBe(false);
+  });
+});

--- a/backend/test/lib/llmRouter.test.js
+++ b/backend/test/lib/llmRouter.test.js
@@ -15,7 +15,7 @@
 //
 // Surface area covered (24 + S45 extension = 30+ cases):
 //   - module shape (3): exports + TASK_ROUTING matches PRD §9.1 + VALID_TASKS
-//   - llmEnabled (4):   no-env false, reasoning-with-Anthropic-key true,
+//   - llmEnabled (4):   no-env false, reasoning-with-Gemini-key true,
 //                       call-summary-with-Gemini-key true, unknown-task false
 //   - getLlmKey (S45, 6): tenantId omitted → ENV-only,
 //                         tenantId present + SupplierCredential present → DB wins over ENV,
@@ -25,9 +25,9 @@
 //                         Prisma error → ENV fallback (never throws)
 //   - llmEnabled (S45 extension, 2): per-tenant SupplierCredential gate,
 //                                    tenantId omitted preserves ENV-only contract
-//   - pickModel (4):    talking-points → claude-opus-4-7,
+//   - pickModel (4):    talking-points → gemini-flash,
 //                       call-summary → gemini-flash,
-//                       unknown → claude-opus-4-7 with unknown-task-fallback reason,
+//                       unknown → gemini-flash with unknown-task-fallback reason,
 //                       every TASK_ROUTING key resolves to non-empty primary
 //   - routeRequest (6): throws on missing task,
 //                       returns full envelope for every valid task,
@@ -160,9 +160,9 @@ describe('llmRouter — module shape', () => {
     expect(r.TASK_ROUTING).toEqual({
       "search": { primary: "perplexity-sonar", fallback: null },
       "citation": { primary: "perplexity-sonar", fallback: null },
-      "reasoning": { primary: "claude-opus-4-7", fallback: "gpt-4" },
-      "talking-points": { primary: "claude-opus-4-7", fallback: "gpt-4" },
-      "form-vs-call": { primary: "claude-opus-4-7", fallback: "gpt-4" },
+      "reasoning": { primary: "gemini-flash", fallback: "gpt-4" },
+      "talking-points": { primary: "gemini-flash", fallback: "gpt-4" },
+      "form-vs-call": { primary: "gemini-flash", fallback: "gpt-4" },
       "bulk-text": { primary: "gemini-flash", fallback: "groq-llama" },
       "call-summary": { primary: "gemini-flash", fallback: null },
       "itinerary-suggest": { primary: "gemini-flash", fallback: "gpt-4" },
@@ -228,14 +228,14 @@ describe('llmEnabled', () => {
     }
   });
 
-  test('returns true for "reasoning" when ANTHROPIC_API_KEY is set', async () => {
+  test('returns true for "reasoning" when GEMINI_API_KEY is set', async () => {
     delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    process.env.ANTHROPIC_API_KEY = 'sk-ant-real';
+    process.env.GEMINI_API_KEY = 'AIzaSy-real';
     const r = loadRouter();
     expect(await r.llmEnabled('reasoning')).toBe(true);
-    // Talking-points + form-vs-call share Claude → also true.
+    // Talking-points + form-vs-call share Gemini Flash → also true.
     expect(await r.llmEnabled('talking-points')).toBe(true);
     expect(await r.llmEnabled('form-vs-call')).toBe(true);
   });
@@ -249,8 +249,8 @@ describe('llmEnabled', () => {
     expect(await r.llmEnabled('call-summary')).toBe(true);
     // Bulk-text also routed to Gemini → also true.
     expect(await r.llmEnabled('bulk-text')).toBe(true);
-    // But "reasoning" goes to Claude — Gemini key alone isn't enough.
-    expect(await r.llmEnabled('reasoning')).toBe(false);
+    // "reasoning" is also Gemini Flash now → also true.
+    expect(await r.llmEnabled('reasoning')).toBe(true);
   });
 
   test('"itinerary-suggest" follows the Gemini key (gemini-flash provider slot)', async () => {
@@ -377,11 +377,11 @@ describe('llmEnabled — S45 per-tenant gate', () => {
 });
 
 describe('pickModel', () => {
-  test('"talking-points" → claude-opus-4-7 with reason "primary"', () => {
+  test('"talking-points" → gemini-flash with reason "primary"', () => {
     const r = loadRouter();
     expect(r.pickModel('talking-points')).toEqual({
       task: 'talking-points',
-      model: 'claude-opus-4-7',
+      model: 'gemini-flash',
       reason: 'primary',
     });
   });
@@ -395,11 +395,11 @@ describe('pickModel', () => {
     });
   });
 
-  test('unknown task → claude-opus-4-7 with reason "unknown-task-fallback"', () => {
+  test('unknown task → gemini-flash with reason "unknown-task-fallback"', () => {
     const r = loadRouter();
     expect(r.pickModel('not-a-real-task')).toEqual({
       task: 'not-a-real-task',
-      model: 'claude-opus-4-7',
+      model: 'gemini-flash',
       reason: 'unknown-task-fallback',
     });
   });
@@ -499,7 +499,7 @@ describe('routeRequest', () => {
       payload: {},
       tenantId: 1,
     });
-    expect(out.model).toBe('claude-opus-4-7');
+    expect(out.model).toBe('gemini-flash');
     expect(out.stub).toBe(true);
     // Warning surfaced for config-drift visibility.
     expect(warnSpy).toHaveBeenCalled();
@@ -528,7 +528,7 @@ describe('routeRequest', () => {
     const match = lines.find((l) => l.startsWith('[llm-router] '));
     expect(match).toBeTruthy();
     expect(match).toContain('task=talking-points');
-    expect(match).toContain('model=claude-opus-4-7');
+    expect(match).toContain('model=gemini-flash');
     expect(match).toContain('tenant=99');
     expect(match).toMatch(/tokens_in=\d+/);
     expect(match).toMatch(/tokens_out=\d+/);
@@ -579,7 +579,7 @@ describe('routeRequest — LlmCallLog persistence (PRD §9.1, R7)', () => {
     expect(arg.data).toMatchObject({
       tenantId: 42,
       task: 'talking-points',
-      model: 'claude-opus-4-7',
+      model: 'gemini-flash',
       reason: 'primary',
       stub: true,
       costEstimate: 0,
@@ -665,7 +665,7 @@ describe('routeRequest — per-tenant budget cap (2026-05-24 product-call)', () 
     const r = loadRouter();
     const out = await r.routeRequest({ task: 'reasoning', payload: {}, tenantId: 42 });
     expect(out.stub).toBe(true);
-    expect(out.model).toBe('claude-opus-4-7');
+    expect(out.model).toBe('gemini-flash');
     // Cap query happened with the right tenant.
     expect(prismaMock.tenantSetting.findUnique).toHaveBeenCalledWith({
       where: { tenantId_key: { tenantId: 42, key: 'budgetCap_llm_monthly_usd_cents' } },
@@ -782,23 +782,23 @@ describe('routeRequest — real provider call (key present, not under test)', ()
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        content: [{ type: 'text', text: 'REAL talking points from Claude.' }],
-        usage: { input_tokens: 12, output_tokens: 34 },
+        candidates: [{ content: { parts: [{ text: 'REAL talking points from Gemini.' }] } }],
+        usageMetadata: { promptTokenCount: 12, candidatesTokenCount: 34 },
       }),
     });
     vi.stubGlobal('fetch', fetchMock);
     process.env.NODE_ENV = 'production';
-    process.env.ANTHROPIC_API_KEY = 'sk-ant-real';
+    process.env.GEMINI_API_KEY = 'AIzaSy-real';
     try {
       const r = loadRouter();
       const out = await r.routeRequest({ task: 'talking-points', payload: { leadId: 7 }, tenantId: 3 });
       expect(out.stub).toBe(false);
-      expect(out.text).toBe('REAL talking points from Claude.');
-      expect(out.model).toBe('claude-opus-4-7');
+      expect(out.text).toBe('REAL talking points from Gemini.');
+      expect(out.model).toBe('gemini-flash');
       expect(out.usage.promptTokens).toBe(12);
       expect(out.usage.completionTokens).toBe(34);
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(String(fetchMock.mock.calls[0][0])).toContain('api.anthropic.com');
+      expect(String(fetchMock.mock.calls[0][0])).toContain('generativelanguage.googleapis.com');
     } finally {
       process.env.NODE_ENV = prevNodeEnv;
       vi.unstubAllGlobals();
@@ -810,7 +810,7 @@ describe('routeRequest — real provider call (key present, not under test)', ()
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
-    process.env.ANTHROPIC_API_KEY = 'sk-ant-real'; // NODE_ENV stays 'test' (vitest default)
+    process.env.GEMINI_API_KEY = 'AIzaSy-real'; // NODE_ENV stays 'test' (vitest default)
     try {
       const r = loadRouter();
       const out = await r.routeRequest({ task: 'talking-points', payload: {}, tenantId: 1 });

--- a/backend/test/routes/super-admin-api-analytics.test.js
+++ b/backend/test/routes/super-admin-api-analytics.test.js
@@ -1,0 +1,382 @@
+// @ts-check
+/**
+ * Unit tests for backend/routes/super_admin_api_analytics.js — API
+ * Analytics module (Super Admin Portal). Aggregates + browses LlmCallLog
+ * (Gemini/OpenAI/Anthropic/Perplexity/Groq) and ApiCallLog (SerpApi et al).
+ *
+ * Mocking strategy: prisma singleton monkey-patch (llmCallLog, apiCallLog,
+ * systemSetting) + a fake req.superAdmin injected ahead of the router —
+ * same pattern as test/routes/super-admin-cron.test.js.
+ *
+ * Pinned:
+ *   GET /overview — days clamp [1,90] default 14; totals merge BOTH tables
+ *     (calls/success/failures/tokens/cost) EXCLUDING stub-mode LlmCallLog
+ *     rows entirely (no real API key configured — llmRouter.js's synthetic
+ *     fallback never hit a real provider, so it's not surfaced on this
+ *     dashboard at all, not even as an informational count); byDay buckets
+ *     by calendar day; byProvider + byModel breakdowns; recentFailures
+ *     surfaces errorMessage, newest-first, capped at 25.
+ *   GET /calls — pagination, provider/status/date-range filters, merges +
+ *     sorts both tables by createdAt desc, tags each row with source.
+ *   GET/PUT /settings/log-retention — default 30, validates 1-3650 range,
+ *     upserts on PUT with the SAME SystemSetting key the retention cron reads.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import prisma from '../../lib/prisma.js';
+prisma.llmCallLog = { findMany: vi.fn() };
+prisma.apiCallLog = { findMany: vi.fn() };
+prisma.systemSetting = { findUnique: vi.fn(), upsert: vi.fn() };
+
+const router = (await import('../../routes/super_admin_api_analytics.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.superAdmin = { username: 'superadmin' };
+    next();
+  });
+  app.use('/api/super-admin/api-analytics', router);
+  return app;
+}
+
+function llmRow(overrides = {}) {
+  return {
+    id: 1,
+    provider: 'gemini',
+    model: 'gemini-2.5-flash',
+    task: 'email-draft',
+    status: 'success',
+    promptTokens: 100,
+    completionTokens: 50,
+    totalTokens: 150,
+    costEstimate: 0.001,
+    stub: false,
+    errorMessage: null,
+    createdAt: new Date('2026-07-10T10:00:00Z'),
+    ...overrides,
+  };
+}
+
+function apiRow(overrides = {}) {
+  return {
+    id: 1,
+    provider: 'serpapi',
+    endpoint: 'google_flights',
+    status: 'success',
+    costEstimate: 0.015,
+    errorMessage: null,
+    createdAt: new Date('2026-07-10T11:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('GET /overview', () => {
+  let app;
+
+  beforeEach(() => {
+    prisma.llmCallLog.findMany.mockReset().mockResolvedValue([]);
+    prisma.apiCallLog.findMany.mockReset().mockResolvedValue([]);
+    app = buildApp();
+  });
+
+  test('defaults to 14 days, clamps above 90', async () => {
+    let res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.days).toBe(14);
+    res = await request(app).get('/api/super-admin/api-analytics/overview?days=999');
+    expect(res.body.days).toBe(90);
+  });
+
+  test('?from + ?to overrides the days preset entirely — filters both queries by the exact range', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/overview?from=2026-06-01&to=2026-06-03&days=999');
+    expect(res.status).toBe(200);
+    const llmWhere = prisma.llmCallLog.findMany.mock.calls[0][0].where.createdAt;
+    expect(llmWhere.gte.toISOString().slice(0, 10)).toBe('2026-06-01');
+    expect(llmWhere.lte.toISOString().slice(0, 10)).toBe('2026-06-03');
+    expect(res.body.until).not.toBeNull();
+  });
+
+  test('?to includes the WHOLE UTC day (end-of-day 23:59:59.999 UTC), not just midnight — asserted in UTC so this passes regardless of the test runner\'s local timezone', async () => {
+    await request(app).get('/api/super-admin/api-analytics/overview?from=2026-06-01&to=2026-06-01');
+    const llmWhere = prisma.llmCallLog.findMany.mock.calls[0][0].where.createdAt;
+    expect(llmWhere.lte.getUTCHours()).toBe(23);
+    expect(llmWhere.lte.getUTCMinutes()).toBe(59);
+    expect(llmWhere.lte.toISOString()).toBe('2026-06-01T23:59:59.999Z');
+  });
+
+  test('a single ?from with no ?to is treated as "just that one day"', async () => {
+    await request(app).get('/api/super-admin/api-analytics/overview?from=2026-06-01');
+    const llmWhere = prisma.llmCallLog.findMany.mock.calls[0][0].where.createdAt;
+    expect(llmWhere.gte.toISOString().slice(0, 10)).toBe('2026-06-01');
+    expect(llmWhere.lte.toISOString().slice(0, 10)).toBe('2026-06-01');
+  });
+
+  test('invalid ?from date -> 400 INVALID_DATE', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/overview?from=not-a-date');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DATE');
+  });
+
+  test('invalid ?to date -> 400 INVALID_DATE', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/overview?to=not-a-date');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DATE');
+  });
+
+  test('no from/to -> until is null in the response (preset-days mode)', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/overview?days=7');
+    expect(res.body.until).toBeNull();
+  });
+
+  test('totals merge LlmCallLog + ApiCallLog counts, tokens, cost', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([llmRow({ status: 'success' }), llmRow({ status: 'failed', errorMessage: 'quota exceeded' })]);
+    prisma.apiCallLog.findMany.mockResolvedValue([apiRow({ status: 'success' })]);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.totals.calls).toBe(3);
+    expect(res.body.totals.success).toBe(2);
+    expect(res.body.totals.failures).toBe(1);
+    expect(res.body.totals.tokens).toBe(300); // 150 + 150 from the two llm rows, api rows contribute 0
+    expect(res.body.totals.cost).toBeCloseTo(0.001 + 0.001 + 0.015, 6);
+  });
+
+  test('stub LLM calls are EXCLUDED entirely from totals.calls/tokens/cost (never hit a real API, no real cost) and stubCalls is not a field on the response', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([
+      llmRow({ stub: true, totalTokens: 999, costEstimate: 5 }),
+      llmRow({ stub: false }),
+    ]);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.totals.calls).toBe(1); // only the real (non-stub) call
+    expect(res.body.totals.tokens).toBe(150); // the stub row's 999 tokens never counted
+    expect(res.body.totals.stubCalls).toBeUndefined(); // stub concept isn't surfaced on this dashboard at all
+  });
+
+  test('a provider/model that ONLY has stub rows produces zero byProvider/byModel entries (never hit a real API)', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([llmRow({ provider: 'anthropic', model: 'claude-opus-4-7', stub: true })]);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.byProvider.find((p) => p.provider === 'anthropic')).toBeUndefined();
+    expect(res.body.byModel.find((m) => m.model === 'claude-opus-4-7')).toBeUndefined();
+    expect(res.body.totals.calls).toBe(0);
+  });
+
+  test('byProvider breaks down calls/tokens/cost/failures per provider across both tables', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([llmRow({ provider: 'gemini' }), llmRow({ provider: 'openai', model: 'gpt-4o', totalTokens: 200, costEstimate: 0.01 })]);
+    prisma.apiCallLog.findMany.mockResolvedValue([apiRow({ provider: 'serpapi' })]);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    const byProvider = Object.fromEntries(res.body.byProvider.map((p) => [p.provider, p]));
+    expect(byProvider.gemini.calls).toBe(1);
+    expect(byProvider.openai.calls).toBe(1);
+    expect(byProvider.openai.tokens).toBe(200);
+    expect(byProvider.serpapi.calls).toBe(1);
+    expect(byProvider.serpapi.tokens).toBe(0);
+  });
+
+  test('byModel only reflects LlmCallLog rows (ApiCallLog has no model concept)', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([llmRow({ model: 'gemini-2.5-flash' })]);
+    prisma.apiCallLog.findMany.mockResolvedValue([apiRow()]);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.byModel).toHaveLength(1);
+    expect(res.body.byModel[0].model).toBe('gemini-2.5-flash');
+  });
+
+  test('recentFailures surfaces errorMessage, newest first, capped at 25', async () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      llmRow({ status: 'failed', errorMessage: `err-${i}`, createdAt: new Date(2026, 6, 1, 0, i) }),
+    );
+    prisma.llmCallLog.findMany.mockResolvedValue(many);
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.body.recentFailures).toHaveLength(25);
+    expect(res.body.recentFailures[0].errorMessage).toBe('err-29'); // newest first
+  });
+
+  test('DB error surfaces as 500, does not leak internals', async () => {
+    prisma.llmCallLog.findMany.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:3307'));
+    const res = await request(app).get('/api/super-admin/api-analytics/overview');
+    expect(res.status).toBe(500);
+    expect(res.body.error).not.toMatch(/ECONNREFUSED/);
+  });
+
+  test('?provider filters both underlying queries', async () => {
+    await request(app).get('/api/super-admin/api-analytics/overview?provider=gemini');
+    expect(prisma.llmCallLog.findMany.mock.calls[0][0].where.provider).toBe('gemini');
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.provider).toBe('gemini');
+  });
+
+  test('?model filters the LlmCallLog query and excludes ApiCallLog entirely', async () => {
+    await request(app).get('/api/super-admin/api-analytics/overview?model=gpt-4o');
+    expect(prisma.llmCallLog.findMany.mock.calls[0][0].where.model).toBe('gpt-4o');
+    // ApiCallLog has no `model` column — the route scopes it out via an
+    // unsatisfiable id filter rather than silently ignoring ?model=.
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.id).toBe(-1);
+  });
+
+  test('?provider + ?model combine (both applied to the LlmCallLog query)', async () => {
+    await request(app).get('/api/super-admin/api-analytics/overview?provider=openai&model=gpt-4o');
+    const llmWhere = prisma.llmCallLog.findMany.mock.calls[0][0].where;
+    expect(llmWhere.provider).toBe('openai');
+    expect(llmWhere.model).toBe('gpt-4o');
+  });
+});
+
+describe('GET /filters', () => {
+  let app;
+
+  beforeEach(() => {
+    prisma.llmCallLog.findMany.mockReset().mockResolvedValue([]);
+    prisma.apiCallLog.findMany.mockReset().mockResolvedValue([]);
+    app = buildApp();
+  });
+
+  test('returns distinct providers merged across both tables, sorted', async () => {
+    prisma.llmCallLog.findMany.mockImplementation((args) =>
+      args && args.select && args.select.provider
+        ? Promise.resolve([{ provider: 'openai' }, { provider: 'gemini' }])
+        : Promise.resolve([]),
+    );
+    prisma.apiCallLog.findMany.mockResolvedValue([{ provider: 'serpapi' }]);
+    const res = await request(app).get('/api/super-admin/api-analytics/filters');
+    expect(res.status).toBe(200);
+    expect(res.body.providers).toEqual(['gemini', 'openai', 'serpapi']);
+  });
+
+  test('returns distinct models from LlmCallLog only, sorted', async () => {
+    prisma.llmCallLog.findMany.mockImplementation((args) =>
+      args && args.select && args.select.model
+        ? Promise.resolve([{ model: 'gpt-4o' }, { model: 'gemini-flash' }])
+        : Promise.resolve([]),
+    );
+    const res = await request(app).get('/api/super-admin/api-analytics/filters');
+    expect(res.body.models).toEqual(['gemini-flash', 'gpt-4o']);
+  });
+
+  test('DB error surfaces as 500, does not leak internals', async () => {
+    prisma.llmCallLog.findMany.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:3307'));
+    const res = await request(app).get('/api/super-admin/api-analytics/filters');
+    expect(res.status).toBe(500);
+    expect(res.body.error).not.toMatch(/ECONNREFUSED/);
+  });
+
+  test('provider/model queries are scoped to stub:false — a stub-only provider never appears as a filter option', async () => {
+    await request(app).get('/api/super-admin/api-analytics/filters');
+    const providerCall = prisma.llmCallLog.findMany.mock.calls.find((c) => c[0].distinct?.[0] === 'provider');
+    const modelCall = prisma.llmCallLog.findMany.mock.calls.find((c) => c[0].distinct?.[0] === 'model');
+    expect(providerCall[0].where).toEqual({ stub: false });
+    expect(modelCall[0].where).toEqual({ stub: false });
+  });
+
+  test('?provider= scopes the model list to that provider only — prevents a mismatched (provider, model) pair', async () => {
+    prisma.llmCallLog.findMany.mockImplementation((args) => {
+      if (args && args.select && args.select.model) {
+        // Confirm the provider filter actually reached this query's where clause.
+        expect(args.where).toEqual({ stub: false, provider: 'openai' });
+        return Promise.resolve([{ model: 'gpt-4o' }, { model: 'gpt-4' }]);
+      }
+      return Promise.resolve([]);
+    });
+    const res = await request(app).get('/api/super-admin/api-analytics/filters?provider=openai');
+    expect(res.body.models).toEqual(['gpt-4', 'gpt-4o']);
+  });
+
+  test('no ?provider= -> model query has no provider constraint (all models across all providers)', async () => {
+    await request(app).get('/api/super-admin/api-analytics/filters');
+    const modelCall = prisma.llmCallLog.findMany.mock.calls.find((c) => c[0].distinct?.[0] === 'model');
+    expect(modelCall[0].where.provider).toBeUndefined();
+  });
+});
+
+describe('GET /calls', () => {
+  let app;
+
+  beforeEach(() => {
+    prisma.llmCallLog.findMany.mockReset().mockResolvedValue([]);
+    prisma.apiCallLog.findMany.mockReset().mockResolvedValue([]);
+    app = buildApp();
+  });
+
+  test('merges both tables, sorted by createdAt desc, tagged with source', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([llmRow({ id: 1, createdAt: new Date('2026-07-10T09:00:00Z') })]);
+    prisma.apiCallLog.findMany.mockResolvedValue([apiRow({ id: 1, createdAt: new Date('2026-07-10T10:00:00Z') })]);
+    const res = await request(app).get('/api/super-admin/api-analytics/calls');
+    expect(res.status).toBe(200);
+    expect(res.body.calls).toHaveLength(2);
+    expect(res.body.calls[0].source).toBe('api'); // newer row first
+    expect(res.body.calls[1].source).toBe('llm');
+  });
+
+  test('paginates the merged+sorted result set', async () => {
+    const rows = Array.from({ length: 5 }, (_, i) => llmRow({ id: i, createdAt: new Date(2026, 6, 1, 0, i) }));
+    prisma.llmCallLog.findMany.mockResolvedValue(rows);
+    const res = await request(app).get('/api/super-admin/api-analytics/calls?page=1&pageSize=2');
+    expect(res.body.calls).toHaveLength(2);
+    expect(res.body.total).toBe(5);
+  });
+
+  test('?provider filters both underlying queries', async () => {
+    await request(app).get('/api/super-admin/api-analytics/calls?provider=gemini');
+    expect(prisma.llmCallLog.findMany.mock.calls[0][0].where.provider).toBe('gemini');
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.provider).toBe('gemini');
+  });
+
+  test('?model filters the LlmCallLog query and excludes ApiCallLog entirely', async () => {
+    await request(app).get('/api/super-admin/api-analytics/calls?model=gemini-flash');
+    expect(prisma.llmCallLog.findMany.mock.calls[0][0].where.model).toBe('gemini-flash');
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.model).toBeUndefined();
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.id).toBe(-1);
+  });
+
+  test('?status=failed filters both underlying queries', async () => {
+    await request(app).get('/api/super-admin/api-analytics/calls?status=failed');
+    expect(prisma.llmCallLog.findMany.mock.calls[0][0].where.status).toBe('failed');
+    expect(prisma.apiCallLog.findMany.mock.calls[0][0].where.status).toBe('failed');
+  });
+
+  test('invalid ?from date -> 400 INVALID_DATE', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/calls?from=not-a-date');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DATE');
+  });
+
+  test('invalid ?to date -> 400 INVALID_DATE', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/calls?to=not-a-date');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DATE');
+  });
+});
+
+describe('GET/PUT /settings/log-retention', () => {
+  let app;
+
+  beforeEach(() => {
+    prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+    prisma.systemSetting.upsert.mockReset().mockResolvedValue({});
+    app = buildApp();
+  });
+
+  test('GET defaults to 30 when unset', async () => {
+    const res = await request(app).get('/api/super-admin/api-analytics/settings/log-retention');
+    expect(res.body.retainDays).toBe(30);
+  });
+
+  test('GET returns the persisted value when set', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '60' });
+    const res = await request(app).get('/api/super-admin/api-analytics/settings/log-retention');
+    expect(res.body.retainDays).toBe(60);
+  });
+
+  test('PUT validates 1-3650 range', async () => {
+    let res = await request(app).put('/api/super-admin/api-analytics/settings/log-retention').send({ retainDays: 0 });
+    expect(res.status).toBe(400);
+    res = await request(app).put('/api/super-admin/api-analytics/settings/log-retention').send({ retainDays: 3651 });
+    expect(res.status).toBe(400);
+  });
+
+  test('PUT upserts using the SAME SystemSetting key the retention cron reads', async () => {
+    const res = await request(app).put('/api/super-admin/api-analytics/settings/log-retention').send({ retainDays: 45 });
+    expect(res.status).toBe(200);
+    expect(res.body.retainDays).toBe(45);
+    expect(prisma.systemSetting.upsert.mock.calls[0][0].where).toEqual({ key: 'api_call_log_retention_days' });
+  });
+});

--- a/backend/test/routes/super-admin-auth.test.js
+++ b/backend/test/routes/super-admin-auth.test.js
@@ -1,0 +1,331 @@
+// @ts-check
+/**
+ * Unit tests for backend/routes/super_admin_auth.js + middleware/superAdminAuth.js.
+ *
+ * Super Admin auth is deliberately separate from the app's User/JWT system:
+ * env-based credentials only (SUPER_ADMIN_USERNAME + SUPER_ADMIN_PASSWORD_HASH
+ * or SUPER_ADMIN_PASSWORD_PLAINTEXT), a dedicated JWT secret
+ * (SUPER_ADMIN_JWT_SECRET, no dev fallback), no DB table for admins — only
+ * one auto-managed SystemSetting row for the promoted-from-plaintext hash.
+ *
+ * Pinned:
+ *   - isSuperAdminConfigured() false when username, JWT secret, or BOTH
+ *     credential vars are missing → /login and requireSuperAdmin both
+ *     respond 503 SUPER_ADMIN_NOT_CONFIGURED. True when either
+ *     SUPER_ADMIN_PASSWORD_HASH or SUPER_ADMIN_PASSWORD_PLAINTEXT is set.
+ *   - /login (hash path): missing username/password → 400; wrong username →
+ *     401 (and still runs a bcrypt.compare against a dummy hash,
+ *     timing-attack hardening); wrong password → 401; happy path → 200 +
+ *     signed JWT.
+ *   - /login (plaintext auto-hash + CHANGE flow): a real (non-placeholder)
+ *     SUPER_ADMIN_PASSWORD_PLAINTEXT is ALWAYS treated as "apply this as the
+ *     current password now" on every login attempt, whether or not a hash
+ *     already exists — this is what makes password CHANGE work (edit .env,
+ *     restart, log in), not just first-time bootstrap. On a correct login it
+ *     hashes + upserts (fully replacing any prior hash) + calls
+ *     redactPlaintextInEnvFile() to blank .env back to the placeholder, and
+ *     returns a "notice". Once the env var IS the placeholder (or unset),
+ *     no re-hash/redaction happens and login verifies against the existing
+ *     persisted hash silently (no notice).
+ *   - requireSuperAdmin: no Authorization header → 401 (+ WWW-Authenticate);
+ *     malformed/garbage token → 401; token signed with the WRONG secret → 401
+ *     (proves it's not reusing the app's JWT_SECRET); token missing role →
+ *     401; valid token → next() called, req.superAdmin populated.
+ *   - GET /me — returns the decoded username via requireSuperAdmin.
+ *   - POST /logout — requires a valid token, returns { ok: true } (stateless).
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import express from 'express';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+
+const TEST_SECRET = 'test-super-admin-secret-do-not-use-in-prod';
+const TEST_USERNAME = 'superadmin';
+let TEST_PASSWORD_HASH;
+
+// prisma is a singleton module (never deleted from require-cache below, same
+// as super-admin-cron.test.js) — monkey-patch systemSetting once up front so
+// getPersistedPasswordHash()/persistPromotedPasswordHash() never hit a real DB.
+import prisma from '../../lib/prisma.js';
+prisma.systemSetting = {
+  findUnique: vi.fn().mockResolvedValue(null),
+  upsert: vi.fn().mockResolvedValue({}),
+};
+
+// Real .env I/O must never run in a test — mock fs at the require-cache seam
+// so redactPlaintextInEnvFile() (required by super_admin_auth.js indirectly
+// via middleware/superAdminAuth.js) becomes a harmless no-op recorder.
+const Module = requireCJS('node:module');
+const fsMock = {
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(() => 'SUPER_ADMIN_PASSWORD_PLAINTEXT=whatever\n'),
+  writeFileSync: vi.fn(),
+};
+const fsPath = requireCJS.resolve('fs');
+const originalFsExports = Module._cache[fsPath] ? Module._cache[fsPath].exports : requireCJS('fs');
+Module._cache[fsPath] = { id: fsPath, filename: fsPath, loaded: true, exports: { ...originalFsExports, ...fsMock } };
+
+function freshApp() {
+  delete requireCJS.cache[requireCJS.resolve('../../config/secrets.js')];
+  delete requireCJS.cache[requireCJS.resolve('../../middleware/superAdminAuth.js')];
+  delete requireCJS.cache[requireCJS.resolve('../../routes/super_admin_auth.js')];
+  const router = requireCJS('../../routes/super_admin_auth.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/super-admin/auth', router);
+  return app;
+}
+
+describe('Super Admin auth — fully configured', () => {
+  let app;
+
+  beforeEach(async () => {
+    TEST_PASSWORD_HASH = await bcrypt.hash('correct-horse-battery-staple', 10);
+    process.env.SUPER_ADMIN_USERNAME = TEST_USERNAME;
+    process.env.SUPER_ADMIN_PASSWORD_HASH = TEST_PASSWORD_HASH;
+    process.env.SUPER_ADMIN_JWT_SECRET = TEST_SECRET;
+    prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+    prisma.systemSetting.upsert.mockReset().mockResolvedValue({});
+    app = freshApp();
+  });
+
+  afterEach(() => {
+    delete process.env.SUPER_ADMIN_USERNAME;
+    delete process.env.SUPER_ADMIN_PASSWORD_HASH;
+    delete process.env.SUPER_ADMIN_JWT_SECRET;
+  });
+
+  test('POST /login with missing username/password → 400', async () => {
+    const res = await request(app).post('/api/super-admin/auth/login').send({ username: TEST_USERNAME });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /login with wrong username → 401 (generic message, no enumeration)', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: 'not-the-admin', password: 'whatever' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid Super Admin credentials');
+  });
+
+  test('POST /login with correct username but wrong password → 401', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'wrong-password' });
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /login happy path → 200 + a JWT that decodes with role SUPER_ADMIN', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'correct-horse-battery-staple' });
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe(TEST_USERNAME);
+    expect(typeof res.body.token).toBe('string');
+
+    const decoded = jwt.verify(res.body.token, TEST_SECRET);
+    expect(decoded.role).toBe('SUPER_ADMIN');
+    expect(decoded.username).toBe(TEST_USERNAME);
+  });
+
+  test('GET /me with no Authorization header → 401', async () => {
+    const res = await request(app).get('/api/super-admin/auth/me');
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toBe('Bearer');
+  });
+
+  test('GET /me with a garbage token → 401', async () => {
+    const res = await request(app).get('/api/super-admin/auth/me').set('Authorization', 'Bearer not-a-real-jwt');
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /me with a token signed by the WRONG secret → 401 (not reusing app JWT_SECRET)', async () => {
+    const wrongToken = jwt.sign({ role: 'SUPER_ADMIN', username: TEST_USERNAME }, 'some-other-secret', { expiresIn: '1h' });
+    const res = await request(app).get('/api/super-admin/auth/me').set('Authorization', `Bearer ${wrongToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /me with a token missing role:SUPER_ADMIN → 401', async () => {
+    const noRoleToken = jwt.sign({ username: TEST_USERNAME }, TEST_SECRET, { expiresIn: '1h' });
+    const res = await request(app).get('/api/super-admin/auth/me').set('Authorization', `Bearer ${noRoleToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /me with a valid token → 200 + username', async () => {
+    const loginRes = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'correct-horse-battery-staple' });
+    const res = await request(app).get('/api/super-admin/auth/me').set('Authorization', `Bearer ${loginRes.body.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ username: TEST_USERNAME, role: 'SUPER_ADMIN' });
+  });
+
+  test('POST /logout with a valid token → 200 { ok: true }', async () => {
+    const loginRes = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'correct-horse-battery-staple' });
+    const res = await request(app).post('/api/super-admin/auth/logout').set('Authorization', `Bearer ${loginRes.body.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  test('POST /logout without a token → 401', async () => {
+    const res = await request(app).post('/api/super-admin/auth/logout');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Super Admin auth — auto-hash-on-first-login + password change (SUPER_ADMIN_PASSWORD_PLAINTEXT)', () => {
+  let app;
+  const TEST_PLAINTEXT = 'first-login-plaintext-pw';
+  const PLACEHOLDER = '<hashed — edit this value to change the password>';
+
+  beforeEach(() => {
+    process.env.SUPER_ADMIN_USERNAME = TEST_USERNAME;
+    process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT = TEST_PLAINTEXT;
+    delete process.env.SUPER_ADMIN_PASSWORD_HASH;
+    process.env.SUPER_ADMIN_JWT_SECRET = TEST_SECRET;
+    prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+    prisma.systemSetting.upsert.mockReset().mockResolvedValue({});
+    fsMock.existsSync.mockReset().mockReturnValue(true);
+    fsMock.readFileSync.mockReset().mockReturnValue('SUPER_ADMIN_PASSWORD_PLAINTEXT=whatever\n');
+    fsMock.writeFileSync.mockReset();
+    app = freshApp();
+  });
+
+  afterEach(() => {
+    delete process.env.SUPER_ADMIN_USERNAME;
+    delete process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT;
+    delete process.env.SUPER_ADMIN_PASSWORD_HASH;
+    delete process.env.SUPER_ADMIN_JWT_SECRET;
+  });
+
+  test('isSuperAdminConfigured() is true with only PLAINTEXT set (no HASH)', async () => {
+    // Configured means /login doesn't 503 — proven indirectly via a real request below.
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'wrong' });
+    expect(res.status).not.toBe(503);
+  });
+
+  test('wrong password against plaintext-only config → 401, no hash persisted, .env not touched', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'not-it' });
+    expect(res.status).toBe(401);
+    expect(prisma.systemSetting.upsert).not.toHaveBeenCalled();
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  test('correct password against plaintext config → 200 + JWT + notice, persists a hash, redacts .env', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: TEST_PLAINTEXT });
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe(TEST_USERNAME);
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.notice).toMatch(/updated from \.env|cleared from \.env/i);
+
+    const decoded = jwt.verify(res.body.token, TEST_SECRET);
+    expect(decoded.role).toBe('SUPER_ADMIN');
+
+    expect(prisma.systemSetting.upsert).toHaveBeenCalledTimes(1);
+    const upsertArgs = prisma.systemSetting.upsert.mock.calls[0][0];
+    expect(upsertArgs.where).toEqual({ key: 'super_admin_password_hash' });
+    expect(upsertArgs.create.value).not.toBe(TEST_PLAINTEXT);
+    await expect(bcrypt.compare(TEST_PLAINTEXT, upsertArgs.create.value)).resolves.toBe(true);
+
+    // .env was rewritten to the placeholder, not left holding the real password.
+    expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
+    const writtenContent = fsMock.writeFileSync.mock.calls[0][1];
+    expect(writtenContent).not.toContain(TEST_PLAINTEXT);
+    expect(writtenContent).toContain(PLACEHOLDER);
+  });
+
+  test('once the env var IS the placeholder, login verifies silently against the persisted hash — no re-hash, no notice, .env not touched again', async () => {
+    const persistedHash = await bcrypt.hash(TEST_PLAINTEXT, 10);
+    prisma.systemSetting.findUnique.mockResolvedValue({ key: 'super_admin_password_hash', value: persistedHash });
+    process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT = PLACEHOLDER; // what .env looks like after the redaction above
+
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: TEST_PLAINTEXT });
+    expect(res.status).toBe(200);
+    expect(res.body.notice).toBeUndefined();
+    expect(prisma.systemSetting.upsert).not.toHaveBeenCalled();
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  test('PASSWORD CHANGE: logging in with the OLD password after .env was changed to a new value still succeeds against the untouched old hash, and does NOT trigger a re-hash (the submission must match the new plaintext to trigger a change)', async () => {
+    const oldHash = await bcrypt.hash('the-old-password', 10);
+    prisma.systemSetting.findUnique.mockResolvedValue({ key: 'super_admin_password_hash', value: oldHash });
+    process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT = 'brand-new-changed-password'; // operator edited .env to set a new password, but hasn't logged in with it yet
+
+    const oldRes = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: 'the-old-password' });
+    // The old password doesn't match the pending new plaintext, so no change
+    // is triggered — the OLD hash is still what's checked, and it still works
+    // until someone actually logs in with the new password.
+    expect(oldRes.status).toBe(200);
+    expect(oldRes.body.notice).toBeUndefined();
+    expect(prisma.systemSetting.upsert).not.toHaveBeenCalled();
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  test('PASSWORD CHANGE: logging in with the NEW password succeeds and redacts .env again', async () => {
+    const oldHash = await bcrypt.hash('the-old-password', 10);
+    prisma.systemSetting.findUnique.mockResolvedValue({ key: 'super_admin_password_hash', value: oldHash });
+    const NEW_PASSWORD = 'brand-new-changed-password';
+    process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT = NEW_PASSWORD;
+
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: TEST_USERNAME, password: NEW_PASSWORD });
+    expect(res.status).toBe(200);
+    expect(res.body.notice).toMatch(/updated from \.env|cleared from \.env/i);
+    expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  test('wrong username still runs a decoy bcrypt.compare (timing-attack hardening) even with a pending plaintext change', async () => {
+    process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT = 'some-new-password';
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: 'not-the-admin', password: 'whatever' });
+    expect(res.status).toBe(401);
+    // Wrong username short-circuits BEFORE the plaintext-change logic runs —
+    // no hash should be replaced from a request that never even matched the username.
+    expect(prisma.systemSetting.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('Super Admin auth — NOT configured (missing env vars)', () => {
+  let app;
+
+  beforeEach(() => {
+    delete process.env.SUPER_ADMIN_USERNAME;
+    delete process.env.SUPER_ADMIN_PASSWORD_HASH;
+    delete process.env.SUPER_ADMIN_PASSWORD_PLAINTEXT;
+    delete process.env.SUPER_ADMIN_JWT_SECRET;
+    app = freshApp();
+  });
+
+  test('POST /login → 503 SUPER_ADMIN_NOT_CONFIGURED', async () => {
+    const res = await request(app)
+      .post('/api/super-admin/auth/login')
+      .send({ username: 'x', password: 'y' });
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('SUPER_ADMIN_NOT_CONFIGURED');
+  });
+
+  test('GET /me → 503 SUPER_ADMIN_NOT_CONFIGURED (guard fires before token check)', async () => {
+    const res = await request(app).get('/api/super-admin/auth/me').set('Authorization', 'Bearer anything');
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('SUPER_ADMIN_NOT_CONFIGURED');
+  });
+});

--- a/backend/test/routes/super-admin-cron-analytics.test.js
+++ b/backend/test/routes/super-admin-cron-analytics.test.js
@@ -1,0 +1,129 @@
+// @ts-check
+/**
+ * Unit tests for backend/routes/super_admin_cron_analytics.js — Cron
+ * Analytics module (Super Admin Portal). Read-only aggregation over
+ * CronExecutionLog powering the charts on /super-admin/cron-analytics.
+ *
+ * Mocking strategy: prisma singleton monkey-patch (cronExecutionLog) + a
+ * fake req.superAdmin injected ahead of the router — same pattern as
+ * test/routes/super-admin-cron.test.js.
+ *
+ * Pinned:
+ *   GET /overview — days query clamps to [1, 90], defaults to 14; totals
+ *     (runs/success/failed/running) computed correctly; byDay buckets by
+ *     calendar day; perCron summarizes runs/failures/avgDurationMs per
+ *     cron name, sorted by run count descending.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import prisma from '../../lib/prisma.js';
+prisma.cronExecutionLog = { findMany: vi.fn() };
+
+const router = (await import('../../routes/super_admin_cron_analytics.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.superAdmin = { username: 'superadmin' };
+    next();
+  });
+  app.use('/api/super-admin/cron-analytics', router);
+  return app;
+}
+
+function log(overrides = {}) {
+  return {
+    cronName: 'testEngine',
+    startedAt: new Date('2026-07-10T10:00:00Z'),
+    durationMs: 100,
+    status: 'success',
+    ...overrides,
+  };
+}
+
+describe('GET /overview', () => {
+  let app;
+
+  beforeEach(() => {
+    prisma.cronExecutionLog.findMany.mockReset().mockResolvedValue([]);
+    app = buildApp();
+  });
+
+  test('defaults to 14 days when ?days is omitted', async () => {
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.status).toBe(200);
+    expect(res.body.days).toBe(14);
+  });
+
+  test('clamps ?days above 90 down to 90', async () => {
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview?days=500');
+    expect(res.body.days).toBe(90);
+  });
+
+  test('non-numeric ?days falls back to the 14-day default', async () => {
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview?days=garbage');
+    expect(res.body.days).toBe(14);
+  });
+
+  test('totals count success/failed/running correctly', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([
+      log({ status: 'success' }),
+      log({ status: 'success' }),
+      log({ status: 'failed' }),
+      log({ status: 'running' }),
+    ]);
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.body.totals).toEqual({ runs: 4, success: 2, failed: 1, running: 1 });
+  });
+
+  test('byDay buckets logs by calendar day (UTC)', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([
+      log({ startedAt: new Date('2026-07-10T01:00:00Z'), status: 'success' }),
+      log({ startedAt: new Date('2026-07-10T23:00:00Z'), status: 'failed' }),
+      log({ startedAt: new Date('2026-07-11T05:00:00Z'), status: 'success' }),
+    ]);
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.body.byDay).toEqual([
+      { date: '2026-07-10', success: 1, failed: 1, running: 0, total: 2 },
+      { date: '2026-07-11', success: 1, failed: 0, running: 0, total: 1 },
+    ]);
+  });
+
+  test('perCron summarizes runs/failures/avgDurationMs per cron, sorted by run count desc', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([
+      log({ cronName: 'busyEngine', durationMs: 100, status: 'success' }),
+      log({ cronName: 'busyEngine', durationMs: 200, status: 'failed' }),
+      log({ cronName: 'quietEngine', durationMs: 50, status: 'success' }),
+    ]);
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.body.perCron).toEqual([
+      { cronName: 'busyEngine', runs: 2, failures: 1, avgDurationMs: 150 },
+      { cronName: 'quietEngine', runs: 1, failures: 0, avgDurationMs: 50 },
+    ]);
+  });
+
+  test('perCron avgDurationMs is null when no log for that cron has a durationMs', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([log({ durationMs: null, status: 'running' })]);
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.body.perCron[0].avgDurationMs).toBeNull();
+  });
+
+  test('empty log set returns zeroed totals and empty arrays, not an error', async () => {
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.status).toBe(200);
+    expect(res.body.totals).toEqual({ runs: 0, success: 0, failed: 0, running: 0 });
+    expect(res.body.byDay).toEqual([]);
+    expect(res.body.perCron).toEqual([]);
+  });
+
+  test('DB error surfaces as 500, does not leak internals', async () => {
+    prisma.cronExecutionLog.findMany.mockRejectedValue(new Error('connection reset'));
+    const res = await request(app).get('/api/super-admin/cron-analytics/overview');
+    expect(res.status).toBe(500);
+    expect(res.body.error).not.toMatch(/connection reset/);
+  });
+});

--- a/backend/test/routes/super-admin-cron.test.js
+++ b/backend/test/routes/super-admin-cron.test.js
@@ -1,0 +1,489 @@
+// @ts-check
+/**
+ * Unit tests for backend/routes/super_admin_cron.js — Cron Maintenance
+ * module (Super Admin Portal).
+ *
+ * Mocking strategy: prisma singleton monkey-patch (cronConfig,
+ * cronExecutionLog, systemSetting) + a fake req.superAdmin injected ahead
+ * of the router (mirrors how server.js mounts requireSuperAdmin before this
+ * router — we bypass the real middleware here and inject the identity
+ * directly, since the auth contract itself is pinned in
+ * super-admin-auth.test.js). lib/cronRegistry and lib/cronDynamicHandlers
+ * are mocked via the require-cache-injection CJS seam (same pattern as
+ * test/cron/marketplaceEngine.test.js) since this route calls their real
+ * functions directly, not through DI.
+ *
+ * Pinned:
+ *   GET /crons — lists all CronConfig rows, decorated with
+ *     isRegisteredInProcess + lastExecutionAt/lastStatus from the newest log.
+ *   GET /crons/:name — 404 on unknown name.
+ *   POST /crons — validates name/schedule/handlerKey/metadataJson; 409 on
+ *     duplicate name; happy path creates isSystem:false + registers live.
+ *   PUT /crons/:name — 403 SYSTEM_CRON_READONLY for isSystem:true rows;
+ *     404 on unknown; happy path updates + re-registers.
+ *   DELETE /crons/:name — 403 SYSTEM_CRON_PROTECTED for isSystem:true;
+ *     404 on unknown; happy path unregisters + deletes.
+ *   POST /crons/:name/enable + /disable — 404 on unknown; happy path
+ *     updates enabled + calls applyConfig for live effect.
+ *   PUT /crons/:name/schedule — 400 on invalid cron expression; happy
+ *     path updates schedule + calls applyConfig.
+ *   POST /crons/:name/run-now — 409 if not currently registered in this
+ *     process; happy path calls runTick with triggerType "manual".
+ *   GET /logs — pagination + cronName/status/date-range/search filters.
+ *   GET /logs/:id — 400 on non-numeric id; 404 on unknown.
+ *   DELETE /logs/:id — 404 on unknown; happy path deletes.
+ *   POST /logs/clear — scoped-by-cronName vs clear-all.
+ *   GET/PUT /settings/log-retention — default 30 when unset; validates
+ *     1-3650 range; upserts on PUT.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+// ── Mock prisma BEFORE requiring SUT ───────────────────────────────────
+import prisma from '../../lib/prisma.js';
+prisma.cronConfig = {
+  findMany: vi.fn(),
+  findUnique: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+prisma.cronExecutionLog = {
+  findMany: vi.fn(),
+  count: vi.fn(),
+  findUnique: vi.fn(),
+  delete: vi.fn(),
+  deleteMany: vi.fn(),
+};
+prisma.systemSetting = {
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+};
+
+// ── Fake cronRegistry + cronDynamicHandlers in the require cache ──────
+const registryMock = {
+  listRegistered: vi.fn(() => []),
+  isValidExpression: vi.fn((expr) => /^(\S+\s+){4}\S+$/.test(String(expr || '').trim())),
+  register: vi.fn().mockResolvedValue({}),
+  applyConfig: vi.fn().mockResolvedValue({ ok: true }),
+  unregister: vi.fn(() => ({ ok: true })),
+  isRegistered: vi.fn(() => true),
+  runTick: vi.fn().mockResolvedValue({ status: 'success', durationMs: 5, errorMessage: null }),
+};
+const registryPath = requireCJS.resolve('../../lib/cronRegistry.js');
+Module._cache[registryPath] = { id: registryPath, filename: registryPath, loaded: true, exports: registryMock };
+
+const handlersMock = {
+  isValidHandlerKey: vi.fn((k) => ['http_webhook_ping', 'log_note'].includes(k)),
+  VALID_HANDLER_KEYS: ['http_webhook_ping', 'log_note'],
+  getHandlerCatalog: vi.fn(() => [
+    { key: 'http_webhook_ping', label: 'HTTP Webhook Ping', description: 'Pings a URL', metadataSchema: {} },
+    { key: 'log_note', label: 'Log Note', description: 'Logs a message', metadataSchema: {} },
+  ]),
+  buildDynamicTickFn: vi.fn(() => vi.fn()),
+};
+const handlersPath = requireCJS.resolve('../../lib/cronDynamicHandlers.js');
+Module._cache[handlersPath] = { id: handlersPath, filename: handlersPath, loaded: true, exports: handlersMock };
+
+const router = requireCJS('../../routes/super_admin_cron.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.superAdmin = { username: 'superadmin' };
+    next();
+  });
+  app.use('/api/super-admin/cron', router);
+  return app;
+}
+
+const app = buildApp();
+
+beforeEach(() => {
+  prisma.cronConfig.findMany.mockReset().mockResolvedValue([]);
+  prisma.cronConfig.findUnique.mockReset().mockResolvedValue(null);
+  prisma.cronConfig.create.mockReset();
+  prisma.cronConfig.update.mockReset();
+  prisma.cronConfig.delete.mockReset().mockResolvedValue({});
+  prisma.cronExecutionLog.findMany.mockReset().mockResolvedValue([]);
+  prisma.cronExecutionLog.count.mockReset().mockResolvedValue(0);
+  prisma.cronExecutionLog.findUnique.mockReset().mockResolvedValue(null);
+  prisma.cronExecutionLog.delete.mockReset().mockResolvedValue({});
+  prisma.cronExecutionLog.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+  prisma.systemSetting.findUnique.mockReset().mockResolvedValue(null);
+  prisma.systemSetting.upsert.mockReset();
+
+  registryMock.listRegistered.mockReset().mockReturnValue([]);
+  registryMock.isValidExpression.mockClear();
+  registryMock.register.mockReset().mockResolvedValue({});
+  registryMock.applyConfig.mockReset().mockResolvedValue({ ok: true });
+  registryMock.unregister.mockReset().mockReturnValue({ ok: true });
+  registryMock.isRegistered.mockReset().mockReturnValue(true);
+  registryMock.runTick.mockReset().mockResolvedValue({ status: 'success', durationMs: 5, errorMessage: null });
+});
+
+describe('GET /crons', () => {
+  test('lists crons decorated with isRegisteredInProcess + last execution info', async () => {
+    prisma.cronConfig.findMany.mockResolvedValue([
+      {
+        id: 1, name: 'leadScoringEngine', schedule: '*/10 * * * *', enabled: true, isSystem: true,
+        logs: [{ startedAt: new Date('2026-07-13T10:00:00Z'), status: 'success' }],
+      },
+    ]);
+    registryMock.listRegistered.mockReturnValue([{ name: 'leadScoringEngine' }]);
+
+    const res = await request(app).get('/api/super-admin/cron/crons');
+    expect(res.status).toBe(200);
+    expect(res.body.crons).toHaveLength(1);
+    expect(res.body.crons[0]).toMatchObject({
+      name: 'leadScoringEngine',
+      isRegisteredInProcess: true,
+      lastStatus: 'success',
+    });
+    expect(res.body.crons[0].logs).toBeUndefined(); // raw relation stripped
+  });
+});
+
+describe('GET /cron-handlers', () => {
+  test('returns the handler catalog from lib/cronDynamicHandlers', async () => {
+    const res = await request(app).get('/api/super-admin/cron/cron-handlers');
+    expect(res.status).toBe(200);
+    expect(res.body.handlers).toHaveLength(2);
+    expect(res.body.handlers[0]).toMatchObject({ key: 'http_webhook_ping', label: 'HTTP Webhook Ping' });
+  });
+});
+
+describe('GET /crons/:name', () => {
+  test('404 on unknown name', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/super-admin/cron/crons/does-not-exist');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('CRON_NOT_FOUND');
+  });
+
+  test('200 with the cron on happy path', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'foo', schedule: '* * * * *', enabled: true });
+    const res = await request(app).get('/api/super-admin/cron/crons/foo');
+    expect(res.status).toBe(200);
+    expect(res.body.cron.name).toBe('foo');
+  });
+});
+
+describe('POST /crons (create dynamic cron)', () => {
+  test('400 on invalid name', async () => {
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'has spaces!', schedule: '* * * * *', handlerKey: 'log_note',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_NAME');
+  });
+
+  test('400 on invalid schedule', async () => {
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'myCron', schedule: 'garbage', handlerKey: 'log_note',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SCHEDULE');
+  });
+
+  test('400 on invalid handlerKey', async () => {
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'myCron', schedule: '* * * * *', handlerKey: 'delete_everything',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_HANDLER_KEY');
+  });
+
+  test('400 on malformed metadataJson', async () => {
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'myCron', schedule: '* * * * *', handlerKey: 'log_note', metadataJson: '{not json',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_METADATA_JSON');
+  });
+
+  test('409 when name already exists', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 5, name: 'myCron' });
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'myCron', schedule: '* * * * *', handlerKey: 'log_note',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CRON_NAME_TAKEN');
+  });
+
+  test('happy path creates isSystem:false + registers live immediately', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    prisma.cronConfig.create.mockResolvedValue({
+      id: 10, name: 'myCron', schedule: '* * * * *', enabled: true, isSystem: false, handlerKey: 'log_note',
+    });
+
+    const res = await request(app).post('/api/super-admin/cron/crons').send({
+      name: 'myCron', description: 'test', schedule: '* * * * *', handlerKey: 'log_note',
+    });
+
+    expect(res.status).toBe(201);
+    expect(prisma.cronConfig.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: 'myCron', isSystem: false, createdBy: 'superadmin' }),
+      }),
+    );
+    expect(registryMock.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'myCron', defaultSchedule: '* * * * *' }),
+    );
+  });
+});
+
+describe('PUT /crons/:name', () => {
+  test('404 on unknown name', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    const res = await request(app).put('/api/super-admin/cron/crons/nope').send({ description: 'x' });
+    expect(res.status).toBe(404);
+  });
+
+  test('403 SYSTEM_CRON_READONLY for isSystem:true rows', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'leadScoringEngine', isSystem: true });
+    const res = await request(app).put('/api/super-admin/cron/crons/leadScoringEngine').send({ description: 'x' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('SYSTEM_CRON_READONLY');
+  });
+
+  test('happy path updates a dynamic cron + re-registers', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 10, name: 'myCron', isSystem: false, schedule: '* * * * *' });
+    prisma.cronConfig.update.mockResolvedValue({
+      id: 10, name: 'myCron', isSystem: false, schedule: '* * * * *', handlerKey: 'log_note', metadataJson: null, description: 'updated',
+    });
+
+    const res = await request(app).put('/api/super-admin/cron/crons/myCron').send({ description: 'updated' });
+    expect(res.status).toBe(200);
+    expect(res.body.cron.description).toBe('updated');
+    expect(registryMock.applyConfig).toHaveBeenCalledWith('myCron');
+  });
+});
+
+describe('DELETE /crons/:name', () => {
+  test('404 on unknown name', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete('/api/super-admin/cron/crons/nope');
+    expect(res.status).toBe(404);
+  });
+
+  test('403 SYSTEM_CRON_PROTECTED for isSystem:true rows', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'leadScoringEngine', isSystem: true });
+    const res = await request(app).delete('/api/super-admin/cron/crons/leadScoringEngine');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('SYSTEM_CRON_PROTECTED');
+    expect(prisma.cronConfig.delete).not.toHaveBeenCalled();
+  });
+
+  test('happy path unregisters + deletes a dynamic cron', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 10, name: 'myCron', isSystem: false });
+    const res = await request(app).delete('/api/super-admin/cron/crons/myCron');
+    expect(res.status).toBe(200);
+    expect(registryMock.unregister).toHaveBeenCalledWith('myCron');
+    expect(prisma.cronConfig.delete).toHaveBeenCalledWith({ where: { name: 'myCron' } });
+  });
+});
+
+describe('POST /crons/:name/enable + /disable', () => {
+  test('enable: 404 on unknown', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    const res = await request(app).post('/api/super-admin/cron/crons/nope/enable');
+    expect(res.status).toBe(404);
+  });
+
+  test('enable: happy path flips enabled:true + calls applyConfig for live effect', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'foo', enabled: false });
+    prisma.cronConfig.update.mockResolvedValue({ id: 1, name: 'foo', enabled: true });
+    const res = await request(app).post('/api/super-admin/cron/crons/foo/enable');
+    expect(res.status).toBe(200);
+    expect(prisma.cronConfig.update).toHaveBeenCalledWith({ where: { name: 'foo' }, data: { enabled: true } });
+    expect(registryMock.applyConfig).toHaveBeenCalledWith('foo');
+  });
+
+  test('disable: happy path flips enabled:false', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'foo', enabled: true });
+    prisma.cronConfig.update.mockResolvedValue({ id: 1, name: 'foo', enabled: false });
+    const res = await request(app).post('/api/super-admin/cron/crons/foo/disable');
+    expect(res.status).toBe(200);
+    expect(prisma.cronConfig.update).toHaveBeenCalledWith({ where: { name: 'foo' }, data: { enabled: false } });
+  });
+});
+
+describe('PUT /crons/:name/schedule', () => {
+  test('400 on invalid cron expression', async () => {
+    const res = await request(app).put('/api/super-admin/cron/crons/foo/schedule').send({ schedule: 'garbage' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_SCHEDULE');
+  });
+
+  test('404 on unknown cron', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue(null);
+    const res = await request(app).put('/api/super-admin/cron/crons/nope/schedule').send({ schedule: '*/5 * * * *' });
+    expect(res.status).toBe(404);
+  });
+
+  test('happy path updates schedule + calls applyConfig (live reschedule)', async () => {
+    prisma.cronConfig.findUnique.mockResolvedValue({ id: 1, name: 'foo', schedule: '* * * * *' });
+    prisma.cronConfig.update.mockResolvedValue({ id: 1, name: 'foo', schedule: '*/5 * * * *' });
+    const res = await request(app).put('/api/super-admin/cron/crons/foo/schedule').send({ schedule: '*/5 * * * *' });
+    expect(res.status).toBe(200);
+    expect(res.body.cron.schedule).toBe('*/5 * * * *');
+    expect(registryMock.applyConfig).toHaveBeenCalledWith('foo');
+  });
+});
+
+describe('POST /crons/:name/run-now', () => {
+  test('409 when not currently registered in this process', async () => {
+    registryMock.isRegistered.mockReturnValue(false);
+    const res = await request(app).post('/api/super-admin/cron/crons/foo/run-now');
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CRON_NOT_REGISTERED');
+  });
+
+  test('happy path calls runTick with triggerType manual', async () => {
+    registryMock.isRegistered.mockReturnValue(true);
+    const res = await request(app).post('/api/super-admin/cron/crons/foo/run-now');
+    expect(res.status).toBe(200);
+    expect(registryMock.runTick).toHaveBeenCalledWith('foo', 'manual');
+    expect(res.body.result.status).toBe('success');
+  });
+});
+
+describe('GET /logs', () => {
+  test('applies cronName/status/date-range/search filters + pagination', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([{ id: 1, cronName: 'foo', status: 'success' }]);
+    prisma.cronExecutionLog.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/super-admin/cron/logs').query({
+      cronName: 'foo', status: 'success', from: '2026-01-01', to: '2026-12-31', search: 'boom', page: '2', pageSize: '10',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.page).toBe(2);
+    expect(res.body.pageSize).toBe(10);
+    const call = prisma.cronExecutionLog.findMany.mock.calls[0][0];
+    expect(call.where.cronName).toBe('foo');
+    expect(call.where.status).toBe('success');
+    expect(call.where.startedAt.gte).toBeInstanceOf(Date);
+    expect(call.where.startedAt.lte).toBeInstanceOf(Date);
+    expect(call.where.OR).toEqual([
+      { cronName: { contains: 'boom' } },
+      { errorMessage: { contains: 'boom' } },
+    ]);
+    expect(call.skip).toBe(10); // (page 2 - 1) * pageSize 10
+  });
+
+  test('400 on invalid `from` date', async () => {
+    const res = await request(app).get('/api/super-admin/cron/logs').query({ from: 'not-a-date' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DATE');
+  });
+
+  test('pageSize is clamped to a max of 200', async () => {
+    prisma.cronExecutionLog.findMany.mockResolvedValue([]);
+    prisma.cronExecutionLog.count.mockResolvedValue(0);
+    const res = await request(app).get('/api/super-admin/cron/logs').query({ pageSize: '99999' });
+    expect(res.status).toBe(200);
+    expect(res.body.pageSize).toBe(200);
+  });
+});
+
+describe('GET /logs/:id', () => {
+  test('400 on non-numeric id', async () => {
+    const res = await request(app).get('/api/super-admin/cron/logs/abc');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_ID');
+  });
+
+  test('404 on unknown id', async () => {
+    prisma.cronExecutionLog.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/super-admin/cron/logs/999');
+    expect(res.status).toBe(404);
+  });
+
+  test('200 happy path', async () => {
+    prisma.cronExecutionLog.findUnique.mockResolvedValue({ id: 5, cronName: 'foo' });
+    const res = await request(app).get('/api/super-admin/cron/logs/5');
+    expect(res.status).toBe(200);
+    expect(res.body.log.id).toBe(5);
+  });
+});
+
+describe('DELETE /logs/:id', () => {
+  test('404 on unknown id', async () => {
+    prisma.cronExecutionLog.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete('/api/super-admin/cron/logs/999');
+    expect(res.status).toBe(404);
+  });
+
+  test('happy path deletes', async () => {
+    prisma.cronExecutionLog.findUnique.mockResolvedValue({ id: 5 });
+    const res = await request(app).delete('/api/super-admin/cron/logs/5');
+    expect(res.status).toBe(200);
+    expect(prisma.cronExecutionLog.delete).toHaveBeenCalledWith({ where: { id: 5 } });
+  });
+});
+
+describe('POST /logs/clear', () => {
+  test('scoped to a single cronName', async () => {
+    prisma.cronExecutionLog.deleteMany.mockResolvedValue({ count: 3 });
+    const res = await request(app).post('/api/super-admin/cron/logs/clear').send({ cronName: 'foo' });
+    expect(res.status).toBe(200);
+    expect(res.body.deletedCount).toBe(3);
+    expect(prisma.cronExecutionLog.deleteMany).toHaveBeenCalledWith({ where: { cronName: 'foo' } });
+  });
+
+  test('clears ALL logs when no cronName given', async () => {
+    prisma.cronExecutionLog.deleteMany.mockResolvedValue({ count: 100 });
+    const res = await request(app).post('/api/super-admin/cron/logs/clear').send({});
+    expect(res.status).toBe(200);
+    expect(prisma.cronExecutionLog.deleteMany).toHaveBeenCalledWith({ where: {} });
+  });
+});
+
+describe('GET/PUT /settings/log-retention', () => {
+  test('GET returns default 30 when no setting row exists', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/super-admin/cron/settings/log-retention');
+    expect(res.status).toBe(200);
+    expect(res.body.retainDays).toBe(30);
+  });
+
+  test('GET returns the persisted value when a row exists', async () => {
+    prisma.systemSetting.findUnique.mockResolvedValue({ value: '90' });
+    const res = await request(app).get('/api/super-admin/cron/settings/log-retention');
+    expect(res.body.retainDays).toBe(90);
+  });
+
+  test('PUT rejects out-of-range values', async () => {
+    const res = await request(app).put('/api/super-admin/cron/settings/log-retention').send({ retainDays: 9999 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_RETENTION_DAYS');
+  });
+
+  test('PUT rejects non-integer values', async () => {
+    const res = await request(app).put('/api/super-admin/cron/settings/log-retention').send({ retainDays: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  test('PUT upserts with the super admin username', async () => {
+    prisma.systemSetting.upsert.mockResolvedValue({ value: '60' });
+    const res = await request(app).put('/api/super-admin/cron/settings/log-retention').send({ retainDays: 60 });
+    expect(res.status).toBe(200);
+    expect(res.body.retainDays).toBe(60);
+    expect(prisma.systemSetting.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: 'cron_log_retention_days' },
+        update: expect.objectContaining({ value: '60', updatedBy: 'superadmin' }),
+      }),
+    );
+  });
+});

--- a/backend/test/routes/travel_personalised_destinations.test.js
+++ b/backend/test/routes/travel_personalised_destinations.test.js
@@ -52,10 +52,10 @@ const JWT_SECRET = process.env.JWT_SECRET || 'enterprise_super_secret_key_2026';
 // here mirrors backend/test/lib/llmRouter.test.js's prismaMock approach.
 const llmRouterMock = {
   routeRequest: vi.fn().mockResolvedValue({
-    text: '[STUB-REASONING] Reasoning output (synthetic). Real Claude/GPT lands when Q11 keys arrive.',
+    text: '[STUB-REASONING] Reasoning output (synthetic). Real Gemini Flash/GPT lands when Q11 keys arrive.',
     finishReason: 'stop',
     usage: { promptTokens: 42, completionTokens: 24, totalTokens: 66 },
-    model: 'claude-opus-4-7',
+    model: 'gemini-flash',
     stub: true,
   }),
 };
@@ -111,10 +111,10 @@ beforeEach(() => {
   // test starts from a known-happy router. Cases that need a different
   // router behaviour (errors, budget-cap) override per case.
   llmRouterMock.routeRequest.mockResolvedValue({
-    text: '[STUB-REASONING] Reasoning output (synthetic). Real Claude/GPT lands when Q11 keys arrive.',
+    text: '[STUB-REASONING] Reasoning output (synthetic). Real Gemini Flash/GPT lands when Q11 keys arrive.',
     finishReason: 'stop',
     usage: { promptTokens: 42, completionTokens: 24, totalTokens: 66 },
-    model: 'claude-opus-4-7',
+    model: 'gemini-flash',
     stub: true,
   });
 });
@@ -159,7 +159,7 @@ describe('happy path — stub-mode envelope shape', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       text: expect.stringContaining('[STUB-REASONING]'),
-      model: 'claude-opus-4-7',
+      model: 'gemini-flash',
       stub: true,
       finishReason: 'stop',
       destinations: null,

--- a/backend/test/scripts/backfill-llm-call-log-provider-cost.test.js
+++ b/backend/test/scripts/backfill-llm-call-log-provider-cost.test.js
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for backend/scripts/backfill-llm-call-log-provider-cost.js —
+ * one-time backfill for LlmCallLog rows written before provider/cost
+ * estimation existed (they're frozen at provider:"unknown", costEstimate:0).
+ *
+ * Pinned:
+ *   - Only rows with provider:"unknown" are read/touched (idempotent).
+ *   - provider is inferred from `model` via lib/apiPricing.js's inferProvider.
+ *   - Non-stub rows get a real costEstimate computed from their token counts.
+ *   - Stub rows are backfilled with the correct provider but costEstimate
+ *     stays 0 (no real API call was made, so there's no real cost).
+ *   - --dry-run makes zero writes but still reports what WOULD change.
+ *   - No rows to backfill -> returns {updated: 0, total: 0}, no error.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import prisma from '../../lib/prisma.js';
+
+prisma.llmCallLog = { ...(prisma.llmCallLog || {}), findMany: vi.fn(), update: vi.fn() };
+
+const { run } = await import('../../scripts/backfill-llm-call-log-provider-cost.js');
+
+function row(overrides = {}) {
+  return {
+    id: 1,
+    model: 'gemini-flash',
+    promptTokens: 1000,
+    completionTokens: 500,
+    stub: false,
+    provider: 'unknown',
+    ...overrides,
+  };
+}
+
+describe('backfill-llm-call-log-provider-cost', () => {
+  let originalArgv;
+
+  beforeEach(() => {
+    prisma.llmCallLog.findMany.mockReset().mockResolvedValue([]);
+    prisma.llmCallLog.update.mockReset().mockResolvedValue({});
+    originalArgv = process.argv;
+    process.argv = ['node', 'script.js'];
+  });
+
+  test('queries only rows with provider:"unknown"', async () => {
+    await run();
+    expect(prisma.llmCallLog.findMany).toHaveBeenCalledWith({ where: { provider: 'unknown' } });
+  });
+
+  test('no rows to backfill -> returns zeroed result, no update calls', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([]);
+    const result = await run();
+    expect(result).toEqual({ updated: 0, total: 0 });
+    expect(prisma.llmCallLog.update).not.toHaveBeenCalled();
+  });
+
+  test('infers provider from model and computes real cost for a non-stub row', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([row({ id: 42, model: 'gpt-4', promptTokens: 1000, completionTokens: 500, stub: false })]);
+    const result = await run();
+    expect(result.updated).toBe(1);
+    const call = prisma.llmCallLog.update.mock.calls[0][0];
+    expect(call.where).toEqual({ id: 42 });
+    expect(call.data.provider).toBe('openai');
+    expect(call.data.costEstimate).toBeGreaterThan(0);
+  });
+
+  test('stub rows get the real provider but costEstimate stays 0', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([row({ id: 7, model: 'gemini-flash', stub: true })]);
+    await run();
+    const call = prisma.llmCallLog.update.mock.calls[0][0];
+    expect(call.data.provider).toBe('gemini');
+    expect(call.data.costEstimate).toBe(0);
+  });
+
+  test('--dry-run makes zero write calls but reports the row count', async () => {
+    process.argv = ['node', 'script.js', '--dry-run'];
+    prisma.llmCallLog.findMany.mockResolvedValue([row({ id: 1 }), row({ id: 2 })]);
+    const result = await run();
+    expect(result).toEqual({ updated: 0, total: 2 });
+    expect(prisma.llmCallLog.update).not.toHaveBeenCalled();
+  });
+
+  test('unknown model -> provider "unknown" is written back (never throws)', async () => {
+    prisma.llmCallLog.findMany.mockResolvedValue([row({ id: 9, model: 'some-made-up-model-xyz' })]);
+    await run();
+    expect(prisma.llmCallLog.update.mock.calls[0][0].data.provider).toBe('unknown');
+  });
+});

--- a/backend/test/services/destinationImageProvider.test.js
+++ b/backend/test/services/destinationImageProvider.test.js
@@ -296,8 +296,8 @@ describe('fetchStrategy — full TeeOutput.imageStrategy', () => {
       { url: 'https://pex.example/dup-a.jpg', attribution: { providerId: 'pexels' } },
       { url: 'https://pex.example/dup-b.jpg', attribution: { providerId: 'pexels' } },
     ]);
-    // AI fallback is last-resort and may hit real network (Gemini/DALL-E)
-    // in CI; pin it to a fast, predictable unique URL so the dedup loop
+    // AI fallback is last-resort and may hit real network (DALL-E) in CI;
+    // pin it to a fast, predictable unique URL so the dedup loop
     // converges without timing out.
     let aiCounter = 0;
     vi.spyOn(aiImageFallbackProvider, 'search').mockImplementation(async () => {

--- a/backend/test/services/whatsappWebClient.test.js
+++ b/backend/test/services/whatsappWebClient.test.js
@@ -41,6 +41,7 @@ prisma.whatsAppThread = {
   deleteMany: vi.fn(),
 };
 prisma.contact = { ...(prisma.contact || {}), findFirst: vi.fn() };
+prisma.whatsAppOptOut = { ...(prisma.whatsAppOptOut || {}), findUnique: vi.fn() };
 
 const wa = requireCJS('../../services/whatsappWebClient');
 
@@ -58,6 +59,7 @@ beforeEach(() => {
   prisma.whatsAppMessage.deleteMany.mockReset().mockResolvedValue({ count: 6 });
   prisma.whatsAppThread.deleteMany.mockReset().mockResolvedValue({ count: 2 });
   prisma.contact.findFirst.mockReset().mockResolvedValue(null);
+  prisma.whatsAppOptOut.findUnique.mockReset().mockResolvedValue(null);
   // Fake socket so emit-bearing paths are observable.
   wa.init({ to: (room) => ({ emit: (ev, payload) => emits.push({ room, ev, payload }) }) });
 });
@@ -266,7 +268,7 @@ describe('shutdown (graceful teardown so the auth store flushes — prevents "lo
     s.client = { destroy: () => new Promise(() => {}) }; // never resolves
     s.state = 'CONNECTED';
     // perClientTimeoutMs short so the test is fast; shutdown still resolves.
-    await expect(wa.shutdown({ perClientTimeoutMs: 20 })).resolves.toEqual({ closed: 1 });
+    await expect(wa.shutdown({ perClientTimeoutMs: 20 })).resolves.toMatchObject({ closed: 1 });
     // Drop the never-resolving client so it can't stall later teardown paths.
     s.client = null;
   });
@@ -275,6 +277,57 @@ describe('shutdown (graceful teardown so the auth store flushes — prevents "lo
     // Stub sessions (client:null) are skipped — shutdown stays fast + resolves.
     const out = await wa.shutdown();
     expect(out).toHaveProperty('closed');
+  });
+});
+
+describe('destroyClientAndOrphans (memory-leak cleanup helper)', () => {
+  test('destroys the client, nulls the handle, and kills orphan browsers', async () => {
+    await wa.connect(TENANT);
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const s = wa.getSession(TENANT);
+    s.client = { destroy };
+    s.state = 'CONNECTED';
+    const killSpy = vi.spyOn(wa, 'killBrowsersForDir').mockImplementation(() => {});
+
+    await wa.destroyClientAndOrphans(TENANT);
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(s.client).toBeNull();
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    killSpy.mockRestore();
+  });
+
+  test('is safe when there is no session', async () => {
+    await expect(wa.destroyClientAndOrphans(999999)).resolves.toBeUndefined();
+  });
+});
+
+describe('scheduleSessionPrune (prevents dead-session registry growth)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('removes a DISCONNECTED session after the prune delay', async () => {
+    await wa.connect(TENANT);
+    const s = wa.getSession(TENANT);
+    s.state = 'DISCONNECTED';
+    wa.scheduleSessionPrune(TENANT);
+    expect(wa.getSession(TENANT)).toBe(s);
+    vi.advanceTimersByTime(300_000);
+    expect(wa.getSession(TENANT)).toBeNull();
+  });
+
+  test('does NOT prune a session that changed state before the timer fired', async () => {
+    await wa.connect(TENANT);
+    const s = wa.getSession(TENANT);
+    s.state = 'AUTH_FAILURE';
+    wa.scheduleSessionPrune(TENANT);
+    s.state = 'CONNECTED';
+    vi.advanceTimersByTime(300_000);
+    expect(wa.getSession(TENANT)).toBe(s);
   });
 });
 
@@ -414,5 +467,26 @@ describe('ingestInbound', () => {
     const updateData = prisma.whatsAppThread.update.mock.calls[0][0].data;
     expect(updateData.unreadCount).toBeUndefined();
     expect(updateData.status).toBe('OPEN');
+  });
+
+  test('opted-out 1:1 number is dropped — no thread/message row, no emit', async () => {
+    prisma.whatsAppOptOut.findUnique.mockResolvedValue({ id: 9, contactPhone: '+919811111102' });
+    const out = await wa.ingestInbound(TENANT, inboundMsg());
+    expect(out).toBeUndefined();
+    expect(prisma.whatsAppOptOut.findUnique).toHaveBeenCalledWith({
+      where: { tenantId_contactPhone: { tenantId: 3, contactPhone: '+919811111102' } },
+    });
+    expect(prisma.whatsAppMessage.create).not.toHaveBeenCalled();
+    expect(prisma.whatsAppThread.create).not.toHaveBeenCalled();
+    expect(prisma.whatsAppThread.update).not.toHaveBeenCalled();
+    expect(emits).toHaveLength(0);
+  });
+
+  test('opted-out check is skipped for group chats — group message still ingested', async () => {
+    prisma.whatsAppOptOut.findUnique.mockResolvedValue({ id: 9, contactPhone: '120363999@g.us' });
+    const out = await wa.ingestInbound(TENANT, inboundMsg({ from: '120363999@g.us', body: 'hi team' }));
+    expect(out).toMatchObject({ threadId: 11 });
+    expect(prisma.whatsAppOptOut.findUnique).not.toHaveBeenCalled();
+    expect(prisma.whatsAppMessage.create).toHaveBeenCalled();
   });
 });

--- a/e2e/tests/travel-diagnostics-api.spec.js
+++ b/e2e/tests/travel-diagnostics-api.spec.js
@@ -547,8 +547,8 @@ test.describe('Travel diagnostics API — talking-points regen (PRD §4.2)', () 
     const body = await res.json();
     expect(body.diagnostic?.id).toBe(id);
     expect(body.talkingPoints).toBeTruthy();
-    // PRD §9.1 — talking-points task routes to Claude Opus primary.
-    expect(body.talkingPoints.model).toBe('claude-opus-4-7');
+    // PRD §9.1 — talking-points task routes to Gemini Flash primary (2026-07-14 swap off Claude Opus).
+    expect(body.talkingPoints.model).toBe('gemini-flash');
     // CI runs without LLM API keys → stub mode.
     expect(body.talkingPoints.stub).toBe(true);
     expect(body.talkingPoints.text).toMatch(/STUB-TALKING-POINTS/);
@@ -572,7 +572,7 @@ test.describe('Travel diagnostics API — talking-points regen (PRD §4.2)', () 
     expect(typeof body.talkingPointsJson).toBe('string');
     const envelope = JSON.parse(body.talkingPointsJson);
     expect(envelope.text).toMatch(/STUB-TALKING-POINTS/);
-    expect(envelope.model).toBe('claude-opus-4-7');
+    expect(envelope.model).toBe('gemini-flash');
     expect(envelope.stub).toBe(true);
     expect(Number.isFinite(Date.parse(envelope.generatedAt))).toBe(true);
   });
@@ -854,12 +854,12 @@ test.describe('Travel diagnostics — Travel Stall Family Travel Quiz seed (PRD 
 // PRD §4.1 — form-vs-call comparison endpoint.
 //
 // Second consumer of lib/llmRouter.js (commit 583c06b) — task
-// "form-vs-call" routes to Claude Opus primary per PRD §9.1, GPT-4
-// fallback. CI runs without LLM API keys so the router returns the
-// deterministic [STUB-FORM-VS-CALL] envelope. The stub text contains
-// "85% match" which → scorePercent=85 → classification="match" per
-// the 80% threshold. Real Claude output replaces this when Q11 keys
-// land; the envelope shape stays identical.
+// "form-vs-call" routes to Gemini Flash primary per PRD §9.1 (2026-07-14
+// swap off Claude Opus), GPT-4 fallback. CI runs without LLM API keys so
+// the router returns the deterministic [STUB-FORM-VS-CALL] envelope. The
+// stub text contains "85% match" which → scorePercent=85 →
+// classification="match" per the 80% threshold. Real Gemini Flash output
+// replaces this when Q11 keys land; the envelope shape stays identical.
 //
 // Tests pin:
 //   - auth gate (401/403 without token)
@@ -927,8 +927,8 @@ test.describe('Travel diagnostics API — form-vs-call comparison (PRD §4.1)', 
     expect(res.status(), `compare: ${await res.text()}`).toBe(200);
     const body = await res.json();
     expect(body.diagnosticId).toBe(id);
-    // PRD §9.1 — form-vs-call task routes to Claude Opus primary.
-    expect(body.model).toBe('claude-opus-4-7');
+    // PRD §9.1 — form-vs-call task routes to Gemini Flash primary (2026-07-14 swap off Claude Opus).
+    expect(body.model).toBe('gemini-flash');
     // CI runs without LLM API keys → stub mode.
     expect(body.stub).toBe(true);
     expect(body.summary).toMatch(/STUB-FORM-VS-CALL/);
@@ -1025,7 +1025,7 @@ test.describe('Travel diagnostics API — form-vs-call comparison (PRD §4.1)', 
   // PRD §4.1 Phase 1.5 — persist + cache. Eliminates duplicate-call noise
   // from LlmSpend telemetry (paired with the 76996c8 dashboard) by letting
   // DiagnosticDetail.jsx Section 3 read a cached envelope on reload
-  // instead of re-firing Claude Opus on every mount.
+  // instead of re-firing the LLM on every mount.
   test('POST /diagnostics/:id/form-vs-call/compare persists the result on TravelDiagnostic.formVsCallJson', async ({ request }) => {
     const token = await getTravelAdmin(request);
     if (!token || created.diagnosticIds.length === 0) test.skip(true, 'no diagnostic available');

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,15 @@ const LeadCapture = lazy(() => import("./pages/settings/LeadCapture"));
 const UserSettings = lazy(() => import("./pages/UserSettings"));
 const Developer = lazy(() => import("./pages/Developer"));
 const Portal = lazy(() => import("./pages/Portal"));
+// Super Admin Portal — fully separate auth system (env-based credentials,
+// no User/tenant table). See middleware/superAdminAuth.js on the backend
+// for the full contract. SuperAdminLayout manages its own auth redirect
+// (checks localStorage superAdminToken) rather than the app's AuthContext.
+const SuperAdminLogin = lazy(() => import("./pages/superadmin/SuperAdminLogin"));
+const SuperAdminLayout = lazy(() => import("./pages/superadmin/SuperAdminLayout"));
+const SuperAdminCronMaintenance = lazy(() => import("./pages/superadmin/SuperAdminCronMaintenance"));
+const SuperAdminCronAnalytics = lazy(() => import("./pages/superadmin/SuperAdminCronAnalytics"));
+const SuperAdminApiAnalytics = lazy(() => import("./pages/superadmin/SuperAdminApiAnalytics"));
 const TravelCustomerPortal = lazy(() => import("./pages/travel/TravelCustomerPortal"));
 const PublicTripMicrosite = lazy(() => import("./pages/travel/PublicTripMicrosite"));
 // Public itinerary share page (no auth) — the advisor's "Share link" opens
@@ -990,6 +999,16 @@ export default function App() {
                   <Route path="/privacy-policy" element={<LegalPage page="privacy-policy" />} />
                   <Route path="/deleted-account-policy" element={<LegalPage page="deleted-account-policy" />} />
                   <Route path="/portal" element={<Portal />} />
+                  {/* Super Admin Portal — deliberately outside the regular
+                      token/user/tenant auth gating above; it manages its own
+                      session via localStorage superAdminToken. */}
+                  <Route path="/super-admin/login" element={<SuperAdminLogin />} />
+                  <Route path="/super-admin" element={<SuperAdminLayout />}>
+                    <Route index element={<Navigate to="/super-admin/cron" replace />} />
+                    <Route path="cron" element={<SuperAdminCronMaintenance />} />
+                    <Route path="cron-analytics" element={<SuperAdminCronAnalytics />} />
+                    <Route path="api-analytics" element={<SuperAdminApiAnalytics />} />
+                  </Route>
                   {/* Travel customer portal — end-user (Contact) login + dashboard
                       + DigiLocker / Aadhaar verification (PRD §4.5 extended).
                       Distinct from /portal (Knowledge Base) + /wellness/portal

--- a/frontend/src/components/CalendarRangePicker.jsx
+++ b/frontend/src/components/CalendarRangePicker.jsx
@@ -1,0 +1,275 @@
+// frontend/src/components/CalendarRangePicker.jsx
+//
+// A single pill button showing the selected range (e.g. "Jul 1 - Jul 11")
+// that opens a month-grid calendar popover — click a start date, then an
+// end date, directly on the calendar (no separate From/To text inputs).
+// No date library dependency — plain Date arithmetic, consistent with the
+// rest of this codebase (no react-datepicker/date-fns/dayjs installed).
+//
+// Controlled component: parent owns { from, to } (YYYY-MM-DD strings, or
+// null/empty for "no range set"). `onChange` fires with the same shape
+// once both ends of a range are picked (or immediately for a single-day
+// pick — "double-tap to pick one date").
+//
+//   <CalendarRangePicker
+//     value={{ from: '2026-07-01', to: '2026-07-11' }}
+//     onChange={(next) => setRange(next)}
+//   />
+
+import { useEffect, useRef, useState } from 'react';
+import { Calendar, ChevronLeft, ChevronRight, X } from 'lucide-react';
+
+function toIsoDate(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function parseIso(s) {
+  if (!s) return null;
+  const [y, m, d] = s.split('-').map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
+function fmtShort(d) {
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+// Build a 6x7 grid of Dates covering the given month, padded with the
+// trailing days of the previous month and leading days of the next so
+// every week row is complete (matches the screenshot's greyed-out
+// out-of-month days).
+function buildMonthGrid(year, month) {
+  const first = new Date(year, month, 1);
+  const startOffset = first.getDay(); // 0=Sun
+  const gridStart = new Date(year, month, 1 - startOffset);
+  const days = [];
+  for (let i = 0; i < 42; i++) {
+    days.push(new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i));
+  }
+  return days;
+}
+
+function isSameDay(a, b) {
+  return a && b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function isBetween(d, start, end) {
+  if (!start || !end) return false;
+  const t = d.getTime();
+  return t > Math.min(start.getTime(), end.getTime()) && t < Math.max(start.getTime(), end.getTime());
+}
+
+export default function CalendarRangePicker({ value, onChange, label = 'Date range' }) {
+  const state = value || { from: '', to: '' };
+  const committedFrom = parseIso(state.from);
+  const committedTo = parseIso(state.to);
+
+  const [open, setOpen] = useState(false);
+  const [viewYear, setViewYear] = useState((committedFrom || new Date()).getFullYear());
+  const [viewMonth, setViewMonth] = useState((committedFrom || new Date()).getMonth());
+  // Draft selection while the popover is open — committed to the parent
+  // (via onChange) only once both ends are picked, so a half-made
+  // selection never leaks out mid-click.
+  const [draftStart, setDraftStart] = useState(committedFrom);
+  const [draftEnd, setDraftEnd] = useState(committedTo);
+  const [hoverDate, setHoverDate] = useState(null);
+  const rootRef = useRef(null);
+
+  // Re-sync draft state from the committed value whenever the popover
+  // (re)opens, so a Cancel-via-outside-click doesn't leave stale drafts.
+  useEffect(() => {
+    if (open) {
+      setDraftStart(committedFrom);
+      setDraftEnd(committedTo);
+      if (committedFrom) {
+        setViewYear(committedFrom.getFullYear());
+        setViewMonth(committedFrom.getMonth());
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocClick = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) setOpen(false);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const goMonth = (delta) => {
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  const pickDay = (day) => {
+    // No selection yet, or a full range already exists → start fresh.
+    if (!draftStart || (draftStart && draftEnd)) {
+      setDraftStart(day);
+      setDraftEnd(null);
+      return;
+    }
+    // One end already picked — clicking again on the SAME day is the
+    // "double-tap to pick one date" single-day-range shortcut.
+    if (isSameDay(day, draftStart)) {
+      onChange?.({ from: toIsoDate(day), to: toIsoDate(day) });
+      setDraftEnd(day);
+      setOpen(false);
+      return;
+    }
+    // Second click completes the range — order-independent (clicking an
+    // earlier date than draftStart flips start/end automatically).
+    const from = day < draftStart ? day : draftStart;
+    const to = day < draftStart ? draftStart : day;
+    setDraftStart(from);
+    setDraftEnd(to);
+    onChange?.({ from: toIsoDate(from), to: toIsoDate(to) });
+    setOpen(false);
+  };
+
+  const reset = () => {
+    setDraftStart(null);
+    setDraftEnd(null);
+    onChange?.({ from: '', to: '' });
+  };
+
+  const days = buildMonthGrid(viewYear, viewMonth);
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+
+  const buttonLabel = committedFrom
+    ? (committedTo && !isSameDay(committedFrom, committedTo)
+      ? `${fmtShort(committedFrom)} - ${fmtShort(committedTo)}`
+      : fmtShort(committedFrom))
+    : label;
+
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        className="input-field"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={label}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          width: 'auto',
+          minWidth: 150,
+          justifyContent: 'flex-start',
+          cursor: 'pointer',
+          fontSize: 'inherit',
+        }}
+      >
+        <Calendar size={14} style={{ flexShrink: 0, color: 'var(--text-secondary, #9aa0ab)' }} />
+        <span style={{ whiteSpace: 'nowrap' }}>{buttonLabel}</span>
+        {committedFrom && (
+          <X
+            size={13}
+            onClick={(e) => { e.stopPropagation(); reset(); }}
+            style={{ marginLeft: 'auto', flexShrink: 0, color: 'var(--text-secondary, #9aa0ab)' }}
+          />
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Select date range"
+          style={{
+            position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 50,
+            background: 'var(--card-bg, #1a1a1a)', color: 'var(--text-primary)',
+            border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
+            borderRadius: 12, boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+            padding: '0.85rem', width: 300,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+            <button type="button" onClick={() => goMonth(-1)} aria-label="Previous month" style={navBtnStyle}>
+              <ChevronLeft size={16} />
+            </button>
+            <strong style={{ fontSize: '0.9rem' }}>{monthLabel}</strong>
+            <button type="button" onClick={() => goMonth(1)} aria-label="Next month" style={navBtnStyle}>
+              <ChevronRight size={16} />
+            </button>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2, marginBottom: 4 }}>
+            {WEEKDAYS.map((w, i) => (
+              <div key={`${w}-${i}`} style={{ textAlign: 'center', fontSize: '0.7rem', color: 'var(--text-secondary, #9aa0ab)', padding: '2px 0' }}>
+                {w}
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2 }}>
+            {days.map((day) => {
+              const inMonth = day.getMonth() === viewMonth;
+              const isStart = isSameDay(day, draftStart);
+              const isEnd = isSameDay(day, draftEnd);
+              const rangeEndForHover = draftEnd || (draftStart && !draftEnd ? hoverDate : null);
+              const inRange = isBetween(day, draftStart, rangeEndForHover);
+              const isEdge = isStart || isEnd;
+              return (
+                <button
+                  key={day.toISOString()}
+                  type="button"
+                  onClick={() => pickDay(day)}
+                  onMouseEnter={() => setHoverDate(day)}
+                  disabled={!inMonth}
+                  style={{
+                    padding: '6px 0',
+                    fontSize: '0.8rem',
+                    border: 'none',
+                    borderRadius: isEdge ? '50%' : 6,
+                    background: isEdge
+                      ? 'var(--accent-color, #3b82f6)'
+                      : inRange
+                        ? 'rgba(59,130,246,0.15)'
+                        : 'transparent',
+                    color: !inMonth
+                      ? 'var(--text-secondary, #6b7280)'
+                      : isEdge
+                        ? '#fff'
+                        : 'var(--text-primary)',
+                    opacity: inMonth ? 1 : 0.4,
+                    cursor: inMonth ? 'pointer' : 'default',
+                  }}
+                >
+                  {day.getDate()}
+                </button>
+              );
+            })}
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--border-color, rgba(255,255,255,0.08))' }}>
+            <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary, #9aa0ab)', maxWidth: 180 }}>
+              Double-click a date to pick just one day, or click two dates to select a range.
+            </span>
+            <button type="button" onClick={reset} className="btn-secondary" style={{ fontSize: '0.75rem', padding: '0.3rem 0.6rem' }}>
+              Reset
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const navBtnStyle = {
+  background: 'transparent',
+  border: 'none',
+  color: 'var(--text-secondary, #9aa0ab)',
+  cursor: 'pointer',
+  padding: 4,
+  display: 'flex',
+};

--- a/frontend/src/pages/superadmin/SuperAdminApiAnalytics.jsx
+++ b/frontend/src/pages/superadmin/SuperAdminApiAnalytics.jsx
@@ -1,0 +1,629 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+} from "recharts";
+import { RefreshCw, ListFilter } from "lucide-react";
+import { superAdminFetch } from "../../utils/superAdminApi";
+import { useNotify } from "../../utils/notify";
+import CalendarRangePicker from "../../components/CalendarRangePicker";
+
+const DAY_OPTIONS = [7, 14, 30, 90];
+// Dark-mode categorical steps from the validated reference palette (8 slots,
+// worst-adjacent CVD ΔE 10.3 — see dataviz skill's palette.md). "unknown" is
+// a fallback/status color, not a categorical identity, so it's excluded from
+// the 8-slot budget and doesn't compete with real providers for a hue.
+const PROVIDER_COLORS = {
+  gemini: "#3987e5", // blue
+  openai: "#199e70", // aqua
+  serpapi: "#c98500", // yellow
+  anthropic: "#008300", // green
+  tripgo: "#9085e9", // violet
+  perplexity: "#e66767", // red
+  zoom: "#d55181", // magenta
+  razorpay: "#d95926", // orange
+  groq: "#f2b82e", // 9th provider — reuses a non-adjacent existing hue rather than a generated color
+  unknown: "#9aa0ab",
+};
+const colorFor = (p) => PROVIDER_COLORS[p] || "#9aa0ab";
+
+function Card({ title, children, right }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+        borderRadius: 10,
+        padding: "1rem 1.1rem",
+        background: "var(--card-bg, rgba(255,255,255,0.02))",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.75rem" }}>
+        <h3 style={{ fontSize: "0.85rem", fontWeight: 700, margin: 0 }}>{title}</h3>
+        {right}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatTile({ label, value, color, hint }) {
+  return (
+    <div style={{ flex: 1, minWidth: 120 }} title={hint}>
+      <div style={{ fontSize: "0.7rem", color: "var(--text-secondary, #9aa0ab)", textTransform: "uppercase", letterSpacing: "0.03em" }}>
+        {label}
+      </div>
+      <div style={{ fontSize: "1.5rem", fontWeight: 700, color: color || "inherit" }}>{value}</div>
+    </div>
+  );
+}
+
+function fmtCost(n) {
+  if (n == null) return "—";
+  return `$${Number(n).toFixed(n < 1 ? 6 : 2)}`;
+}
+
+// Custom tooltip for "Cost by model" — shows the EXACT model id (the raw
+// string stored on LlmCallLog.model, e.g. "gemini-2.5-flash-lite" vs the
+// shorter "gemini-flash" bucket) plus provider/calls/tokens/cost together,
+// since the default Recharts formatter only ever shows the one hovered series.
+function ModelCostTooltip({ active, payload }) {
+  if (!active || !payload || !payload.length) return null;
+  const row = payload[0].payload;
+  return (
+    <div style={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12, padding: "0.5rem 0.65rem", borderRadius: 6 }}>
+      <div style={{ fontWeight: 700, marginBottom: 4 }}>Model ID: {row.model}</div>
+      <div>
+        Provider: <span style={{ color: colorFor(row.provider), fontWeight: 700 }}>{row.provider}</span>
+      </div>
+      <div>Calls: {row.calls}</div>
+      <div>Tokens: {row.tokens.toLocaleString()}</div>
+      <div>Failures: {row.failures}</div>
+      <div style={{ color: "#f2b82e", fontWeight: 700, marginTop: 2 }}>Cost: {fmtCost(row.cost)}</div>
+    </div>
+  );
+}
+
+function fmtDate(d) {
+  if (!d) return "—";
+  return new Date(d).toLocaleString();
+}
+
+export default function SuperAdminApiAnalytics() {
+  const notify = useNotify();
+  const [tab, setTab] = useState("overview"); // 'overview' | 'calls' | 'settings'
+  const [days, setDays] = useState(14);
+  // A custom date/range from the calendar picker always overrides `days`
+  // entirely — set together as one piece of state so "pick a range" and
+  // "pick a preset" can't disagree about which one is active.
+  const [dateRange, setDateRange] = useState({ from: "", to: "" });
+  const [providerFilter, setProviderFilter] = useState("");
+  const [modelFilter, setModelFilter] = useState("");
+  const [filterOptions, setFilterOptions] = useState({ providers: [], models: [] });
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (dateRange.from || dateRange.to) {
+        if (dateRange.from) params.set("from", dateRange.from);
+        if (dateRange.to) params.set("to", dateRange.to);
+      } else {
+        params.set("days", String(days));
+      }
+      if (providerFilter) params.set("provider", providerFilter);
+      if (modelFilter) params.set("model", modelFilter);
+      const res = await superAdminFetch(`/api-analytics/overview?${params.toString()}`);
+      setData(res);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [days, dateRange, providerFilter, modelFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (providerFilter) params.set("provider", providerFilter);
+    superAdminFetch(`/api-analytics/filters?${params.toString()}`)
+      .then((opts) => {
+        setFilterOptions(opts);
+        // If the currently-selected model doesn't belong to the newly
+        // scoped list (e.g. provider changed to "openai" while "gemini-flash"
+        // was selected), clear it rather than silently querying an
+        // impossible combination that always returns zero results.
+        setModelFilter((current) => (current && !opts.models.includes(current) ? "" : current));
+      })
+      .catch(() => {}); // non-fatal — dropdowns just stay empty
+  }, [providerFilter]);
+
+  const providerPie = data ? data.byProvider.map((p) => ({ name: p.provider, value: p.calls, color: colorFor(p.provider) })) : [];
+
+  return (
+    <div>
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.25rem", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h1 style={{ fontSize: "1.4rem", fontWeight: 700, margin: 0 }}>API Analytics</h1>
+          <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.85rem", margin: "4px 0 0" }}>
+            Every external API call (Gemini, OpenAI, Anthropic, Perplexity, Groq, SerpApi, TripGo, Zoom, Razorpay) — tokens, cost, and failures.
+          </p>
+        </div>
+        {tab === "overview" && (
+          <button className="btn-secondary" onClick={load} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <RefreshCw size={15} /> Refresh
+          </button>
+        )}
+      </header>
+
+      {tab === "overview" && (
+        // Filter row — one row, above everything, scopes every chart/stat
+        // below it so the numbers always agree with each other.
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginBottom: "1rem" }}>
+          <select
+            className="input-field"
+            value={dateRange.from || dateRange.to ? "" : days}
+            onChange={(e) => {
+              setDays(Number(e.target.value));
+              setDateRange({ from: "", to: "" }); // preset always wins over a custom range
+            }}
+            style={{ width: 140 }}
+          >
+            {(dateRange.from || dateRange.to) && <option value="">Custom range</option>}
+            {DAY_OPTIONS.map((d) => (
+              <option key={d} value={d}>
+                Last {d} days
+              </option>
+            ))}
+          </select>
+          <CalendarRangePicker value={dateRange} onChange={setDateRange} label="Pick date / range" />
+          <select className="input-field" value={providerFilter} onChange={(e) => setProviderFilter(e.target.value)} style={{ width: 170 }}>
+            <option value="">All providers</option>
+            {filterOptions.providers.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <select className="input-field" value={modelFilter} onChange={(e) => setModelFilter(e.target.value)} style={{ width: 200 }}>
+            <option value="">All models</option>
+            {filterOptions.models.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+          {(providerFilter || modelFilter || dateRange.from || dateRange.to) && (
+            <button
+              className="btn-secondary"
+              onClick={() => {
+                setProviderFilter("");
+                setModelFilter("");
+                setDateRange({ from: "", to: "" });
+              }}
+              style={{ fontSize: "0.8rem" }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 6, marginBottom: "1rem", borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+        {[
+          { key: "overview", label: "Overview" },
+          { key: "calls", label: "Call Log" },
+          { key: "settings", label: "Log Retention" },
+        ].map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            style={{
+              background: "none",
+              border: "none",
+              borderBottom: tab === t.key ? "2px solid var(--accent-color, #3b82f6)" : "2px solid transparent",
+              color: tab === t.key ? "var(--accent-color, #3b82f6)" : "var(--text-primary, #fff)",
+              padding: "0.6rem 0.9rem",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "overview" &&
+        (loading && !data ? (
+          <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>
+        ) : !data ? (
+          <p style={{ color: "#f28b82" }}>Failed to load analytics.</p>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+              <StatTile label="Total Calls" value={data.totals.calls} />
+              <StatTile label="Success" value={data.totals.success} color="#6fcf73" />
+              <StatTile label="Failures" value={data.totals.failures} color="#f28b82" />
+              <StatTile label="Total Tokens" value={data.totals.tokens.toLocaleString()} />
+              <StatTile label="Estimated Cost" value={fmtCost(data.totals.cost)} />
+            </div>
+
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 420px), 1fr))", gap: "1rem" }}>
+              <Card title="Calls over time">
+                <ResponsiveContainer width="100%" height={260}>
+                  <LineChart data={data.byDay}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                    <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                    <Tooltip contentStyle={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12 }} />
+                    <Legend wrapperStyle={{ fontSize: 12 }} />
+                    <Line type="monotone" dataKey="total" name="Calls" stroke="#60a5fa" strokeWidth={2} dot={false} />
+                    <Line type="monotone" dataKey="failed" name="Failed" stroke="#f28b82" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </Card>
+
+              <Card title="Cost over time">
+                <ResponsiveContainer width="100%" height={260}>
+                  <LineChart data={data.byDay}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                    <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => fmtCost(v)} />
+                    <Tooltip contentStyle={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12 }} formatter={(v) => fmtCost(v)} />
+                    <Line type="monotone" dataKey="cost" name="Cost" stroke="#f2b82e" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </Card>
+
+              <Card title="Calls by provider">
+                {providerPie.length === 0 ? (
+                  <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.8rem" }}>No calls in this window.</p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={260}>
+                    <PieChart>
+                      <Pie data={providerPie} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={90} label={(e) => `${e.name}: ${e.value}`}>
+                        {providerPie.map((d) => (
+                          <Cell key={d.name} fill={d.color} />
+                        ))}
+                      </Pie>
+                      <Tooltip contentStyle={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12 }} />
+                    </PieChart>
+                  </ResponsiveContainer>
+                )}
+              </Card>
+            </div>
+
+            <Card title="Cost by model">
+              {data.byModel.length === 0 ? (
+                <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.8rem" }}>No real (non-stub) LLM calls in this window.</p>
+              ) : (
+                <>
+                  <ResponsiveContainer width="100%" height={Math.max(200, data.byModel.length * 32)}>
+                    <BarChart data={data.byModel} layout="vertical" margin={{ left: 40 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                      <XAxis type="number" tick={{ fontSize: 11 }} />
+                      <YAxis type="category" dataKey="model" tick={{ fontSize: 10 }} width={180} />
+                      <Tooltip content={<ModelCostTooltip />} />
+                      <Legend wrapperStyle={{ fontSize: 12 }} />
+                      <Bar dataKey="cost" fill="#f2b82e" name="cost" />
+                    </BarChart>
+                  </ResponsiveContainer>
+
+                  <div style={{ overflowX: "auto", marginTop: "0.85rem" }}>
+                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8rem" }}>
+                      <thead>
+                        <tr style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+                          <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Model</th>
+                          <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Provider</th>
+                          <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Hits (calls)</th>
+                          <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Tokens</th>
+                          <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Failures</th>
+                          <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Cost</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.byModel.map((m) => (
+                          <tr key={m.model} style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.05))" }}>
+                            <td style={{ padding: "0.4rem 0.6rem", fontWeight: 600 }}>{m.model}</td>
+                            <td style={{ padding: "0.4rem 0.6rem", color: colorFor(m.provider), fontWeight: 700 }}>{m.provider}</td>
+                            <td style={{ padding: "0.4rem 0.6rem", textAlign: "right" }}>{m.calls}</td>
+                            <td style={{ padding: "0.4rem 0.6rem", textAlign: "right" }}>{m.tokens.toLocaleString()}</td>
+                            <td style={{ padding: "0.4rem 0.6rem", textAlign: "right", color: m.failures > 0 ? "#f28b82" : "inherit" }}>{m.failures}</td>
+                            <td style={{ padding: "0.4rem 0.6rem", textAlign: "right" }}>{fmtCost(m.cost)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              )}
+            </Card>
+
+            <Card title="Recent failures — what & why">
+              {data.recentFailures.length === 0 ? (
+                <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.8rem" }}>No failures in this window.</p>
+              ) : (
+                <div style={{ overflowX: "auto" }}>
+                  <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8rem" }}>
+                    <thead>
+                      <tr style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+                        <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>When</th>
+                        <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Provider</th>
+                        <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Model / Endpoint</th>
+                        <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.recentFailures.map((f, i) => (
+                        <tr key={i} style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.05))" }}>
+                          <td style={{ padding: "0.4rem 0.6rem", whiteSpace: "nowrap" }}>{fmtDate(f.createdAt)}</td>
+                          <td style={{ padding: "0.4rem 0.6rem" }}>
+                            <span style={{ color: colorFor(f.provider), fontWeight: 700 }}>{f.provider}</span>
+                          </td>
+                          <td style={{ padding: "0.4rem 0.6rem" }}>{f.model || "—"}</td>
+                          <td style={{ padding: "0.4rem 0.6rem", color: "#f28b82", maxWidth: 400 }}>{f.errorMessage || "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </Card>
+          </div>
+        ))}
+
+      {tab === "calls" && <CallLogTab />}
+      {tab === "settings" && <RetentionSettingsTab />}
+    </div>
+  );
+}
+
+function CallLogTab() {
+  const notify = useNotify();
+  const [calls, setCalls] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [filters, setFilters] = useState({ provider: "", model: "", status: "", search: "", from: "", to: "" });
+  const [filterOptions, setFilterOptions] = useState({ providers: [], models: [] });
+  const pageSize = 25;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+      Object.entries(filters).forEach(([k, v]) => v && params.set(k, v));
+      const data = await superAdminFetch(`/api-analytics/calls?${params.toString()}`);
+      setCalls(data.calls || []);
+      setTotal(data.total || 0);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, filters]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (filters.provider) params.set("provider", filters.provider);
+    superAdminFetch(`/api-analytics/filters?${params.toString()}`)
+      .then((opts) => {
+        setFilterOptions(opts);
+        // Same rule as the Overview tab — a model belonging to a different
+        // provider than the one now selected would silently 0-result the query.
+        setFilters((f) => (f.model && !opts.models.includes(f.model) ? { ...f, model: "" } : f));
+      })
+      .catch(() => {});
+  }, [filters.provider]);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: "1rem", alignItems: "center" }}>
+        <ListFilter size={15} color="var(--text-secondary, #9aa0ab)" />
+        <select
+          className="input-field"
+          style={{ width: 160 }}
+          value={filters.provider}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, provider: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">All providers</option>
+          {filterOptions.providers.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          className="input-field"
+          style={{ width: 200 }}
+          value={filters.model}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, model: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">All models</option>
+          {filterOptions.models.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <select
+          className="input-field"
+          style={{ width: 140 }}
+          value={filters.status}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, status: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">All statuses</option>
+          <option value="success">Success</option>
+          <option value="failed">Failed</option>
+        </select>
+        <input
+          className="input-field"
+          style={{ width: 220 }}
+          placeholder="Search model/task/error…"
+          value={filters.search}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, search: e.target.value }));
+            setPage(1);
+          }}
+        />
+      </div>
+
+      {loading ? (
+        <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>
+      ) : calls.length === 0 ? (
+        <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>No calls match these filters.</p>
+      ) : (
+        <div style={{ overflowX: "auto", border: "1px solid var(--border-color, rgba(255,255,255,0.08))", borderRadius: 8 }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8rem" }}>
+            <thead style={{ background: "rgba(107,114,128,0.08)" }}>
+              <tr>
+                {["When", "Source", "Provider", "Model/Endpoint", "Status", "Tokens", "Cost", "Error"].map((h) => (
+                  <th key={h} style={{ padding: "0.5rem 0.6rem", textAlign: "left", whiteSpace: "nowrap" }}>
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {calls.map((c) => (
+                <tr key={c.id} style={{ borderTop: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+                  <td style={{ padding: "0.45rem 0.6rem", whiteSpace: "nowrap" }}>{fmtDate(c.createdAt)}</td>
+                  <td style={{ padding: "0.45rem 0.6rem" }}>{c.source === "llm" ? "LLM" : "API"}</td>
+                  <td style={{ padding: "0.45rem 0.6rem", color: colorFor(c.provider), fontWeight: 700 }}>{c.provider}</td>
+                  <td style={{ padding: "0.45rem 0.6rem" }}>{c.model || "—"}</td>
+                  <td style={{ padding: "0.45rem 0.6rem" }}>
+                    <span style={{ color: c.status === "failed" ? "#f28b82" : "#6fcf73", fontWeight: 700 }}>{c.status}</span>
+                    {c.stub && <span style={{ marginLeft: 6, fontSize: "0.65rem", color: "#9aa0ab" }}>STUB</span>}
+                  </td>
+                  <td style={{ padding: "0.45rem 0.6rem" }}>{c.totalTokens || "—"}</td>
+                  <td style={{ padding: "0.45rem 0.6rem" }}>{fmtCost(c.cost)}</td>
+                  <td style={{ padding: "0.45rem 0.6rem", color: "#f28b82", maxWidth: 300 }}>{c.errorMessage || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 10, marginTop: "0.75rem", fontSize: "0.8rem" }}>
+        <span>{total} total calls</span>
+        <button className="btn-secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+          Prev
+        </button>
+        <span>
+          {page} / {totalPages}
+        </span>
+        <button className="btn-secondary" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RetentionSettingsTab() {
+  const notify = useNotify();
+  const [retainDays, setRetainDays] = useState(30);
+  const [custom, setCustom] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const presets = [7, 15, 30, 60, 90];
+
+  useEffect(() => {
+    superAdminFetch("/api-analytics/settings/log-retention")
+      .then((d) => setRetainDays(d.retainDays))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const save = async (days) => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      await superAdminFetch("/api-analytics/settings/log-retention", {
+        method: "PUT",
+        body: JSON.stringify({ retainDays: days }),
+      });
+      setRetainDays(days);
+      setSaved(true);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setSaving(false);
+  };
+
+  if (loading) return <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <p style={{ fontSize: "0.85rem", color: "var(--text-secondary, #9aa0ab)" }}>
+        LLM + API call logs older than this window are purged automatically by the daily retention sweep (03:20).
+      </p>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: "1rem" }}>
+        {presets.map((d) => (
+          <button key={d} className={retainDays === d ? "btn-primary" : "btn-secondary"} onClick={() => save(d)} disabled={saving}>
+            {d} days
+          </button>
+        ))}
+      </div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <input
+          className="input-field"
+          type="number"
+          min={1}
+          max={3650}
+          placeholder="Custom (1-3650)"
+          value={custom}
+          onChange={(e) => setCustom(e.target.value)}
+          style={{ width: 180 }}
+        />
+        <button
+          className="btn-secondary"
+          disabled={saving || !custom}
+          onClick={() => {
+            const n = parseInt(custom, 10);
+            if (Number.isFinite(n)) save(n);
+          }}
+        >
+          Save custom
+        </button>
+      </div>
+      <p style={{ fontSize: "0.8rem", marginTop: "0.75rem" }}>
+        Current setting: <strong>{retainDays} days</strong>
+        {saved && <span style={{ color: "#6fcf73", marginLeft: 8 }}>Saved</span>}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/superadmin/SuperAdminCronAnalytics.jsx
+++ b/frontend/src/pages/superadmin/SuperAdminCronAnalytics.jsx
@@ -1,0 +1,275 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+} from "recharts";
+import { RefreshCw } from "lucide-react";
+import { superAdminFetch } from "../../utils/superAdminApi";
+import { useNotify } from "../../utils/notify";
+
+const DAY_OPTIONS = [7, 14, 30, 90];
+const STATUS_COLORS = { success: "#6fcf73", failed: "#f28b82", running: "#60a5fa" };
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Custom tooltip for the runs-over-time bar chart — states plainly which
+// statuses occurred (a flat-zero line for "failed"/"running" reads as
+// invisible on the chart itself, so the exact counts need to live here) and
+// flags today's bar as a partial/in-progress day so a lower bar there isn't
+// misread as "activity dropped".
+function RunsOverTimeTooltip({ active, payload, label }) {
+  if (!active || !payload || !payload.length) return null;
+  const row = payload[0].payload;
+  const isToday = label === todayKey();
+  return (
+    <div style={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12, padding: "0.5rem 0.65rem", borderRadius: 6 }}>
+      <div style={{ fontWeight: 700, marginBottom: 4 }}>
+        {label}
+        {isToday && <span style={{ color: "#f2b82e", fontWeight: 400 }}> (today — still in progress)</span>}
+      </div>
+      <div style={{ color: STATUS_COLORS.success }}>Success: {row.success}</div>
+      <div style={{ color: STATUS_COLORS.failed }}>Failed: {row.failed}</div>
+      <div style={{ color: STATUS_COLORS.running }}>Running: {row.running}</div>
+      <div style={{ marginTop: 2, fontWeight: 700 }}>Total: {row.total}</div>
+    </div>
+  );
+}
+
+function Card({ title, children, right }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+        borderRadius: 10,
+        padding: "1rem 1.1rem",
+        background: "var(--card-bg, rgba(255,255,255,0.02))",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.75rem" }}>
+        <h3 style={{ fontSize: "0.85rem", fontWeight: 700, margin: 0 }}>{title}</h3>
+        {right}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatTile({ label, value, color }) {
+  return (
+    <div style={{ flex: 1, minWidth: 120 }}>
+      <div style={{ fontSize: "0.7rem", color: "var(--text-secondary, #9aa0ab)", textTransform: "uppercase", letterSpacing: "0.03em" }}>
+        {label}
+      </div>
+      <div style={{ fontSize: "1.5rem", fontWeight: 700, color: color || "inherit" }}>{value}</div>
+    </div>
+  );
+}
+
+export default function SuperAdminCronAnalytics() {
+  const notify = useNotify();
+  const [days, setDays] = useState(14);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // "Runs over time" gets its OWN date range, independent of the page-level
+  // selector above — that selector also drives the stat tiles, pie chart,
+  // and per-cron table, so widening it just to see a longer trend line would
+  // change every other number on the page too. Defaults to 30 days since a
+  // 2-day window renders as noise (see the ≤2-day warning below).
+  const [chartDays, setChartDays] = useState(30);
+  const [chartData, setChartData] = useState(null);
+  const [chartLoading, setChartLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await superAdminFetch(`/cron-analytics/overview?days=${days}`);
+      setData(res);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [days]);
+
+  const loadChart = useCallback(async () => {
+    setChartLoading(true);
+    try {
+      const res = await superAdminFetch(`/cron-analytics/overview?days=${chartDays}`);
+      setChartData(res);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setChartLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chartDays]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    loadChart();
+  }, [loadChart]);
+
+  const pieData = data
+    ? [
+        { name: "Success", value: data.totals.success, color: STATUS_COLORS.success },
+        { name: "Failed", value: data.totals.failed, color: STATUS_COLORS.failed },
+        { name: "Running", value: data.totals.running, color: STATUS_COLORS.running },
+      ].filter((d) => d.value > 0)
+    : [];
+
+  return (
+    <div>
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.25rem", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h1 style={{ fontSize: "1.4rem", fontWeight: 700, margin: 0 }}>Cron Analytics</h1>
+          <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.85rem", margin: "4px 0 0" }}>
+            Run volume, success/failure rate, and duration trends across every cron engine.
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <select className="input-field" value={days} onChange={(e) => setDays(Number(e.target.value))} style={{ width: 140 }}>
+            {DAY_OPTIONS.map((d) => (
+              <option key={d} value={d}>
+                Last {d} days
+              </option>
+            ))}
+          </select>
+          <button className="btn-secondary" onClick={load} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <RefreshCw size={15} /> Refresh
+          </button>
+        </div>
+      </header>
+
+      {loading && !data ? (
+        <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>
+      ) : !data ? (
+        <p style={{ color: "#f28b82" }}>Failed to load analytics.</p>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+            <StatTile label="Total Runs" value={data.totals.runs} />
+            <StatTile label="Success" value={data.totals.success} color={STATUS_COLORS.success} />
+            <StatTile label="Failed" value={data.totals.failed} color={STATUS_COLORS.failed} />
+            <StatTile label="Running" value={data.totals.running} color={STATUS_COLORS.running} />
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 420px), 1fr))", gap: "1rem" }}>
+            <Card
+              title="Runs over time"
+              right={
+                <select
+                  className="input-field"
+                  value={chartDays}
+                  onChange={(e) => setChartDays(Number(e.target.value))}
+                  style={{ width: 130, fontSize: "0.78rem", padding: "0.3rem 0.5rem" }}
+                >
+                  {DAY_OPTIONS.map((d) => (
+                    <option key={d} value={d}>
+                      Last {d} days
+                    </option>
+                  ))}
+                </select>
+              }
+            >
+              {chartLoading && !chartData ? (
+                <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.8rem" }}>Loading…</p>
+              ) : !chartData ? (
+                <p style={{ color: "#f28b82", fontSize: "0.8rem" }}>Failed to load.</p>
+              ) : (
+                <>
+                  {chartData.byDay.length <= 2 && (
+                    <p style={{ fontSize: "0.75rem", color: "var(--text-secondary, #9aa0ab)", margin: "0 0 0.5rem" }}>
+                      Only {chartData.byDay.length} day{chartData.byDay.length === 1 ? "" : "s"} of data in this window — pick a wider range above to see a real trend.
+                    </p>
+                  )}
+                  <ResponsiveContainer width="100%" height={260}>
+                    <BarChart data={chartData.byDay}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                      <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                      <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                      <Tooltip content={<RunsOverTimeTooltip />} />
+                      <Legend wrapperStyle={{ fontSize: 12 }} />
+                      <Bar dataKey="success" name="Success" stackId="runs" fill={STATUS_COLORS.success} />
+                      <Bar dataKey="failed" name="Failed" stackId="runs" fill={STATUS_COLORS.failed} />
+                      <Bar dataKey="running" name="Running" stackId="runs" fill={STATUS_COLORS.running} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </>
+              )}
+            </Card>
+
+            <Card title="Status split">
+              {pieData.length === 0 ? (
+                <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.8rem" }}>No runs in this window.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height={260}>
+                  <PieChart>
+                    <Pie data={pieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={90} label={(e) => `${e.name}: ${e.value}`}>
+                      {pieData.map((d) => (
+                        <Cell key={d.name} fill={d.color} />
+                      ))}
+                    </Pie>
+                    <Tooltip contentStyle={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12 }} />
+                  </PieChart>
+                </ResponsiveContainer>
+              )}
+            </Card>
+          </div>
+
+          <Card title="Per-cron summary">
+            <ResponsiveContainer width="100%" height={Math.max(200, data.perCron.length * 32)}>
+              <BarChart data={data.perCron} layout="vertical" margin={{ left: 40 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                <XAxis type="number" tick={{ fontSize: 11 }} allowDecimals={false} />
+                <YAxis type="category" dataKey="cronName" tick={{ fontSize: 10 }} width={160} />
+                <Tooltip contentStyle={{ background: "#1a1d24", border: "1px solid rgba(255,255,255,0.1)", fontSize: 12 }} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar dataKey="runs" fill="#60a5fa" name="Runs" />
+                <Bar dataKey="failures" fill={STATUS_COLORS.failed} name="Failures" />
+              </BarChart>
+            </ResponsiveContainer>
+          </Card>
+
+          <Card title="Average duration by cron (ms)">
+            <div style={{ overflowX: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8rem" }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+                    <th style={{ textAlign: "left", padding: "0.4rem 0.6rem" }}>Cron</th>
+                    <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Runs</th>
+                    <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Failures</th>
+                    <th style={{ textAlign: "right", padding: "0.4rem 0.6rem" }}>Avg Duration</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.perCron.map((c) => (
+                    <tr key={c.cronName} style={{ borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.05))" }}>
+                      <td style={{ padding: "0.4rem 0.6rem", fontWeight: 600 }}>{c.cronName}</td>
+                      <td style={{ padding: "0.4rem 0.6rem", textAlign: "right" }}>{c.runs}</td>
+                      <td style={{ padding: "0.4rem 0.6rem", textAlign: "right", color: c.failures > 0 ? STATUS_COLORS.failed : "inherit" }}>{c.failures}</td>
+                      <td style={{ padding: "0.4rem 0.6rem", textAlign: "right" }}>{c.avgDurationMs != null ? `${c.avgDurationMs}ms` : "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/superadmin/SuperAdminCronMaintenance.jsx
+++ b/frontend/src/pages/superadmin/SuperAdminCronMaintenance.jsx
@@ -1,0 +1,885 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import {
+  RefreshCw,
+  Plus,
+  Play,
+  Trash2,
+  Power,
+  PowerOff,
+  Pencil,
+  X,
+  ListFilter,
+  Search,
+} from "lucide-react";
+import { superAdminFetch } from "../../utils/superAdminApi";
+import { useNotify } from "../../utils/notify";
+import CalendarRangePicker from "../../components/CalendarRangePicker";
+
+function useHandlerCatalog() {
+  const [handlers, setHandlers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    superAdminFetch("/cron/cron-handlers")
+      .then((data) => {
+        if (!mounted) return;
+        setHandlers(data.handlers || []);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setHandlers([]);
+      })
+      .finally(() => {
+        if (!mounted) return;
+        setLoading(false);
+      });
+    return () => { mounted = false; };
+  }, []);
+
+  return { handlers, loading };
+}
+
+// Quick-pick presets for the schedule editor so most admins never need to
+// type a raw cron expression. "Custom" (the plain input below) covers
+// anything else, including the odd offsets (":13", ":37") the built-in
+// engines use to avoid a top-of-the-hour thundering herd.
+const SCHEDULE_PRESETS = [
+  { label: "Every 5 minutes", value: "*/5 * * * *" },
+  { label: "Every 15 minutes", value: "*/15 * * * *" },
+  { label: "Every 30 minutes", value: "*/30 * * * *" },
+  { label: "Every hour", value: "0 * * * *" },
+  { label: "Every 6 hours", value: "0 */6 * * *" },
+  { label: "Daily at 9:00 AM", value: "0 9 * * *" },
+  { label: "Daily at midnight", value: "0 0 * * *" },
+  { label: "Weekly (Monday 1 AM)", value: "0 1 * * 1" },
+];
+
+function StatusPill({ status }) {
+  const colors = {
+    success: { bg: "rgba(46,125,50,0.15)", fg: "#6fcf73" },
+    failed: { bg: "rgba(239,68,68,0.15)", fg: "#f28b82" },
+    running: { bg: "rgba(59,130,246,0.15)", fg: "#60a5fa" },
+  };
+  const c = colors[status] || { bg: "rgba(154,160,171,0.15)", fg: "#9aa0ab" };
+  return (
+    <span style={{ background: c.bg, color: c.fg, padding: "2px 8px", borderRadius: 10, fontSize: "0.7rem", fontWeight: 700, textTransform: "uppercase" }}>
+      {status || "—"}
+    </span>
+  );
+}
+
+function fmtDate(d) {
+  if (!d) return "—";
+  try {
+    return new Date(d).toLocaleString();
+  } catch {
+    return String(d);
+  }
+}
+
+// Plain-English relative time ("2 minutes ago") — falls back to the full
+// date once it's more than a week old, since "312 hours ago" stops being
+// useful and an admin scanning the table wants an absolute date at that point.
+function fmtRelative(d) {
+  if (!d) return "—";
+  const then = new Date(d).getTime();
+  if (Number.isNaN(then)) return "—";
+  const diffMs = Date.now() - then;
+  const diffSec = Math.round(diffMs / 1000);
+  if (diffSec < 5) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? "" : "s"} ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? "" : "s"} ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 7) return `${diffDay} day${diffDay === 1 ? "" : "s"} ago`;
+  return fmtDate(d);
+}
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+function fmtHour12(h, m) {
+  const period = h < 12 ? "AM" : "PM";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return `${hour12}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+/**
+ * Translates a 5-field cron expression into a plain-English phrase for
+ * non-technical admins. Falls back to the raw expression (still shown
+ * alongside, in monospace) for anything this doesn't recognize — this is
+ * a readability aid, not a full cron parser.
+ */
+function describeCronSchedule(expr) {
+  const raw = String(expr || "").trim();
+  const parts = raw.split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [min, hour, dom, month, dow] = parts;
+
+  // Every N minutes/seconds — "*/N * * * *"
+  if (/^\*\/\d+$/.test(min) && hour === "*" && dom === "*" && month === "*" && dow === "*") {
+    const n = min.slice(2);
+    return `Every ${n} minute${n === "1" ? "" : "s"}`;
+  }
+  // Every minute
+  if (min === "*" && hour === "*" && dom === "*" && month === "*" && dow === "*") {
+    return "Every minute";
+  }
+  // Every N hours — "0 */N * * *"
+  if (/^\d+$/.test(min) && /^\*\/\d+$/.test(hour) && dom === "*" && month === "*" && dow === "*") {
+    const n = hour.slice(2);
+    return `Every ${n} hour${n === "1" ? "" : "s"}`;
+  }
+  // Every hour, on the :MM
+  if (/^\d+$/.test(min) && hour === "*" && dom === "*" && month === "*" && dow === "*") {
+    return `Every hour, at :${min.padStart(2, "0")}`;
+  }
+  // Multiple fixed minutes every hour — "13,43 * * * *"
+  if (/^\d+(,\d+)+$/.test(min) && hour === "*" && dom === "*" && month === "*" && dow === "*") {
+    const minutes = min.split(",");
+    const paddedList = minutes.map((m) => `:${m.padStart(2, "0")}`).join(", ");
+    return `${minutes.length}x per hour (at ${paddedList})`;
+  }
+  // Daily at fixed time — "M H * * *"
+  if (/^\d+$/.test(min) && /^\d+$/.test(hour) && dom === "*" && month === "*" && dow === "*") {
+    return `Every day at ${fmtHour12(parseInt(hour, 10), parseInt(min, 10))}`;
+  }
+  // Weekly at fixed time on one day — "M H * * D"
+  if (/^\d+$/.test(min) && /^\d+$/.test(hour) && dom === "*" && month === "*" && /^\d$/.test(dow)) {
+    const dayName = DAY_NAMES[parseInt(dow, 10)] || `day ${dow}`;
+    return `Every ${dayName} at ${fmtHour12(parseInt(hour, 10), parseInt(min, 10))}`;
+  }
+  return null; // unrecognized shape — caller falls back to raw expression only
+}
+
+function ScheduleDisplay({ schedule }) {
+  const plain = describeCronSchedule(schedule);
+  return (
+    <div>
+      <div>{plain || <span style={{ fontFamily: "monospace" }}>{schedule}</span>}</div>
+      {plain && (
+        <div style={{ fontSize: "0.68rem", color: "var(--text-secondary, #9aa0ab)", fontFamily: "monospace" }}>
+          {schedule}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SuperAdminCronMaintenance() {
+  const notify = useNotify();
+  const { handlers } = useHandlerCatalog();
+  const [tab, setTab] = useState("crons"); // 'crons' | 'logs' | 'settings'
+  const [crons, setCrons] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [editing, setEditing] = useState(null); // cron object being edited, or null
+  const [scheduleEditing, setScheduleEditing] = useState(null); // cron name whose schedule is being edited
+  const [scheduleDraft, setScheduleDraft] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState(""); // '' | 'enabled' | 'disabled'
+
+  const filteredCrons = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return crons.filter((c) => {
+      if (statusFilter === "enabled" && !c.enabled) return false;
+      if (statusFilter === "disabled" && c.enabled) return false;
+      if (!q) return true;
+      return c.name.toLowerCase().includes(q) || (c.description || "").toLowerCase().includes(q);
+    });
+  }, [crons, search, statusFilter]);
+
+  const loadCrons = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await superAdminFetch("/cron/crons");
+      setCrons(data.crons || []);
+    } catch (e) {
+      setError(e.message);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadCrons();
+  }, [loadCrons]);
+
+  const handleToggleEnabled = async (cron) => {
+    try {
+      const data = await superAdminFetch(`/cron/crons/${encodeURIComponent(cron.name)}/${cron.enabled ? "disable" : "enable"}`, {
+        method: "POST",
+      });
+      // Patch just this row in place — avoids a full reload flashing the
+      // table to "Loading…" and losing scroll position for a one-field change.
+      // data.cron is the raw CronConfig row (no isRegisteredInProcess/lastExecutionAt/
+      // lastStatus decoration), so merge onto the existing row rather than replace it.
+      setCrons((prev) => prev.map((c) => (c.name === cron.name ? { ...c, ...data.cron } : c)));
+    } catch (e) {
+      notify.error(e.message);
+    }
+  };
+
+  const handleRunNow = async (cron) => {
+    try {
+      const data = await superAdminFetch(`/cron/crons/${encodeURIComponent(cron.name)}/run-now`, { method: "POST" });
+      notify.success(`Ran "${cron.name}": ${data.result.status}${data.result.errorMessage ? " — " + data.result.errorMessage : ""}`);
+      // Patch just this row in place — the run just completed, so reflect
+      // it immediately instead of a full reload that flashes "Loading…".
+      setCrons((prev) =>
+        prev.map((c) =>
+          c.name === cron.name ? { ...c, lastExecutionAt: new Date().toISOString(), lastStatus: data.result.status } : c,
+        ),
+      );
+    } catch (e) {
+      notify.error(e.message);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await superAdminFetch(`/cron/crons/${encodeURIComponent(deleteTarget.name)}`, { method: "DELETE" });
+      setCrons((prev) => prev.filter((c) => c.name !== deleteTarget.name));
+      setDeleteTarget(null);
+    } catch (e) {
+      notify.error(e.message);
+    }
+  };
+
+  const openScheduleEdit = (cron) => {
+    setScheduleEditing(cron.name);
+    setScheduleDraft(cron.schedule);
+  };
+
+  const submitScheduleEdit = async () => {
+    try {
+      const data = await superAdminFetch(`/cron/crons/${encodeURIComponent(scheduleEditing)}/schedule`, {
+        method: "PUT",
+        body: JSON.stringify({ schedule: scheduleDraft }),
+      });
+      setCrons((prev) => prev.map((c) => (c.name === scheduleEditing ? { ...c, ...data.cron } : c)));
+      setScheduleEditing(null);
+    } catch (e) {
+      notify.error(e.message);
+    }
+  };
+
+  return (
+    <div>
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.25rem", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h1 style={{ fontSize: "1.4rem", fontWeight: 700, margin: 0 }}>Cron Maintenance</h1>
+          <p style={{ color: "var(--text-secondary, #9aa0ab)", fontSize: "0.85rem", margin: "4px 0 0" }}>
+            View, schedule, enable/disable, and audit every cron engine on this server.
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button className="btn-secondary" onClick={loadCrons} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <RefreshCw size={15} /> Refresh
+          </button>
+          <button className="btn-primary" onClick={() => setShowCreate(true)} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <Plus size={15} /> Create Cron
+          </button>
+        </div>
+      </header>
+
+      <div style={{ display: "flex", gap: 6, marginBottom: "1rem", borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+        {[
+          { key: "crons", label: "All Crons" },
+          { key: "logs", label: "Execution Logs" },
+          { key: "settings", label: "Log Retention" },
+        ].map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            style={{
+              background: "none",
+              border: "none",
+              borderBottom: tab === t.key ? "2px solid var(--accent-color, #3b82f6)" : "2px solid transparent",
+              color: tab === t.key ? "var(--accent-color, #3b82f6)" : "var(--text-primary, #fff)",
+              padding: "0.6rem 0.9rem",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "crons" && (
+        <>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: "0.85rem", alignItems: "center" }}>
+            <div style={{ position: "relative", maxWidth: 320, flex: "1 1 260px" }}>
+              <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "var(--text-secondary, #9aa0ab)" }} />
+              <input
+                className="input-field"
+                style={{ paddingLeft: 30, width: "100%" }}
+                placeholder="Search crons by name or description…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+            <select
+              className="input-field"
+              style={{ width: 160 }}
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              aria-label="Filter by status"
+            >
+              <option value="">All statuses</option>
+              <option value="enabled">Enabled</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </div>
+          <CronsTable
+            crons={filteredCrons}
+            loading={loading}
+            error={error}
+            onToggleEnabled={handleToggleEnabled}
+            onRunNow={handleRunNow}
+            onEdit={setEditing}
+            onEditSchedule={openScheduleEdit}
+            onDelete={setDeleteTarget}
+            emptyMessage={
+              search || statusFilter
+                ? `No ${statusFilter || ""} crons match${search ? ` "${search}"` : ""}.`
+                : "No crons registered yet."
+            }
+          />
+        </>
+      )}
+      {tab === "logs" && <LogsTab crons={crons} />}
+      {tab === "settings" && <RetentionSettingsTab />}
+
+      {showCreate && (
+        <CreateCronModal
+          handlers={handlers}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false);
+            loadCrons();
+          }}
+        />
+      )}
+
+      {editing && (
+        <EditCronModal
+          handlers={handlers}
+          cron={editing}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            loadCrons();
+          }}
+        />
+      )}
+
+      {scheduleEditing && (
+        <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && setScheduleEditing(null)}>
+          <div style={modalStyle}>
+            <ModalHeader title="Edit Schedule" onClose={() => setScheduleEditing(null)} />
+            <div style={{ padding: "1rem 1.25rem", display: "flex", flexDirection: "column", gap: 10 }}>
+              <label style={{ fontSize: "0.8rem", display: "flex", flexDirection: "column", gap: 4 }}>
+                <span>Run how often?</span>
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                  {SCHEDULE_PRESETS.map((p) => (
+                    <button
+                      key={p.value}
+                      type="button"
+                      onClick={() => setScheduleDraft(p.value)}
+                      className={scheduleDraft === p.value ? "btn-primary" : "btn-secondary"}
+                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.6rem" }}
+                    >
+                      {p.label}
+                    </button>
+                  ))}
+                </div>
+              </label>
+              <label style={{ fontSize: "0.8rem", display: "flex", flexDirection: "column", gap: 4 }}>
+                <span>Or enter a custom cron expression</span>
+                <input className="input-field" style={{ fontFamily: "monospace" }} value={scheduleDraft} onChange={(e) => setScheduleDraft(e.target.value)} placeholder="*/15 * * * *" />
+              </label>
+              <p style={{ fontSize: "0.8rem", margin: 0 }}>
+                This will run: <strong>{describeCronSchedule(scheduleDraft) || "(unrecognized expression — will still be validated on save)"}</strong>
+              </p>
+              <p style={{ fontSize: "0.75rem", color: "var(--text-secondary, #9aa0ab)", margin: 0 }}>
+                Takes effect immediately — no restart required.
+              </p>
+            </div>
+            <ModalFooter onCancel={() => setScheduleEditing(null)} onConfirm={submitScheduleEdit} confirmLabel="Save schedule" />
+          </div>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && setDeleteTarget(null)}>
+          <div style={modalStyle}>
+            <ModalHeader title="Delete cron?" onClose={() => setDeleteTarget(null)} />
+            <div style={{ padding: "1rem 1.25rem" }}>
+              <p style={{ fontSize: "0.85rem" }}>
+                This permanently deletes <strong>{deleteTarget.name}</strong> and stops it from running. This cannot be undone.
+              </p>
+            </div>
+            <ModalFooter onCancel={() => setDeleteTarget(null)} onConfirm={handleDelete} confirmLabel="Delete" danger />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CronsTable({ crons, loading, error, onToggleEnabled, onRunNow, onEdit, onEditSchedule, onDelete, emptyMessage }) {
+  if (loading) return <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>;
+  if (error) return <p style={{ color: "#f28b82" }}>{error}</p>;
+  if (crons.length === 0) return <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>{emptyMessage || "No crons registered yet."}</p>;
+
+  return (
+    <div style={{ overflowX: "auto", border: "1px solid var(--border-color, rgba(255,255,255,0.08))", borderRadius: 8 }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.82rem" }}>
+        <thead style={{ background: "rgba(107,114,128,0.08)" }}>
+          <tr>
+            {["Name", "Description", "Status", "Schedule", "Last Execution", "Last Status", "Created By", "Updated At", "Actions"].map((h) => (
+              <th key={h} style={{ padding: "0.6rem 0.7rem", textAlign: "left", fontWeight: 600, whiteSpace: "nowrap" }}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {crons.map((c) => (
+            <tr key={c.name} style={{ borderTop: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+              <td style={{ padding: "0.55rem 0.7rem", fontWeight: 600 }}>
+                {c.name}
+                {!c.isSystem && (
+                  <span style={{ marginLeft: 6, fontSize: "0.65rem", color: "var(--accent-color, #3b82f6)", fontWeight: 700 }}>DYNAMIC</span>
+                )}
+                {!c.isRegisteredInProcess && (
+                  <div style={{ fontSize: "0.68rem", color: "#f2b82e" }}>not live in this process — restart may be needed</div>
+                )}
+              </td>
+              <td style={{ padding: "0.55rem 0.7rem", maxWidth: 260, color: "var(--text-secondary, #9aa0ab)" }}>{c.description || "—"}</td>
+              <td style={{ padding: "0.55rem 0.7rem" }}>
+                <span style={{ color: c.enabled ? "#6fcf73" : "#9aa0ab", fontWeight: 700 }}>{c.enabled ? "Enabled" : "Disabled"}</span>
+              </td>
+              <td style={{ padding: "0.55rem 0.7rem" }}><ScheduleDisplay schedule={c.schedule} /></td>
+              <td style={{ padding: "0.55rem 0.7rem", whiteSpace: "nowrap" }} title={fmtDate(c.lastExecutionAt)}>{fmtRelative(c.lastExecutionAt)}</td>
+              <td style={{ padding: "0.55rem 0.7rem" }}><StatusPill status={c.lastStatus} /></td>
+              <td style={{ padding: "0.55rem 0.7rem" }}>{c.createdBy || "—"}</td>
+              <td style={{ padding: "0.55rem 0.7rem", whiteSpace: "nowrap" }}>{fmtDate(c.updatedAt)}</td>
+              <td style={{ padding: "0.55rem 0.7rem" }}>
+                <div style={{ display: "flex", gap: 4 }}>
+                  <button title="Run now" onClick={() => onRunNow(c)} className="btn-secondary" style={{ padding: "0.3rem" }}>
+                    <Play size={13} />
+                  </button>
+                  <button title={c.enabled ? "Disable" : "Enable"} onClick={() => onToggleEnabled(c)} className="btn-secondary" style={{ padding: "0.3rem" }}>
+                    {c.enabled ? <PowerOff size={13} /> : <Power size={13} />}
+                  </button>
+                  <button title="Edit schedule" onClick={() => onEditSchedule(c)} className="btn-secondary" style={{ padding: "0.3rem" }}>
+                    <Pencil size={13} />
+                  </button>
+                  {!c.isSystem && (
+                    <button title="Delete" onClick={() => onDelete(c)} className="btn-secondary" style={{ padding: "0.3rem", color: "#f28b82" }}>
+                      <Trash2 size={13} />
+                    </button>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CreateCronModal({ handlers, onClose, onCreated }) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [schedule, setSchedule] = useState("*/15 * * * *");
+  const [handlerKey, setHandlerKey] = useState(handlers[0]?.key || "");
+  const [metadataJson, setMetadataJson] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    setError("");
+    setSubmitting(true);
+    try {
+      await superAdminFetch("/cron/crons", {
+        method: "POST",
+        body: JSON.stringify({ name, description, schedule, handlerKey, metadataJson: metadataJson || undefined }),
+      });
+      onCreated();
+    } catch (e) {
+      setError(e.message);
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div style={modalStyle}>
+        <ModalHeader title="Create New Cron" onClose={onClose} />
+        <div style={{ padding: "1rem 1.25rem", display: "flex", flexDirection: "column", gap: 10 }}>
+          <Field label="Cron Name">
+            <input className="input-field" value={name} onChange={(e) => setName(e.target.value)} placeholder="my_custom_ping" />
+          </Field>
+          <Field label="Description">
+            <input className="input-field" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </Field>
+          <Field label="Run how often?">
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 6 }}>
+              {SCHEDULE_PRESETS.map((p) => (
+                <button
+                  key={p.value}
+                  type="button"
+                  onClick={() => setSchedule(p.value)}
+                  className={schedule === p.value ? "btn-primary" : "btn-secondary"}
+                  style={{ fontSize: "0.75rem", padding: "0.35rem 0.6rem" }}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+            <input className="input-field" style={{ fontFamily: "monospace" }} value={schedule} onChange={(e) => setSchedule(e.target.value)} placeholder="*/15 * * * *" />
+            <p style={{ fontSize: "0.78rem", margin: "4px 0 0" }}>
+              This will run: <strong>{describeCronSchedule(schedule) || "(unrecognized expression)"}</strong>
+            </p>
+          </Field>
+          <Field label="Handler">
+            <select className="input-field" value={handlerKey} onChange={(e) => setHandlerKey(e.target.value)} disabled={handlers.length === 0}>
+              {handlers.map((h) => (
+                <option key={h.key} value={h.key}>{h.label}</option>
+              ))}
+            </select>
+            {handlers.length === 0 && (
+              <p style={{ fontSize: "0.75rem", color: "var(--text-secondary, #9aa0ab)", margin: "4px 0 0" }}>Loading handlers…</p>
+            )}
+          </Field>
+          <Field label="Metadata (JSON, optional)">
+            <textarea
+              className="input-field"
+              style={{ fontFamily: "monospace" }}
+              rows={3}
+              value={metadataJson}
+              onChange={(e) => setMetadataJson(e.target.value)}
+              placeholder={handlerKey === "http_webhook_ping" ? '{"url":"https://example.com/webhook"}' : '{"message":"hello"}'}
+            />
+          </Field>
+          {error && <p style={{ color: "#f28b82", fontSize: "0.8rem", margin: 0 }}>{error}</p>}
+        </div>
+        <ModalFooter onCancel={onClose} onConfirm={submit} confirmLabel={submitting ? "Creating…" : "Create"} disabled={submitting || !name || !schedule} />
+      </div>
+    </div>
+  );
+}
+
+function EditCronModal({ handlers, cron, onClose, onSaved }) {
+  const [description, setDescription] = useState(cron.description || "");
+  const [handlerKey, setHandlerKey] = useState(cron.handlerKey || handlers[0]?.key || "");
+  const [metadataJson, setMetadataJson] = useState(cron.metadataJson || "");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    setError("");
+    setSubmitting(true);
+    try {
+      await superAdminFetch(`/cron/crons/${encodeURIComponent(cron.name)}`, {
+        method: "PUT",
+        body: JSON.stringify({ description, handlerKey, metadataJson }),
+      });
+      onSaved();
+    } catch (e) {
+      setError(e.message);
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div style={modalStyle}>
+        <ModalHeader title={`Edit ${cron.name}`} onClose={onClose} />
+        <div style={{ padding: "1rem 1.25rem", display: "flex", flexDirection: "column", gap: 10 }}>
+          <Field label="Description">
+            <input className="input-field" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </Field>
+          <Field label="Handler">
+            <select className="input-field" value={handlerKey} onChange={(e) => setHandlerKey(e.target.value)} disabled={handlers.length === 0}>
+              {handlers.map((h) => (
+                <option key={h.key} value={h.key}>{h.label}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Metadata (JSON)">
+            <textarea className="input-field" style={{ fontFamily: "monospace" }} rows={3} value={metadataJson} onChange={(e) => setMetadataJson(e.target.value)} />
+          </Field>
+          {error && <p style={{ color: "#f28b82", fontSize: "0.8rem", margin: 0 }}>{error}</p>}
+        </div>
+        <ModalFooter onCancel={onClose} onConfirm={submit} confirmLabel={submitting ? "Saving…" : "Save"} disabled={submitting} />
+      </div>
+    </div>
+  );
+}
+
+function LogsTab({ crons }) {
+  const notify = useNotify();
+  const [logs, setLogs] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [filters, setFilters] = useState({ cronName: "", status: "", search: "" });
+  // Date range — single pill button + calendar-grid popover (click a start
+  // date then an end date directly on the calendar), not two bare
+  // <input type="date"> boxes or a preset dropdown.
+  const [dateRange, setDateRange] = useState({ from: "", to: "" });
+  const { from, to } = dateRange;
+  const pageSize = 25;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+      Object.entries(filters).forEach(([k, v]) => v && params.set(k, v));
+      if (from) params.set("from", from);
+      if (to) params.set("to", to);
+      const data = await superAdminFetch(`/cron/logs?${params.toString()}`);
+      setLogs(data.logs || []);
+      setTotal(data.total || 0);
+    } catch (e) {
+      console.error(e);
+    }
+    setLoading(false);
+  }, [page, filters, from, to]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const clearLogs = async (cronName) => {
+    const ok = await notify.confirm({
+      title: "Clear logs?",
+      message: cronName ? `Clear all logs for ${cronName}?` : "Clear ALL cron logs?",
+      confirmText: "Clear logs",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await superAdminFetch("/cron/logs/clear", { method: "POST", body: JSON.stringify({ cronName: cronName || undefined }) });
+      setPage(1);
+      load();
+    } catch (e) {
+      notify.error(e.message);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: "1rem", alignItems: "center" }}>
+        <ListFilter size={15} color="var(--text-secondary, #9aa0ab)" />
+        <select className="input-field" style={{ width: 200 }} value={filters.cronName} onChange={(e) => { setFilters((f) => ({ ...f, cronName: e.target.value })); setPage(1); }}>
+          <option value="">All crons</option>
+          {crons.map((c) => <option key={c.name} value={c.name}>{c.name}</option>)}
+        </select>
+        <select className="input-field" style={{ width: 140 }} value={filters.status} onChange={(e) => { setFilters((f) => ({ ...f, status: e.target.value })); setPage(1); }}>
+          <option value="">All statuses</option>
+          <option value="success">Success</option>
+          <option value="failed">Failed</option>
+          <option value="running">Running</option>
+        </select>
+        <CalendarRangePicker
+          value={dateRange}
+          onChange={(next) => { setDateRange(next); setPage(1); }}
+          label="Date range"
+        />
+        <input className="input-field" style={{ width: 200 }} placeholder="Search error/name…" value={filters.search} onChange={(e) => { setFilters((f) => ({ ...f, search: e.target.value })); setPage(1); }} />
+        <button className="btn-secondary" onClick={() => clearLogs(filters.cronName)} style={{ marginLeft: "auto", color: "#f28b82" }}>
+          Clear {filters.cronName ? `"${filters.cronName}"` : "all"} logs
+        </button>
+      </div>
+
+      {loading ? (
+        <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>
+      ) : logs.length === 0 ? (
+        <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>No logs match these filters.</p>
+      ) : (
+        <div style={{ overflowX: "auto", border: "1px solid var(--border-color, rgba(255,255,255,0.08))", borderRadius: 8 }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.82rem" }}>
+            <thead style={{ background: "rgba(107,114,128,0.08)" }}>
+              <tr>
+                {["Cron", "Started", "Finished", "Duration", "Status", "Trigger", "Error"].map((h) => (
+                  <th key={h} style={{ padding: "0.55rem 0.7rem", textAlign: "left", fontWeight: 600 }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => (
+                <tr key={l.id} style={{ borderTop: "1px solid var(--border-color, rgba(255,255,255,0.08))" }}>
+                  <td style={{ padding: "0.5rem 0.7rem", fontWeight: 600 }}>{l.cronName}</td>
+                  <td style={{ padding: "0.5rem 0.7rem", whiteSpace: "nowrap" }} title={fmtDate(l.startedAt)}>{fmtRelative(l.startedAt)}</td>
+                  <td style={{ padding: "0.5rem 0.7rem", whiteSpace: "nowrap" }} title={fmtDate(l.finishedAt)}>{fmtRelative(l.finishedAt)}</td>
+                  <td style={{ padding: "0.5rem 0.7rem" }}>{l.durationMs != null ? `${l.durationMs}ms` : "—"}</td>
+                  <td style={{ padding: "0.5rem 0.7rem" }}><StatusPill status={l.status} /></td>
+                  <td style={{ padding: "0.5rem 0.7rem" }}>{l.triggerType}</td>
+                  <td style={{ padding: "0.5rem 0.7rem", maxWidth: 280, color: "#f28b82" }}>{l.errorMessage || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "0.75rem", fontSize: "0.8rem" }}>
+        <span style={{ color: "var(--text-secondary, #9aa0ab)" }}>{total} total log{total === 1 ? "" : "s"}</span>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button className="btn-secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</button>
+          <span style={{ padding: "0.4rem 0.6rem" }}>{page} / {totalPages}</span>
+          <button className="btn-secondary" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>Next</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RetentionSettingsTab() {
+  const notify = useNotify();
+  const [retainDays, setRetainDays] = useState(30);
+  const [custom, setCustom] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const presets = [7, 15, 30, 60, 90];
+
+  useEffect(() => {
+    superAdminFetch("/cron/settings/log-retention")
+      .then((d) => setRetainDays(d.retainDays))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const save = async (days) => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      await superAdminFetch("/cron/settings/log-retention", {
+        method: "PUT",
+        body: JSON.stringify({ retainDays: days }),
+      });
+      setRetainDays(days);
+      setSaved(true);
+    } catch (e) {
+      notify.error(e.message);
+    }
+    setSaving(false);
+  };
+
+  if (loading) return <p style={{ color: "var(--text-secondary, #9aa0ab)" }}>Loading…</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <p style={{ fontSize: "0.85rem", color: "var(--text-secondary, #9aa0ab)" }}>
+        Execution logs older than this window are purged automatically by the daily retention sweep (03:15).
+      </p>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: "1rem" }}>
+        {presets.map((d) => (
+          <button
+            key={d}
+            onClick={() => save(d)}
+            className={retainDays === d ? "btn-primary" : "btn-secondary"}
+            disabled={saving}
+          >
+            {d} Days
+          </button>
+        ))}
+      </div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <input
+          className="input-field"
+          type="number"
+          min={1}
+          max={3650}
+          style={{ width: 120 }}
+          placeholder="Custom"
+          value={custom}
+          onChange={(e) => setCustom(e.target.value)}
+        />
+        <button className="btn-secondary" disabled={saving || !custom} onClick={() => save(parseInt(custom, 10))}>
+          Set custom
+        </button>
+      </div>
+      <p style={{ fontSize: "0.8rem", marginTop: "1rem" }}>
+        Current setting: <strong>{retainDays} days</strong>
+        {saved && <span style={{ color: "#6fcf73", marginLeft: 8 }}>Saved ✓</span>}
+      </p>
+    </div>
+  );
+}
+
+// ── Small shared UI helpers ─────────────────────────────────────────────
+
+function Field({ label, children }) {
+  return (
+    <label style={{ fontSize: "0.8rem", display: "flex", flexDirection: "column", gap: 4 }}>
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function ModalHeader({ title, onClose }) {
+  return (
+    <header style={{ padding: "1rem 1.25rem", borderBottom: "1px solid var(--border-color, rgba(255,255,255,0.08))", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      <h3 style={{ margin: 0, fontSize: "1rem", fontWeight: 700 }}>{title}</h3>
+      <button onClick={onClose} aria-label="Close" style={{ background: "transparent", border: "none", color: "var(--text-secondary, #9aa0ab)", cursor: "pointer" }}>
+        <X size={18} />
+      </button>
+    </header>
+  );
+}
+
+function ModalFooter({ onCancel, onConfirm, confirmLabel, disabled, danger }) {
+  return (
+    <footer style={{ padding: "0.75rem 1.25rem", borderTop: "1px solid var(--border-color, rgba(255,255,255,0.08))", display: "flex", justifyContent: "flex-end", gap: 8 }}>
+      <button className="btn-secondary" onClick={onCancel}>Cancel</button>
+      <button
+        className="btn-primary"
+        onClick={onConfirm}
+        disabled={disabled}
+        style={danger ? { background: "#dc2626" } : undefined}
+      >
+        {confirmLabel}
+      </button>
+    </footer>
+  );
+}
+
+const overlayStyle = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.55)",
+  zIndex: 1000,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2rem",
+};
+
+const modalStyle = {
+  background: "var(--card-bg, #1a1a1a)",
+  color: "var(--text-primary, #fff)",
+  borderRadius: 12,
+  width: "min(480px, 100%)",
+  border: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+  maxHeight: "90vh",
+};

--- a/frontend/src/pages/superadmin/SuperAdminLayout.jsx
+++ b/frontend/src/pages/superadmin/SuperAdminLayout.jsx
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+import { Outlet, useNavigate, NavLink } from "react-router-dom";
+import { ShieldCheck, Clock, LogOut, BarChart3, Activity } from "lucide-react";
+import {
+  getSuperAdminToken,
+  getSuperAdminUsername,
+  clearSuperAdminSession,
+  superAdminFetch,
+} from "../../utils/superAdminApi";
+
+// Sidebar modules. Add a new module by appending one entry here + one
+// <Route> in App.jsx; nothing else in this shell needs to change.
+const MODULES = [
+  { path: "/super-admin/cron", label: "Cron Maintenance", icon: Clock },
+  { path: "/super-admin/cron-analytics", label: "Cron Analytics", icon: BarChart3 },
+  { path: "/super-admin/api-analytics", label: "API Analytics", icon: Activity },
+];
+
+export default function SuperAdminLayout() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!getSuperAdminToken()) {
+      navigate("/super-admin/login", { replace: true });
+    }
+  }, [navigate]);
+
+  const handleLogout = async () => {
+    try {
+      await superAdminFetch("/auth/logout", { method: "POST" });
+    } catch {
+      // stateless JWT — logout locally regardless of network result
+    }
+    clearSuperAdminSession();
+    navigate("/super-admin/login", { replace: true });
+  };
+
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden", background: "var(--bg-color, #0b0c10)", color: "var(--text-primary, #fff)" }}>
+      <aside
+        style={{
+          width: 220,
+          flexShrink: 0,
+          height: "100%",
+          borderRight: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+          display: "flex",
+          flexDirection: "column",
+          padding: "1.25rem 0.75rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 0.5rem", marginBottom: "1.5rem" }}>
+          <ShieldCheck size={20} color="var(--accent-color, #3b82f6)" />
+          <span style={{ fontWeight: 700, fontSize: "0.95rem" }}>Super Admin</span>
+        </div>
+
+        <nav style={{ display: "flex", flexDirection: "column", gap: 2, flex: 1 }}>
+          {MODULES.map((m) => (
+            <NavLink
+              key={m.path}
+              to={m.path}
+              style={({ isActive }) => ({
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "0.55rem 0.6rem",
+                borderRadius: 8,
+                fontSize: "0.85rem",
+                textDecoration: "none",
+                color: isActive ? "var(--accent-color, #3b82f6)" : "var(--text-primary, #fff)",
+                background: isActive ? "rgba(59,130,246,0.12)" : "transparent",
+              })}
+            >
+              <m.icon size={16} />
+              {m.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div style={{ borderTop: "1px solid var(--border-color, rgba(255,255,255,0.08))", paddingTop: "0.75rem", marginTop: "0.75rem" }}>
+          <div style={{ fontSize: "0.75rem", color: "var(--text-secondary, #9aa0ab)", padding: "0 0.5rem", marginBottom: "0.5rem", wordBreak: "break-all" }}>
+            {getSuperAdminUsername()}
+          </div>
+          <button
+            onClick={handleLogout}
+            className="btn-secondary"
+            style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: "0.8rem" }}
+          >
+            <LogOut size={14} /> Log out
+          </button>
+        </div>
+      </aside>
+
+      <main style={{ flex: 1, padding: "1.75rem", overflow: "auto" }}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/superadmin/SuperAdminLogin.jsx
+++ b/frontend/src/pages/superadmin/SuperAdminLogin.jsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ShieldCheck } from "lucide-react";
+import { superAdminFetch, setSuperAdminSession, getSuperAdminToken } from "../../utils/superAdminApi";
+
+export default function SuperAdminLogin() {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  if (getSuperAdminToken()) {
+    navigate("/super-admin/cron", { replace: true });
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const data = await superAdminFetch("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ username, password }),
+      });
+      setSuperAdminSession(data.token, data.username);
+      navigate("/super-admin/cron", { replace: true });
+    } catch (err) {
+      setError(err.message || "Login failed");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-color, #0b0c10)",
+        color: "var(--text-primary, #fff)",
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        autoComplete="off"
+        style={{
+          width: "min(380px, 90vw)",
+          background: "var(--card-bg, rgba(255,255,255,0.04))",
+          border: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+          borderRadius: 12,
+          padding: "2rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: "0.5rem" }}>
+          <ShieldCheck size={22} color="var(--accent-color, #3b82f6)" />
+          <h1 style={{ fontSize: "1.15rem", fontWeight: 700, margin: 0 }}>Super Admin Portal</h1>
+        </div>
+        <p style={{ fontSize: "0.8rem", color: "var(--text-secondary, #9aa0ab)", margin: 0 }}>
+          System administration only. This is not your regular CRM login.
+        </p>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "0.85rem" }}>
+          Username
+          <input
+            className="input-field"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoFocus
+            autoComplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "0.85rem" }}>
+          Password
+          <input
+            className="input-field"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            data-1p-ignore
+            data-lpignore="true"
+          />
+        </label>
+
+        {error && (
+          <div style={{ fontSize: "0.8rem", color: "#f28b82" }}>{error}</div>
+        )}
+
+        <button
+          type="submit"
+          className="btn-primary"
+          disabled={loading || !username || !password}
+          style={{ padding: "0.6rem", fontWeight: 600 }}
+        >
+          {loading ? "Signing in…" : "Log in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/utils/superAdminApi.js
+++ b/frontend/src/utils/superAdminApi.js
@@ -1,0 +1,67 @@
+/**
+ * superAdminApi.js — fetch helper for the Super Admin Portal.
+ *
+ * Deliberately separate from utils/api.js's fetchApi: the Super Admin token
+ * is stored under its own localStorage key (never mixed with the regular
+ * app JWT) and 401s redirect to /super-admin/login, not the main /login.
+ */
+
+const TOKEN_KEY = "superAdminToken";
+const USERNAME_KEY = "superAdminUsername";
+
+export function getSuperAdminToken() {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setSuperAdminSession(token, username) {
+  localStorage.setItem(TOKEN_KEY, token);
+  if (username) localStorage.setItem(USERNAME_KEY, username);
+}
+
+export function getSuperAdminUsername() {
+  return localStorage.getItem(USERNAME_KEY);
+}
+
+export function clearSuperAdminSession() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USERNAME_KEY);
+}
+
+export async function superAdminFetch(path, options = {}) {
+  const token = getSuperAdminToken();
+  const headers = {
+    "Content-Type": "application/json",
+    ...(options.headers || {}),
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(`/api/super-admin${path}`, { ...options, headers });
+
+  // A 401 on /auth/login means "wrong credentials", not "session expired" —
+  // there's no prior session to expire. Only treat 401 as a dead session
+  // when we actually sent a token (i.e. this wasn't a login attempt).
+  if (res.status === 401 && token) {
+    clearSuperAdminSession();
+    if (!window.location.pathname.endsWith("/login")) {
+      window.location.href = "/super-admin/login";
+    }
+    throw new Error("Super Admin session expired");
+  }
+
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    // no body / non-JSON response
+  }
+
+  if (!res.ok) {
+    const message = (body && body.error) || `Request failed (${res.status})`;
+    const err = new Error(message);
+    err.status = res.status;
+    err.code = body && body.code;
+    throw err;
+  }
+
+  return body;
+}


### PR DESCRIPTION
### 1. Super Admin Portal — Cron Management + Analytics (new)
A completely separate, env-credential-based admin surface (`/super-admin/*`), isolated from the regular User/tenant auth system.

- **Central cron registry** (`lib/cronRegistry.js`): all 46 cron engines retrofitted from inline `node-cron` onto a shared registry backed by `CronConfig`/`CronExecutionLog` Prisma models — live reschedule/enable/disable with no restart, full execution history with overlap guarding, configurable log retention.
- **Cron Maintenance UI**: create/edit/delete/run-now for every cron, paginated execution logs with filters (including a calendar date-range picker), configurable retention window.
- **Cron Analytics dashboard**: runs-over-time (stacked bar, not line — avoids implying a false trend from sparse days), success/fail split, per-cron duration summary. The "Runs over time" chart has its own independent date-range control, decoupled from the page-level stat tiles.
- **API Analytics dashboard**: tracks every external LLM/API call (Gemini, OpenAI, Anthropic, Perplexity, Groq, SerpApi, TripGo, Zoom, Razorpay) — tokens, real per-model cost estimates (`lib/apiPricing.js`), success/failure with error detail. Supports provider/model filters AND an explicit date/date-range picker (in addition to the preset "Last N days" dropdown) on both the Overview and Call Log tabs. Stub-mode calls (no API key configured — llmRouter.js's synthetic fallback) are fully excluded from every aggregate, never surfaced as if they were real spend.
- **Auth**: `SUPER_ADMIN_USERNAME` + `SUPER_ADMIN_PASSWORD_PLAINTEXT` in `.env`, dedicated JWT secret, no dev fallback. First successful login auto-hashes the password into the DB and rewrites `.env`'s plaintext value back to a placeholder sentinel — the real password never sits on disk longer than one login cycle. Editing `.env` with a new plaintext value later and logging in with it fully replaces the persisted hash (old credential is invalidated the moment the new one is used), supporting password changes at any time without manual DB access.

### 2. Resource-leak hardening (WhatsApp Web + flyer rendering)
- `services/whatsappWebClient.js`: caps concurrent headless-Chromium boot-restores to the N most-recently-active tenants (`WHATSAPP_WEB_RESTORE_MAX_TENANTS`, default 10); prunes dead session objects from the in-memory registry after a timeout; refactors session teardown into `destroyClientAndOrphans()`, which also force-kills orphan Chromium processes via an OS-level `taskkill`/`pkill` safety net (not just a promise-timeout). Also fixes opted-out WhatsApp contacts' inbound 1:1 messages still reaching the inbox.
- `services/flyerRenderEngine.js`: adds a concurrency gate + per-step promise-timeout around the Puppeteer PNG-render path, PLUS native puppeteer `timeout`/`protocolTimeout` launch options (these actually terminate the underlying Chromium process on expiry, unlike a bare `Promise.race`). **Fixed during this PR's review**: the merge had accidentally left a duplicate/redundant concurrency gate from an earlier teammate PR, whose call path double-acquired the render semaphore — this caused every render past the concurrency cap (default 2) to deadlock permanently. Removed the dead duplicate gate, restored the teammate's `timeout`/`protocolTimeout` options, verified live with a 4-concurrent-render smoke test (no deadlock, cap correctly enforced at 2, timeout-triggered cleanup still closes the browser and releases the slot).

### Incidental / drive-by
- `services/imageProviders/aiImageFallbackProvider.js`: removes Gemini Imagen from the image-generation fallback cascade (the project's Gemini key is reserved for text tasks).
- `routes/travel_diagnostics.js`, `routes/travel_personalised_destinations.js`, `e2e/tests/travel-diagnostics-api.spec.js`: comment/assertion updates reflecting the LLM router's reasoning-task model swap (Claude Opus → Gemini Flash primary) — no behavior change in these files themselves.
- `services/marketingFlyerCopyLLM.js`, `services/landingPageGeneratorLLM.js`: wired into the same `LlmCallLog` cost-tracking as the API Analytics work, using real Gemini `usageMetadata` token counts rather than a length-heuristic estimate.
- New `frontend/src/components/CalendarRangePicker.jsx`: dependency-free date/range picker (no date-fns/react-datepicker), used by both the Cron Maintenance log filters and the API Analytics date filters.

## Bug fixed during review (not shipped)
A date-boundary bug was caught and fixed before merge: `?to=<date>` on the API Analytics endpoints parsed the date as UTC midnight but bumped "end of day" using local-time `setHours()` — on an IST server this silently clipped the last ~5.5 hours of the selected day's data. Fixed with `setUTCHours()` in both `/overview` and `/calls`, with a regression test asserting the exact UTC ISO boundary.

## Testing
- Full backend vitest suite: 15,005 passing at the pre-existing baseline (96 unrelated failures in travel-visa/stripe-webhook/auth-cookie/schema-invariants specs — unchanged by this diff, confirmed via repeated isolated + full-suite runs) + several hundred new/updated tests across cron registry, API/Cron analytics, auth, pricing, and the date-range filtering.
- Frontend: `vite build` clean, ESLint clean on all touched/new pages.
- Manually verified end-to-end: cron retrofit (enable/disable/schedule-edit, zero restart), Super Admin login → auto-hash → `.env` redaction → password-change cycle, both analytics dashboards against live data, custom date/range filtering (including the UTC boundary fix), and the flyerRenderEngine deadlock fix under real concurrent load (mocked puppeteer).
- Confirmed neither analytics dashboard makes any LLM/external API call itself — both are pure Prisma reads; cost/token figures come only from data already written by real application code elsewhere.