### PR TITLE
fix(backend): WhatsApp boot-restore + WorkflowEngine cascade memory guards

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -515,6 +515,9 @@ WHATSAPP_WEB_DISABLED=
 WHATSAPP_WEB_CHROME_PATH=
 WHATSAPP_WEB_RESTORE_ON_BOOT=
 WHATSAPP_WEB_RESTORE_MAX_TENANTS=
+# Memory-pressure guard: skip boot-restore if process RSS already exceeds this
+# many megabytes. Default: 2048 (2 GB).
+WHATSAPP_WEB_RESTORE_MEMORY_MB_CAP=
 
 # ─── WhatsApp Gateway (Phase 1-2 extraction — OPTIONAL, default OFF) ────────────
 # Extracts whatsapp-web.js + Puppeteer into a standalone microservice (wa-gateway/)
@@ -807,6 +810,13 @@ ATTENDANCE_SHIFT_START_MINUTE=0
 ATTENDANCE_SHIFT_END_HOUR=18
 ATTENDANCE_SHIFT_END_MINUTE=0
 ATTENDANCE_ON_TIME_TOLERANCE_MIN=15
+
+# ─── Workflow / Automation rule engine (backend/lib/eventBus.js) ─────────────
+# Defensive guard rails for runaway automation-rule cascades. Set to 0 to
+# disable a guard entirely.
+# Maximum event chain depth (e.g. approval.created → create_approval → ...).
+# Default: 10.
+WORKFLOW_MAX_EVENT_CHAIN_DEPTH=
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # End of file. If you added a new env-var to backend code, append it here in

--- a/backend/lib/eventBus.js
+++ b/backend/lib/eventBus.js
@@ -8,6 +8,14 @@ const prisma = require("./prisma");
 const bus = new EventEmitter();
 bus.setMaxListeners(100);
 
+// Defensive guard rails for misconfigured automation rules that would otherwise
+// emit events in a tight cascade and exhaust memory / CPU. Both are opt-out via
+// env (set to 0 to disable).
+const MAX_EVENT_CHAIN_DEPTH = (() => {
+  const v = parseInt(process.env.WORKFLOW_MAX_EVENT_CHAIN_DEPTH, 10);
+  return Number.isFinite(v) && v >= 0 ? v : 10;
+})();
+
 // Global io reference for routes to emit events with socket.io support
 let globalIo = null;
 
@@ -246,7 +254,12 @@ function renderTemplate(template, payload) {
  * @param {number} tenantId   tenant scope
  * @param {object} [io]       Socket.io server instance (optional, uses global if not provided)
  */
-async function emitEvent(eventName, payload, tenantId, io) {
+async function emitEvent(eventName, payload, tenantId, io, depth = 0) {
+  if (depth > MAX_EVENT_CHAIN_DEPTH) {
+    console.warn(`[WorkflowEngine] Event chain depth exceeded for ${eventName}; breaking potential cascade.`);
+    return;
+  }
+
   // Use provided io or fall back to global io reference
   const ioInstance = io || getIO();
   bus.emit(eventName, { payload, tenantId, io: ioInstance });
@@ -262,7 +275,7 @@ async function emitEvent(eventName, payload, tenantId, io) {
       if (!evaluateCondition(rule.condition, payload)) {
         continue;
       }
-      await executeAction(rule, payload, tenantId, io);
+      await executeAction(rule, payload, tenantId, io, depth);
     } catch (e) {
       console.error(`[WorkflowEngine] Rule ${rule.id} failed:`, e.message);
     }
@@ -276,8 +289,16 @@ async function emitEvent(eventName, payload, tenantId, io) {
 /**
  * Execute a single automation rule action.
  */
-async function executeAction(rule, payload, tenantId, io) {
-  const config = rule.targetState ? JSON.parse(rule.targetState) : {};
+async function executeAction(rule, payload, tenantId, io, depth = 0) {
+  let config = {};
+  if (rule.targetState) {
+    try {
+      config = JSON.parse(rule.targetState);
+    } catch (e) {
+      console.warn(`[WorkflowEngine] Rule ${rule.id} targetState is not valid JSON, treating as empty: ${e.message}`);
+      config = {};
+    }
+  }
 
   switch (rule.actionType) {
     case "send_email": {
@@ -429,7 +450,8 @@ async function executeAction(rule, payload, tenantId, io) {
             reason: created.reason,
           },
           tenantId,
-          io
+          io,
+          depth + 1
         );
       } catch (e) {
         console.error("[WorkflowEngine] approval.created emit failed:", e.message);

--- a/backend/services/whatsappWebClient.js
+++ b/backend/services/whatsappWebClient.js
@@ -68,6 +68,32 @@ const STATE = Object.freeze({
 
 const AUTH_DIR = path.join(__dirname, "..", ".wwebjs_auth");
 
+// Boot-restore guard rails. Puppeteer/Chrome is the single largest memory user
+// in this process; on boxes with saved .wwebjs_auth profiles we have seen
+// restoreSessions() push Node RSS past 16 GB and crash the backend. These flags
+// let operators opt out of auto-restore, cap how many sessions we revive, and
+// refuse to launch Chrome when the process is already under memory pressure.
+const RESTORE_ON_BOOT = !/^(0|false|no|disabled)$/i.test(
+  process.env.WHATSAPP_WEB_RESTORE_ON_BOOT || "1"
+);
+const MAX_RESTORE_SESSIONS = (() => {
+  const v = parseInt(process.env.WHATSAPP_WEB_MAX_RESTORE_SESSIONS, 10);
+  return Number.isFinite(v) && v >= 0 ? v : 4;
+})();
+const RESTORE_MEMORY_MB_CAP = (() => {
+  const v = parseInt(process.env.WHATSAPP_WEB_RESTORE_MEMORY_MB_CAP, 10);
+  return Number.isFinite(v) && v >= 256 ? v : 2048;
+})();
+
+function getMemoryMB() {
+  try {
+    const usage = process.memoryUsage();
+    return Math.round((usage.rss || usage.heapUsed || 0) / 1024 / 1024);
+  } catch {
+    return 0;
+  }
+}
+
 // Puppeteer/whatsapp-web.js emit async errors from deep inside Chromium when a
 // session is torn down (phone unlinks → LOGOUT, browser closes mid-inject, a
 // frame detaches during navigation). These surface as unhandledRejection /
@@ -107,11 +133,13 @@ function init(io) {
   _io = io;
   console.log("[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…");
   module.exports.installPuppeteerCrashGuard();
-  // Reap orphan Chromiums a previous unclean exit left holding the saved
-  // session dirs (pm2 SIGKILL doesn't propagate to Chrome children) BEFORE
-  // restoreSessions() launches fresh ones — otherwise old + new stack.
-  // killBrowsersForDir targets ONLY chromes whose cmdline references the
-  // exact session dir; it's a no-op under test and when no dir exists.
+  // Before restoring anything, kill any Chromium processes left behind by a
+  // previous crashed/restarted Node process. Their profiles are locked and they
+  // hold memory; if we launch fresh Chromes on top of them we multiply the
+  // footprint and can OOM the box.
+  module.exports.killAllOrphanBrowsers();
+  // Also do a per-tenant sweep for any chromes whose cmdline references the
+  // exact session dir — catches orphans the broad pgrep sweep may miss.
   try {
     const fs = require("fs");
     for (const e of fs.readdirSync(AUTH_DIR, { withFileTypes: true })) {
@@ -155,6 +183,14 @@ async function restoreSessions() {
     console.log("[whatsappWeb] WHATSAPP_WEB_RESTORE_ON_BOOT=0 — skipping boot-time session restore");
     return { restored: 0, reason: "restore-on-boot-disabled" };
   }
+
+  const memMB = getMemoryMB();
+  if (memMB > RESTORE_MEMORY_MB_CAP) {
+    console.warn(
+      `[whatsappWeb] boot-restore: skipped — process already using ${memMB} MB (cap ${RESTORE_MEMORY_MB_CAP} MB)`
+    );
+    return { restored: 0, reason: "memory-pressure" };
+  }
   const fs = require("fs"); // required locally — this module loads fs lazily per-function
   let entries = [];
   try {
@@ -170,6 +206,7 @@ async function restoreSessions() {
   }
   if (!tenantIds.length) return { restored: 0 };
   // Cap concurrent Chrome launches on boot to avoid memory spikes / OOM on live.
+  // Restore the most-recently-active tenants first; the rest reconnect on demand.
   if (RESTORE_MAX_TENANTS > 0 && tenantIds.length > RESTORE_MAX_TENANTS) {
     tenantIds.sort((a, b) => {
       try {
@@ -184,7 +221,7 @@ async function restoreSessions() {
   }
   console.log(`[whatsappWeb] boot-restore: re-initializing ${tenantIds.length} saved session(s): ${tenantIds.join(", ")}`);
   let i = 0;
-  for (const tenantId of tenantIds) {
+  for (const tenantId of capped) {
     if (i > 0) await new Promise((r) => setTimeout(r, 1500)); // stagger Chrome launches
     i += 1;
     module.exports
@@ -192,7 +229,7 @@ async function restoreSessions() {
       .then(() => console.log(`[whatsappWeb] boot-restore: tenant ${tenantId} resuming from saved session`))
       .catch((err) => console.warn(`[whatsappWeb] boot-restore tenant ${tenantId} failed: ${err.message}`));
   }
-  return { restored: tenantIds.length };
+  return { restored: capped.length };
 }
 
 function getSession(tenantId) {
@@ -434,6 +471,29 @@ function killBrowsersForDir(tenantId) {
     console.log(`[whatsappWeb] tenant ${tenantId} killed any orphan chromium holding ${marker}`);
   } catch (e) {
     console.warn(`[whatsappWeb] tenant ${tenantId} orphan-kill best-effort failed: ${e.message}`);
+  }
+}
+
+// Kill every Chromium whose command line references any session-travel-* profile.
+// Used once at init() to clean up zombies left by a previous crash/restart before
+// we spawn fresh browsers. Best-effort no-op.
+function killAllOrphanBrowsers() {
+  if (process.env.NODE_ENV === "test") return; // never spawn shells under test
+  try {
+    const { execSync } = require("child_process");
+    if (process.platform === "win32") {
+      const ps =
+        `Get-CimInstance Win32_Process | ` +
+        `Where-Object { $_.Name -eq 'chrome.exe' -and $_.CommandLine -like '*session-travel-*' } | ` +
+        `ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`;
+      const encoded = Buffer.from(ps, "utf16le").toString("base64");
+      execSync(`powershell -NoProfile -NonInteractive -EncodedCommand ${encoded}`, { stdio: "ignore", timeout: 15000 });
+    } else {
+      execSync(`pkill -f "session-travel-" || true`, { stdio: "ignore", timeout: 15000, shell: "/bin/sh" });
+    }
+    console.log("[whatsappWeb] init: killed any orphan chromium processes from previous runs");
+  } catch (e) {
+    console.warn(`[whatsappWeb] init: orphan-kill best-effort failed: ${e.message}`);
   }
 }
 
@@ -2253,6 +2313,7 @@ module.exports = {
   clearSession,
   reapDeadClient,
   killBrowsersForDir,
+  killAllOrphanBrowsers,
   parsePgrepPids,
   clearStaleLocks,
   resolveChromePath,

--- a/backend/test/lib/eventBus.test.js
+++ b/backend/test/lib/eventBus.test.js
@@ -434,6 +434,24 @@ describe('emitEvent — prisma async tail (rule fan-out + webhook delivery)', ()
     // Both rules attempted — sibling not aborted by predecessor's failure.
     expect(prisma.notification.create).toHaveBeenCalledTimes(2);
   });
+
+  test('breaks a call that already exceeds the configured event chain depth cap', async () => {
+    // Calling emitEvent with depth > MAX should short-circuit and warn,
+    // preventing runaway cascades from misconfigured rules.
+    prisma.automationRule.findMany.mockResolvedValueOnce([
+      { id: 1, name: 'loop', triggerType: 'evt', actionType: 'send_sms', condition: null, targetState: null },
+    ]);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await emitEvent('evt', { userId: 5 }, 42, null, 11);
+
+    const depthWarnings = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('Event chain depth exceeded')
+    );
+    expect(depthWarnings.length).toBeGreaterThanOrEqual(1);
+    // No rules should have been evaluated once we short-circuit.
+    expect(prisma.automationRule.findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe('executeAction — send_notification', () => {
@@ -792,6 +810,22 @@ describe('executeAction — create_approval', () => {
       (c) => c[0]?.where?.triggerType === 'approval.created'
     );
     expect(approvalCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('executeAction — malformed targetState', () => {
+  test('treats non-JSON targetState as empty config and still writes audit log', async () => {
+    const rule = {
+      id: 1, name: 'r', triggerType: 'evt', actionType: 'send_sms',
+      targetState: 'amount > 100000',
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await executeAction(rule, { phone: '9999999999' }, 42);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('targetState is not valid JSON')
+    );
+    warnSpy.mockRestore();
+    expect(prisma.auditLog.create).toHaveBeenCalled();
   });
 });
 

--- a/backend/test/services/whatsappWebClient.test.js
+++ b/backend/test/services/whatsappWebClient.test.js
@@ -64,6 +64,18 @@ beforeEach(() => {
   wa.init({ to: (room) => ({ emit: (ev, payload) => emits.push({ room, ev, payload }) }) });
 });
 
+describe('boot restore guard rails', () => {
+  test('restoreSessions is disabled under test env without launching Chrome', async () => {
+    const result = await wa.restoreSessions();
+    expect(result.restored).toBe(0);
+    expect(result.reason).toBe('disabled');
+  });
+  test('killAllOrphanBrowsers is exported and is a safe no-op under test', () => {
+    expect(typeof wa.killAllOrphanBrowsers).toBe('function');
+    expect(() => wa.killAllOrphanBrowsers()).not.toThrow();
+  });
+});
+
 describe('phone helpers', () => {
   test('normalizePhone adds 91 for bare 10-digit, strips non-digits', () => {
     expect(wa.normalizePhone('9811111102')).toBe('919811111102');


### PR DESCRIPTION
## Summary
Combines the WhatsApp Web boot-restore guards and WorkflowEngine cascade breaker from #1212 onto a clean branch to address the demo memory blowout.

### Changes
- **WhatsApp Web**
  - Kill orphan Chromiums before restoring sessions (broad pgrep sweep + per-session-dir sweep).
  - Skip boot-restore when process RSS already exceeds WHATSAPP_WEB_RESTORE_MEMORY_MB_CAP (default 2048 MB).
  - Keep existing RESTORE_ON_BOOT switch and RESTORE_MAX_TENANTS cap.
- **WorkflowEngine**
  - Add MAX_EVENT_CHAIN_DEPTH guard to prevent unbounded event cascades (notably create_approval -> approval.created loops).
  - Safely parse rule.targetState; non-JSON values now log and skip instead of throwing repeatedly.

### Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.10 [39m[90m/Users/globussoft-m1/Documents/GitHub/globussoft-crm[39m

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mboot restore guard rails[2m > [22m[2mrestoreSessions is disabled under test env without launching Chrome
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mboot restore guard rails[2m > [22m[2mkillAllOrphanBrowsers is exported and is a safe no-op under test
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mphone helpers[2m > [22m[2mnormalizePhone adds 91 for bare 10-digit, strips non-digits
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mphone helpers[2m > [22m[2mtoChatId / fromChatId round-trip
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mchat classification (@c.us + @lid are 1:1; groups/channels excluded)[2m > [22m[2mchatAddressKind maps the address spaces
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mchat classification (@c.us + @lid are 1:1; groups/channels excluded)[2m > [22m[2misIndividualChatId accepts @c.us AND @lid only
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mchat classification (@c.us + @lid are 1:1; groups/channels excluded)[2m > [22m[2mresolveIndividual: @c.us derives the number from the id
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mchat classification (@c.us + @lid are 1:1; groups/channels excluded)[2m > [22m[2mresolveIndividual: @lid resolves real phone via getContactLidAndPhone
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mchat classification (@c.us + @lid are 1:1; groups/channels excluded)[2m > [22m[2mresolveIndividual: unresolvable @lid falls back to a stable lid key
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mstub semantics under test env[2m > [22m[2misEnabled is false (no tenant / not connected)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mstub semantics under test env[2m > [22m[2mgetState for unknown tenant is DISCONNECTED
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mstub semantics under test env[2m > [22m[2mconnect() never launches a browser under test → DISCONNECTED stub
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mstub semantics under test env[2m > [22m[2mdisconnect() returns DISCONNECTED
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionMessage persists a QUEUED OUTBOUND row
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionMessage persists a QUEUED OUTBOUND row
[22m[39m[whatsappWeb STUB] sendText tenant=3 subBrand=(none) to=919811111102 textLen=2 — operator must scan the WhatsApp QR to go live

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionMessage WITHOUT a threadId ensures a thread and links the message
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionMessage WITHOUT a threadId ensures a thread and links the message
[22m[39m[whatsappWeb STUB] sendText tenant=3 subBrand=(none) to=919811111103 textLen=10 — operator must scan the WhatsApp QR to go live

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendTemplateMessage carries templateName onto the row + renders bodyPreview
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendTemplateMessage carries templateName onto the row + renders bodyPreview
[22m[39m[whatsappWeb STUB] sendText tenant=3 subBrand=(none) to=919811111102 textLen=27 — operator must scan the WhatsApp QR to go live

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendBestEffort sends fallbackText (no template gate on WhatsApp Web)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendBestEffort sends fallbackText (no template gate on WhatsApp Web)
[22m[39m[whatsappWeb STUB] sendText tenant=3 subBrand=(none) to=919811111102 textLen=10 — operator must scan the WhatsApp QR to go live

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionFile persists QUEUED row with media metadata
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2msend surface (stub → QUEUED + persisted row)[2m > [22m[2msendSessionFile persists QUEUED row with media metadata
[22m[39m[whatsappWeb STUB] sendFile tenant=3 to=919811111102 file=a.jpg (image/jpeg, 2b) — scan the QR to go live

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mread surface stubs[2m > [22m[2mgetMessageTemplates is empty (WhatsApp Web has no template catalogue)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mread surface stubs[2m > [22m[2mgetContacts / getMessages return empty when not connected
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mack mapping[2m > [22m[2mmapAck covers the WhatsApp ack ladder
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mack mapping[2m > [22m[2mapplyAck advances a SENT row to READ + emits whatsapp:status
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mack mapping[2m > [22m[2mapplyAck never downgrades (READ row ignores DELIVERED ack)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mpurgeChats (disconnect clears the mirror)[2m > [22m[2mdeletes all messages then threads for the tenant
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mpurgeChats (disconnect clears the mirror)[2m > [22m[2mdeletes all messages then threads for the tenant
[22m[39m[whatsappWeb] tenant 3 purged 2 threads / 6 messages

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mcontactName fallback (stale Prisma client)[2m > [22m[2mthread create retries without contactName when the column is unknown
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/lib/eventBus.test.js[2m > [22m[2mexecuteAction — send_webhook (delegates to webhookDelivery.deliverSingle)[2m > [22m[2mreaches the audit row even when webhookDelivery is invoked
[22m[39m[Webhook] evt -> https://hooks.example.com/cb: 200

[90mstdout[2m | backend/test/lib/eventBus.test.js[2m > [22m[2mexecuteAction — malformed targetState[2m > [22m[2mtreats non-JSON targetState as empty config and still writes audit log
[22m[39m[WorkflowEngine] SMS action: to=9999999999, msg=r

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mdestroys every live client, suppresses auto-reconnect, and does NOT wipe the dir
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mdestroys every live client, suppresses auto-reconnect, and does NOT wipe the dir
[22m[39m[whatsappWeb] graceful shutdown — destroying 1 live session(s) so their auth stores flush cleanly

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mdestroys every live client, suppresses auto-reconnect, and does NOT wipe the dir
[22m[39m[whatsappWeb] graceful shutdown done — 1/1 session(s) closed cleanly, 1 orphan Chromium process(es) killed

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2ma hung client.destroy is time-boxed, never blocking shutdown
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2ma hung client.destroy is time-boxed, never blocking shutdown
[22m[39m[whatsappWeb] graceful shutdown — destroying 1 live session(s) so their auth stores flush cleanly

 [32m✓[39m backend/test/lib/eventBus.test.js [2m([22m[2m115 tests[22m[2m)[22m[32m 22[2mms[22m[39m
[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2ma hung client.destroy is time-boxed, never blocking shutdown
[22m[39mprisma:error 
Invalid `prisma.tenant.findUnique()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/travelWhatsappLeadCapture.js:43:35

  40 if (verticalCache.has(tenantId)) return verticalCache.get(tenantId);
  41 let isTravel = false;
  42 try {
→ 43   const t = await prisma.tenant.findUnique(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2ma hung client.destroy is time-boxed, never blocking shutdown
[22m[39m[whatsappWeb] graceful shutdown done — 1/1 session(s) closed cleanly, 1 orphan Chromium process(es) killed

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mshutdown is safe with no destroyable clients (returns a count)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mshutdown is safe with no destroyable clients (returns a count)
[22m[39m[whatsappWeb] graceful shutdown — destroying 1 live session(s) so their auth stores flush cleanly

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mshutdown (graceful teardown so the auth store flushes — prevents "logged out on restart")[2m > [22m[2mshutdown is safe with no destroyable clients (returns a count)
[22m[39m[whatsappWeb] graceful shutdown done — 0/1 session(s) closed cleanly, 0 orphan Chromium process(es) killed

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mdestroyClientAndOrphans (memory-leak cleanup helper)[2m > [22m[2mdestroys the client, nulls the handle, and kills orphan browsers
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mdestroyClientAndOrphans (memory-leak cleanup helper)[2m > [22m[2mis safe when there is no session
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mscheduleSessionPrune (prevents dead-session registry growth)[2m > [22m[2mremoves a DISCONNECTED session after the prune delay
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mscheduleSessionPrune (prevents dead-session registry growth)[2m > [22m[2mremoves a DISCONNECTED session after the prune delay
[22m[39m[whatsappWeb] tenant 3 pruned stale DISCONNECTED session from registry

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mscheduleSessionPrune (prevents dead-session registry growth)[2m > [22m[2mdoes NOT prune a session that changed state before the timer fired
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2misPuppeteerTeardownError (crash guard only swallows benign puppeteer teardown noise)[2m > [22m[2mclassifies the real "detached Frame" crash as a teardown error
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2misPuppeteerTeardownError (crash guard only swallows benign puppeteer teardown noise)[2m > [22m[2mclassifies "Target closed" / "Session closed" as teardown errors
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2misPuppeteerTeardownError (crash guard only swallows benign puppeteer teardown noise)[2m > [22m[2mdoes NOT swallow a genuine application error (must still crash)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mclearStaleLocks (recover a session locked by an unclean restart)[2m > [22m[2mremoves stale Chromium singleton locks but KEEPS the session data
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mclearStaleLocks (recover a session locked by an unclean restart)[2m > [22m[2mremoves stale Chromium singleton locks but KEEPS the session data
[22m[39m[whatsappWeb] tenant 9421 cleared 3 stale Chromium lock artifact(s) before launch

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mclearStaleLocks (recover a session locked by an unclean restart)[2m > [22m[2mis a safe no-op when the session dir does not exist
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mthread create race (P2002 recovery)[2m > [22m[2ma concurrent create that loses the race recovers by updating the winner
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mnew inbound → thread create (unread 1) + INBOUND row + whatsapp:received emit
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mfromMe echoes, channels, and status broadcasts are skipped
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mgroup (@g.us) messages ARE ingested, keyed by the group id, sender-prefixed
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mduplicate providerMsgId is not re-persisted
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mexisting ASSIGNED thread does not bump unreadCount
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mopted-out 1:1 number is dropped — no thread/message row, no emit
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mingestInbound[2m > [22m[2mopted-out check is skipped for group chats — group message still ingested
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mdefaults to enabled (true) when unset — matches historical always-restore behavior
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2m0 disables boot-restore
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mfalse disables boot-restore
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mFALSE disables boot-restore
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mno disables boot-restore
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mNO disables boot-restore
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2m1 (or any non-disable value) keeps boot-restore enabled
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mtrue (or any non-disable value) keeps boot-restore enabled
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2myes (or any non-disable value) keeps boot-restore enabled
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2manything-else (or any non-disable value) keeps boot-restore enabled
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mrestoreOnBootEnabled — WHATSAPP_WEB_RESTORE_ON_BOOT guard[2m > [22m[2mrestoreSessions() short-circuits with reason "restore-on-boot-disabled" when the guard is off — proven via the exported hook so this doesn't depend on defeating canLaunch()/NODE_ENV=test
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mparses newline-separated PIDs into numbers
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mexcludes the calling process's own PID — this is the actual bug fix
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mhandles pgrep finding nothing (empty/whitespace-only output)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mignores garbage/non-numeric lines rather than throwing
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mde-dupes repeated PIDs
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mparsePgrepPids — pkill self-kill bug fix (Linux/macOS)[2m > [22m[2mdrops zero/negative values (never valid PIDs)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

[90mstdout[2m | backend/test/services/whatsappWebClient.test.js[2m > [22m[2mkillBrowsersForDir — NODE_ENV=test guard[2m > [22m[2mis a no-op under NODE_ENV=test (never spawns a shell)
[22m[39m[whatsappWeb] init — socket handle attached; restoring previously-linked sessions…

 [32m✓[39m backend/test/services/whatsappWebClient.test.js [2m([22m[2m63 tests[22m[2m)[22m[32m 54[2mms[22m[39m
[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPOST /api/landing-pages (create)[2m > [22m[2mhappy path: 201 with auto-generated slug + persists tenantId from req.user
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPOST /api/landing-pages (create)[2m > [22m[2mtemplateType without content pulls the template body
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPUT /api/landing-pages/:id (update)[2m > [22m[2mhappy path: tenant-scoped update returns 200; only present keys go to update
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPUT /api/landing-pages/:id (update)[2m > [22m[2m#456 PUBLISHED slug change with ?confirmSlugChange=true proceeds
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPUT /api/landing-pages/:id (update)[2m > [22m[2mPhase 11 — linking a Wanderlux page to a trip defaults register.mode to lead
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

[90mstdout[2m | backend/test/routes/landing-pages.test.js[2m > [22m[2mPOST /api/landing-pages/:id/publish | /unpublish | /duplicate[2m > [22m[2mpublish: sets PUBLISHED + publishedAt
[22m[39mprisma:error 
Invalid `prisma.landingPageVersion.findFirst()` invocation in
/Users/globussoft-m1/Documents/GitHub/globussoft-crm/backend/lib/landingPageVersions.js:48:48

  45   throw new Error(`snapshot source must be one of: ${[...VALID_SOURCES].join(', ')}`);
  46 }
  47 
→ 48 const last = await prisma.landingPageVersion.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:55
   | 
54 |   provider = "mysql"
55 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1

 [32m✓[39m backend/test/routes/landing-pages.test.js [2m([22m[2m112 tests[22m[2m)[22m[32m 258[2mms[22m[39m

[2m Test Files [22m [1m[32m3 passed[39m[22m[90m (3)[39m
[2m      Tests [22m [1m[32m290 passed[39m[22m[90m (290)[39m
[2m   Start at [22m 18:44:55
[2m   Duration [22m 850ms[2m (transform 301ms, setup 0ms, import 940ms, tests 334ms, environment 0ms)[22m → 290 passed.
- Full backend suite shows only unrelated  module failures (pre-existing).

Closes #1212

### Deployment note
After merge, deploy to demo with WHATSAPP_WEB_RESTORE_ON_BOOT=0, remove/reset session-travel-58, and deactivate automation rules 1, 5, 11492 until targetState is corrected.