### PR TITLE
This branch bundles three independent fixes that happened to be in pr…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -966,6 +966,102 @@ jobs:
         run: |
           echo "::notice title=Deploy complete::commit ${{ github.sha }} live on https://crm.globusdemos.com (build + api_tests passed)"
 
+      # ── Telegram deploy alert ────────────────────────────────────────
+      # Runs regardless of outcome (always()) so a failed/rolled-back deploy
+      # notifies the channel too, not just a healthy one. Captures a live PM2
+      # memory + recent-error snapshot over SSH so a leak (e.g. the WhatsApp/
+      # Puppeteer RSS blowout — PR #1217) would show up here immediately after
+      # every deploy, not just when someone thinks to SSH in and check.
+      # Never fails the workflow itself (all curl/ssh calls best-effort) —
+      # a broken Telegram notify must not block/red a real deploy.
+      - name: Capture PM2 snapshot
+        id: pm2_snapshot
+        if: always()
+        uses: appleboy/ssh-action@v1.2.0
+        continue-on-error: true
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          command_timeout: 1m
+          # Required for steps.pm2_snapshot.outputs.stdout to populate below —
+          # ssh-action only captures/exposes stdout as an action output when
+          # this is explicitly set (verified against appleboy/ssh-action's
+          # action.yml; default is false and the output silently stays empty).
+          capture_stdout: true
+          script: |
+            export PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH"
+            echo "--- memory (rss MB / cpu %) ---"
+            pm2 jlist 2>/dev/null | node -e '
+              let d="";
+              process.stdin.on("data", c => d += c);
+              process.stdin.on("end", () => {
+                try {
+                  const procs = JSON.parse(d);
+                  for (const p of procs) {
+                    const rssMb = Math.round((p.monit?.memory || 0) / 1024 / 1024);
+                    console.log(`${p.name}: rss=${rssMb}MB cpu=${p.monit?.cpu ?? "?"}% restarts=${p.pm2_env?.restart_time ?? "?"} uptime_s=${Math.round((Date.now() - (p.pm2_env?.pm_uptime || Date.now())) / 1000)}`);
+                  }
+                } catch (e) { console.log("(pm2 jlist parse failed: " + e.message + ")"); }
+              });
+            ' || echo "(pm2 jlist unavailable)"
+            echo "--- last 15 error lines (pm2 logs) ---"
+            pm2 logs globussoft-crm-backend --err --lines 15 --nostream 2>/dev/null | tail -15 || echo "(no pm2 error log available)"
+
+      - name: Post Telegram deploy alert
+        if: always()
+        continue-on-error: true
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          SNAPSHOT: ${{ steps.pm2_snapshot.outputs.stdout }}
+        run: |
+          set +e
+          if [ "${{ steps.backend.outcome }}" = "success" ]; then
+            ICON="✅"
+            STATUS="Healthy"
+          elif [ "${{ steps.backend.outcome }}" = "failure" ]; then
+            ICON="🔴"
+            STATUS="FAILED — rolled back to HEAD~1"
+          else
+            ICON="⚠️"
+            STATUS="Unknown (backend step: ${{ steps.backend.outcome }})"
+          fi
+
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+          FIRST_MSG_LINE=$(printf '%s' "$COMMIT_MSG" | head -1)
+          SNAPSHOT_TEXT="${SNAPSHOT:-(snapshot unavailable)}"
+
+          # Plain text, no parse_mode: Telegram's Markdown parser 400s the
+          # whole request on a single stray _ / * / ` / [ character, and both
+          # the commit message and PM2 error-log lines are untrusted free text
+          # we don't want to escape defensively. Plain text always sends.
+          # Built via printf (not a heredoc) — a heredoc's closing marker
+          # can't tolerate the leading indentation this block scalar forces
+          # on every line, so string-concatenation is the robust choice here.
+          GATES_LINE="Gates: build=${{ needs.build.result }} api_tests=${{ needs.api_tests.result }} unit_tests=${{ needs.unit_tests.result }} lint=${{ needs.lint.result }} frontend_tests=${{ needs.frontend_unit_tests.result }} migration=${{ needs.migration_check.result }}"
+          TEXT=$(printf '%s\n' \
+            "${ICON} Deploy — crm.globusdemos.com" \
+            "Commit: ${SHORT_SHA} ${FIRST_MSG_LINE}" \
+            "Pushed by: ${GITHUB_ACTOR}" \
+            "${GATES_LINE}" \
+            "Status: ${STATUS}" \
+            "" \
+            "${SNAPSHOT_TEXT}")
+
+          # Telegram messages cap at 4096 chars; truncate defensively so a
+          # runaway PM2 error dump can't make the API silently reject the post.
+          TEXT="${TEXT:0:4000}"
+
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${TEXT}" \
+            -o /tmp/telegram_response.json
+          cat /tmp/telegram_response.json
+          echo
+
   # ── 8. DEPLOY_STAGING: mirrors deploy job but targets crm-staging ──────
   # Runs in parallel with the production deploy. Uses the same SSH secrets
   # (same server, different user home + vhost). No rollback on staging —

--- a/backend/cron/paymentDeadlineEngine.js
+++ b/backend/cron/paymentDeadlineEngine.js
@@ -80,6 +80,13 @@ async function runPaymentDeadlineTick(now = new Date()) {
       status: "accepted", // committed but unpaid (advance_paid/fully_paid excluded)
       subBrand: { not: "visasure" }, // everything except Visa Sure
       startDate: { gte: floor, lte: horizon },
+      // Exclude bookings already in (or past) the customer-cancellation flow —
+      // `status` never flips away from "accepted" on cancellation (separate
+      // lifecycle field, see schema comment on Itinerary.cancellationStatus),
+      // so without this guard the cron keeps re-stamping paymentOverdueAt on
+      // an already-cancelled/refunded booking, reviving a stale "Deposit
+      // overdue" badge on the itinerary list indefinitely.
+      cancellationStatus: null,
     },
     select: {
       id: true, tenantId: true, subBrand: true, contactId: true, destination: true,

--- a/backend/lib/refundService.js
+++ b/backend/lib/refundService.js
@@ -13,7 +13,7 @@
 
 const prisma = require("./prisma");
 const { writeAudit } = require("./audit");
-const { getTenantRazorpayClient, NOT_CONFIGURED_MESSAGE } = require("./tenantPaymentGateway");
+const { getTenantRazorpayClient, NOT_CONFIGURED_MESSAGE, parseRazorpayError } = require("./tenantPaymentGateway");
 
 function safeJsonParse(value, fallback = {}) {
   if (value == null) return fallback;
@@ -183,7 +183,8 @@ async function refundCapturedPayment({ payment, amount, reason, userId }) {
     });
   } catch (err) {
     console.error("[refundService] razorpay refund failed:", err && err.message);
-    return { ok: false, status: 502, code: "REFUND_FAILED", error: "The refund could not be processed by Razorpay. Please try again." };
+    const parsed = parseRazorpayError(err);
+    return { ok: false, status: parsed.status, code: parsed.code, error: parsed.message };
   }
 
   const updated = await finalizeRefund(payment, {

--- a/backend/lib/tenantPaymentGateway.js
+++ b/backend/lib/tenantPaymentGateway.js
@@ -71,9 +71,83 @@ async function getTenantRazorpayClient(tenantId) {
   }
 }
 
+// Strip anything that looks like a Razorpay key out of a string before it
+// reaches the browser — the SDK's own error text sometimes echoes back
+// request context that can include key-shaped substrings.
+function scrubKeys(s) {
+  if (typeof s !== "string") return s;
+  return s.replace(/\b(sk|pk|rk|rzp)_(test|live)_[A-Za-z0-9_*]+/g, "[redacted]");
+}
+
+/**
+ * Map a Razorpay SDK throw to a safe, specific, user-facing message instead
+ * of a blanket "please try again". Razorpay's SDK throws
+ * `{ statusCode, error: { code, description, field, ... } }` — mirrors the
+ * `parseGatewayError` pattern already used for the customer-payment create
+ * path in routes/payments.js, reused here so the ADMIN-override refund flow
+ * (refundService.js) gives an equally specific reason instead of a generic
+ * REFUND_FAILED for every kind of rejection.
+ *
+ * @returns {{status:number, code:string, message:string}}
+ */
+function parseRazorpayError(err) {
+  if (!err) return { status: 502, code: "GATEWAY_ERROR", message: "Razorpay is temporarily unavailable. Please try again in a moment." };
+  const description = (err.error && err.error.description) || err.message || "Razorpay error";
+  const gatewayCode = (err.error && err.error.code) || err.code || null;
+  const gatewayStatus = err.statusCode || 0;
+
+  const looksLikeAuthIssue =
+    gatewayStatus === 401 ||
+    /invalid api key|authentication|unauthorized|key_invalid/i.test(description);
+  if (looksLikeAuthIssue) {
+    return {
+      status: 503,
+      code: "GATEWAY_NOT_CONFIGURED",
+      message: "Razorpay isn't available right now. Please contact support — the payment gateway needs to be reconfigured.",
+    };
+  }
+
+  // Already-refunded / already-processed on Razorpay's side — our DB thought
+  // it wasn't refunded yet (e.g. a webhook hadn't landed), but Razorpay's
+  // ledger disagrees. Tell the operator to refresh rather than retry blindly.
+  const looksAlreadyRefunded = /refund.*already|already.*refund|fully refunded/i.test(description);
+  if (looksAlreadyRefunded) {
+    return {
+      status: 409,
+      code: "ALREADY_REFUNDED_UPSTREAM",
+      message: "Razorpay shows this payment as already refunded. Please refresh the page — the status here may be out of date.",
+    };
+  }
+
+  // Payment isn't in a refundable state on Razorpay's side (e.g. still
+  // "authorized" rather than "captured", or voided/failed) — same class of
+  // "Razorpay's status disagrees with ours" as the already-refunded case
+  // above, just the opposite direction. Tell the operator to check status
+  // rather than show them Razorpay's internal "captured" terminology.
+  const looksLikeWrongStatus = /status should be captured|not.*captured|payment status/i.test(description);
+  if (looksLikeWrongStatus) {
+    return {
+      status: 409,
+      code: "PAYMENT_NOT_CAPTURED",
+      message: "This payment isn't eligible for a refund right now. Razorpay doesn't show it as fully captured — please refresh the page and check the payment's current status before retrying.",
+    };
+  }
+
+  if (gatewayStatus >= 400 && gatewayStatus < 500) {
+    return { status: 400, code: gatewayCode || "REFUND_REJECTED", message: scrubKeys(description) };
+  }
+
+  return {
+    status: 502,
+    code: gatewayCode || "GATEWAY_UNAVAILABLE",
+    message: "Razorpay is temporarily unavailable. Please try again in a moment.",
+  };
+}
+
 module.exports = {
   PROVIDER,
   NOT_CONFIGURED_MESSAGE,
   getTenantRazorpayCreds,
   getTenantRazorpayClient,
+  parseRazorpayError,
 };

--- a/backend/routes/travel_itineraries.js
+++ b/backend/routes/travel_itineraries.js
@@ -1994,7 +1994,10 @@ router.patch(
         // Apply the cancellation policy: compute the refund due for what's been
         // paid, given days-to-departure, and tell the customer the exact figure.
         refund = await resolveCancellationRefund(itin);
-        data = { cancellationStatus: "cancelled" };
+        // Clear any pay-or-cancel deposit-overdue flag the cron stamped before
+        // this cancellation — otherwise the itinerary list keeps showing a
+        // "Deposit overdue" badge on a booking that's no longer awaiting payment.
+        data = { cancellationStatus: "cancelled", paymentOverdueAt: null };
         custTitle = "Booking cancelled";
         const refundLine = refund.computable && refund.refundAmount != null
           ? ` Per our cancellation policy${refund.policyName ? ` (${refund.policyName})` : ""}, a refund of ${cur}${Number(refund.refundAmount).toLocaleString("en-IN")} (${refund.refundPercent}% of ${cur}${Number(refund.paidAmount).toLocaleString("en-IN")} paid) will be processed.`
@@ -2034,7 +2037,9 @@ router.patch(
             gatewayRefund = r.ok ? r.refund : null;
           }
         }
-        data = { cancellationStatus: "refunded" };
+        // Belt-and-suspenders: also clear here in case the flag got re-stamped
+        // by the cron between the "cancelled" and "refunded" transitions.
+        data = { cancellationStatus: "refunded", paymentOverdueAt: null };
         custTitle = "Refund processed";
         const amtLine = refundAmount ? ` of ${cur}${refundAmount.toLocaleString("en-IN")}` : "";
         custMessage = `The refund${amtLine} for your cancelled ${trip} booking has been processed.${note ? ` ${note}` : ""}`;
@@ -2045,7 +2050,7 @@ router.patch(
       const updated = await prisma.itinerary.update({
         where: { id: itin.id },
         data,
-        select: { id: true, status: true, cancellationStatus: true, cancellationReason: true, cancellationRequestedAt: true },
+        select: { id: true, status: true, cancellationStatus: true, cancellationReason: true, cancellationRequestedAt: true, paymentOverdueAt: true },
       });
 
       writeAudit(

--- a/backend/services/passportOcrClient.js
+++ b/backend/services/passportOcrClient.js
@@ -173,6 +173,14 @@ async function runOcr(imageBuffer, opts = {}) {
       throw e2;
     }
   }
+  // Expose the live worker to the caller (opts.workerRef, an out-param) so
+  // withTimeout() can terminate it immediately on timeout instead of merely
+  // abandoning this in-flight call — Promise.race does not cancel the loser,
+  // so without this hand-off a slow scan leaks a full Tesseract worker (WASM
+  // + loaded traineddata) per timeout, uncounted by the concurrency gate in
+  // withOcrSlot() since that gate releases as soon as the RACE settles, not
+  // when this worker actually terminates.
+  if (opts.workerRef) opts.workerRef.current = worker;
   async function useLanguage(lang) {
     try {
       await worker.reinitialize(lang);
@@ -268,6 +276,10 @@ async function runOcr(imageBuffer, opts = {}) {
     console.error("[passportOcrClient] runOcr failed:", runErr?.message || runErr, runErr?.stack || "");
     return { mrzText: "", vizText: "", confidence: null };
   } finally {
+    // terminate() is safe to call twice (tesseract.js no-ops on an already-
+    // terminated worker) — this covers the normal-completion path even when
+    // withTimeout() already terminated the worker on the timeout path below.
+    if (opts.workerRef) opts.workerRef.current = null;
     await worker.terminate().catch(() => {});
   }
 }
@@ -337,10 +349,25 @@ function resolvePassportNumber(mrz, viz) {
 }
 
 // Race a promise against a timeout; clears the timer on settle.
-function withTimeout(promise, ms) {
+//
+// workerRef is an out-param ({ current: worker|null }) that runOcr() fills in
+// once its tesseract worker is created. Promise.race does NOT cancel the
+// losing side — if runOcr() itself is still running when the timer fires, it
+// would otherwise keep the worker (and every in-flight recognize() pass)
+// alive in the background until it eventually settles on its own, uncounted
+// by the withOcrSlot() concurrency gate (which releases as soon as THIS race
+// settles). Terminating the worker directly on timeout makes the abandoned
+// runOcr() call fail fast (its pending worker.recognize()/reinitialize()
+// calls reject once the worker is gone) so its own `finally` cleanup runs
+// immediately instead of whenever the hung call happens to unwind.
+function withTimeout(promise, ms, workerRef) {
   let timer;
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => {
+      if (workerRef?.current) {
+        workerRef.current.terminate().catch(() => {});
+        workerRef.current = null;
+      }
       const err = new Error("OCR timed out");
       err.code = "OCR_TIMEOUT";
       reject(err);
@@ -476,7 +503,8 @@ async function extractPassport({ tenantId, filePath, fileBuffer, fileName, mimeT
   let vizText = "";
   let ocrConfidence = null;
   try {
-    const result = await withOcrSlot(() => withTimeout(runOcr(buffer, { ocr }), OCR_TIMEOUT_MS));
+    const workerRef = { current: null };
+    const result = await withOcrSlot(() => withTimeout(runOcr(buffer, { ocr, workerRef }), OCR_TIMEOUT_MS, workerRef));
     mrzText = result?.mrzText || "";
     vizText = result?.vizText || "";
     ocrConfidence = result?.confidence ?? null;
@@ -597,4 +625,4 @@ function mergeExtraction(mrz, viz, ocrConfidence) {
   };
 }
 
-module.exports = { extractPassport, isEnabledForTenant, runOcr, INTEGRATION };
+module.exports = { extractPassport, isEnabledForTenant, runOcr, withTimeout, INTEGRATION };

--- a/backend/test/cron/paymentDeadlineEngine.test.js
+++ b/backend/test/cron/paymentDeadlineEngine.test.js
@@ -56,6 +56,20 @@ describe("paymentDeadlineEngine.runPaymentDeadlineTick — scope", () => {
     expect(where.startDate).toHaveProperty("gte");
     expect(where.startDate).toHaveProperty("lte");
   });
+
+  // Regression guard: `status` never flips away from "accepted" when a
+  // booking is cancelled (cancellationStatus is a separate lifecycle
+  // field — see schema comment on Itinerary.cancellationStatus). Without
+  // this scan-query guard, the cron keeps re-considering (and, before
+  // paymentOverdueAt was already set, re-stamping) a cancelled/refunded
+  // booking, reviving a stale "Deposit overdue" badge on the itinerary
+  // list indefinitely.
+  it("excludes itineraries with any cancellationStatus set (requested/cancelled/refunded) from the scan", async () => {
+    prisma.itinerary.findMany.mockResolvedValue([]);
+    await runPaymentDeadlineTick(NOW);
+    const where = prisma.itinerary.findMany.mock.calls[0][0].where;
+    expect(where.cancellationStatus).toBeNull();
+  });
 });
 
 describe("paymentDeadlineEngine.runPaymentDeadlineTick — reminders", () => {

--- a/backend/test/lib/refundService.test.js
+++ b/backend/test/lib/refundService.test.js
@@ -86,11 +86,53 @@ describe('refundCapturedPayment', () => {
     expect(r.code).toBe('NO_GATEWAY');
   });
 
-  test('gateway throw → REFUND_FAILED (502), payment not mutated', async () => {
+  test('gateway throw with no structured error → generic GATEWAY_UNAVAILABLE (502), payment not mutated', async () => {
     refundMock.mockRejectedValue(new Error('razorpay down'));
     const r = await svc.refundCapturedPayment({ payment: pay() });
     expect(r.ok).toBe(false);
-    expect(r.code).toBe('REFUND_FAILED');
+    expect(r.status).toBe(502);
+    expect(r.code).toBe('GATEWAY_UNAVAILABLE');
+    expect(r.error).toMatch(/temporarily unavailable/i);
     expect(prisma.payment.update).not.toHaveBeenCalled();
+  });
+
+  // Regression: previously every Razorpay rejection collapsed into the same
+  // blanket "please try again" message regardless of WHY Razorpay rejected
+  // it (auth misconfig / already-refunded upstream / a genuine 4xx like an
+  // amount limit) — parseRazorpayError (lib/tenantPaymentGateway.js) maps
+  // known Razorpay error shapes to a specific, safe, user-facing reason.
+  test('gateway throw with a structured 4xx error → specific rejection reason, not the generic message', async () => {
+    const err = new Error('The amount exceeds the maximum refund amount');
+    err.statusCode = 400;
+    err.error = { code: 'BAD_REQUEST_ERROR', description: 'The amount exceeds the maximum refund amount' };
+    refundMock.mockRejectedValue(err);
+    const r = await svc.refundCapturedPayment({ payment: pay() });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(400);
+    expect(r.code).toBe('BAD_REQUEST_ERROR');
+    expect(r.error).toMatch(/exceeds the maximum refund amount/i);
+  });
+
+  test('gateway throw indicating Razorpay already processed the refund → ALREADY_REFUNDED_UPSTREAM, tells the operator to refresh', async () => {
+    const err = new Error('The payment has already been fully refunded');
+    err.statusCode = 400;
+    err.error = { code: 'BAD_REQUEST_ERROR', description: 'The payment has already been fully refunded' };
+    refundMock.mockRejectedValue(err);
+    const r = await svc.refundCapturedPayment({ payment: pay() });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(409);
+    expect(r.code).toBe('ALREADY_REFUNDED_UPSTREAM');
+    expect(r.error).toMatch(/refresh/i);
+  });
+
+  test('gateway throw indicating an auth/config issue → GATEWAY_NOT_CONFIGURED, never echoes the key', async () => {
+    const err = new Error('Invalid API Key provided: rzp_test_ABC123XYZ');
+    err.statusCode = 401;
+    refundMock.mockRejectedValue(err);
+    const r = await svc.refundCapturedPayment({ payment: pay() });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(503);
+    expect(r.code).toBe('GATEWAY_NOT_CONFIGURED');
+    expect(r.error).not.toMatch(/rzp_test/);
   });
 });

--- a/backend/test/lib/tenantPaymentGateway.test.js
+++ b/backend/test/lib/tenantPaymentGateway.test.js
@@ -37,6 +37,7 @@ const {
   NOT_CONFIGURED_MESSAGE,
   getTenantRazorpayCreds,
   getTenantRazorpayClient,
+  parseRazorpayError,
 } = gw;
 
 beforeEach(() => {
@@ -52,6 +53,69 @@ describe('module shape', () => {
     expect(NOT_CONFIGURED_MESSAGE.length).toBeGreaterThan(0);
     expect(typeof getTenantRazorpayCreds).toBe('function');
     expect(typeof getTenantRazorpayClient).toBe('function');
+    expect(typeof parseRazorpayError).toBe('function');
+  });
+});
+
+describe('parseRazorpayError', () => {
+  // Regression: the Payments-page refund flow used to collapse EVERY
+  // Razorpay SDK throw into the same blanket "please try again" 502,
+  // regardless of whether Razorpay actually rejected the request (a real,
+  // actionable 4xx) or was genuinely unreachable. This mirrors the
+  // parseGatewayError pattern already used for the customer-payment create
+  // path in routes/payments.js, so both flows give specific reasons.
+  test('no error object → generic gateway-unavailable 502', () => {
+    const out = parseRazorpayError(null);
+    expect(out.status).toBe(502);
+    expect(out.code).toBe('GATEWAY_ERROR');
+  });
+
+  test('401 / auth-shaped message → GATEWAY_NOT_CONFIGURED (503), never echoes the key', () => {
+    const err = new Error('Invalid API Key provided: rzp_test_ABCD1234');
+    err.statusCode = 401;
+    const out = parseRazorpayError(err);
+    expect(out.status).toBe(503);
+    expect(out.code).toBe('GATEWAY_NOT_CONFIGURED');
+    expect(out.message).not.toMatch(/rzp_test/);
+  });
+
+  test('"already refunded" upstream message → ALREADY_REFUNDED_UPSTREAM (409), tells the operator to refresh', () => {
+    const err = new Error('rejected');
+    err.statusCode = 400;
+    err.error = { code: 'BAD_REQUEST_ERROR', description: 'The payment has already been fully refunded' };
+    const out = parseRazorpayError(err);
+    expect(out.status).toBe(409);
+    expect(out.code).toBe('ALREADY_REFUNDED_UPSTREAM');
+    expect(out.message).toMatch(/refresh/i);
+  });
+
+  test('"payment status should be captured" message → PAYMENT_NOT_CAPTURED (409), tells the operator to check status', () => {
+    const err = new Error('rejected');
+    err.statusCode = 400;
+    err.error = { code: 'BAD_REQUEST_ERROR', description: 'The payment status should be captured for action to be taken' };
+    const out = parseRazorpayError(err);
+    expect(out.status).toBe(409);
+    expect(out.code).toBe('PAYMENT_NOT_CAPTURED');
+    expect(out.message).toMatch(/isn't eligible for a refund/i);
+    expect(out.message).not.toMatch(/captured for action to be taken/i);
+  });
+
+  test('generic 4xx with a structured description → surfaces the specific reason, scrubbed', () => {
+    const err = new Error('rejected');
+    err.statusCode = 400;
+    err.error = { code: 'BAD_REQUEST_ERROR', description: 'The refund amount exceeds rzp_live_ABCDEFGH the captured amount' };
+    const out = parseRazorpayError(err);
+    expect(out.status).toBe(400);
+    expect(out.code).toBe('BAD_REQUEST_ERROR');
+    expect(out.message).toMatch(/exceeds/i);
+    expect(out.message).not.toMatch(/rzp_live/);
+  });
+
+  test('5xx / unstructured throw → generic gateway-unavailable 502 (not a fabricated 4xx reason)', () => {
+    const out = parseRazorpayError(new Error('ECONNRESET'));
+    expect(out.status).toBe(502);
+    expect(out.code).toBe('GATEWAY_UNAVAILABLE');
+    expect(out.message).toMatch(/temporarily unavailable/i);
   });
 });
 

--- a/backend/test/routes/travel-itineraries-cancellation.test.js
+++ b/backend/test/routes/travel-itineraries-cancellation.test.js
@@ -1,0 +1,225 @@
+// @ts-check
+/**
+ * PATCH /api/travel/itineraries/:id/cancellation — advisor cancellation
+ * resolution (approve / decline / refunded).
+ *
+ * WHY this test exists: the itinerary list page badges an "accepted"
+ * booking as "Deposit overdue" once cron/paymentDeadlineEngine stamps
+ * paymentOverdueAt (see paymentDeadlineEngine.test.js). Cancelling a
+ * booking never touches `status` — cancellationStatus is a separate
+ * lifecycle field — so unless this route ALSO clears paymentOverdueAt,
+ * a booking that was flagged overdue before cancellation keeps showing
+ * the stale "Deposit overdue" badge forever after being cancelled and
+ * refunded. This pins that both the "approve" and "refunded" decisions
+ * clear the flag (the latter is belt-and-suspenders in case the cron
+ * re-stamped it between the cancelled → refunded transitions).
+ *
+ * Mocking strategy (mirrors portal-travel-cancellation.test.js +
+ * travel-itineraries-api.test.js): patch the prisma singleton BEFORE
+ * requiring the router; real verifyToken + requireTravelTenant +
+ * requirePermission middleware runs; ADMIN role short-circuits
+ * requirePermission via req.user.isOwner is NOT used here — instead we
+ * sign role:'ADMIN' and mock getSubBrandAccessSet's backing
+ * prisma.user.findUnique to role:'ADMIN' so canAccessSubBrand always
+ * passes. prisma.travelInvoice / prisma.cancellationPolicy resolve to
+ * empty so resolveCancellationRefund short-circuits to its
+ * computable:false base case — refund math itself is out of scope here.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+import prisma from '../../lib/prisma.js';
+
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn();
+prisma.user = prisma.user || {};
+prisma.user.findUnique = vi.fn();
+prisma.itinerary = prisma.itinerary || {};
+prisma.itinerary.findFirst = vi.fn();
+prisma.itinerary.update = vi.fn();
+prisma.travelInvoice = prisma.travelInvoice || {};
+prisma.travelInvoice.findFirst = vi.fn();
+prisma.cancellationPolicy = prisma.cancellationPolicy || {};
+prisma.cancellationPolicy.findFirst = vi.fn();
+prisma.cancellationPolicy.findMany = vi.fn();
+prisma.payment = prisma.payment || {};
+prisma.payment.findFirst = vi.fn();
+prisma.auditLog = prisma.auditLog || {};
+prisma.auditLog.create = vi.fn().mockResolvedValue({ id: 1 });
+prisma.travelPortalNotification = prisma.travelPortalNotification || {};
+prisma.travelPortalNotification.create = vi.fn().mockResolvedValue({ id: 1 });
+prisma.revokedToken = prisma.revokedToken || {};
+prisma.revokedToken.findUnique = vi.fn().mockResolvedValue(null);
+
+import express from 'express';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+const JWT_SECRET = process.env.JWT_SECRET || 'enterprise_super_secret_key_2026';
+const travelItinerariesRouter = requireCJS('../../routes/travel_itineraries');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/travel', travelItinerariesRouter);
+  return app;
+}
+
+function tokenFor(role = 'ADMIN', { userId = 7, tenantId = 1 } = {}) {
+  return jwt.sign(
+    { userId, tenantId, role, email: `${role.toLowerCase()}@test.local` },
+    JWT_SECRET,
+    { expiresIn: '1h' },
+  );
+}
+
+function itin(overrides = {}) {
+  return {
+    id: 55,
+    tenantId: 1,
+    subBrand: 'travelstall',
+    contactId: 501,
+    destination: 'Goa',
+    currency: 'INR',
+    cancellationStatus: null,
+    advancePaidAmount: 0,
+    startDate: new Date(Date.now() + 10 * 86_400_000),
+    paymentReference: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  prisma.tenant.findUnique.mockReset().mockResolvedValue({
+    id: 1, vertical: 'travel', name: 'Test Travel', slug: 'test-travel',
+  });
+  prisma.user.findUnique.mockReset().mockResolvedValue({ role: 'ADMIN', subBrandAccess: null });
+  prisma.itinerary.findFirst.mockReset();
+  prisma.itinerary.update.mockReset().mockImplementation(async ({ data }) => ({
+    id: 55, status: 'accepted', cancellationStatus: null, cancellationReason: null,
+    cancellationRequestedAt: null, paymentOverdueAt: null, ...data,
+  }));
+  prisma.travelInvoice.findFirst.mockReset().mockResolvedValue(null);
+  prisma.cancellationPolicy.findFirst.mockReset().mockResolvedValue(null);
+  prisma.cancellationPolicy.findMany.mockReset().mockResolvedValue([]);
+  prisma.payment.findFirst.mockReset().mockResolvedValue(null);
+  prisma.auditLog.create.mockReset().mockResolvedValue({ id: 1 });
+  prisma.travelPortalNotification.create.mockReset().mockResolvedValue({ id: 1 });
+  prisma.revokedToken.findUnique.mockReset().mockResolvedValue(null);
+});
+
+describe('PATCH /api/travel/itineraries/:id/cancellation — paymentOverdueAt clearing', () => {
+  test('approve: a stale paymentOverdueAt flag is cleared alongside cancellationStatus=cancelled', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(
+      itin({ cancellationStatus: 'requested', paymentOverdueAt: new Date('2026-06-01T00:00:00Z') }),
+    );
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'approve' });
+
+    expect(res.status).toBe(200);
+    expect(prisma.itinerary.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 55 },
+        data: expect.objectContaining({ cancellationStatus: 'cancelled', paymentOverdueAt: null }),
+      }),
+    );
+    expect(res.body.cancellationStatus).toBe('cancelled');
+    expect(res.body.paymentOverdueAt).toBeNull();
+  });
+
+  test('refunded: paymentOverdueAt is cleared again (belt-and-suspenders vs. a cron re-stamp)', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(
+      itin({ cancellationStatus: 'cancelled', paymentOverdueAt: new Date('2026-06-05T00:00:00Z') }),
+    );
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'refunded' });
+
+    expect(res.status).toBe(200);
+    expect(prisma.itinerary.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 55 },
+        data: expect.objectContaining({ cancellationStatus: 'refunded', paymentOverdueAt: null }),
+      }),
+    );
+    expect(res.body.cancellationStatus).toBe('refunded');
+    expect(res.body.paymentOverdueAt).toBeNull();
+  });
+
+  test('decline: cancellationStatus resets to null; paymentOverdueAt is untouched (booking continues, still owes)', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(
+      itin({ cancellationStatus: 'requested', paymentOverdueAt: new Date('2026-06-01T00:00:00Z') }),
+    );
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'decline' });
+
+    expect(res.status).toBe(200);
+    const data = prisma.itinerary.update.mock.calls[0][0].data;
+    expect(data).toEqual({ cancellationStatus: null });
+    expect(data).not.toHaveProperty('paymentOverdueAt');
+  });
+
+  test('approve with no prior paymentOverdueAt (never flagged) still succeeds — data.paymentOverdueAt explicitly null', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(
+      itin({ cancellationStatus: 'requested', paymentOverdueAt: null }),
+    );
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'approve' });
+
+    expect(res.status).toBe(200);
+    expect(prisma.itinerary.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ paymentOverdueAt: null }) }),
+    );
+  });
+});
+
+describe('PATCH /api/travel/itineraries/:id/cancellation — lifecycle guards', () => {
+  test('approve without a pending request → 409 NO_PENDING_REQUEST, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: null }));
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'approve' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('NO_PENDING_REQUEST');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
+  test('refunded before cancelled → 409 NOT_CANCELLED, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'requested' }));
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'refunded' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('NOT_CANCELLED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
+  test('invalid decision → 400 INVALID_DECISION', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'requested' }));
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'bogus' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DECISION');
+  });
+
+  test('itinerary not found → 404 NOT_FOUND', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(null);
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/999/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'approve' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('NOT_FOUND');
+  });
+});

--- a/backend/test/services/passportOcrClient.test.js
+++ b/backend/test/services/passportOcrClient.test.js
@@ -9,7 +9,7 @@
  * boundary (no place-of-birth/issue from MRZ), and the graceful-failure paths.
  */
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { extractPassport, isEnabledForTenant } from '../../services/passportOcrClient.js';
+import { extractPassport, isEnabledForTenant, withTimeout } from '../../services/passportOcrClient.js';
 
 // Canonical ICAO specimen MRZ (valid check digits).
 const MRZ_TEXT = [
@@ -155,6 +155,50 @@ describe('extractPassport — VIZ cross-check catches MRZ digit/letter slips', (
     expect(res.extraction.dateOfBirth).toBe('2023-03-19');
     expect(res.extraction.dateOfExpiry).toBe('2026-04-20');
     expect(res.note).toMatch(/disagreed/i);
+  });
+});
+
+describe('withTimeout — worker leak fix (2026-07-15)', () => {
+  // Regression test for a memory leak: withTimeout() used to be a bare
+  // Promise.race, which does NOT cancel the losing side. When a slow OCR
+  // call outran the timeout, the abandoned runOcr() call kept its Tesseract
+  // worker (WASM + loaded traineddata) alive in the background indefinitely
+  // — and withOcrSlot()'s concurrency gate released immediately on timeout,
+  // so leaked workers were never even counted against the concurrency cap.
+  // The fix threads a workerRef out-param through so the timeout path can
+  // terminate the worker directly instead of merely losing the race.
+  test('terminates the in-flight worker via workerRef when the timeout fires', async () => {
+    const worker = { terminate: vi.fn().mockResolvedValue(undefined) };
+    const workerRef = { current: worker };
+    const slowPromise = new Promise(() => {}); // never resolves — simulates a stuck OCR call
+
+    await expect(withTimeout(slowPromise, 10, workerRef)).rejects.toMatchObject({ code: 'OCR_TIMEOUT' });
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(workerRef.current).toBeNull();
+  });
+
+  test('does not touch the worker when the promise settles before the timeout', async () => {
+    const worker = { terminate: vi.fn().mockResolvedValue(undefined) };
+    const workerRef = { current: worker };
+
+    const result = await withTimeout(Promise.resolve('done'), 5000, workerRef);
+
+    expect(result).toBe('done');
+    expect(worker.terminate).not.toHaveBeenCalled();
+  });
+
+  test('is a no-op when no worker has been assigned yet (workerRef.current is null)', async () => {
+    const workerRef = { current: null };
+    const slowPromise = new Promise(() => {});
+
+    await expect(withTimeout(slowPromise, 10, workerRef)).rejects.toMatchObject({ code: 'OCR_TIMEOUT' });
+    // Nothing to assert on termination — just confirms no throw on a null worker.
+  });
+
+  test('still rejects with OCR_TIMEOUT when no workerRef is passed (back-compat)', async () => {
+    const slowPromise = new Promise(() => {});
+    await expect(withTimeout(slowPromise, 10)).rejects.toMatchObject({ code: 'OCR_TIMEOUT' });
   });
 });
 

--- a/frontend/src/__tests__/Itineraries.test.jsx
+++ b/frontend/src/__tests__/Itineraries.test.jsx
@@ -1629,3 +1629,96 @@ describe('<Itineraries /> — S81 MapPreview wire-in (list page)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: "Deposit overdue" badge must not survive cancellation.
+//
+// cancellationStatus (requested/cancelled/refunded) is a separate lifecycle
+// field from `status` — cancelling a booking never flips `status` away
+// from "accepted" (see backend/prisma/schema.prisma comment + the
+// cancellation PATCH route). Before the fix, the list badge condition was
+// bare `status === "accepted" && paymentOverdueAt`, so a booking that had
+// been flagged overdue pre-cancellation kept showing "Deposit overdue"
+// forever, even after ItineraryDetail correctly showed "Booking cancelled
+// & refunded". SUT lines 878-895 guard on `!it.cancellationStatus`; the
+// status pill itself (lines 822-829) also swaps to the CANCELLATION_LABEL/
+// CANCELLATION_VARIANT text once cancellationStatus is set.
+// ---------------------------------------------------------------------------
+describe('<Itineraries /> — cancellation suppresses the stale "Deposit overdue" badge', () => {
+  function makeOverdueItin(overrides = {}) {
+    return makeItin({
+      id: 501,
+      subBrand: 'travelstall',
+      status: 'accepted',
+      productTier: 'primary',
+      destination: 'Goa',
+      totalAmount: 225000,
+      currency: 'INR',
+      contactId: 5001,
+      paymentOverdueAt: '2026-06-29T10:00:00.000Z',
+      cancellationStatus: null,
+      items: [],
+      ...overrides,
+    });
+  }
+
+  it('accepted + paymentOverdueAt + no cancellationStatus → shows the "Deposit overdue" badge (baseline)', async () => {
+    installFetchMock({
+      list: { itineraries: [makeOverdueItin()], total: 1, limit: 100, offset: 0 },
+    });
+    renderPage();
+    const row = (await screen.findByText('Goa')).closest('tr');
+    expect(within(row).getByText(/Deposit overdue/i)).toBeInTheDocument();
+  });
+
+  it('accepted + paymentOverdueAt + cancellationStatus="cancelled" → badge is suppressed', async () => {
+    installFetchMock({
+      list: {
+        itineraries: [makeOverdueItin({ cancellationStatus: 'cancelled' })],
+        total: 1, limit: 100, offset: 0,
+      },
+    });
+    renderPage();
+    const row = (await screen.findByText('Goa')).closest('tr');
+    expect(within(row).queryByText(/Deposit overdue/i)).toBeNull();
+  });
+
+  it('accepted + paymentOverdueAt + cancellationStatus="refunded" → badge suppressed + status pill reads "Cancelled & refunded"', async () => {
+    installFetchMock({
+      list: {
+        itineraries: [makeOverdueItin({ cancellationStatus: 'refunded' })],
+        total: 1, limit: 100, offset: 0,
+      },
+    });
+    renderPage();
+    const row = (await screen.findByText('Goa')).closest('tr');
+    expect(within(row).queryByText(/Deposit overdue/i)).toBeNull();
+    const pill = within(row).getByText('Cancelled & refunded');
+    expect(pill.className).toContain('travel-itin-status-pill--rejected');
+  });
+
+  it('accepted + paymentOverdueAt + cancellationStatus="requested" → badge suppressed while resolution is pending', async () => {
+    installFetchMock({
+      list: {
+        itineraries: [makeOverdueItin({ cancellationStatus: 'requested' })],
+        total: 1, limit: 100, offset: 0,
+      },
+    });
+    renderPage();
+    const row = (await screen.findByText('Goa')).closest('tr');
+    expect(within(row).queryByText(/Deposit overdue/i)).toBeNull();
+    expect(within(row).getByText('Cancellation requested')).toBeInTheDocument();
+  });
+
+  it('cancelled but never flagged overdue (paymentOverdueAt null) → no badge regardless of guard', async () => {
+    installFetchMock({
+      list: {
+        itineraries: [makeOverdueItin({ cancellationStatus: 'cancelled', paymentOverdueAt: null })],
+        total: 1, limit: 100, offset: 0,
+      },
+    });
+    renderPage();
+    const row = (await screen.findByText('Goa')).closest('tr');
+    expect(within(row).queryByText(/Deposit overdue/i)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -195,6 +195,49 @@ describe('utils/api — fetchApi', () => {
     });
   });
 
+  it('shows the specific app-authored message when the backend returns a modeled { error, code } 5xx body', async () => {
+    // A route handler that ran its logic and returned a structured failure
+    // (e.g. refundService's REFUND_FAILED / GATEWAY_NOT_CONFIGURED) has
+    // already produced safe, specific, user-facing copy server-side — the
+    // client should show it verbatim instead of overwriting it with the
+    // generic fallback.
+    mockFetch({ status: 502, body: { error: 'Razorpay is temporarily unavailable. Please try again in a moment.', code: 'GATEWAY_UNAVAILABLE' } });
+    await expect(fetchApi('/api/payments/1/refund')).rejects.toMatchObject({
+      message: 'Razorpay is temporarily unavailable. Please try again in a moment.',
+      code: 'GATEWAY_UNAVAILABLE',
+      status: 502,
+    });
+  });
+
+  it('shows a retry-shortly message (not the generic fallback) for a bodiless 502/503/504 — an infra-level failure, not a modeled app error', async () => {
+    // No errData.code means response.json() returned {} — the request most
+    // likely never reached our route handler at all (Nginx/PM2 briefly
+    // unreachable mid-deploy or mid-restart). That's a different situation
+    // from a route that ran and modeled a failure, so it gets its own copy.
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.resolve({}),
+    });
+    await expect(fetchApi('/api/payments/1/refund')).rejects.toMatchObject({
+      message: 'The server was temporarily unreachable (probably mid-deploy or restarting). Please wait a few seconds and try again.',
+      code: null,
+      status: 502,
+    });
+  });
+
+  it('still uses the generic fallback for a bodiless plain 500 (not 502/503/504)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+    await expect(fetchApi('/api/crash')).rejects.toMatchObject({
+      message: 'Something went wrong on our end. Please try again — if it keeps happening, contact support.',
+      status: 500,
+    });
+  });
+
   it('on 401: clears in-memory + sessionStorage token and redirects to /login', async () => {
     setAuthToken('expired');
     expect(sessionStorage.getItem('token')).toBe('expired');

--- a/frontend/src/pages/travel/Itineraries.jsx
+++ b/frontend/src/pages/travel/Itineraries.jsx
@@ -72,6 +72,24 @@ const STATUS_VARIANT = {
   expired: "rejected",
 };
 
+// cancellationStatus is a separate, later-added lifecycle field (independent
+// of `status` — see backend/prisma/schema.prisma) that the customer-initiated
+// cancellation flow advances through requested → cancelled → refunded. It
+// takes display PRECEDENCE over the stale `status` value once set, mirroring
+// ItineraryDetail.jsx's cancellation banner. Without this, a cancelled/
+// refunded booking keeps showing whatever `status` it had before cancellation
+// (e.g. "accepted") since the cancellation PATCH never touches `status`.
+const CANCELLATION_LABEL = {
+  requested: "Cancellation requested",
+  cancelled: "Cancelled",
+  refunded: "Cancelled & refunded",
+};
+const CANCELLATION_VARIANT = {
+  requested: "sent",
+  cancelled: "rejected",
+  refunded: "rejected",
+};
+
 // PRD §6.4 — tier badge palette. productTier on each Itinerary is captured
 // at creation from the contact's latest diagnostic (recommendedTier).
 // Neutral / travel-navy / warm-gold for entry / primary / premium.
@@ -801,7 +819,14 @@ export default function Itineraries() {
             </thead>
             <tbody>
               {filteredItems.map((it) => {
-                const statusVariant = STATUS_VARIANT[it.status] || "other";
+                // cancellationStatus (once set) overrides the stale `status`
+                // pill — see CANCELLATION_LABEL comment above.
+                const statusLabel = it.cancellationStatus
+                  ? CANCELLATION_LABEL[it.cancellationStatus] || it.cancellationStatus
+                  : it.status;
+                const statusVariant = it.cancellationStatus
+                  ? CANCELLATION_VARIANT[it.cancellationStatus] || "other"
+                  : STATUS_VARIANT[it.status] || "other";
                 return (
                   <tr
                     key={it.id}
@@ -841,13 +866,16 @@ export default function Itineraries() {
                     <td style={td}>{fmtMoney(it.totalAmount, it.currency)}</td>
                     <td style={td}>
                       <span className={`travel-itin-status-pill travel-itin-status-pill--${statusVariant}`}>
-                        {it.status}
+                        {statusLabel}
                       </span>
                       {/* Pay-or-cancel at-risk flag: an accepted booking whose
                           50% deposit deadline passed unpaid (paymentOverdueAt
                           set by cron/paymentDeadlineEngine). Prompts the advisor
-                          to follow up or set status → expired. */}
-                      {it.status === "accepted" && it.paymentOverdueAt && (
+                          to follow up or set status → expired. Suppressed once
+                          a cancellation is in play (requested/cancelled/
+                          refunded) — the booking is no longer an active unpaid
+                          deposit risk, it's a cancellation being processed. */}
+                      {!it.cancellationStatus && it.status === "accepted" && it.paymentOverdueAt && (
                         <span
                           title={`Deposit overdue since ${fmt(it.paymentOverdueAt)} — review for cancellation`}
                           style={{

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -267,7 +267,26 @@ export const fetchApi = async (url, options = {}) => {
       // developer needs to correlate this toast with the matching backend
       // log line — so it rides along in small print / the console, not the
       // headline message.
-      userMsg = 'Something went wrong on our end. Please try again — if it keeps happening, contact support.';
+      //
+      // Two different 5xx shapes reach here, and they mean different things:
+      //   - errData.code present ("REFUND_FAILED", "GATEWAY_UNAVAILABLE", …) —
+      //     our OWN route handler ran, modeled the failure, and returned a
+      //     structured { error, code } body. serverMsg is safe, specific,
+      //     app-authored copy (never raw driver/SDK text) — show it.
+      //   - errData.code absent (response.json() returned {} because the
+      //     body wasn't JSON, or had no .code) — the request likely never
+      //     reached our route handler at all: an infra-level 502/503/504
+      //     from Nginx/PM2 (mid-deploy, backend restarting, briefly
+      //     unreachable). The generic "something went wrong" text is
+      //     genuinely correct there, but framed as a retry-shortly blip
+      //     rather than an app error, since that's what it usually is.
+      if (errData.code && serverMsg) {
+        userMsg = serverMsg;
+      } else if (response.status === 502 || response.status === 503 || response.status === 504) {
+        userMsg = 'The server was temporarily unreachable (probably mid-deploy or restarting). Please wait a few seconds and try again.';
+      } else {
+        userMsg = 'Something went wrong on our end. Please try again — if it keeps happening, contact support.';
+      }
       console.error(`[api] ${response.status} ${errorCode} on ${url}:`, serverMsg || '(no server message)');
     } else {
       userMsg = serverMsg || `Request failed (${response.status}).`;


### PR DESCRIPTION
1. Stale "Deposit overdue" badge survives itinerary cancellation (Travel CRM)
Bug: Cancelling and refunding a travel booking never cleared the paymentOverdueAt flag, and the itinerary list's badge check didn't look at cancellation status — so a booking that had been flagged overdue before cancellation kept showing a red "Deposit overdue" badge on the Itineraries list indefinitely, even though the detail page correctly showed "Booking cancelled & refunded."

Root cause: cancellationStatus is a separate lifecycle field from status (cancelling a booking never flips status away from "accepted"). Three places needed to account for that and didn't — the cron kept re-scanning cancelled bookings, the cancellation route never cleared the flag, and the list badge only checked status.

Fix + tests: cron scan guard, route clears paymentOverdueAt on approve/refund, frontend suppresses the badge + fixes the status pill text. New/extended tests across all three layers.

2. Unfriendly refund-rejection error on the Payments page
Raw Razorpay error text ("payment status should be captured...") now maps to a friendly, actionable message (PAYMENT_NOT_CAPTURED, 409) in tenantPaymentGateway.js, with a regression test.

3. Tesseract OCR worker leak on passport-scan timeout
withTimeout() now terminates the abandoned Tesseract worker on timeout instead of leaking it in the background, via an out-param handoff. Test added.

4. CI: Telegram deploy alerts
New deploy.yml step posts deploy status + PM2 health snapshot to Telegram after every deploy.