### PR TITLE
Add generic lead custom fields, wellness attendance geofencing, and r…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -627,6 +627,9 @@ LLM_MODEL_GROQ=
 SERP_API_KEY=
 # Optional — SerpApi request timeout in ms (default 15000).
 SERP_API_TIMEOUT_MS=
+# Optional — exact-query cache lifetime in ms (default 120000 / 2 minutes).
+# Set to 0 to always fetch fresh Google Flights data.
+SERP_API_CACHE_TTL_MS=
 #
 # Ground TRANSFERS — OpenStreetMap (Nominatim geocode + OSRM driving route).
 # Key-FREE + worldwide (covers India + Saudi, which TripGo did NOT). Real road

--- a/backend/controllers/audienceController.js
+++ b/backend/controllers/audienceController.js
@@ -103,6 +103,47 @@ const prisma = new PrismaClient();
  *                   type: string
  *                   example: Internal server error
  */
+// Generic-vertical-only Lead custom fields (Settings > Lead Fields /
+// routes/lead_custom_fields.js) — mirrors attachLeadCustomFieldsBatch in
+// routes/contacts.js so ConvertedLeads.jsx (which reads this endpoint, not
+// GET /api/contacts) also gets one column per admin-defined field, with
+// null for contacts that predate the field. Best-effort: a failure here
+// returns the contacts unchanged rather than breaking the list.
+async function attachLeadCustomFieldsBatch(contacts, tenantId) {
+    if (!Array.isArray(contacts) || !contacts.length) return contacts;
+    try {
+        const definitions = await prisma.leadCustomFieldDefinition.findMany({ where: { tenantId } });
+        if (!definitions.length) return contacts.map((c) => ({ ...c, customFields: {} }));
+        const contactIds = contacts.map((c) => c.id).filter((id) => id != null);
+        const values = await prisma.leadCustomFieldValue.findMany({
+            where: { tenantId, contactId: { in: contactIds } },
+        });
+        const valuesByContact = new Map();
+        for (const v of values) {
+            if (!valuesByContact.has(v.contactId)) valuesByContact.set(v.contactId, []);
+            valuesByContact.get(v.contactId).push(v);
+        }
+        const byFieldId = new Map(definitions.map((d) => [d.id, d]));
+        return contacts.map((c) => {
+            const customFields = {};
+            for (const def of definitions) customFields[def.fieldKey] = null;
+            for (const v of valuesByContact.get(c.id) || []) {
+                const def = byFieldId.get(v.fieldId);
+                if (!def) continue;
+                const raw =
+                    def.fieldType === "number" ? v.valueNumber
+                    : def.fieldType === "date" ? v.valueDate
+                    : def.fieldType === "checkbox" ? v.valueBool
+                    : v.valueText;
+                customFields[def.fieldKey] = raw;
+            }
+            return { ...c, customFields };
+        });
+    } catch (_e) {
+        return contacts.map((c) => ({ ...c, customFields: {} }));
+    }
+}
+
 exports.getContactsByStatus = async (req, res) => {
     try {
         const status = req.query.status || "Customer";
@@ -126,11 +167,13 @@ exports.getContactsByStatus = async (req, res) => {
             });
         }
 
+        const withCustomFields = await attachLeadCustomFieldsBatch(contacts, req.user.tenantId);
+
         return res.status(200).json({
             success: true,
             message: "Contacts fetched successfully",
-            count: contacts.length,
-            data: contacts,
+            count: withCustomFields.length,
+            data: withCustomFields,
         });
 
     } catch (error) {

--- a/backend/lib/attendanceGeofence.js
+++ b/backend/lib/attendanceGeofence.js
@@ -1,0 +1,121 @@
+// attendanceGeofence.js — geo-tagged attendance (wellness vertical only).
+//
+// Decides whether a clock-in/out punch is accepted, given the coordinates
+// the browser captured and the punching user's assigned clinics.
+//
+// Design (per product decisions):
+//   - Enforced ONLY for wellness-vertical tenants. Other verticals (travel,
+//     generic) share the same clock-in/out route unmodified.
+//   - A user with NO assigned Location (UserLocation rows) is NOT enforced —
+//     falls back to today's unconditional-accept behaviour. This lets an
+//     admin roll geofencing out clinic-by-clinic without locking out staff
+//     who haven't been assigned yet.
+//   - A user CAN be assigned to multiple clinics (e.g. a doctor splitting
+//     time across two locations) — the punch passes if it's within radius
+//     of ANY ONE of their assigned Locations.
+//   - GPS accuracy is checked independently of distance: a reading fuzzier
+//     than ACCURACY_THRESHOLD_M is rejected before the distance check even
+//     runs, since a low-accuracy fix can't reliably confirm OR deny
+//     proximity.
+//   - Locations without their own geofenceRadiusM fall back to
+//     DEFAULT_RADIUS_M rather than requiring a backfill on every existing row.
+//
+// Reuses the exact haversine implementation already shipped for travel POI
+// dedup (lib/poiDedup.js) instead of a second copy.
+
+const { haversineDistanceMeters } = require("./poiDedup");
+
+const DEFAULT_RADIUS_M = 150;
+const ACCURACY_THRESHOLD_M = 100;
+
+/**
+ * @param {{latitude:number, longitude:number, accuracy:number}} coords
+ * @returns {{ok:boolean, code?:string, error?:string}}
+ */
+function checkAccuracy(coords) {
+  const { latitude, longitude, accuracy } = coords || {};
+  if (
+    typeof latitude !== "number" || !Number.isFinite(latitude) ||
+    typeof longitude !== "number" || !Number.isFinite(longitude)
+  ) {
+    return { ok: false, code: "LOCATION_REQUIRED", error: "Location coordinates are required to punch in/out at this clinic." };
+  }
+  if (typeof accuracy === "number" && Number.isFinite(accuracy) && accuracy > ACCURACY_THRESHOLD_M) {
+    return {
+      ok: false,
+      code: "ACCURACY_TOO_LOW",
+      error: `Your location reading isn't precise enough (±${Math.round(accuracy)}m). Move somewhere with a clearer GPS signal and try again.`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Resolve whether `coords` falls within radius of ANY of `locations`.
+ * @param {{latitude:number, longitude:number}} coords
+ * @param {Array<{id:number, name:string, latitude:number|null, longitude:number|null, geofenceRadiusM:number|null}>} locations
+ * @returns {{ok:boolean, matchedLocationId?:number, code?:string, error?:string}}
+ */
+function checkWithinAnyRadius(coords, locations) {
+  const usable = (locations || []).filter((l) => typeof l.latitude === "number" && typeof l.longitude === "number");
+  if (usable.length === 0) {
+    // Assigned to a Location, but that Location has no coordinates set —
+    // can't enforce a check we have no reference point for. Fail open
+    // (mirrors the "no assignment" case) rather than block every punch at
+    // a mis-configured clinic.
+    return { ok: true };
+  }
+  let nearest = null;
+  for (const loc of usable) {
+    const radius = typeof loc.geofenceRadiusM === "number" ? loc.geofenceRadiusM : DEFAULT_RADIUS_M;
+    const distance = haversineDistanceMeters(coords.latitude, coords.longitude, loc.latitude, loc.longitude);
+    if (distance <= radius) {
+      return { ok: true, matchedLocationId: loc.id };
+    }
+    if (!nearest || distance < nearest.distance) nearest = { id: loc.id, name: loc.name, distance };
+  }
+  return {
+    ok: false,
+    code: "OUTSIDE_RADIUS",
+    error: nearest
+      ? `You're ${Math.round(nearest.distance)}m from ${nearest.name} — outside the allowed range. Move closer and try again.`
+      : "You're outside the allowed range of your assigned clinic. Move closer and try again.",
+  };
+}
+
+/**
+ * Full geofence decision for a punch attempt.
+ *
+ * @param {object} opts
+ * @param {string} opts.vertical - req.travelTenant/tenant.vertical style value
+ * @param {Array} opts.assignedLocations - Location rows the user is assigned to (already fetched)
+ * @param {{latitude?:number, longitude?:number, accuracy?:number}} opts.coords - raw body input
+ * @returns {{enforced:boolean, ok:boolean, code?:string, error?:string, matchedLocationId?:number}}
+ */
+function evaluatePunchGeofence({ vertical, assignedLocations, coords }) {
+  if (vertical !== "wellness") {
+    return { enforced: false, ok: true };
+  }
+  if (!assignedLocations || assignedLocations.length === 0) {
+    return { enforced: false, ok: true };
+  }
+
+  const accCheck = checkAccuracy(coords || {});
+  if (!accCheck.ok) {
+    return { enforced: true, ok: false, code: accCheck.code, error: accCheck.error };
+  }
+
+  const radiusCheck = checkWithinAnyRadius(coords, assignedLocations);
+  if (!radiusCheck.ok) {
+    return { enforced: true, ok: false, code: radiusCheck.code, error: radiusCheck.error };
+  }
+  return { enforced: true, ok: true, matchedLocationId: radiusCheck.matchedLocationId };
+}
+
+module.exports = {
+  DEFAULT_RADIUS_M,
+  ACCURACY_THRESHOLD_M,
+  checkAccuracy,
+  checkWithinAnyRadius,
+  evaluatePunchGeofence,
+};

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -338,30 +338,36 @@ model Tenant {
   // Closes out the remaining 18 drifters; data-leak gate already covered by
   // the tenantId column itself, this just makes Prisma aware of the FK so
   // joins/cascades work uniformly with the rest of the schema.
-  voiceSessions        VoiceSession[]
-  abTests              AbTest[]
-  touchpoints          Touchpoint[]
-  webVisitors          WebVisitor[]
-  chatbots             Chatbot[]
-  chatbotConversations ChatbotConversation[]
-  cannedResponses      CannedResponse[]
-  surveys              Survey[]
-  surveyResponses      SurveyResponse[]
+  voiceSessions              VoiceSession[]
+  abTests                    AbTest[]
+  touchpoints                Touchpoint[]
+  webVisitors                WebVisitor[]
+  chatbots                   Chatbot[]
+  chatbotConversations       ChatbotConversation[]
+  // Lead custom fields (generic vertical only) — admin-defined fields +
+  // their per-lead values. Deliberately separate from CustomEntity/
+  // CustomField/CustomValue (the existing generic EAV system) — see the
+  // model comment above LeadCustomFieldDefinition for why.
+  leadCustomFieldDefinitions LeadCustomFieldDefinition[]
+  leadCustomFieldValues      LeadCustomFieldValue[]
+  cannedResponses            CannedResponse[]
+  surveys                    Survey[]
+  surveyResponses            SurveyResponse[]
   // Parent-child review system — Survey owns ordered SurveyQuestion rows
   // and per-question SurveyAnswer rows. Survey itself already has its
   // back-relation above; the two child tables need their own so the
   // Prisma client validates.
-  surveyQuestions      SurveyQuestion[]
-  surveyAnswers        SurveyAnswer[]
-  documentTemplates    DocumentTemplate[]
-  dashboards           Dashboard[]
-  customReports        CustomReport[]
-  sharedInboxes        SharedInbox[]
-  liveChatSessions     LiveChatSession[]
-  liveChatMessages     LiveChatMessage[]
-  documentViews        DocumentView[]
-  socialPosts          SocialPost[]
-  socialMentions       SocialMention[]
+  surveyQuestions            SurveyQuestion[]
+  surveyAnswers              SurveyAnswer[]
+  documentTemplates          DocumentTemplate[]
+  dashboards                 Dashboard[]
+  customReports              CustomReport[]
+  sharedInboxes              SharedInbox[]
+  liveChatSessions           LiveChatSession[]
+  liveChatMessages           LiveChatMessage[]
+  documentViews              DocumentView[]
+  socialPosts                SocialPost[]
+  socialMentions             SocialMention[]
 
   // #592 — Find Duplicates dismiss persistence (DismissedDuplicateGroup model
   // at the bottom of this file). Per-tenant scoped.
@@ -609,6 +615,13 @@ model User {
   leaveApprovals LeaveRequest[] @relation("LeaveApprover")
   leaveBalances  LeaveBalance[]
 
+  // Geo-tagged attendance (wellness only) — clinics this staff member is
+  // assigned to. Many-to-many since a doctor/professional can split time
+  // across multiple clinics; the geofence check on clock-in/out passes if
+  // the punch is within radius of ANY one of them. Empty/no rows = geofence
+  // NOT enforced for this user (falls back to today's unenforced behaviour).
+  assignedLocations UserLocation[]
+
   // Wave 2 Agent II — POS cashier shifts.
   cashierShifts Shift[] @relation("CashierShifts")
 
@@ -851,6 +864,8 @@ model Contact {
   travelPortalNotifications TravelPortalNotification[]
   // Travel itineraries (PRD Phase 1).
   itineraries               Itinerary[]
+  // Generic-vertical admin-configurable Lead custom fields.
+  leadCustomFieldValues     LeadCustomFieldValue[]
 
   /// One Contact per email-per-tenant; same email may exist in different tenants (each tenant maintains its own CRM). Allows a single person to legitimately appear as a contact in multiple customers' CRMs without collision.
   @@unique([email, tenantId])
@@ -872,6 +887,84 @@ model Contact {
   @@index([tenantId, status, slaBreached])
   @@index([tenantId, name])
   @@index([tenantId, phone])
+}
+
+// ── Lead Custom Fields (generic vertical only, admin-configurable) ──
+//
+// Purpose-built for Contact/Lead, deliberately NOT built on the existing
+// generic CustomEntity/CustomField/CustomValue EAV system (schema above
+// this comment references Activity, not those — see custom_objects.js for
+// that separate, unrelated system). Kept isolated so this feature has zero
+// shared blast radius with whatever else uses the generic EAV tables.
+//
+// An ADMIN defines fields in Settings > Lead Fields (fieldType chosen at
+// definition time, not per-value) — ADMIN never has to duplicate that
+// choice; the CRM renders the right input widget and validates/stores the
+// value in the matching typed column automatically. Scoped to tenants using
+// the generic vertical only; wellness/travel are untouched by this feature.
+
+model LeadCustomFieldDefinition {
+  id           Int      @id @default(autoincrement())
+  fieldKey     String // stable machine key, e.g. "referral_source" — derived from label at creation, never renamed after
+  label        String // human-readable label shown on the form, e.g. "Referral Source"
+  // "text" | "textarea" | "number" | "dropdown" | "checkbox" | "radio" |
+  // "date" | "url" | "multiselect". fieldType itself is still locked after
+  // creation (see routes/lead_custom_fields.js) — changing type would
+  // misinterpret already-stored typed-column values. `options` CAN be
+  // edited post-creation for dropdown/radio/multiselect (add/rename/remove
+  // choices) — see that route's comment for the rename/remove tradeoff.
+  fieldType    String
+  options      String?  @db.Text // JSON array of strings — dropdown/radio/multiselect only
+  tooltip      String? // optional helper text shown near the input (Freshworks-style "what is this field for")
+  placeholder  String? // optional input placeholder text
+  isRequired   Boolean  @default(false)
+  displayOrder Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  tenantId Int    @default(1)
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  values LeadCustomFieldValue[]
+
+  /// One field key per tenant — "referral_source" can exist independently in tenant A and tenant B's field definitions without collision.
+  @@unique([tenantId, fieldKey])
+  @@index([tenantId, displayOrder])
+}
+
+model LeadCustomFieldValue {
+  id        Int                       @id @default(autoincrement())
+  contactId Int
+  contact   Contact                   @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  fieldId   Int
+  field     LeadCustomFieldDefinition @relation(fields: [fieldId], references: [id], onDelete: Cascade)
+
+  // Typed value columns — only the column matching the field's declared
+  // fieldType is populated; the others stay null. This is what lets
+  // "sort/filter leads by a custom Number/Date field" work as a real
+  // numeric/date comparison instead of a string comparison, and is why
+  // this isn't a single free-text `value` column.
+  // valueText covers: text, textarea, url (raw string), dropdown/radio (the
+  // selected option string), AND multiselect (JSON array of selected
+  // option strings, e.g. ["Product A","Product B"] — deliberately not a
+  // new table; multiselect is the only type needing >1 value per lead per
+  // field, and a JSON-array string in the existing text column covers it
+  // without a schema shape change, at the cost of not being filterable by
+  // "contains option X" via a plain WHERE clause — acceptable for v1).
+  valueText   String?   @db.Text
+  valueNumber Float?
+  valueDate   DateTime?
+  valueBool   Boolean? // "checkbox"
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tenantId Int    @default(1)
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  /// One value row per (contact, field) — updating a lead's custom field value upserts this row rather than accumulating history rows.
+  @@unique([contactId, fieldId])
+  @@index([tenantId, fieldId])
 }
 
 model Activity {
@@ -4146,17 +4239,25 @@ model Location {
   timezone    String  @default("Asia/Kolkata")
   isActive    Boolean @default(true)
 
+  // Geo-tagged attendance (wellness only) — radius in meters within which a
+  // clock-in/out is accepted for staff assigned to this Location. Null =
+  // caller applies its own default (150m — see routes/attendance.js) rather
+  // than every existing row needing a backfill.
+  geofenceRadiusM Int?
+
   // Operating hours JSON: { mon: ["09:00","20:00"], tue: ..., sun: null }
   hours String? @db.Text
 
   tenantId Int
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  patients  Patient[]
-  visits    Visit[]
+  patients      Patient[]
+  visits        Visit[]
   // Wave 11 Agent GG — resources + holidays scoped to this clinic.
-  resources Resource[]
-  holidays  Holiday[]
+  resources     Resource[]
+  holidays      Holiday[]
+  // Geo-tagged attendance (wellness only) — staff assigned to this clinic.
+  assignedUsers UserLocation[]
 
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
@@ -4165,6 +4266,27 @@ model Location {
 
   @@index([tenantId, isActive])
   @@index([tenantId, city])
+}
+
+// Geo-tagged attendance (wellness only) — many-to-many User↔Location
+// assignment. A staff member can be assigned to multiple clinics (e.g. a
+// doctor splitting time across two locations); the clock-in/out geofence
+// check passes if the punch is within radius of ANY one of their assigned
+// Locations. No rows for a user = geofencing not enforced for them (see
+// routes/attendance.js).
+model UserLocation {
+  id Int @id @default(autoincrement())
+
+  userId Int
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  locationId Int
+  location   Location @relation(fields: [locationId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([userId, locationId])
+  @@index([locationId])
 }
 
 // Per-tenant wellness role catalog. Replaces the hard-coded
@@ -4881,6 +5003,19 @@ model Attendance {
   clockOutAt         DateTime?
   clockInLocationId  Int?
   clockOutLocationId Int?
+
+  // Geo-tagged attendance (wellness only) — the actual GPS reading captured
+  // by the browser at punch time, kept for audit regardless of whether a
+  // geofence was enforced. Float lat/lng mirrors the existing precedent at
+  // ItineraryItem.latitude/longitude (travel vertical); accuracy is the
+  // browser's reported GPS accuracy radius in meters (used for the
+  // ACCURACY_TOO_LOW guard in routes/attendance.js).
+  clockInLat        Float?
+  clockInLng        Float?
+  clockInAccuracyM  Int?
+  clockOutLat       Float?
+  clockOutLng       Float?
+  clockOutAccuracyM Int?
 
   source            String @default("MANUAL")
   biometricDeviceId Int?
@@ -8790,7 +8925,7 @@ model StatusComponent {
   sortOrder           Int                   @default(0)
   status              String                @default("operational") // operational | degraded | partial_outage | major_outage | maintenance | no_data
   isPublic            Boolean               @default(true)
-  probeUrl            String?               // relative URL or probe key
+  probeUrl            String? // relative URL or probe key
   consecutiveFailures Int                   @default(0)
   lastProbedAt        DateTime?
   createdAt           DateTime              @default(now())
@@ -8800,24 +8935,24 @@ model StatusComponent {
 }
 
 model StatusIncident {
-  id          Int                    @id @default(autoincrement())
-  title       String
-  impact      String                 @default("minor") // none | minor | major | critical | maintenance
-  status      String                 @default("investigating") // investigating | identified | monitoring | resolved
-  components  StatusComponent[]
-  createdAt   DateTime               @default(now())
-  resolvedAt  DateTime?
-  updatedAt   DateTime               @updatedAt
-  updates     StatusIncidentUpdate[]
+  id         Int                    @id @default(autoincrement())
+  title      String
+  impact     String                 @default("minor") // none | minor | major | critical | maintenance
+  status     String                 @default("investigating") // investigating | identified | monitoring | resolved
+  components StatusComponent[]
+  createdAt  DateTime               @default(now())
+  resolvedAt DateTime?
+  updatedAt  DateTime               @updatedAt
+  updates    StatusIncidentUpdate[]
 }
 
 model StatusIncidentUpdate {
-  id          Int            @id @default(autoincrement())
-  incidentId  Int
-  incident    StatusIncident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
-  status      String         // investigating | identified | monitoring | resolved
-  message     String         @db.Text
-  createdAt   DateTime       @default(now())
+  id         Int            @id @default(autoincrement())
+  incidentId Int
+  incident   StatusIncident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
+  status     String // investigating | identified | monitoring | resolved
+  message    String         @db.Text
+  createdAt  DateTime       @default(now())
 
   @@index([incidentId, createdAt])
 }

--- a/backend/routes/attendance.js
+++ b/backend/routes/attendance.js
@@ -44,8 +44,45 @@ const { writeAudit } = require("../lib/audit");
 // the three history endpoints (/me /staff/:id /summary) silently returned empty
 // rows when the operator passed to < from.
 const { validateDateRange } = require("../lib/validateDateRange");
+// Geo-tagged attendance (wellness only) — see lib/attendanceGeofence.js for
+// the full design rationale (multi-location, unenforced-when-unassigned,
+// accuracy threshold, per-Location radius).
+const { evaluatePunchGeofence } = require("../lib/attendanceGeofence");
 
 const router = express.Router();
+
+// Resolve the punching user's tenant vertical + assigned clinics in one
+// round trip. Returns { vertical, assignedLocations } — assignedLocations
+// is [] for non-wellness tenants (never queried) or wellness users with no
+// UserLocation rows (evaluatePunchGeofence treats [] as "not enforced").
+async function resolveGeofenceContext(tenantId, userId) {
+  const tenant = await prisma.tenant.findUnique({ where: { id: tenantId }, select: { vertical: true } });
+  const vertical = tenant ? tenant.vertical : null;
+  if (vertical !== "wellness") return { vertical, assignedLocations: [] };
+
+  // userId is always req.user.userId (the caller's own JWT-derived id, never
+  // attacker-supplied) so this can't leak another user's assignments — the
+  // location.tenantId filter is defense-in-depth against a UserLocation row
+  // ever pointing at a Location outside the caller's own tenant.
+  const rows = await prisma.userLocation.findMany({
+    where: { userId, location: { tenantId } },
+    select: { location: { select: { id: true, name: true, latitude: true, longitude: true, geofenceRadiusM: true } } },
+  });
+  return { vertical, assignedLocations: rows.map((r) => r.location) };
+}
+
+// Body coords are sent as strings/numbers by fetch/JSON — coerce once here
+// so lib/attendanceGeofence.js can assume real numbers or undefined.
+function parseCoords(body) {
+  const lat = Number(body && body.latitude);
+  const lng = Number(body && body.longitude);
+  const acc = Number(body && body.accuracy);
+  return {
+    latitude: Number.isFinite(lat) ? lat : undefined,
+    longitude: Number.isFinite(lng) ? lng : undefined,
+    accuracy: Number.isFinite(acc) ? acc : undefined,
+  };
+}
 
 // Standard tenant-where helper -- mirrors the pattern used by routes/wellness.js
 // and routes/inventory.js. Routes that need cross-tenant lookups (the biometric
@@ -184,12 +221,24 @@ router.post("/clock-in", verifyToken, async (req, res) => {
       });
     }
 
+    // Geo-tagged attendance (wellness only) — see lib/attendanceGeofence.js.
+    // Not enforced for non-wellness tenants or users with no assigned clinic.
+    const coords = parseCoords(req.body);
+    const { vertical, assignedLocations } = await resolveGeofenceContext(tenantId, userId);
+    const geofence = evaluatePunchGeofence({ vertical, assignedLocations, coords });
+    if (geofence.enforced && !geofence.ok) {
+      return res.status(403).json({ error: geofence.error, code: geofence.code });
+    }
+
     const data = {
       tenantId,
       userId,
       date: day,
       clockInAt: now,
       clockInLocationId: req.body.locationId ? parseInt(req.body.locationId) : null,
+      clockInLat: coords.latitude ?? null,
+      clockInLng: coords.longitude ?? null,
+      clockInAccuracyM: coords.accuracy != null ? Math.round(coords.accuracy) : null,
       source: "MANUAL",
     };
 
@@ -199,7 +248,14 @@ router.post("/clock-in", verifyToken, async (req, res) => {
       // through this flow, but the schema permits it). Update in place.
       row = await prisma.attendance.update({
         where: { id: existing.id },
-        data: { clockInAt: now, clockInLocationId: data.clockInLocationId, source: "MANUAL" },
+        data: {
+          clockInAt: now,
+          clockInLocationId: data.clockInLocationId,
+          clockInLat: data.clockInLat,
+          clockInLng: data.clockInLng,
+          clockInAccuracyM: data.clockInAccuracyM,
+          source: "MANUAL",
+        },
       });
     } else {
       row = await prisma.attendance.create({ data });
@@ -260,6 +316,14 @@ router.post("/clock-out", verifyToken, async (req, res) => {
       });
     }
 
+    // Geo-tagged attendance (wellness only) — see lib/attendanceGeofence.js.
+    const coords = parseCoords(req.body);
+    const { vertical, assignedLocations } = await resolveGeofenceContext(tenantId, userId);
+    const geofence = evaluatePunchGeofence({ vertical, assignedLocations, coords });
+    if (geofence.enforced && !geofence.ok) {
+      return res.status(403).json({ error: geofence.error, code: geofence.code });
+    }
+
     const totalMinutes = Math.max(0, Math.round((now.getTime() - existing.clockInAt.getTime()) / 60000));
 
     const row = await prisma.attendance.update({
@@ -267,6 +331,9 @@ router.post("/clock-out", verifyToken, async (req, res) => {
       data: {
         clockOutAt: now,
         clockOutLocationId: req.body.locationId ? parseInt(req.body.locationId) : null,
+        clockOutLat: coords.latitude ?? null,
+        clockOutLng: coords.longitude ?? null,
+        clockOutAccuracyM: coords.accuracy != null ? Math.round(coords.accuracy) : null,
         totalMinutes,
         // Status semantics:
         //   - HALF_DAY if shift was shorter than 4 hours (240 minutes)

--- a/backend/routes/contacts.js
+++ b/backend/routes/contacts.js
@@ -225,6 +225,182 @@ async function attachTravelRelationshipTimeline(contact, tenantId) {
   }
 }
 
+// GENERIC-VERTICAL-ONLY Lead custom fields — see Settings > Lead Fields
+// (routes/lead_custom_fields.js). Admin-defined fields + their per-lead
+// values, kept deliberately separate from the CustomEntity/CustomField/
+// CustomValue EAV system (routes/custom_objects.js). Best-effort — a
+// failure here must never break the surrounding Contact request. No
+// vertical check is needed: for wellness/travel tenants no
+// LeadCustomFieldDefinition rows exist (the admin UI that creates them is
+// gated to the generic vertical), so this is naturally a no-op there.
+async function attachLeadCustomFields(contact, tenantId) {
+  if (!contact || typeof contact !== "object" || !contact.id) return contact;
+  try {
+    const [definitions, values] = await Promise.all([
+      prisma.leadCustomFieldDefinition.findMany({ where: { tenantId } }),
+      prisma.leadCustomFieldValue.findMany({ where: { tenantId, contactId: contact.id } }),
+    ]);
+    return { ...contact, customFields: buildCustomFieldsObject(definitions, values) };
+  } catch (_e) {
+    return { ...contact, customFields: {} };
+  }
+}
+
+// Batch sibling of attachLeadCustomFields — for LIST endpoints (GET /) so a
+// page of N contacts costs 2 extra queries total, not 2N. Every contact in
+// the list gets a `customFields` object keyed by EVERY field this tenant has
+// defined (not just the ones it has a value for) — so a lead created before
+// a field existed shows that field as null rather than the key being absent
+// entirely, matching how the create/edit forms always render every defined
+// field. Best-effort: a failure here returns the contacts unchanged rather
+// than breaking the list.
+async function attachLeadCustomFieldsBatch(contacts, tenantId) {
+  if (!Array.isArray(contacts) || !contacts.length) return contacts;
+  try {
+    const definitions = await prisma.leadCustomFieldDefinition.findMany({ where: { tenantId } });
+    if (!definitions.length) return contacts.map((c) => ({ ...c, customFields: {} }));
+    const contactIds = contacts.map((c) => c.id).filter((id) => id != null);
+    const values = await prisma.leadCustomFieldValue.findMany({
+      where: { tenantId, contactId: { in: contactIds } },
+    });
+    const valuesByContact = new Map();
+    for (const v of values) {
+      if (!valuesByContact.has(v.contactId)) valuesByContact.set(v.contactId, []);
+      valuesByContact.get(v.contactId).push(v);
+    }
+    return contacts.map((c) => ({
+      ...c,
+      customFields: buildCustomFieldsObject(definitions, valuesByContact.get(c.id) || []),
+    }));
+  } catch (_e) {
+    return contacts.map((c) => ({ ...c, customFields: {} }));
+  }
+}
+
+// Shared projection: every field DEFINITION becomes a key (null when this
+// contact has no stored value for it — covers leads created before the
+// field existed), overlaid with whatever VALUES actually exist.
+function buildCustomFieldsObject(definitions, values) {
+  const customFields = {};
+  for (const def of definitions) {
+    customFields[def.fieldKey] = null;
+  }
+  const byFieldId = new Map(definitions.map((d) => [d.id, d]));
+  for (const v of values) {
+    const def = byFieldId.get(v.fieldId);
+    if (!def) continue;
+    let raw;
+    if (def.fieldType === "number") raw = v.valueNumber;
+    else if (def.fieldType === "date") raw = v.valueDate;
+    else if (def.fieldType === "checkbox") raw = v.valueBool;
+    else if (def.fieldType === "multiselect") {
+      try {
+        raw = v.valueText ? JSON.parse(v.valueText) : null;
+      } catch (_e) {
+        raw = v.valueText;
+      }
+    } else {
+      // text, textarea, dropdown, radio, url
+      raw = v.valueText;
+    }
+    customFields[def.fieldKey] = raw;
+  }
+  return customFields;
+}
+
+// Simple URL validator — allows http(s):// and mailto: schemes. Returns
+// false for obvious non-URLs; intentionally permissive so users can store
+// internal links or domain-only strings if they choose.
+function isValidUrl(str) {
+  try {
+    const url = new URL(str);
+    return ["http:", "https:", "mailto:"].includes(url.protocol);
+  } catch (_e) {
+    return false;
+  }
+}
+
+// Coerce a raw incoming value into the correct typed column(s) for a
+// LeadCustomFieldDefinition. Returns null when the value should be cleared
+// (null/undefined/empty array/empty string). Does NOT throw — invalid input
+// is best-effort dropped so the surrounding Contact request stays intact.
+function coerceCustomFieldValue(def, raw) {
+  if (raw === null || raw === undefined || raw === "") return null;
+
+  if (def.fieldType === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? { valueNumber: n } : null;
+  }
+  if (def.fieldType === "date") {
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : { valueDate: d };
+  }
+  if (def.fieldType === "checkbox") {
+    return { valueBool: Boolean(raw) };
+  }
+  if (def.fieldType === "multiselect") {
+    const arr = Array.isArray(raw) ? raw : [raw];
+    const clean = arr.map((o) => String(o).trim()).filter(Boolean);
+    return clean.length ? { valueText: JSON.stringify(clean) } : null;
+  }
+  if (def.fieldType === "radio") {
+    const s = String(raw).trim();
+    return s ? { valueText: s } : null;
+  }
+  if (def.fieldType === "url") {
+    const s = String(raw).trim();
+    return s && isValidUrl(s) ? { valueText: s } : null;
+  }
+  // text, textarea, dropdown
+  const s = String(raw).trim();
+  return s ? { valueText: s.slice(0, 2000) } : null;
+}
+
+// Persists req.body.customFields (a { fieldKey: value } object) as
+// LeadCustomFieldValue rows for the given contact, validating each key
+// against this tenant's LeadCustomFieldDefinition rows first. Unknown keys
+// (no matching definition) are silently ignored rather than erroring — the
+// admin may have deleted a field after a stale form was left open in
+// another tab. Best-effort: a failure here must never block the Contact
+// create/update it's attached to (the primary contact write already
+// succeeded by the time this runs).
+async function writeLeadCustomFieldValues(contactId, tenantId, customFields) {
+  if (!customFields || typeof customFields !== "object") return;
+  const keys = Object.keys(customFields);
+  if (!keys.length) return;
+  try {
+    const definitions = await prisma.leadCustomFieldDefinition.findMany({
+      where: { tenantId, fieldKey: { in: keys } },
+    });
+    const byKey = new Map(definitions.map((d) => [d.fieldKey, d]));
+    for (const key of keys) {
+      const def = byKey.get(key);
+      if (!def) continue; // unknown/stale field key — ignore rather than error
+      const raw = customFields[key];
+      const clearData = { valueText: null, valueNumber: null, valueDate: null, valueBool: null };
+      const typed = raw === null || raw === undefined || raw === ""
+        ? null
+        : coerceCustomFieldValue(def, raw);
+      if (!typed) {
+        // Explicit clear — upsert with all-null value columns so a previously-
+        // set value can be cleared from the UI.
+        await prisma.leadCustomFieldValue.upsert({
+          where: { contactId_fieldId: { contactId, fieldId: def.id } },
+          create: { contactId, fieldId: def.id, tenantId, ...clearData },
+          update: clearData,
+        });
+      } else {
+        await prisma.leadCustomFieldValue.upsert({
+          where: { contactId_fieldId: { contactId, fieldId: def.id } },
+          create: { contactId, fieldId: def.id, tenantId, ...clearData, ...typed },
+          update: typed,
+        });
+      }
+    }
+  } catch (e) {
+    console.error("[contacts] writeLeadCustomFieldValues failed (non-fatal):", e && e.message);
+  }
+}
 
 // Protect all contact routes
 router.use(verifyToken);
@@ -304,7 +480,12 @@ router.get('/', async (req, res) => {
     const contacts = await prisma.contact.findMany(findManyArgs);
     // #464: strip read-restricted fields per the caller's role.
     const filtered = await filterReadFields(contacts, req.user.role, "Contact", req.user.tenantId);
-    res.json(filtered);
+    // Generic-vertical-only: attach { fieldKey: value|null } to every row
+    // (no-op elsewhere — see attachLeadCustomFieldsBatch). Skipped for the
+    // ?fields=summary slim shape, which is an explicit "give me the minimal
+    // projection" opt-in.
+    const withCustomFields = isSummary ? filtered : await attachLeadCustomFieldsBatch(filtered, req.user.tenantId);
+    res.json(withCustomFields);
   } catch (_err) {
     res.status(500).json({ error: 'Failed to fetch contacts' });
   }
@@ -330,7 +511,10 @@ router.get('/:id', async (req, res) => {
     // Travel-only: merge the contact's bookings (Itineraries) + invoices into
     // the activity timeline so booking-only customers aren't shown empty.
     const withTimeline = await attachTravelRelationshipTimeline(withWallet, req.user.tenantId);
-    res.json(withTimeline);
+    // Generic-vertical-only: attach { fieldKey: value } from this tenant's
+    // Lead custom field definitions/values (no-op elsewhere — see helper).
+    const withCustomFields = await attachLeadCustomFields(withTimeline, req.user.tenantId);
+    res.json(withCustomFields);
   } catch (_err) {
     res.status(500).json({ error: 'Failed to fetch contact' });
   }
@@ -346,6 +530,12 @@ router.post('/', async (req, res) => {
     req.body = await filterWriteFields(req.body, req.user.role, "Contact", req.user.tenantId);
     // PRD Gap §1.1e — strip walletBalance from writes (read-only computed surface).
     req.body = stripWalletBalanceWrite(req.body);
+    // Generic-vertical-only Lead custom fields (Settings > Lead Fields) —
+    // customFields is NOT a real Contact column, so it must never reach
+    // prisma.contact.create's spread below. Captured here, written to
+    // LeadCustomFieldValue AFTER the contact create succeeds (see below).
+    const customFields = req.body.customFields;
+    delete req.body.customFields;
     // #160 #166: validate before hitting Prisma so bad inputs return 400 with a
     // clear code instead of a 500 from the DB layer.
     const inputErr = validateContactInput(req.body, { isUpdate: false });
@@ -419,6 +609,9 @@ router.post('/', async (req, res) => {
     }
 
     const contact = await prisma.contact.create({ data: { ...normalised, tenantId: req.user.tenantId } });
+    // Generic-vertical-only Lead custom fields — best-effort, after the
+    // primary create already succeeded (see writeLeadCustomFieldValues).
+    await writeLeadCustomFieldValues(contact.id, req.user.tenantId, customFields);
     try { const { emitEvent } = require('../lib/eventBus'); await emitEvent('contact.created', { contactId: contact.id, name: contact.name, email: contact.email, userId: req.user.userId }, req.user.tenantId, req.io); } catch (_e) { /* event bus optional */ }
     // [GP-CRM integration] Fire lead.new to registered webhooks (e.g. GlobusPhone)
     // when a Lead contact is created. Carries the id/name/phone/email shape the
@@ -570,6 +763,10 @@ router.put('/:id', async (req, res) => {
     req.body = await filterWriteFields(req.body, req.user.role, "Contact", req.user.tenantId);
     // PRD Gap §1.1e — strip walletBalance from writes (read-only computed surface).
     req.body = stripWalletBalanceWrite(req.body);
+    // Generic-vertical-only Lead custom fields — see the POST handler above
+    // for why this must be stripped before the Prisma spread.
+    const customFields = req.body.customFields;
+    delete req.body.customFields;
     // #168: same input checks as create so PUT can't bypass POST validation.
     const inputErr = validateContactInput(req.body, { isUpdate: true });
     if (inputErr) return res.status(inputErr.status).json(inputErr);
@@ -582,6 +779,9 @@ router.put('/:id', async (req, res) => {
       updateData.birthDate = new Date(updateData.birthDate);
     }
     const contact = await prisma.contact.update({ where: { id: existing.id }, data: updateData });
+    // Generic-vertical-only Lead custom fields — best-effort, after the
+    // primary update already succeeded.
+    await writeLeadCustomFieldValues(contact.id, req.user.tenantId, customFields);
 
     // #179: audit only the keys that actually changed (skip unchanged + DB internals).
     const changes = diffFields(existing, contact, Object.keys(req.body || {}));

--- a/backend/routes/lead_custom_fields.js
+++ b/backend/routes/lead_custom_fields.js
@@ -1,0 +1,212 @@
+// Lead Custom Fields — admin-configurable extra fields on Contact/Lead
+// records (generic vertical only; see Settings > Lead Fields).
+//
+// Purpose-built for Contact/Lead, deliberately NOT built on the existing
+// generic CustomEntity/CustomField/CustomValue EAV system (routes/
+// custom_objects.js) — kept isolated so this feature has zero shared blast
+// radius with whatever else uses those tables. See the model comment above
+// LeadCustomFieldDefinition in prisma/schema.prisma for the full rationale.
+//
+// Definitions (this file) are ADMIN-only. Reading/writing a lead's actual
+// custom-field VALUES happens inline in routes/contacts.js (create/update/
+// get), keyed by fieldKey, so a value round-trips through the normal
+// Contact create/update/get calls rather than a separate endpoint.
+
+const express = require("express");
+const router = express.Router();
+const prisma = require("../lib/prisma");
+const { verifyToken, verifyRole } = require("../middleware/auth");
+
+const adminOnly = [verifyToken, verifyRole(["ADMIN"])];
+
+const VALID_FIELD_TYPES = new Set(["text", "textarea", "number", "dropdown", "radio", "date", "url", "checkbox", "multiselect"]);
+const FIELD_TYPES_WITH_OPTIONS = new Set(["dropdown", "radio", "multiselect"]);
+const FIELD_KEY_RE = /^[a-z][a-z0-9_]{0,49}$/;
+
+function slugifyLabel(label) {
+  return String(label || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 50);
+}
+
+// GET /api/lead-custom-fields — list this tenant's field definitions.
+// Open to all authenticated roles (USER/MANAGER need this to render the
+// Lead create/edit form) — only mutation is admin-gated.
+router.get("/", async (req, res) => {
+  try {
+    const rows = await prisma.leadCustomFieldDefinition.findMany({
+      where: { tenantId: req.user.tenantId },
+      orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+    });
+    const withParsedOptions = rows.map((r) => ({
+      ...r,
+      options: r.options ? JSON.parse(r.options) : null,
+    }));
+    res.json(withParsedOptions);
+  } catch (err) {
+    console.error("[lead-custom-fields] list error:", err && err.message);
+    res.status(500).json({ error: "Failed to load lead custom fields" });
+  }
+});
+
+// POST /api/lead-custom-fields — create a new field definition (ADMIN only)
+router.post("/", adminOnly, async (req, res) => {
+  try {
+    const { label, fieldType, options, isRequired, tooltip, placeholder } = req.body || {};
+
+    const trimmedLabel = typeof label === "string" ? label.trim() : "";
+    if (!trimmedLabel) {
+      return res.status(400).json({ error: "label is required", code: "LABEL_REQUIRED" });
+    }
+    if (trimmedLabel.length > 80) {
+      return res.status(400).json({ error: "label must be 80 characters or fewer", code: "LABEL_TOO_LONG" });
+    }
+    if (!VALID_FIELD_TYPES.has(fieldType)) {
+      return res.status(400).json({
+        error: `fieldType must be one of: ${[...VALID_FIELD_TYPES].join(", ")}`,
+        code: "INVALID_FIELD_TYPE",
+      });
+    }
+
+    let optionsJson = null;
+    if (FIELD_TYPES_WITH_OPTIONS.has(fieldType)) {
+      if (!Array.isArray(options) || options.length === 0) {
+        return res.status(400).json({
+          error: "options (a non-empty array of strings) is required for this field type",
+          code: "OPTIONS_REQUIRED",
+        });
+      }
+      const cleanOptions = options
+        .map((o) => String(o).trim())
+        .filter(Boolean)
+        .slice(0, 50);
+      if (!cleanOptions.length) {
+        return res.status(400).json({ error: "options must contain at least one non-empty value", code: "OPTIONS_REQUIRED" });
+      }
+      optionsJson = JSON.stringify(cleanOptions);
+    }
+
+    const fieldKey = slugifyLabel(trimmedLabel);
+    if (!fieldKey || !FIELD_KEY_RE.test(fieldKey)) {
+      return res.status(400).json({
+        error: "label must contain at least one letter to derive a valid field key",
+        code: "INVALID_FIELD_KEY",
+      });
+    }
+
+    const existing = await prisma.leadCustomFieldDefinition.findUnique({
+      where: { tenantId_fieldKey: { tenantId: req.user.tenantId, fieldKey } },
+    });
+    if (existing) {
+      return res.status(409).json({
+        error: "A field with this label (or one that produces the same key) already exists",
+        code: "DUPLICATE_FIELD_KEY",
+      });
+    }
+
+    const maxOrder = await prisma.leadCustomFieldDefinition.aggregate({
+      where: { tenantId: req.user.tenantId },
+      _max: { displayOrder: true },
+    });
+
+    const created = await prisma.leadCustomFieldDefinition.create({
+      data: {
+        tenantId: req.user.tenantId,
+        fieldKey,
+        label: trimmedLabel,
+        fieldType,
+        options: optionsJson,
+        tooltip: typeof tooltip === "string" ? tooltip.trim().slice(0, 255) || null : null,
+        placeholder: typeof placeholder === "string" ? placeholder.trim().slice(0, 255) || null : null,
+        isRequired: Boolean(isRequired),
+        displayOrder: (maxOrder?._max?.displayOrder ?? 0) + 1,
+      },
+    });
+
+    res.status(201).json({ ...created, options: optionsJson ? JSON.parse(optionsJson) : null });
+  } catch (err) {
+    console.error("[lead-custom-fields] create error:", err && err.message);
+    res.status(500).json({ error: "Failed to create lead custom field" });
+  }
+});
+
+// PUT /api/lead-custom-fields/:id — update label/options/required/order (ADMIN only)
+// fieldType and fieldKey are immutable after creation — changing a field's
+// type after values have been stored against it would silently orphan or
+// misinterpret existing LeadCustomFieldValue rows, so a rename-in-place is
+// not offered; an admin who needs a different type creates a new field.
+router.put("/:id", adminOnly, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return res.status(400).json({ error: "Invalid field id" });
+
+    const existing = await prisma.leadCustomFieldDefinition.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing) return res.status(404).json({ error: "Field not found" });
+
+    const { label, options, isRequired, displayOrder, tooltip, placeholder } = req.body || {};
+    const data = {};
+
+    if (label !== undefined) {
+      const trimmedLabel = String(label).trim();
+      if (!trimmedLabel) return res.status(400).json({ error: "label cannot be empty", code: "LABEL_REQUIRED" });
+      if (trimmedLabel.length > 80) return res.status(400).json({ error: "label must be 80 characters or fewer", code: "LABEL_TOO_LONG" });
+      data.label = trimmedLabel;
+    }
+    if (options !== undefined) {
+      if (!FIELD_TYPES_WITH_OPTIONS.has(existing.fieldType)) {
+        return res.status(400).json({ error: "options can only be set on fields with choices", code: "NOT_A_CHOICE_FIELD" });
+      }
+      const cleanOptions = Array.isArray(options)
+        ? options.map((o) => String(o).trim()).filter(Boolean).slice(0, 50)
+        : [];
+      if (!cleanOptions.length) {
+        return res.status(400).json({ error: "options must contain at least one non-empty value", code: "OPTIONS_REQUIRED" });
+      }
+      data.options = JSON.stringify(cleanOptions);
+    }
+    if (tooltip !== undefined) {
+      data.tooltip = typeof tooltip === "string" ? tooltip.trim().slice(0, 255) || null : null;
+    }
+    if (placeholder !== undefined) {
+      data.placeholder = typeof placeholder === "string" ? placeholder.trim().slice(0, 255) || null : null;
+    }
+    if (isRequired !== undefined) data.isRequired = Boolean(isRequired);
+    if (displayOrder !== undefined && Number.isFinite(Number(displayOrder))) {
+      data.displayOrder = Number(displayOrder);
+    }
+
+    const updated = await prisma.leadCustomFieldDefinition.update({ where: { id }, data });
+    res.json({ ...updated, options: updated.options ? JSON.parse(updated.options) : null });
+  } catch (err) {
+    console.error("[lead-custom-fields] update error:", err && err.message);
+    res.status(500).json({ error: "Failed to update lead custom field" });
+  }
+});
+
+// DELETE /api/lead-custom-fields/:id — remove a field definition (ADMIN only).
+// Cascades to LeadCustomFieldValue rows (onDelete: Cascade in schema) — a
+// deleted field's stored values are removed too, not left orphaned.
+router.delete("/:id", adminOnly, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return res.status(400).json({ error: "Invalid field id" });
+
+    const existing = await prisma.leadCustomFieldDefinition.findFirst({
+      where: { id, tenantId: req.user.tenantId },
+    });
+    if (!existing) return res.status(404).json({ error: "Field not found" });
+
+    await prisma.leadCustomFieldDefinition.delete({ where: { id } });
+    res.json({ success: true });
+  } catch (err) {
+    console.error("[lead-custom-fields] delete error:", err && err.message);
+    res.status(500).json({ error: "Failed to delete lead custom field" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/travel_flight_quotes.js
+++ b/backend/routes/travel_flight_quotes.js
@@ -218,6 +218,25 @@ router.post("/agent-quotes", verifyToken, requireTravelTenant, async (req, res) 
       if (!from || !to) {
         return res.status(400).json({ error: `options[${i}]: route.from and route.to are required`, code: "MISSING_ROUTE" });
       }
+      let returnLeg = null;
+      if (o.returnLeg != null) {
+        const r = o.returnLeg || {};
+        const returnAirline = typeof r.airline === "string" ? r.airline.trim() : "";
+        const returnFrom = r.route && r.route.from ? String(r.route.from).trim() : "";
+        const returnTo = r.route && r.route.to ? String(r.route.to).trim() : "";
+        if (!returnAirline || !returnFrom || !returnTo) {
+          return res.status(400).json({ error: `options[${i}]: return flight airline and route are required`, code: "INVALID_RETURN_LEG" });
+        }
+        returnLeg = {
+          airline: returnAirline,
+          flightNumber: typeof r.flightNumber === "string" && r.flightNumber.trim() ? r.flightNumber.trim() : null,
+          fareClass: typeof r.fareClass === "string" && r.fareClass.trim() ? r.fareClass.trim() : null,
+          route: { from: returnFrom, to: returnTo },
+          departAt: r.departAt || null,
+          arriveAt: r.arriveAt || null,
+          baggage: typeof r.baggage === "string" && r.baggage.trim() ? r.baggage.trim() : null,
+        };
+      }
       parsed.push({
         airline,
         pricePerPax,
@@ -228,6 +247,7 @@ router.post("/agent-quotes", verifyToken, requireTravelTenant, async (req, res) 
         departAt: o.departAt || null,
         arriveAt: o.arriveAt || null,
         baggage: typeof o.baggage === "string" && o.baggage.trim() ? o.baggage.trim() : null,
+        returnLeg,
       });
     }
 
@@ -326,7 +346,7 @@ router.post("/agent-quotes", verifyToken, requireTravelTenant, async (req, res) 
           itineraryId: itin.id,
           itemType: "flight",
           position: position++,
-          description: `${opt.airline}${opt.flightNumber ? ` ${opt.flightNumber}` : ""} ${opt.from}→${opt.to}${opt.fareClass ? ` (${opt.fareClass})` : ""}`,
+          description: `${opt.airline}${opt.flightNumber ? ` ${opt.flightNumber}` : ""} ${opt.from}→${opt.to}${opt.returnLeg ? ` · return ${opt.returnLeg.airline}${opt.returnLeg.flightNumber ? ` ${opt.returnLeg.flightNumber}` : ""} ${opt.returnLeg.route.from}→${opt.returnLeg.route.to}` : ""}${opt.fareClass ? ` (${opt.fareClass})` : ""}`,
           detailsJson: JSON.stringify({
             airline: opt.airline,
             flightNumber: opt.flightNumber,
@@ -335,6 +355,7 @@ router.post("/agent-quotes", verifyToken, requireTravelTenant, async (req, res) 
             departAt: opt.departAt,
             arriveAt: opt.arriveAt,
             baggage: opt.baggage,
+            returnLeg: opt.returnLeg,
             currency,
             source: "agent-quick-quote",
           }),

--- a/backend/routes/travel_itineraries.js
+++ b/backend/routes/travel_itineraries.js
@@ -5685,6 +5685,12 @@ router.post("/itineraries/public/:shareToken/create-payment-order", async (req, 
         currency,
         receipt: `itin_${itin.id}_${kind}_${Date.now()}`,
         notes: { itineraryId: String(itin.id), shareToken: token, kind },
+        // Explicit, not relying on the tenant's Razorpay account-level default —
+        // some accounts/payment methods leave a charge "authorized" (held, not
+        // settled) rather than auto-capturing it. verify-payment below also
+        // capture()s defensively if it ever sees "authorized" despite this, but
+        // asking for auto-capture at order-creation time is the primary fix.
+        payment_capture: 1,
       });
     } catch (gErr) {
       console.error("[travel-itin-public] razorpay order error:", gErr && gErr.message);
@@ -5810,12 +5816,15 @@ router.post("/itineraries/public/:shareToken/verify-payment", async (req, res) =
       });
     }
 
-    // Authoritative amount: fetch the captured payment from Razorpay rather
-    // than trusting any client-supplied figure.
-    let paidMajor = 0;
+    // Authoritative amount + STATE: fetch the payment from Razorpay rather
+    // than trusting any client-supplied figure. `amount` is present on an
+    // "authorized" (held, not yet settled) payment too, so checking amount
+    // alone is not enough — a payment we never actually collected could pass
+    // that check and get recorded as SUCCESS. Require status === "captured"
+    // before advancing the itinerary / creating the Payment row.
+    let payment;
     try {
-      const payment = await rp.client.payments.fetch(razorpay_payment_id);
-      paidMajor = payment && payment.amount ? Number(payment.amount) / 100 : 0;
+      payment = await rp.client.payments.fetch(razorpay_payment_id);
     } catch (fErr) {
       console.error("[travel-itin-public] razorpay payments.fetch error:", fErr && fErr.message);
       if (isFormPost) {
@@ -5823,7 +5832,25 @@ router.post("/itineraries/public/:shareToken/verify-payment", async (req, res) =
       }
       return res.status(502).json({ error: "Could not confirm payment. Please contact support.", code: "GATEWAY_ERROR" });
     }
-    if (!(paidMajor > 0)) {
+    let paidMajor = payment && payment.amount ? Number(payment.amount) / 100 : 0;
+
+    // "authorized" means Razorpay is holding the charge but hasn't settled it
+    // yet (payment_capture:1 on order-create should prevent this, but some
+    // payment methods/account configs can still land here) — attempt an
+    // explicit capture rather than immediately failing the customer's checkout.
+    if (payment && payment.status === "authorized" && paidMajor > 0) {
+      try {
+        const captured = await rp.client.payments.capture(razorpay_payment_id, payment.amount, payment.currency);
+        payment = captured;
+        paidMajor = captured && captured.amount ? Number(captured.amount) / 100 : paidMajor;
+      } catch (cErr) {
+        console.error("[travel-itin-public] razorpay payments.capture error:", cErr && cErr.message);
+        // Fall through — the status check below will reject it as not captured.
+      }
+    }
+
+    if (!(paidMajor > 0) || !payment || payment.status !== "captured") {
+      console.warn(`[travel-itin-public] verify-payment: payment ${razorpay_payment_id} not captured (status=${payment && payment.status})`);
       if (isFormPost) {
         return res.redirect(303, `/p/itinerary/${encodeURIComponent(token)}/payment-success?error=Payment%20not%20captured`);
       }

--- a/backend/server.js
+++ b/backend/server.js
@@ -600,6 +600,7 @@ const pagesRoutes = require("./routes/pages");
 // roles.read guards inside the handler.
 const usersRoutes = require("./routes/users");
 const contactsRoutes = require("./routes/contacts");
+const leadCustomFieldsRoutes = require("./routes/lead_custom_fields");
 const dealsRoutes = require("./routes/deals");
 const calendarRoutes = require("./routes/calendar");
 const aiScoringRoutes = require("./routes/ai_scoring");
@@ -1107,6 +1108,7 @@ app.use("/api/pages", pagesRoutes);
 app.use("/api/pages", landingPagesPublic);
 app.use("/api/users", usersRoutes);
 app.use("/api/contacts", contactsRoutes);
+app.use("/api/lead-custom-fields", leadCustomFieldsRoutes);
 app.use("/api/deals", dealsRoutes);
 app.use("/api/calendar", calendarRoutes);
 app.use("/api/ai_scoring", aiScoringRoutes);

--- a/backend/services/serpApiClient.js
+++ b/backend/services/serpApiClient.js
@@ -38,7 +38,7 @@ function isConfigured() {
 // keyed on the exact query collapses those duplicates so identical searches
 // within the TTL cost ZERO extra calls. Bypassed under test (tests inject a
 // mock axios and must stay deterministic across cases).
-const CACHE_TTL_MS = Number(process.env.SERP_API_CACHE_TTL_MS || 10 * 60 * 1000);
+const CACHE_TTL_MS = Number(process.env.SERP_API_CACHE_TTL_MS || 2 * 60 * 1000);
 const _cache = new Map(); // key → { at:number, data:Array }
 function _cacheGet(key) {
   if (process.env.NODE_ENV === "test") return undefined;
@@ -55,8 +55,18 @@ function _cacheSet(key, data) {
 }
 
 function num(v) {
+  if (v == null || v === "") return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
+}
+
+function travelClass(value) {
+  return {
+    Economy: 1,
+    "Premium Economy": 2,
+    Business: 3,
+    First: 4,
+  }[value] || 1;
 }
 
 // ── API Analytics logging ───────────────────────────────────────────
@@ -144,6 +154,7 @@ async function searchFlights(q = {}, ax = axios) {
     outbound_date: q.departDate,
     currency: q.currency || "INR",
     adults: q.adults || 1,
+    travel_class: travelClass(q.cabinClass),
     gl: "in",
     hl: "en",
     api_key: SERP_KEY(),
@@ -154,7 +165,10 @@ async function searchFlights(q = {}, ax = axios) {
   } else {
     params.type = 2; // one-way (else SerpApi demands a return_date)
   }
-  const cacheKey = `F|${q.from}|${q.to}|${q.departDate}|${q.returnDate || ""}|${q.adults}|${q.children}|${q.currency}`;
+  // Every request parameter that can alter Google Flights results must be in
+  // the key. Otherwise, for example, a Business-class search could be shown
+  // to a later Economy search for the same route/date during the cache TTL.
+  const cacheKey = `F|${q.from}|${q.to}|${q.departDate}|${q.returnDate || ""}|${q.adults}|${q.children}|${q.infants || 0}|${q.cabinClass || "Economy"}|${q.currency}`;
   const hit = _cacheGet(cacheKey);
   if (hit) return hit;
   const startedAt = Date.now();

--- a/backend/services/tboClient.js
+++ b/backend/services/tboClient.js
@@ -39,6 +39,9 @@ const TBO_PASSWORD = () => process.env.TBO_PASSWORD || "";
 const TIMEOUT_MS = Number(process.env.TBO_TIMEOUT_MS || 12000);
 
 function num(v) {
+  // Number(null) is 0, which would make an unknown seat count look like a
+  // sold-out flight in the UI. Preserve omitted supplier fields as null.
+  if (v == null || v === "") return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
 }

--- a/backend/test/lib/attendanceGeofence.test.js
+++ b/backend/test/lib/attendanceGeofence.test.js
@@ -1,0 +1,181 @@
+// Unit tests for backend/lib/attendanceGeofence.js — geo-tagged attendance
+// (wellness vertical only). WHY this exists: clock-in/out needed a way to
+// verify a staff member is actually near their clinic before accepting the
+// punch, without breaking travel/generic tenants (which share the same
+// route unmodified) or blocking wellness staff who haven't been assigned a
+// Location yet.
+//
+// Covers: checkAccuracy (missing coords / low-accuracy rejection),
+// checkWithinAnyRadius (single + multi-location "any" match, per-Location
+// radius override, default radius fallback, unusable/no-coordinate
+// Locations fail open), and the top-level evaluatePunchGeofence orchestrator
+// (non-wellness bypass, no-assignment bypass, enforced accept/reject).
+//
+// Pure module — no prisma, no external SDK, no mocking needed. Reuses the
+// real haversineDistanceMeters from lib/poiDedup.js (already covered by its
+// own test file), so distances below are computed with real trigonometry,
+// not stubbed.
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_RADIUS_M,
+  ACCURACY_THRESHOLD_M,
+  checkAccuracy,
+  checkWithinAnyRadius,
+  evaluatePunchGeofence,
+} from '../../lib/attendanceGeofence';
+
+// Ranchi clinic coordinates (arbitrary real-world point) as the reference.
+const CLINIC = { id: 1, name: 'Ranchi Clinic', latitude: 23.3441, longitude: 85.3096, geofenceRadiusM: null };
+// ~11m north of CLINIC (well within any reasonable radius).
+const NEARBY = { latitude: 23.34420, longitude: 85.3096, accuracy: 20 };
+// ~1.1km north of CLINIC (outside a 150m default radius).
+const FAR = { latitude: 23.3541, longitude: 85.3096, accuracy: 20 };
+
+describe('attendanceGeofence — module shape', () => {
+  it('exports the expected constants + functions', () => {
+    expect(DEFAULT_RADIUS_M).toBe(150);
+    expect(ACCURACY_THRESHOLD_M).toBe(100);
+    expect(typeof checkAccuracy).toBe('function');
+    expect(typeof checkWithinAnyRadius).toBe('function');
+    expect(typeof evaluatePunchGeofence).toBe('function');
+  });
+});
+
+describe('checkAccuracy', () => {
+  it('missing latitude/longitude → LOCATION_REQUIRED', () => {
+    const out = checkAccuracy({});
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('LOCATION_REQUIRED');
+  });
+
+  it('non-finite latitude (NaN from a bad body) → LOCATION_REQUIRED', () => {
+    const out = checkAccuracy({ latitude: NaN, longitude: 85.3 });
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('LOCATION_REQUIRED');
+  });
+
+  it('accuracy worse than the 100m threshold → ACCURACY_TOO_LOW', () => {
+    const out = checkAccuracy({ latitude: 23.34, longitude: 85.3, accuracy: 150 });
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('ACCURACY_TOO_LOW');
+    expect(out.error).toMatch(/150m/);
+  });
+
+  it('accuracy exactly at the threshold (100m) is accepted, not rejected', () => {
+    const out = checkAccuracy({ latitude: 23.34, longitude: 85.3, accuracy: 100 });
+    expect(out.ok).toBe(true);
+  });
+
+  it('no accuracy field at all → accepted (browser may not report it)', () => {
+    const out = checkAccuracy({ latitude: 23.34, longitude: 85.3 });
+    expect(out.ok).toBe(true);
+  });
+
+  it('good accuracy (10m) → accepted', () => {
+    const out = checkAccuracy({ latitude: 23.34, longitude: 85.3, accuracy: 10 });
+    expect(out.ok).toBe(true);
+  });
+});
+
+describe('checkWithinAnyRadius', () => {
+  it('single Location, punch nearby → ok with matchedLocationId', () => {
+    const out = checkWithinAnyRadius(NEARBY, [CLINIC]);
+    expect(out.ok).toBe(true);
+    expect(out.matchedLocationId).toBe(1);
+  });
+
+  it('single Location, punch far away (default 150m radius) → OUTSIDE_RADIUS', () => {
+    const out = checkWithinAnyRadius(FAR, [CLINIC]);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('OUTSIDE_RADIUS');
+    expect(out.error).toMatch(/Ranchi Clinic/);
+  });
+
+  it('Location.geofenceRadiusM overrides the 150m default (a large campus radius accepts a far punch)', () => {
+    const bigCampus = { ...CLINIC, geofenceRadiusM: 2000 };
+    const out = checkWithinAnyRadius(FAR, [bigCampus]);
+    expect(out.ok).toBe(true);
+  });
+
+  it('Location.geofenceRadiusM can also be stricter than the default (a small radius rejects a punch the default would accept)', () => {
+    const tinyRadius = { ...CLINIC, geofenceRadiusM: 5 };
+    const out = checkWithinAnyRadius(NEARBY, [tinyRadius]);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('OUTSIDE_RADIUS');
+  });
+
+  it('multi-location: passes if within radius of ANY assigned clinic, even if far from another', () => {
+    const otherFarClinic = { id: 2, name: 'Delhi Clinic', latitude: 28.6139, longitude: 77.2090, geofenceRadiusM: null };
+    const out = checkWithinAnyRadius(NEARBY, [otherFarClinic, CLINIC]);
+    expect(out.ok).toBe(true);
+    expect(out.matchedLocationId).toBe(1);
+  });
+
+  it('multi-location: fails only if outside radius of EVERY assigned clinic', () => {
+    const otherFarClinic = { id: 2, name: 'Delhi Clinic', latitude: 28.6139, longitude: 77.2090, geofenceRadiusM: null };
+    const out = checkWithinAnyRadius(FAR, [otherFarClinic, CLINIC]);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('OUTSIDE_RADIUS');
+  });
+
+  it('assigned Location with no lat/lng set → fails open (ok:true), can\'t enforce with no reference point', () => {
+    const misconfigured = { id: 3, name: 'New Clinic (no coords yet)', latitude: null, longitude: null, geofenceRadiusM: null };
+    const out = checkWithinAnyRadius(NEARBY, [misconfigured]);
+    expect(out.ok).toBe(true);
+  });
+});
+
+describe('evaluatePunchGeofence — orchestrator', () => {
+  it('non-wellness vertical (travel) → not enforced, regardless of coords or assignments', () => {
+    const out = evaluatePunchGeofence({ vertical: 'travel', assignedLocations: [CLINIC], coords: {} });
+    expect(out.enforced).toBe(false);
+    expect(out.ok).toBe(true);
+  });
+
+  it('non-wellness vertical (generic) → not enforced', () => {
+    const out = evaluatePunchGeofence({ vertical: 'generic', assignedLocations: [CLINIC], coords: FAR });
+    expect(out.enforced).toBe(false);
+    expect(out.ok).toBe(true);
+  });
+
+  it('wellness tenant, user with NO assigned Locations → not enforced (roll-out-friendly default)', () => {
+    const out = evaluatePunchGeofence({ vertical: 'wellness', assignedLocations: [], coords: {} });
+    expect(out.enforced).toBe(false);
+    expect(out.ok).toBe(true);
+  });
+
+  it('wellness tenant, assigned + nearby + good accuracy → enforced + accepted', () => {
+    const out = evaluatePunchGeofence({ vertical: 'wellness', assignedLocations: [CLINIC], coords: NEARBY });
+    expect(out.enforced).toBe(true);
+    expect(out.ok).toBe(true);
+    expect(out.matchedLocationId).toBe(1);
+  });
+
+  it('wellness tenant, assigned + missing coords → enforced + rejected LOCATION_REQUIRED (accuracy check runs before distance)', () => {
+    const out = evaluatePunchGeofence({ vertical: 'wellness', assignedLocations: [CLINIC], coords: {} });
+    expect(out.enforced).toBe(true);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('LOCATION_REQUIRED');
+  });
+
+  it('wellness tenant, assigned + fuzzy GPS reading → enforced + rejected ACCURACY_TOO_LOW BEFORE the distance check runs', () => {
+    // FAR coords would also fail on distance, but accuracy is checked first —
+    // pin that a fuzzy-but-in-range reading still gets ACCURACY_TOO_LOW, not
+    // OUTSIDE_RADIUS, so the user gets the right actionable message.
+    const out = evaluatePunchGeofence({
+      vertical: 'wellness',
+      assignedLocations: [CLINIC],
+      coords: { latitude: NEARBY.latitude, longitude: NEARBY.longitude, accuracy: 500 },
+    });
+    expect(out.enforced).toBe(true);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('ACCURACY_TOO_LOW');
+  });
+
+  it('wellness tenant, assigned + good accuracy + too far → enforced + rejected OUTSIDE_RADIUS', () => {
+    const out = evaluatePunchGeofence({ vertical: 'wellness', assignedLocations: [CLINIC], coords: FAR });
+    expect(out.enforced).toBe(true);
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('OUTSIDE_RADIUS');
+  });
+});

--- a/backend/test/routes/attendance.test.js
+++ b/backend/test/routes/attendance.test.js
@@ -73,6 +73,16 @@ prisma.leaveRequest = prisma.leaveRequest || {};
 prisma.leaveRequest.findMany = vi.fn().mockResolvedValue([]);
 prisma.user = prisma.user || {};
 prisma.user.findFirst = vi.fn();
+// Geo-tagged attendance (wellness only) — resolveGeofenceContext() queries
+// these on every clock-in/out. Default to a non-wellness tenant so all the
+// PRE-EXISTING tests above (none of which set up geofence state) keep their
+// original "unenforced" behaviour without modification; the dedicated
+// describe('Geo-tagged attendance (wellness only)') block below overrides
+// both per-test.
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn();
+prisma.userLocation = prisma.userLocation || {};
+prisma.userLocation.findMany = vi.fn();
 prisma.biometricDevice = prisma.biometricDevice || {};
 prisma.biometricDevice.findMany = vi.fn();
 prisma.biometricDevice.findFirst = vi.fn();
@@ -141,9 +151,16 @@ beforeEach(() => {
   prisma.biometricDevice.create.mockReset();
   prisma.biometricDevice.update.mockReset();
   prisma.biometricDevice.delete.mockReset();
+  prisma.tenant.findUnique.mockReset();
+  prisma.userLocation.findMany.mockReset();
   prisma.attendance.findMany.mockResolvedValue([]);
   prisma.attendance.findUnique.mockResolvedValue(null);
   prisma.biometricDevice.findMany.mockResolvedValue([]);
+  // Default: non-wellness tenant → resolveGeofenceContext short-circuits
+  // before ever querying userLocation, matching every pre-existing test's
+  // assumption of unconditional-accept clock-in/out.
+  prisma.tenant.findUnique.mockResolvedValue({ vertical: 'generic' });
+  prisma.userLocation.findMany.mockResolvedValue([]);
 });
 
 // ── /clock-in ──────────────────────────────────────────────────────────
@@ -281,6 +298,163 @@ describe('POST /clock-out', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('HALF_DAY');
+  });
+});
+
+// ── Geo-tagged attendance (wellness only) ───────────────────────────────
+//
+// Real distance math (not stubbed) — same reference coordinates as
+// backend/test/lib/attendanceGeofence.test.js: a Ranchi clinic + a point
+// ~11m away (NEARBY, inside any reasonable radius) + a point ~1.1km away
+// (FAR, outside the 150m default). resolveGeofenceContext() itself isn't
+// exported, so these tests exercise it indirectly through the route.
+const RANCHI_CLINIC = { id: 1, name: 'Ranchi Clinic', latitude: 23.3441, longitude: 85.3096, geofenceRadiusM: null };
+const NEARBY_COORDS = { latitude: 23.34420, longitude: 85.3096, accuracy: 20 };
+const FAR_COORDS = { latitude: 23.3541, longitude: 85.3096, accuracy: 20 };
+
+describe('Geo-tagged attendance (wellness only)', () => {
+  describe('POST /clock-in', () => {
+    test('non-wellness tenant (travel/generic) → geofence not enforced even with no coords sent', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'travel' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+      prisma.attendance.create.mockResolvedValue({ id: 900, tenantId: 1, userId: 7, source: 'MANUAL' });
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send({});
+
+      expect(res.status).toBe(201);
+      expect(prisma.attendance.create).toHaveBeenCalledTimes(1);
+      // travel tenant never even queries assigned locations (short-circuits
+      // on vertical !== 'wellness' before the userLocation lookup).
+      expect(prisma.userLocation.findMany).not.toHaveBeenCalled();
+    });
+
+    test('wellness tenant, user has no assigned Location → geofence not enforced (roll-out default)', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([]);
+      prisma.attendance.create.mockResolvedValue({ id: 901, tenantId: 1, userId: 7, source: 'MANUAL' });
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send({});
+
+      expect(res.status).toBe(201);
+      expect(prisma.attendance.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('wellness tenant, assigned + no coords sent → 403 LOCATION_REQUIRED, no row created', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send({});
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('LOCATION_REQUIRED');
+      expect(prisma.attendance.create).not.toHaveBeenCalled();
+    });
+
+    test('wellness tenant, assigned + fuzzy GPS (accuracy > 100m) → 403 ACCURACY_TOO_LOW', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send({
+        latitude: NEARBY_COORDS.latitude, longitude: NEARBY_COORDS.longitude, accuracy: 500,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('ACCURACY_TOO_LOW');
+      expect(prisma.attendance.create).not.toHaveBeenCalled();
+    });
+
+    test('wellness tenant, assigned + too far from clinic → 403 OUTSIDE_RADIUS', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send(FAR_COORDS);
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('OUTSIDE_RADIUS');
+      expect(prisma.attendance.create).not.toHaveBeenCalled();
+    });
+
+    test('wellness tenant, assigned + within radius + good accuracy → 201, coords persisted on the row', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+      prisma.attendance.create.mockResolvedValue({ id: 902, tenantId: 1, userId: 7, source: 'MANUAL' });
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send(NEARBY_COORDS);
+
+      expect(res.status).toBe(201);
+      const createArgs = prisma.attendance.create.mock.calls[0][0];
+      expect(createArgs.data.clockInLat).toBe(NEARBY_COORDS.latitude);
+      expect(createArgs.data.clockInLng).toBe(NEARBY_COORDS.longitude);
+      expect(createArgs.data.clockInAccuracyM).toBe(20);
+    });
+
+    test('wellness tenant, assigned to MULTIPLE clinics → accepted if within radius of any one', async () => {
+      const farAwayClinic = { id: 2, name: 'Delhi Clinic', latitude: 28.6139, longitude: 77.2090, geofenceRadiusM: null };
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: farAwayClinic }, { location: RANCHI_CLINIC }]);
+      prisma.attendance.create.mockResolvedValue({ id: 903, tenantId: 1, userId: 7, source: 'MANUAL' });
+
+      const res = await authedReq('post', '/api/attendance/clock-in').send(NEARBY_COORDS);
+
+      expect(res.status).toBe(201);
+      expect(prisma.attendance.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /clock-out', () => {
+    test('wellness tenant, assigned + too far from clinic → 403 OUTSIDE_RADIUS, no update written', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+      prisma.attendance.findUnique.mockResolvedValue({
+        id: 950, tenantId: 1, userId: 7,
+        date: new Date('2026-05-25T00:00:00.000Z'),
+        clockInAt: new Date(Date.now() - 60 * 60 * 1000),
+        clockOutAt: null,
+      });
+
+      const res = await authedReq('post', '/api/attendance/clock-out').send(FAR_COORDS);
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('OUTSIDE_RADIUS');
+      expect(prisma.attendance.update).not.toHaveBeenCalled();
+    });
+
+    test('wellness tenant, assigned + within radius → 200, coords persisted on the row', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+      const clockInAt = new Date(Date.now() - 5 * 60 * 60 * 1000);
+      prisma.attendance.findUnique.mockResolvedValue({
+        id: 951, tenantId: 1, userId: 7,
+        date: new Date('2026-05-25T00:00:00.000Z'),
+        clockInAt, clockOutAt: null,
+      });
+      prisma.attendance.update.mockImplementation(({ where, data }) => ({ id: where.id, ...data }));
+
+      const res = await authedReq('post', '/api/attendance/clock-out').send(NEARBY_COORDS);
+
+      expect(res.status).toBe(200);
+      const updateArgs = prisma.attendance.update.mock.calls[0][0];
+      expect(updateArgs.data.clockOutLat).toBe(NEARBY_COORDS.latitude);
+      expect(updateArgs.data.clockOutLng).toBe(NEARBY_COORDS.longitude);
+      expect(updateArgs.data.clockOutAccuracyM).toBe(20);
+    });
+
+    test('travel tenant sharing the same route → geofence not enforced on clock-out either', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'travel' });
+      prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
+      prisma.attendance.findUnique.mockResolvedValue({
+        id: 952, tenantId: 1, userId: 7,
+        date: new Date('2026-05-25T00:00:00.000Z'),
+        clockInAt: new Date(Date.now() - 60 * 60 * 1000),
+        clockOutAt: null,
+      });
+      prisma.attendance.update.mockImplementation(({ where, data }) => ({ id: where.id, ...data }));
+
+      const res = await authedReq('post', '/api/attendance/clock-out').send(FAR_COORDS);
+
+      expect(res.status).toBe(200);
+      expect(prisma.attendance.update).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/backend/test/routes/contacts.test.js
+++ b/backend/test/routes/contacts.test.js
@@ -185,6 +185,13 @@ prisma.itinerary.findMany = vi.fn().mockResolvedValue([]);
 prisma.travelInvoice = prisma.travelInvoice || {};
 prisma.travelInvoice.findMany = vi.fn().mockResolvedValue([]);
 
+// Generic-vertical Lead custom fields (attachLeadCustomFields / Batch / write)
+prisma.leadCustomFieldDefinition = prisma.leadCustomFieldDefinition || {};
+prisma.leadCustomFieldDefinition.findMany = vi.fn().mockResolvedValue([]);
+prisma.leadCustomFieldValue = prisma.leadCustomFieldValue || {};
+prisma.leadCustomFieldValue.findMany = vi.fn().mockResolvedValue([]);
+prisma.leadCustomFieldValue.upsert = vi.fn().mockResolvedValue({});
+
 import express from 'express';
 import request from 'supertest';
 const contactsRouter = requireCJS('../../routes/contacts');
@@ -238,6 +245,9 @@ beforeEach(() => {
   prisma.tenant.findUnique.mockReset().mockResolvedValue({ vertical: 'generic' });
   prisma.itinerary.findMany.mockReset().mockResolvedValue([]);
   prisma.travelInvoice.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldDefinition.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldValue.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldValue.upsert.mockReset().mockResolvedValue({});
   writeAuditMock.mockReset().mockResolvedValue(undefined);
   diffFieldsMock.mockReset().mockReturnValue({});
   emitEventMock.mockReset();
@@ -660,6 +670,95 @@ describe('GET /api/contacts?fields=summary — opt-in slim shape (#920 slice 1)'
     // Slim select still in place under pagination.
     expect(args).toHaveProperty('select');
     expect(args).not.toHaveProperty('include');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Generic-vertical Lead custom fields (Settings > Lead Fields)
+// ─────────────────────────────────────────────────────────────────────
+describe('Lead custom fields — read/write integration', () => {
+  test('GET /api/contacts attaches customFields keyed by field definitions', async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 10, tenantId: TENANT_ID, fieldKey: 'referral', label: 'Referral', fieldType: 'text' },
+      { id: 11, tenantId: TENANT_ID, fieldKey: 'priority', label: 'Priority', fieldType: 'dropdown', options: JSON.stringify(['High', 'Low']) },
+    ]);
+    prisma.leadCustomFieldValue.findMany.mockResolvedValue([
+      { contactId: SAMPLE_CONTACT.id, fieldId: 11, valueText: 'High', tenantId: TENANT_ID },
+    ]);
+
+    const res = await request(makeApp()).get('/api/contacts');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].customFields).toEqual({
+      referral: null,
+      priority: 'High',
+    });
+  });
+
+  test('GET /api/contacts/:id parses multiselect values from JSON', async () => {
+    prisma.contact.findFirst.mockResolvedValue(SAMPLE_CONTACT);
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 12, tenantId: TENANT_ID, fieldKey: 'tags', label: 'Tags', fieldType: 'multiselect', options: JSON.stringify(['A', 'B', 'C']) },
+    ]);
+    prisma.leadCustomFieldValue.findMany.mockResolvedValue([
+      { contactId: SAMPLE_CONTACT.id, fieldId: 12, valueText: JSON.stringify(['A', 'C']), tenantId: TENANT_ID },
+    ]);
+
+    const res = await request(makeApp()).get(`/api/contacts/${SAMPLE_CONTACT.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.customFields.tags).toEqual(['A', 'C']);
+  });
+
+  test('POST /api/contacts persists customFields values after contact create', async () => {
+    findDuplicateMock.mockResolvedValue(null);
+    prisma.contact.create.mockResolvedValue(SAMPLE_CONTACT);
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 13, tenantId: TENANT_ID, fieldKey: 'website', label: 'Website', fieldType: 'url' },
+      { id: 14, tenantId: TENANT_ID, fieldKey: 'notes', label: 'Notes', fieldType: 'textarea' },
+      { id: 15, tenantId: TENANT_ID, fieldKey: 'active', label: 'Active', fieldType: 'checkbox' },
+    ]);
+
+    await request(makeApp())
+      .post('/api/contacts')
+      .send({
+        name: 'Amita Rao',
+        email: 'amita@example.com',
+        customFields: {
+          website: 'https://example.com',
+          notes: 'Important lead',
+          active: true,
+        },
+      });
+
+    const upserts = prisma.leadCustomFieldValue.upsert.mock.calls.map((c) => c[0]);
+    const websiteCall = upserts.find((c) => c.where.contactId_fieldId.fieldId === 13);
+    expect(websiteCall.create.valueText).toBe('https://example.com');
+    const notesCall = upserts.find((c) => c.where.contactId_fieldId.fieldId === 14);
+    expect(notesCall.create.valueText).toBe('Important lead');
+    const activeCall = upserts.find((c) => c.where.contactId_fieldId.fieldId === 15);
+    expect(activeCall.create.valueBool).toBe(true);
+  });
+
+  test('POST /api/contacts skips invalid URL values for url fields', async () => {
+    findDuplicateMock.mockResolvedValue(null);
+    prisma.contact.create.mockResolvedValue(SAMPLE_CONTACT);
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 13, tenantId: TENANT_ID, fieldKey: 'website', label: 'Website', fieldType: 'url' },
+    ]);
+
+    await request(makeApp())
+      .post('/api/contacts')
+      .send({
+        name: 'Amita Rao',
+        email: 'amita@example.com',
+        customFields: { website: 'not-a-url' },
+      });
+
+    const upserts = prisma.leadCustomFieldValue.upsert.mock.calls.map((c) => c[0]);
+    const websiteCall = upserts.find((c) => c.where.contactId_fieldId.fieldId === 13);
+    // Invalid URL is treated as a clear — all typed columns are null.
+    expect(websiteCall.update).toEqual({ valueText: null, valueNumber: null, valueDate: null, valueBool: null });
   });
 });
 

--- a/backend/test/routes/lead-custom-fields.test.js
+++ b/backend/test/routes/lead-custom-fields.test.js
@@ -1,0 +1,235 @@
+// @ts-check
+/**
+ * Unit tests for backend/routes/lead_custom_fields.js
+ *
+ * Pins the admin-configurable Lead Custom Fields route:
+ *   - GET /api/lead-custom-fields (authenticated, any role)
+ *   - POST /api/lead-custom-fields (ADMIN only)
+ *   - PUT /api/lead-custom-fields/:id (ADMIN only)
+ *   - DELETE /api/lead-custom-fields/:id (ADMIN only)
+ *
+ * Covers the expanded field-type set (text, textarea, number, dropdown,
+ * radio, date, url, checkbox, multiselect) plus tooltip/placeholder.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import express from 'express';
+import request from 'supertest';
+
+import prisma from '../../lib/prisma.js';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+// ── Patch auth middleware to pass-through ──────────────────────────────
+const authMw = requireCJS('../../middleware/auth');
+authMw.verifyToken = (_req, _res, next) => next();
+authMw.verifyRole = () => (_req, _res, next) => next();
+
+// ── Prisma singleton patching ──────────────────────────────────────────
+prisma.leadCustomFieldDefinition = prisma.leadCustomFieldDefinition || {};
+prisma.leadCustomFieldDefinition.findMany = vi.fn();
+prisma.leadCustomFieldDefinition.findUnique = vi.fn();
+prisma.leadCustomFieldDefinition.findFirst = vi.fn();
+prisma.leadCustomFieldDefinition.create = vi.fn();
+prisma.leadCustomFieldDefinition.update = vi.fn();
+prisma.leadCustomFieldDefinition.delete = vi.fn();
+prisma.leadCustomFieldDefinition.aggregate = vi.fn();
+
+const leadCustomFieldsRouter = requireCJS('../../routes/lead_custom_fields');
+
+const TENANT_ID = 1;
+const USER_ID = 7;
+
+function makeApp({ role = 'ADMIN' } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { userId: USER_ID, tenantId: TENANT_ID, role };
+    next();
+  });
+  app.use('/api/lead-custom-fields', leadCustomFieldsRouter);
+  return app;
+}
+
+beforeEach(() => {
+  prisma.leadCustomFieldDefinition.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldDefinition.findUnique.mockReset().mockResolvedValue(null);
+  prisma.leadCustomFieldDefinition.findFirst.mockReset().mockResolvedValue(null);
+  prisma.leadCustomFieldDefinition.create.mockReset();
+  prisma.leadCustomFieldDefinition.update.mockReset();
+  prisma.leadCustomFieldDefinition.delete.mockReset();
+  prisma.leadCustomFieldDefinition.aggregate.mockReset().mockResolvedValue({ _max: { displayOrder: null } });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+describe('GET /api/lead-custom-fields', () => {
+  test('lists definitions with parsed options for this tenant', async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 1, tenantId: TENANT_ID, fieldKey: 'source', label: 'Source', fieldType: 'dropdown', options: JSON.stringify(['Google', 'Referral']), tooltip: null, placeholder: null, isRequired: false, displayOrder: 1 },
+      { id: 2, tenantId: TENANT_ID, fieldKey: 'notes', label: 'Notes', fieldType: 'textarea', options: null, tooltip: 'Extra details', placeholder: 'Enter notes', isRequired: true, displayOrder: 2 },
+    ]);
+
+    const res = await request(makeApp()).get('/api/lead-custom-fields');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].options).toEqual(['Google', 'Referral']);
+    expect(res.body[1].options).toBeNull();
+    expect(res.body[1].tooltip).toBe('Extra details');
+    expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith({
+      where: { tenantId: TENANT_ID },
+      orderBy: [{ displayOrder: 'asc' }, { id: 'asc' }],
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+describe('POST /api/lead-custom-fields', () => {
+  test('creates a text field', async () => {
+    prisma.leadCustomFieldDefinition.create.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'referral_source', label: 'Referral Source', fieldType: 'text', options: null, tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'Referral Source',
+      fieldType: 'text',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.fieldKey).toBe('referral_source');
+  });
+
+  test.each([
+    ['dropdown', ['Google', 'Referral']],
+    ['radio', ['Yes', 'No']],
+    ['multiselect', ['A', 'B', 'C']],
+  ])('creates a %s field with options', async (fieldType, options) => {
+    prisma.leadCustomFieldDefinition.create.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'choice', label: 'Choice', fieldType, options: JSON.stringify(options), tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'Choice',
+      fieldType,
+      options,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.options).toEqual(options);
+  });
+
+  test.each(['textarea', 'number', 'date', 'url', 'checkbox'])('creates a %s field without options', async (fieldType) => {
+    prisma.leadCustomFieldDefinition.create.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: fieldType, label: fieldType, fieldType, options: null, tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: fieldType,
+      fieldType,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.fieldType).toBe(fieldType);
+  });
+
+  test('rejects an unsupported fieldType', async () => {
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'Bad',
+      fieldType: 'formula',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_FIELD_TYPE');
+  });
+
+  test('rejects a dropdown without options', async () => {
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'No options',
+      fieldType: 'dropdown',
+      options: [],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('OPTIONS_REQUIRED');
+  });
+
+  test('stores tooltip and placeholder', async () => {
+    prisma.leadCustomFieldDefinition.create.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'url', label: 'Website', fieldType: 'url', options: null, tooltip: 'Company website', placeholder: 'https://example.com', isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'Website',
+      fieldType: 'url',
+      tooltip: 'Company website',
+      placeholder: 'https://example.com',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.tooltip).toBe('Company website');
+    expect(res.body.placeholder).toBe('https://example.com');
+  });
+
+  test('rejects a duplicate fieldKey', async () => {
+    prisma.leadCustomFieldDefinition.findUnique.mockResolvedValue({ id: 1 });
+
+    const res = await request(makeApp()).post('/api/lead-custom-fields').send({
+      label: 'Referral Source',
+      fieldType: 'text',
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('DUPLICATE_FIELD_KEY');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+describe('PUT /api/lead-custom-fields/:id', () => {
+  test('updates radio options and tooltip', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'priority', label: 'Priority', fieldType: 'radio', options: JSON.stringify(['High', 'Low']), tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+    prisma.leadCustomFieldDefinition.update.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'priority', label: 'Priority', fieldType: 'radio', options: JSON.stringify(['High', 'Medium', 'Low']), tooltip: 'Choose priority', placeholder: 'Pick one', isRequired: true, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).put('/api/lead-custom-fields/1').send({
+      options: ['High', 'Medium', 'Low'],
+      tooltip: 'Choose priority',
+      placeholder: 'Pick one',
+      isRequired: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.options).toEqual(['High', 'Medium', 'Low']);
+    expect(res.body.tooltip).toBe('Choose priority');
+  });
+
+  test('rejects options update on a non-choice field', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'notes', label: 'Notes', fieldType: 'text', options: null, tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).put('/api/lead-custom-fields/1').send({
+      options: ['A', 'B'],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('NOT_A_CHOICE_FIELD');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+describe('DELETE /api/lead-custom-fields/:id', () => {
+  test('deletes an existing field', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({
+      id: 1, tenantId: TENANT_ID, fieldKey: 'source', label: 'Source', fieldType: 'dropdown', options: null, tooltip: null, placeholder: null, isRequired: false, displayOrder: 1,
+    });
+
+    const res = await request(makeApp()).delete('/api/lead-custom-fields/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/backend/test/routes/travel-itineraries-public-payment.test.js
+++ b/backend/test/routes/travel-itineraries-public-payment.test.js
@@ -1,0 +1,241 @@
+// @ts-check
+/**
+ * POST /api/travel/itineraries/public/:shareToken/create-payment-order
+ * POST /api/travel/itineraries/public/:shareToken/verify-payment
+ *
+ * Regression coverage for a real billing-correctness bug: verify-payment used
+ * to advance the itinerary to advance_paid/fully_paid (and create a Payment
+ * row with status:"SUCCESS") based ONLY on `payment.amount > 0` from
+ * rp.client.payments.fetch(). Razorpay's `amount` field is present on an
+ * "authorized" (charge held, NOT yet settled) payment just as much as on a
+ * "captured" (settled) one — so a payment that was only ever authorized (and
+ * could later expire/void on Razorpay's side with the money never actually
+ * collected) still passed the old check and got recorded as a successful
+ * payment. Weeks later, an admin refunding that row would hit Razorpay's
+ * real PAYMENT_NOT_CAPTURED rejection — correctly, because nothing was ever
+ * captured — but the booking had already been marked paid in our system.
+ *
+ * The fix: verify-payment now requires payment.status === "captured" before
+ * advancing anything, and — since payment_capture:1 wasn't previously passed
+ * on order creation either — attempts an explicit payments.capture() call
+ * when Razorpay hands back "authorized" instead of immediately failing the
+ * customer's checkout. create-payment-order now also passes
+ * payment_capture:1 explicitly so this doesn't depend on the tenant's
+ * Razorpay account-level capture default.
+ *
+ * Mocking strategy (mirrors payments-refund.test.js): patch
+ * getTenantRazorpayClient BEFORE requiring the router. These are PUBLIC
+ * (unauthenticated, shareToken-based) routes — no JWT involved.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import prisma from '../../lib/prisma.js';
+import { createRequire } from 'node:module';
+
+const requireCJS = createRequire(import.meta.url);
+
+const fetchMock = vi.fn();
+const captureMock = vi.fn();
+const ordersCreateMock = vi.fn();
+const getTenantRazorpayClientMock = vi.fn();
+requireCJS('../../lib/tenantPaymentGateway').getTenantRazorpayClient = getTenantRazorpayClientMock;
+
+prisma.itinerary = { findUnique: vi.fn(), update: vi.fn() };
+prisma.itineraryItem = { findFirst: vi.fn(), findMany: vi.fn() };
+prisma.payment = { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: 1 }) };
+prisma.tenantSetting = { findUnique: vi.fn().mockResolvedValue(null) };
+prisma.travelPortalNotification = prisma.travelPortalNotification || {};
+prisma.travelPortalNotification.create = vi.fn().mockResolvedValue({ id: 1 });
+// Best-effort side-effects on the happy path (notify admin/customer,
+// upsert a travel invoice, emit itinerary.accepted) — none are under test
+// here, mocked only so they no-op quietly instead of surfacing prisma-
+// surface-guard warnings for genuinely out-of-scope call sites.
+prisma.contact = prisma.contact || {};
+prisma.contact.findUnique = vi.fn().mockResolvedValue(null);
+prisma.travelInvoice = prisma.travelInvoice || {};
+prisma.travelInvoice.findFirst = vi.fn().mockResolvedValue(null);
+prisma.automationRule = prisma.automationRule || {};
+prisma.automationRule.findMany = vi.fn().mockResolvedValue([]);
+
+import express from 'express';
+import request from 'supertest';
+import crypto from 'crypto';
+
+const travelItinerariesRouter = requireCJS('../../routes/travel_itineraries');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use('/api/travel', travelItinerariesRouter);
+  return app;
+}
+
+const SHARE_TOKEN = 'a'.repeat(32);
+const KEY_SECRET = 'test_key_secret_123';
+
+function itin(overrides = {}) {
+  return {
+    id: 55,
+    tenantId: 1,
+    subBrand: 'travelstall',
+    contactId: 501,
+    destination: 'Spain',
+    currency: 'INR',
+    status: 'accepted',
+    shareToken: SHARE_TOKEN,
+    totalAmount: 100000,
+    advancePaidAmount: 0,
+    paymentReference: null,
+    ...overrides,
+  };
+}
+
+function signature(orderId, paymentId) {
+  return crypto.createHmac('sha256', KEY_SECRET).update(`${orderId}|${paymentId}`).digest('hex');
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  captureMock.mockReset();
+  ordersCreateMock.mockReset();
+  getTenantRazorpayClientMock.mockReset().mockResolvedValue({
+    client: { payments: { fetch: fetchMock, capture: captureMock }, orders: { create: ordersCreateMock } },
+    keyId: 'rzp_test_abc',
+    keySecret: KEY_SECRET,
+  });
+  prisma.itinerary.findUnique.mockReset();
+  prisma.itinerary.update.mockReset().mockImplementation(async ({ data }) => ({ ...itin(), ...data }));
+  prisma.itineraryItem.findFirst.mockReset();
+  prisma.itineraryItem.findMany.mockReset().mockResolvedValue([]);
+  prisma.payment.create.mockReset().mockResolvedValue({ id: 1 });
+});
+
+describe('POST /itineraries/public/:shareToken/create-payment-order', () => {
+  test('passes payment_capture:1 explicitly — does not rely on the account-level default', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+    ordersCreateMock.mockResolvedValue({ id: 'order_ABC' });
+
+    await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/create-payment-order`)
+      .send({ kind: 'advance' });
+
+    expect(ordersCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_capture: 1 }),
+    );
+  });
+});
+
+describe('POST /itineraries/public/:shareToken/verify-payment', () => {
+  test('captured payment → advances the itinerary and records the payment', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+    fetchMock.mockResolvedValue({ id: 'pay_1', amount: 5000000, currency: 'INR', status: 'captured' });
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_1',
+        razorpay_signature: signature('order_ABC', 'pay_1'),
+      });
+
+    expect(res.status).toBe(201);
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(prisma.itinerary.update).toHaveBeenCalled();
+    expect(prisma.payment.create).toHaveBeenCalled();
+  });
+
+  // The core regression test: an "authorized" (amount > 0, but NOT settled)
+  // payment must NOT be recorded as a successful booking payment merely
+  // because amount is present — the OLD code's exact bug.
+  test('authorized-but-not-captured payment: attempts capture(); if capture succeeds, proceeds', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+    fetchMock.mockResolvedValue({ id: 'pay_2', amount: 5000000, currency: 'INR', status: 'authorized' });
+    captureMock.mockResolvedValue({ id: 'pay_2', amount: 5000000, currency: 'INR', status: 'captured' });
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_2',
+        razorpay_signature: signature('order_ABC', 'pay_2'),
+      });
+
+    expect(captureMock).toHaveBeenCalledWith('pay_2', 5000000, 'INR');
+    expect(res.status).toBe(201);
+    expect(prisma.itinerary.update).toHaveBeenCalled();
+    expect(prisma.payment.create).toHaveBeenCalled();
+  });
+
+  test('authorized-but-not-captured payment: capture() itself fails → NOT_CAPTURED, itinerary NOT advanced', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+    fetchMock.mockResolvedValue({ id: 'pay_3', amount: 5000000, currency: 'INR', status: 'authorized' });
+    captureMock.mockRejectedValue(new Error('capture failed'));
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_3',
+        razorpay_signature: signature('order_ABC', 'pay_3'),
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('NOT_CAPTURED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  // Regression pin for the OLD bug shape: a payment that's neither captured
+  // nor capturable (e.g. failed/voided) must be rejected even though Razorpay
+  // still returns a non-zero `amount` field on the fetch response.
+  test('failed/voided payment with amount > 0 but status never becomes captured → NOT_CAPTURED', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+    fetchMock.mockResolvedValue({ id: 'pay_4', amount: 5000000, currency: 'INR', status: 'failed' });
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_4',
+        razorpay_signature: signature('order_ABC', 'pay_4'),
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('NOT_CAPTURED');
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  test('bad signature is rejected before any Razorpay call', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin());
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_5',
+        razorpay_signature: 'not-a-real-signature',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_SIGNATURE');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('idempotent on paymentReference — already-recorded payment id short-circuits without re-fetching Razorpay', async () => {
+    prisma.itinerary.findUnique.mockResolvedValue(itin({ paymentReference: 'pay_1', advancePaidAmount: 30000 }));
+
+    const res = await request(makeApp())
+      .post(`/api/travel/itineraries/public/${SHARE_TOKEN}/verify-payment`)
+      .send({
+        razorpay_order_id: 'order_ABC',
+        razorpay_payment_id: 'pay_1',
+        razorpay_signature: signature('order_ABC', 'pay_1'),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.idempotent).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/services/serpApiClient.test.js
+++ b/backend/test/services/serpApiClient.test.js
@@ -62,7 +62,7 @@ describe('searchFlights', () => {
     const out = await serp.searchFlights({ from: 'DEL', to: 'JED', departDate: '2026-08-02', adults: 2, currency: 'INR' }, ax);
     // params
     const params = ax.get.mock.calls[0][1].params;
-    expect(params).toMatchObject({ engine: 'google_flights', departure_id: 'DEL', arrival_id: 'JED', outbound_date: '2026-08-02', type: 2, adults: 2 });
+    expect(params).toMatchObject({ engine: 'google_flights', departure_id: 'DEL', arrival_id: 'JED', outbound_date: '2026-08-02', type: 2, adults: 2, travel_class: 1 });
     expect(params.return_date).toBeUndefined();
     // mapping
     expect(out).toHaveLength(2);
@@ -76,6 +76,12 @@ describe('searchFlights', () => {
     const params = ax.get.mock.calls[0][1].params;
     expect(params.return_date).toBe('2026-08-09');
     expect(params.type).toBeUndefined();
+  });
+
+  test('maps the requested cabin class to SerpApi travel_class', async () => {
+    const ax = { get: vi.fn().mockResolvedValue({ data: { best_flights: [], other_flights: [] } }) };
+    await serp.searchFlights({ from: 'DEL', to: 'JED', departDate: '2026-08-02', cabinClass: 'Business' }, ax);
+    expect(ax.get.mock.calls[0][1].params.travel_class).toBe(3);
   });
 
   test('SerpApi error body → null', async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -49,6 +49,7 @@ const Settings = lazy(() => import("./pages/Settings"));
 // enable/disable toggles + cooldowns + Meta form-ID routing mappings.
 // ADMIN-only via RoleGuard at the route declaration below.
 const LeadCapture = lazy(() => import("./pages/settings/LeadCapture"));
+const LeadFields = lazy(() => import("./pages/settings/LeadFields"));
 const UserSettings = lazy(() => import("./pages/UserSettings"));
 const Developer = lazy(() => import("./pages/Developer"));
 const Portal = lazy(() => import("./pages/Portal"));
@@ -1295,6 +1296,16 @@ export default function App() {
                       element={
                         <RoleGuard allow={["ADMIN"]} message="Lead Capture settings require admin access.">
                           <LeadCapture />
+                        </RoleGuard>
+                      }
+                    />
+                    {/* Lead custom fields — generic vertical only; LeadFields.jsx
+                        itself redirects away for wellness/travel tenants. */}
+                    <Route
+                      path="settings/lead-fields"
+                      element={
+                        <RoleGuard allow={["ADMIN"]} message="Lead Fields settings require admin access.">
+                          <LeadFields />
                         </RoleGuard>
                       }
                     />

--- a/frontend/src/pages/ContactDetail.jsx
+++ b/frontend/src/pages/ContactDetail.jsx
@@ -1,14 +1,18 @@
 import { fetchApi } from '../utils/api';
 import { formatMoney } from '../utils/money';
 import { formatDate, formatDateTime } from '../utils/date';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Phone, Mail, Calendar, Paperclip, Upload, Trash2, FileText, Download, Target, Pencil, MessageSquareText, Sparkles } from 'lucide-react';
+import { AuthContext } from '../App';
 
 const PHONE_RE = /^\+?[\d\s\-().]{7,15}$/;
 
 const ContactDetail = () => {
   const { id } = useParams();
+  const auth = useContext(AuthContext);
+  const isWellness = auth?.tenant?.vertical === 'wellness';
+  const isTravel = auth?.tenant?.vertical === 'travel';
   const [contact, setContact] = useState(null);
   const [attachments, setAttachments] = useState([]);
   const [showUpload, setShowUpload] = useState(false);
@@ -16,7 +20,16 @@ const ContactDetail = () => {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [editError, setEditError] = useState('');
-  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', company: '', title: '' });
+  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', company: '', title: '', customFields: {} });
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  const [customFieldDefs, setCustomFieldDefs] = useState([]);
+
+  useEffect(() => {
+    if (isWellness || isTravel) return;
+    fetchApi('/api/lead-custom-fields')
+      .then(d => setCustomFieldDefs(Array.isArray(d) ? d : []))
+      .catch(() => setCustomFieldDefs([]));
+  }, [isWellness, isTravel]);
 
   const openEdit = () => {
     setEditForm({
@@ -25,6 +38,7 @@ const ContactDetail = () => {
       phone: contact.phone || '',
       company: contact.company || '',
       title: contact.title || '',
+      customFields: { ...(contact.customFields || {}) },
     });
     setEditError('');
     setEditing(true);
@@ -56,6 +70,99 @@ const ContactDetail = () => {
 
   const loadContact = () => {
     fetchApi(`/api/contacts/${id}`).then(data => setContact(data)).catch(() => {});
+  };
+
+  // Generic-vertical-only Lead custom fields — renders the right input
+  // widget per admin-defined field type (Settings > Lead Fields).
+  const handleCustomFieldChange = (key, value) => {
+    setEditForm(prev => ({ ...prev, customFields: { ...prev.customFields, [key]: value } }));
+  };
+
+  const renderCustomFieldInputs = () => {
+    if (isWellness || isTravel || customFieldDefs.length === 0) return null;
+    return customFieldDefs.map((f) => {
+      const value = editForm.customFields?.[f.fieldKey] ?? '';
+      const label = (
+        <span style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>{f.label}</span>
+      );
+      const titleAttr = f.tooltip ? { title: f.tooltip } : {};
+      const placeholder = f.placeholder || `${f.label}…`;
+
+      if (f.fieldType === 'checkbox') {
+        return (
+          <label key={f.id} style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.8rem' }} {...titleAttr}>
+            <input type="checkbox" checked={Boolean(value)} onChange={e => handleCustomFieldChange(f.fieldKey, e.target.checked)} />
+            {f.label}
+          </label>
+        );
+      }
+      if (f.fieldType === 'dropdown' || f.fieldType === 'radio') {
+        return (
+          <label key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }} {...titleAttr}>
+            {label}
+            <select className="input-field" required={f.isRequired} value={value} onChange={e => handleCustomFieldChange(f.fieldKey, e.target.value)} style={{ padding: '0.45rem', fontSize: '0.85rem' }}>
+              <option value="">Select…</option>
+              {(f.options || []).map((opt) => <option key={opt} value={opt}>{opt}</option>)}
+            </select>
+          </label>
+        );
+      }
+      if (f.fieldType === 'multiselect') {
+        const selected = Array.isArray(value) ? value : (value ? [value] : []);
+        return (
+          <div key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }} {...titleAttr}>
+            {label}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+              {(f.options || []).map((opt) => (
+                <label key={opt} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.8rem', padding: '0.2rem 0.5rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--surface-color)', cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(opt)}
+                    onChange={(e) => {
+                      const next = e.target.checked ? [...selected, opt] : selected.filter((s) => s !== opt);
+                      handleCustomFieldChange(f.fieldKey, next);
+                    }}
+                  />
+                  {opt}
+                </label>
+              ))}
+            </div>
+          </div>
+        );
+      }
+      if (f.fieldType === 'textarea') {
+        return (
+          <label key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }} {...titleAttr}>
+            {label}
+            <textarea
+              className="input-field"
+              required={f.isRequired}
+              value={value}
+              placeholder={placeholder}
+              maxLength={2000}
+              rows={3}
+              onChange={e => handleCustomFieldChange(f.fieldKey, e.target.value)}
+              style={{ padding: '0.45rem', fontSize: '0.85rem' }}
+            />
+          </label>
+        );
+      }
+      const inputType = f.fieldType === 'date' ? 'date' : f.fieldType === 'number' ? 'number' : f.fieldType === 'url' ? 'url' : 'text';
+      return (
+        <label key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }} {...titleAttr}>
+          {label}
+          <input
+            className="input-field"
+            type={inputType}
+            required={f.isRequired}
+            placeholder={placeholder}
+            value={value}
+            onChange={e => handleCustomFieldChange(f.fieldKey, e.target.value)}
+            style={{ padding: '0.45rem', fontSize: '0.85rem' }}
+          />
+        </label>
+      );
+    });
   };
 
   const [summarizing, setSummarizing] = useState(false);
@@ -140,17 +247,17 @@ const ContactDetail = () => {
             {editing ? (
               <form onSubmit={handleSaveEdit} style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
                 <label style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>Name
-                  <input className="input-field" required value={editForm.name} onChange={e => setEditForm({ ...editForm, name: e.target.value })} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
+                  <input className="input-field" required value={editForm.name} onChange={e => setEditForm(prev => ({ ...prev, name: e.target.value }))} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
                 </label>
                 <label style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>Email
-                  <input className="input-field" type="email" value={editForm.email} onChange={e => setEditForm({ ...editForm, email: e.target.value })} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
+                  <input className="input-field" type="email" value={editForm.email} onChange={e => setEditForm(prev => ({ ...prev, email: e.target.value }))} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
                 </label>
                 <label style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>Phone
                   <input
                     className="input-field"
                     type="tel"
                     value={editForm.phone}
-                    onChange={e => setEditForm({ ...editForm, phone: e.target.value.replace(/[^\d+\s\-().]/g, '') })}
+                    onChange={e => setEditForm(prev => ({ ...prev, phone: e.target.value.replace(/[^\d+\s\-().]/g, '') }))}
                     onBlur={e => {
                       const v = e.target.value.trim();
                       if (v && !PHONE_RE.test(v)) setEditError('Enter a valid phone number (digits, +, spaces, hyphens only)');
@@ -159,11 +266,12 @@ const ContactDetail = () => {
                   />
                 </label>
                 <label style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>Company
-                  <input className="input-field" value={editForm.company} onChange={e => setEditForm({ ...editForm, company: e.target.value })} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
+                  <input className="input-field" value={editForm.company} onChange={e => setEditForm(prev => ({ ...prev, company: e.target.value }))} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
                 </label>
                 <label style={{ fontSize: '0.7rem', fontWeight: '600', color: 'var(--text-secondary)' }}>Title
-                  <input className="input-field" value={editForm.title} onChange={e => setEditForm({ ...editForm, title: e.target.value })} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
+                  <input className="input-field" value={editForm.title} onChange={e => setEditForm(prev => ({ ...prev, title: e.target.value }))} style={{ padding: '0.45rem', fontSize: '0.85rem', marginTop: '0.2rem' }} />
                 </label>
+                {renderCustomFieldInputs()}
                 {editError && <p style={{ color: '#ef4444', fontSize: '0.75rem', margin: 0 }}>{editError}</p>}
                 <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.25rem' }}>
                   <button type="submit" className="btn-primary" disabled={saving} style={{ padding: '0.4rem 0.9rem', fontSize: '0.8rem' }}>{saving ? 'Saving…' : 'Save'}</button>
@@ -204,6 +312,23 @@ const ContactDetail = () => {
                   Source: {contact.source}
                 </div>
               )}
+              {/* Generic-vertical-only Lead custom fields (Settings > Lead
+                  Fields) — read-only display; edit via the Edit button above. */}
+              {!isWellness && !isTravel && customFieldDefs.map((f) => {
+                const raw = contact.customFields?.[f.fieldKey];
+                if (raw === null || raw === undefined || raw === '') return null;
+                let display;
+                if (f.fieldType === 'checkbox') display = raw ? 'Yes' : 'No';
+                else if (f.fieldType === 'date') display = formatDate(raw);
+                else if (f.fieldType === 'multiselect') display = Array.isArray(raw) ? raw.join(', ') : String(raw);
+                else if (f.fieldType === 'url') display = <a href={String(raw)} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>{String(raw)}</a>;
+                else display = String(raw);
+                return (
+                  <div key={f.id} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+                    {f.label}: {display}
+                  </div>
+                );
+              })}
             </div>
 
             {/* AI-generated chat summary — append-only via "Sync Lead" on the

--- a/frontend/src/pages/Contacts.jsx
+++ b/frontend/src/pages/Contacts.jsx
@@ -1,5 +1,6 @@
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
+import { formatDateMedium as formatDate } from '../utils/date';
 import React, { useState, useEffect, useContext } from 'react';
 import { Search, Plus, Trash2, RefreshCw, TrendingUp, Upload, X, FileSpreadsheet, UserCheck, GitMerge, EyeOff } from 'lucide-react';
 import { Link } from 'react-router-dom';
@@ -73,7 +74,10 @@ const Contacts = () => {
   // wellness tenants (isTravel false) keep the full unfiltered list.
   const { tenant, user } = useContext(AuthContext) || {};
   const isTravel = tenant?.vertical === 'travel';
+  const isWellness = tenant?.vertical === 'wellness';
   const isAdmin = user?.role === 'ADMIN';
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  const [customFieldDefs, setCustomFieldDefs] = useState([]);
   const assignableStaff = (contact) => {
     if (!isTravel || !contact?.subBrand) return staff;
     return staff.filter(
@@ -183,6 +187,17 @@ const Contacts = () => {
     fetchContacts();
     fetchApi('/api/staff').then(data => setStaff(data)).catch(() => {});
   }, []);
+
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  // Own effect keyed on [isWellness, isTravel] (not the mount-only effect
+  // above) so it re-fires once AuthContext's tenant finishes loading —
+  // tenant can still be undefined on the very first render.
+  useEffect(() => {
+    if (isWellness || isTravel) return;
+    fetchApi('/api/lead-custom-fields')
+      .then(d => setCustomFieldDefs(Array.isArray(d) ? d : []))
+      .catch(() => setCustomFieldDefs([]));
+  }, [isWellness, isTravel]);
 
   const handleAssign = async (contactId, assignedToId) => {
     await fetchApi(`/api/contacts/${contactId}/assign`, {
@@ -381,8 +396,16 @@ const Contacts = () => {
         </div>
         
         {/* #633: stable-table — pins tableLayout=fixed so row hover never
-            shifts column widths, plus column widths set explicitly below. */}
-        <table className="stable-table" style={{ borderCollapse: 'collapse', textAlign: 'left' }}>
+            shifts column widths, plus column widths set explicitly below.
+            Wrapped in an overflow-x:auto container (rather than relying on
+            .stable-table's mobile-only <768px scroll rule) because the
+            dynamic Lead-custom-field columns below can push total column
+            width past 100% on desktop too — without this wrapper the
+            overflow spills into the page's own horizontal scrollbar instead
+            of scrolling just the table. minWidth ensures the fixed-percent
+            columns don't get crushed once custom-field columns are added. */}
+        <div style={{ overflowX: 'auto' }}>
+        <table className="stable-table" style={{ borderCollapse: 'collapse', textAlign: 'left', minWidth: customFieldDefs.length ? `${900 + customFieldDefs.length * 140}px` : undefined }}>
           <colgroup>
             <col style={{ width: '18%' }} />
             <col style={{ width: '20%' }} />
@@ -390,6 +413,7 @@ const Contacts = () => {
             <col style={{ width: '14%' }} />
             <col style={{ width: '10%' }} />
             <col style={{ width: '10%' }} />
+            {customFieldDefs.map(f => <col key={f.id} style={{ width: '140px' }} />)}
             <col style={{ width: '10%' }} />
             <col style={{ width: '6%' }} />
           </colgroup>
@@ -402,15 +426,19 @@ const Contacts = () => {
               {/* #593: rules-based score (leadScoringEngine.js); dropped misleading "AI" prefix. */}
               <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Lead Score</th>
               <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Status</th>
+              {/* Generic-vertical-only Lead custom fields (Settings > Lead Fields). */}
+              {customFieldDefs.map(f => (
+                <th key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>{f.label}</th>
+              ))}
               <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Assigned To</th>
               <th style={{ padding: '1rem', textAlign: 'right' }}>Actions</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
-              <tr><td colSpan="8" style={{ padding: '2rem', textAlign: 'center' }}>Loading contacts...</td></tr>
+              <tr><td colSpan={8 + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center' }}>Loading contacts...</td></tr>
             ) : visibleContacts.length === 0 ? (
-              <tr><td colSpan="8" style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>
+              <tr><td colSpan={8 + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>
                 {contacts.length === 0
                   ? 'No contacts yet. Click "Add Contact" or import a CSV.'
                   : `No contacts match "${searchTerm}"${statusFilter !== 'All' ? ` with status ${statusFilter}` : ''}.`}
@@ -468,6 +496,34 @@ const Contacts = () => {
                     {contact.status}
                   </span>
                 </td>
+                {/* Generic-vertical-only Lead custom fields — value or a
+                    dash for contacts that predate the field. */}
+                {customFieldDefs.map(f => {
+                  const raw = contact.customFields?.[f.fieldKey];
+                  let display;
+                  if (raw === null || raw === undefined || raw === '') {
+                    display = null;
+                  } else if (f.fieldType === 'checkbox') {
+                    display = raw ? 'Yes' : 'No';
+                  } else if (f.fieldType === 'date') {
+                    display = formatDate(raw);
+                  } else if (f.fieldType === 'multiselect') {
+                    display = Array.isArray(raw) ? raw.join(', ') : String(raw);
+                  } else if (f.fieldType === 'url') {
+                    display = (
+                      <a href={String(raw)} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>
+                        {String(raw)}
+                      </a>
+                    );
+                  } else {
+                    display = String(raw);
+                  }
+                  return (
+                    <td key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+                      {display ?? <span style={{ color: 'var(--border-color)' }}>—</span>}
+                    </td>
+                  );
+                })}
                 <td style={{ padding: '1rem' }}>
                   {isAdmin ? (
                     <select
@@ -501,6 +557,7 @@ const Contacts = () => {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
 
       {showImportModal && (

--- a/frontend/src/pages/ConvertedLeads.jsx
+++ b/frontend/src/pages/ConvertedLeads.jsx
@@ -1,8 +1,9 @@
 import { fetchApi } from '../utils/api';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { UserPlus, Search, Users, Filter, Undo2 } from 'lucide-react';
 import { useNotify } from '../utils/notify';
 import { formatDateMedium as formatDate } from '../utils/date';
+import { AuthContext } from '../App';
 
 // #366: include Junk so the chip can show its count if the tenant uses it.
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned', 'Junk'];
@@ -10,6 +11,9 @@ const SOURCE_OPTIONS = ['Organic', 'Referral', 'LinkedIn', 'Cold Call', 'Website
 
 const ConvertedLeads = () => {
   const notify = useNotify();
+  const auth = useContext(AuthContext);
+  const isWellness = auth?.tenant?.vertical === 'wellness';
+  const isTravel = auth?.tenant?.vertical === 'travel';
   const [leads, setLeads] = useState([]);
   const [staff, setStaff] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -17,6 +21,8 @@ const ConvertedLeads = () => {
   const [selectedStatus, setSelectedStatus] = useState('Prospect');
   const [selectedLeads, setSelectedLeads] = useState([]);
   const [bulkAgent, setBulkAgent] = useState('');
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  const [customFieldDefs, setCustomFieldDefs] = useState([]);
   // #366: per-status counts powering the chip labels, e.g. "Prospect (12)".
   const [statusCounts, setStatusCounts] = useState({});
 
@@ -72,6 +78,13 @@ const ConvertedLeads = () => {
     fetchStaff();
     fetchStatusCounts();
   }, [selectedStatus]);
+
+  useEffect(() => {
+    if (isWellness || isTravel) return;
+    fetchApi('/api/lead-custom-fields')
+      .then(d => setCustomFieldDefs(Array.isArray(d) ? d : []))
+      .catch(() => setCustomFieldDefs([]));
+  }, [isWellness, isTravel]);
 
   const handleStatusChange = (status) => {
     setSelectedStatus(status);
@@ -249,7 +262,10 @@ const ConvertedLeads = () => {
             </div>
           </div>
 
-          <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left' }}>
+          {/* overflow-x wrapper — the dynamic Lead-custom-field columns
+              can push this table wider than the viewport. */}
+          <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left', minWidth: customFieldDefs.length ? `${900 + customFieldDefs.length * 140}px` : undefined }}>
             <thead>
               <tr style={{ borderBottom: '1px solid var(--border-color)', backgroundColor: 'var(--table-header-bg)' }}>
                 <th style={{ padding: '1rem', width: '40px' }}>
@@ -261,6 +277,10 @@ const ConvertedLeads = () => {
                 {/* #593: rules-based score (leadScoringEngine.js); dropped misleading "AI" prefix. */}
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Lead Score</th>
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Source</th>
+                {/* Generic-vertical-only Lead custom fields (Settings > Lead Fields). */}
+                {customFieldDefs.map(f => (
+                  <th key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>{f.label}</th>
+                ))}
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Assigned To</th>
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Created</th>
                 {/* #367: per-row Revert to Lead control. */}
@@ -269,9 +289,9 @@ const ConvertedLeads = () => {
             </thead>
             <tbody>
               {loading ? (
-                <tr><td colSpan="9" style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>Loading leads...</td></tr>
+                <tr><td colSpan={9 + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>Loading leads...</td></tr>
               ) : filteredLeads.length === 0 ? (
-                <tr><td colSpan="9" style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>No leads found</td></tr>
+                <tr><td colSpan={9 + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>No leads found</td></tr>
               ) : filteredLeads.map(lead => (
                 <tr key={lead.id} style={{ borderBottom: '1px solid var(--border-color)' }} className="table-row-hover">
                   <td style={{ padding: '1rem' }}>
@@ -303,6 +323,34 @@ const ConvertedLeads = () => {
                       {lead.source || 'Organic'}
                     </span>
                   </td>
+                  {/* Generic-vertical-only Lead custom fields — value or a
+                      dash for leads that predate the field. */}
+                  {customFieldDefs.map(f => {
+                    const raw = lead.customFields?.[f.fieldKey];
+                    let display;
+                    if (raw === null || raw === undefined || raw === '') {
+                      display = null;
+                    } else if (f.fieldType === 'checkbox') {
+                      display = raw ? 'Yes' : 'No';
+                    } else if (f.fieldType === 'date') {
+                      display = formatDate(raw);
+                    } else if (f.fieldType === 'multiselect') {
+                      display = Array.isArray(raw) ? raw.join(', ') : String(raw);
+                    } else if (f.fieldType === 'url') {
+                      display = (
+                        <a href={String(raw)} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>
+                          {String(raw)}
+                        </a>
+                      );
+                    } else {
+                      display = String(raw);
+                    }
+                    return (
+                      <td key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+                        {display ?? <span style={{ color: 'var(--border-color)' }}>—</span>}
+                      </td>
+                    );
+                  })}
                   <td style={{ padding: '1rem' }}>
                     <select
                       className="input-field"
@@ -345,6 +393,7 @@ const ConvertedLeads = () => {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Leads.jsx
+++ b/frontend/src/pages/Leads.jsx
@@ -100,8 +100,12 @@ const Leads = () => {
   // itinerary advancePaidAmount for leads that have no itinerary row yet.
   const [tmcPaidByEmail, setTmcPaidByEmail] = useState({});
   const [editing, setEditing] = useState(null);
-  const [editForm, setEditForm] = useState({ name: '', email: '', company: '', title: '', source: '' });
+  const [editForm, setEditForm] = useState({ name: '', email: '', company: '', title: '', source: '', customFields: {} });
   const [editSaving, setEditSaving] = useState(false);
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  // Fetched once; empty array for wellness/travel (no fetch attempted) or
+  // for a generic tenant that hasn't defined any fields yet.
+  const [customFieldDefs, setCustomFieldDefs] = useState([]);
   // #600 — Initial source defaults differ per vertical: wellness leads
   // typically arrive walk-in/WhatsApp; generic CRM leads default to Organic.
   const [newLead, setNewLead] = useState({
@@ -116,6 +120,7 @@ const Leads = () => {
     treatmentOfInterest: '',
     preferredLocationId: '',
     preferredPractitionerId: '',
+    customFields: {},
   });
 
   const fetchLeads = () => {
@@ -200,6 +205,15 @@ const Leads = () => {
       .then(d => setLocations(Array.isArray(d) ? d : (d?.locations || [])))
       .catch(() => setLocations([]));
   }, [isWellness]);
+
+  // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
+  // Skipped entirely for wellness/travel tenants.
+  useEffect(() => {
+    if (isWellness || isTravel) return;
+    fetchApi('/api/lead-custom-fields')
+      .then(d => setCustomFieldDefs(Array.isArray(d) ? d : []))
+      .catch(() => setCustomFieldDefs([]));
+  }, [isWellness, isTravel]);
 
   // #892 — close the Create drawer on Escape. Attached only while the drawer
   // is open so we don't trap key events for users not actively creating.
@@ -339,7 +353,7 @@ const Leads = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...newLead, name: trimmedName, phone: phoneOut, countryCode: undefined }),
       });
-      setNewLead({ name: '', email: '', company: '', title: '', countryCode: '+1', phone: '', source: 'Organic', status: 'Lead' });
+      setNewLead({ name: '', email: '', company: '', title: '', countryCode: '+1', phone: '', source: 'Organic', status: 'Lead', customFields: {} });
       // #892 — close the drawer on successful create; the list refresh
       // below puts the new row at the top so the user sees the result.
       setCreating(false);
@@ -368,6 +382,7 @@ const Leads = () => {
       company: lead.company || '',
       title: lead.title || '',
       source: lead.source || '',
+      customFields: { ...(lead.customFields || {}) },
     });
     setEditing(lead);
   };
@@ -386,6 +401,7 @@ const Leads = () => {
           company: editForm.company.trim(),
           title: editForm.title.trim(),
           source: editForm.source,
+          customFields: editForm.customFields || {},
         }),
       });
       notify.success('Lead updated');
@@ -453,6 +469,99 @@ const Leads = () => {
 
   const handleChange = (field, value) => {
     setNewLead(prev => ({ ...prev, [field]: value }));
+  };
+
+  // Generic-vertical-only Lead custom fields — renders the right input
+  // widget per admin-defined field type (Settings > Lead Fields). Shared
+  // between the Create and Edit forms; each caller passes its own
+  // `values`/`onChange` so this stays a pure render helper with no state
+  // of its own.
+  const renderCustomFieldInputs = (values, onChange) => {
+    if (isWellness || isTravel || customFieldDefs.length === 0) return null;
+    return customFieldDefs.map((f) => {
+      const value = values?.[f.fieldKey] ?? '';
+      const handle = (v) => onChange(f.fieldKey, v);
+      const label = f.label;
+      const placeholder = f.placeholder || (f.isRequired ? label : `${label} (optional)`);
+      const titleAttr = f.tooltip ? { title: f.tooltip } : {};
+
+      if (f.fieldType === 'checkbox') {
+        return (
+          <label key={f.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }} {...titleAttr}>
+            <input type="checkbox" checked={Boolean(value)} onChange={e => handle(e.target.checked)} />
+            {label}
+          </label>
+        );
+      }
+      if (f.fieldType === 'dropdown' || f.fieldType === 'radio') {
+        return (
+          <select key={f.id} className="input-field" required={f.isRequired} value={value} onChange={e => handle(e.target.value)} {...titleAttr}>
+            <option value="">{placeholder}</option>
+            {(f.options || []).map((opt) => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        );
+      }
+      if (f.fieldType === 'multiselect') {
+        const selected = Array.isArray(value) ? value : (value ? [value] : []);
+        return (
+          <div key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }} {...titleAttr}>
+            <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-secondary)' }}>{label}</span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+              {(f.options || []).map((opt) => {
+                const checked = selected.includes(opt);
+                return (
+                  <label key={opt} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.85rem', padding: '0.25rem 0.5rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--surface-color)', cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        const next = e.target.checked ? [...selected, opt] : selected.filter((s) => s !== opt);
+                        handle(next);
+                      }}
+                    />
+                    {opt}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        );
+      }
+      if (f.fieldType === 'date') {
+        return (
+          <input key={f.id} type="date" placeholder={placeholder} required={f.isRequired} className="input-field" value={value} onChange={e => handle(e.target.value)} {...titleAttr} />
+        );
+      }
+      if (f.fieldType === 'number') {
+        return (
+          <input key={f.id} type="number" placeholder={placeholder} required={f.isRequired} className="input-field" value={value} onChange={e => handle(e.target.value)} {...titleAttr} />
+        );
+      }
+      if (f.fieldType === 'url') {
+        return (
+          <input key={f.id} type="url" placeholder={placeholder} required={f.isRequired} className="input-field" value={value} onChange={e => handle(e.target.value)} {...titleAttr} />
+        );
+      }
+      if (f.fieldType === 'textarea') {
+        return (
+          <textarea key={f.id} placeholder={placeholder} required={f.isRequired} maxLength={2000} className="input-field" rows={3} value={value} onChange={e => handle(e.target.value)} {...titleAttr} />
+        );
+      }
+      // text
+      return (
+        <input key={f.id} type="text" placeholder={placeholder} required={f.isRequired} maxLength={2000} className="input-field" value={value} onChange={e => handle(e.target.value)} {...titleAttr} />
+      );
+    });
+  };
+
+  const handleCustomFieldChangeNew = (key, value) => {
+    setNewLead(prev => ({ ...prev, customFields: { ...prev.customFields, [key]: value } }));
+  };
+
+  const handleCustomFieldChangeEdit = (key, value) => {
+    setEditForm(prev => ({ ...prev, customFields: { ...prev.customFields, [key]: value } }));
   };
 
   const filteredLeads = leads.filter(lead => {
@@ -661,6 +770,11 @@ const Leads = () => {
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Source</th>
                 {isTravel && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Sub-brand</th>}
                 {isTravel && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Amount</th>}
+                {/* Generic-vertical-only Lead custom fields (Settings > Lead Fields) —
+                    one column per admin-defined field, in displayOrder. */}
+                {customFieldDefs.map(f => (
+                  <th key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>{f.label}</th>
+                ))}
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Assigned To</th>
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Created</th>
                 <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Actions</th>
@@ -668,9 +782,9 @@ const Leads = () => {
             </thead>
             <tbody>
               {loading ? (
-                <tr><td colSpan={isAdmin ? 10 + (isTravel ? 2 : 0) : 9 + (isTravel ? 2 : 0)} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>Loading leads...</td></tr>
+                <tr><td colSpan={(isAdmin ? 10 : 9) + (isTravel ? 2 : 0) + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>Loading leads...</td></tr>
               ) : filteredLeads.length === 0 ? (
-                <tr><td colSpan={isAdmin ? 10 + (isTravel ? 2 : 0) : 9 + (isTravel ? 2 : 0)} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>No leads found</td></tr>
+                <tr><td colSpan={(isAdmin ? 10 : 9) + (isTravel ? 2 : 0) + customFieldDefs.length} style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary)' }}>No leads found</td></tr>
               ) : filteredLeads.map(lead => (
                 <tr
                   key={lead.id}
@@ -753,6 +867,35 @@ const Leads = () => {
                       </td>
                     );
                   })()}
+                  {/* Generic-vertical-only Lead custom fields — shows every
+                      defined field's value, or a dash for leads that predate
+                      the field (backend fills the key with null). */}
+                  {customFieldDefs.map(f => {
+                    const raw = lead.customFields?.[f.fieldKey];
+                    let display;
+                    if (raw === null || raw === undefined || raw === '') {
+                      display = null;
+                    } else if (f.fieldType === 'checkbox') {
+                      display = raw ? 'Yes' : 'No';
+                    } else if (f.fieldType === 'date') {
+                      display = formatDate(raw);
+                    } else if (f.fieldType === 'multiselect') {
+                      display = Array.isArray(raw) ? raw.join(', ') : String(raw);
+                    } else if (f.fieldType === 'url') {
+                      display = (
+                        <a href={String(raw)} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-color)' }}>
+                          {String(raw)}
+                        </a>
+                      );
+                    } else {
+                      display = String(raw);
+                    }
+                    return (
+                      <td key={f.id} style={{ padding: '1rem', color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+                        {display ?? <span style={{ color: 'var(--border-color)' }}>—</span>}
+                      </td>
+                    );
+                  })}
                   <td style={{ padding: '1rem' }} onClick={e => e.stopPropagation()}>
                     {isAdmin ? (
                       <select
@@ -965,6 +1108,8 @@ const Leads = () => {
                   </>
                 )}
 
+                {renderCustomFieldInputs(newLead.customFields, handleCustomFieldChangeNew)}
+
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '0.5rem' }}>
                   <button
                     type="button"
@@ -998,11 +1143,11 @@ const Leads = () => {
                 </button>
               </div>
               <form onSubmit={submitEdit} style={{ display: 'flex', flexDirection: 'column', gap: '0.875rem' }}>
-                <input type="text" placeholder="Full Name" required className="input-field" value={editForm.name} onChange={e => setEditForm({ ...editForm, name: e.target.value })} />
-                <input type="email" placeholder="Email Address" className="input-field" value={editForm.email} onChange={e => setEditForm({ ...editForm, email: e.target.value })} />
-                <input type="text" placeholder="Company" className="input-field" value={editForm.company} onChange={e => setEditForm({ ...editForm, company: e.target.value })} />
-                <input type="text" placeholder="Job Title" className="input-field" value={editForm.title} onChange={e => setEditForm({ ...editForm, title: e.target.value })} />
-                <select className="input-field" value={editForm.source} onChange={e => setEditForm({ ...editForm, source: e.target.value })}>
+                <input type="text" placeholder="Full Name" required className="input-field" value={editForm.name} onChange={e => setEditForm(prev => ({ ...prev, name: e.target.value }))} />
+                <input type="email" placeholder="Email Address" className="input-field" value={editForm.email} onChange={e => setEditForm(prev => ({ ...prev, email: e.target.value }))} />
+                <input type="text" placeholder="Company" className="input-field" value={editForm.company} onChange={e => setEditForm(prev => ({ ...prev, company: e.target.value }))} />
+                <input type="text" placeholder="Job Title" className="input-field" value={editForm.title} onChange={e => setEditForm(prev => ({ ...prev, title: e.target.value }))} />
+                <select className="input-field" value={editForm.source} onChange={e => setEditForm(prev => ({ ...prev, source: e.target.value }))}>
                   {isWellness
                     ? WELLNESS_SOURCE_OPTIONS.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)
                     : isTravel
@@ -1010,6 +1155,7 @@ const Leads = () => {
                     : SOURCE_OPTIONS.map(s => <option key={s} value={s}>{s}</option>)
                   }
                 </select>
+                {renderCustomFieldInputs(editForm.customFields, handleCustomFieldChangeEdit)}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '0.5rem' }}>
                   <button type="button" onClick={() => setEditing(null)} style={{ padding: '0.5rem 1rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--surface-color)', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.875rem' }}>Cancel</button>
                   <button type="submit" className="btn-primary" disabled={editSaving} style={{ padding: '0.5rem 1rem', fontSize: '0.875rem' }}>{editSaving ? 'Saving…' : 'Save Changes'}</button>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -26,6 +26,7 @@ import {
   CreditCard,
   ArrowRight,
   Stethoscope,
+  Sliders,
   Bot,
 } from "lucide-react";
 import { fetchApi, getAuthToken } from "../utils/api";
@@ -772,6 +773,29 @@ export default function Settings() {
           >
             <CreditCard size={14} /> Manage Subscription Plans{" "}
             <ArrowRight size={13} />
+          </Link>
+        )}
+        {/* Lead custom fields — generic vertical only. LeadFields.jsx itself
+            also redirects a direct URL hit from wellness/travel tenants. */}
+        {ctxTenant?.vertical !== "wellness" && ctxTenant?.vertical !== "travel" && (
+          <Link
+            to="/settings/lead-fields"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              marginTop: "1rem",
+              marginLeft: "0.75rem",
+              padding: "8px 14px",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              background: "var(--primary-color, var(--accent-color))",
+              color: "#fff",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            <Sliders size={14} /> Lead Fields <ArrowRight size={13} />
           </Link>
         )}
       </header>

--- a/frontend/src/pages/public/TripBooking.jsx
+++ b/frontend/src/pages/public/TripBooking.jsx
@@ -296,6 +296,7 @@ export default function TripBooking() {
   const optionsMode = !!itin.optionsMode;
   const flightOptions = optionsMode ? itin.items.filter((i) => i.itemType === "flight") : [];
   const selected = flightOptions.find((o) => String(o.id) === String(selectedId)) || null;
+  const selectedIsRoundTrip = isRoundTripFlight(selected);
   const displayTotal = optionsMode ? (selected ? Number(selected.totalPrice) : null) : itin.totalAmount;
   const displayAdvance = optionsMode
     ? (selected ? Math.round(Number(selected.totalPrice) * (itin.advanceRatio || 0) * 100) / 100 : null)
@@ -384,6 +385,7 @@ export default function TripBooking() {
             {flightOptions.map((item) => {
               const checked = String(selectedId) === String(item.id);
               const details = flightDetails(item);
+              const isRoundTrip = isRoundTripFlight(item);
               return (
                 <li key={item.id}>
                   <label
@@ -408,7 +410,7 @@ export default function TripBooking() {
                     </div>
                     {item.totalPrice != null && (
                       <div style={{ fontWeight: 700, color: "#122647", whiteSpace: "nowrap" }}>
-                        {fmtMoney(item.totalPrice, itin.currency)}
+                        <div>{fmtMoney(item.totalPrice, itin.currency)}</div>
                       </div>
                     )}
                   </label>
@@ -449,7 +451,7 @@ export default function TripBooking() {
       <section style={costBox} aria-labelledby="cost-heading">
         <h2 id="cost-heading" style={{ ...sectionHeading, marginTop: 0 }}>Trip cost</h2>
         <Line
-          label="Total"
+          label={selectedIsRoundTrip ? "Round-trip total (outbound + return)" : "Total"}
           value={displayTotal != null ? fmtMoney(displayTotal, itin.currency) : "Select an option above"}
           bold
         />
@@ -650,13 +652,25 @@ function fmtDateTime(d) {
 // item's detailsJson so the customer sees timing + baggage, not just a code.
 // detailsJson is set by the flight quick-quote (airline/flightNumber/fareClass/
 // route/departAt/arriveAt/baggage) and is already on the public projection.
-function flightDetails(item) {
+function flightQuoteData(item) {
   let d = {};
   try {
     d = item.detailsJson
       ? (typeof item.detailsJson === "string" ? JSON.parse(item.detailsJson) : item.detailsJson)
       : {};
   } catch { d = {}; }
+  return d;
+}
+
+function isRoundTripFlight(item) {
+  const d = flightQuoteData(item);
+  // This presentation is exclusively for paired Flight quick-quote options.
+  // Other itinerary flight items retain their existing customer-facing labels.
+  return d.source === "agent-quick-quote" && Boolean(d.returnLeg);
+}
+
+function flightDetails(item) {
+  const d = flightQuoteData(item);
   const parts = [];
   const dep = fmtDateTime(d.departAt);
   const arr = fmtDateTime(d.arriveAt);
@@ -664,6 +678,11 @@ function flightDetails(item) {
   if (arr) parts.push(`Arrives ${arr}`);
   if (d.fareClass) parts.push(String(d.fareClass));
   if (d.baggage) parts.push(`Baggage: ${d.baggage}`);
+  if (d.source === "agent-quick-quote" && d.returnLeg) {
+    const r = d.returnLeg;
+    const returnDep = fmtDateTime(r.departAt);
+    parts.push(`Return: ${r.airline || ""}${r.flightNumber ? ` ${r.flightNumber}` : ""} ${r.route?.from || ""}→${r.route?.to || ""}${returnDep ? `, ${returnDep}` : ""}`.trim());
+  }
   return parts;
 }
 

--- a/frontend/src/pages/settings/LeadFields.jsx
+++ b/frontend/src/pages/settings/LeadFields.jsx
@@ -1,0 +1,406 @@
+/**
+ * /settings/lead-fields — Lead Custom Fields admin page.
+ *
+ * Backend: /api/lead-custom-fields (routes/lead_custom_fields.js).
+ * ADMIN-only page (RoleGuard wrap at the App.jsx route). Generic vertical
+ * only — wellness/travel tenants never see this page's Settings link, and
+ * the route itself is additionally guarded here so a direct URL visit from
+ * a non-generic tenant is redirected rather than rendering.
+ *
+ * Lets an ADMIN define extra fields that then appear on every Lead's
+ * create/edit form + detail view (Leads.jsx, ContactDetail.jsx) for THIS
+ * tenant only. Field type (text/number/dropdown/date/checkbox) is chosen
+ * once at creation time and cannot be changed afterward — see the backend
+ * route's comment for why (it would orphan/misinterpret already-stored
+ * values).
+ *
+ * Styling mirrors the app's real shared design system (.card / .btn-primary
+ * / .btn-secondary / .input-field / .stable-table / EmptyState / FormField)
+ * rather than hand-rolled inline styles — see Currencies.jsx for the sibling
+ * settings-CRUD page this pattern was pulled from.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { Plus, Trash2, Loader, ListChecks, ArrowUp, ArrowDown } from "lucide-react";
+import { AuthContext } from "../../App";
+import { fetchApi } from "../../utils/api";
+import { useNotify } from "../../utils/notify";
+import { EmptyState, FormField } from "../../components/ui";
+
+const FIELD_TYPE_OPTIONS = [
+  { value: "text", label: "Text field" },
+  { value: "textarea", label: "Text area" },
+  { value: "number", label: "Number" },
+  { value: "dropdown", label: "Dropdown" },
+  { value: "radio", label: "Radio button" },
+  { value: "date", label: "Date picker" },
+  { value: "url", label: "URL" },
+  { value: "checkbox", label: "Checkbox (Yes/No)" },
+  { value: "multiselect", label: "Multiselect" },
+];
+
+const FIELD_TYPES_WITH_OPTIONS = new Set(["dropdown", "radio", "multiselect"]);
+
+const FIELD_TYPE_LABELS = Object.fromEntries(FIELD_TYPE_OPTIONS.map((o) => [o.value, o.label]));
+
+const th = { padding: "0.75rem 1rem", fontSize: "0.78rem", textTransform: "uppercase", letterSpacing: "0.04em", color: "var(--text-secondary)", fontWeight: 600 };
+const td = { padding: "0.75rem 1rem", fontSize: "0.9rem" };
+const iconBtn = { background: "var(--subtle-bg)", border: "1px solid var(--border-color)", borderRadius: 6, padding: "0.375rem 0.5rem", cursor: "pointer", display: "inline-flex", alignItems: "center" };
+
+export default function LeadFields() {
+  const { tenant } = useContext(AuthContext) || {};
+  const isWellness = tenant?.vertical === "wellness";
+  const isTravel = tenant?.vertical === "travel";
+
+  const notify = useNotify();
+  const [fields, setFields] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [newLabel, setNewLabel] = useState("");
+  const [newFieldType, setNewFieldType] = useState("text");
+  const [newOptionsText, setNewOptionsText] = useState("");
+  const [newTooltip, setNewTooltip] = useState("");
+  const [newPlaceholder, setNewPlaceholder] = useState("");
+  const [newRequired, setNewRequired] = useState(false);
+  const [savingNew, setSavingNew] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
+  const [reordering, setReordering] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const data = await fetchApi("/api/lead-custom-fields");
+      setFields(Array.isArray(data) ? data : []);
+    } catch (err) {
+      notify.error(err?.message || "Failed to load lead fields");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isWellness || isTravel) return; // gated below anyway; skip the fetch
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Generic-vertical-only feature — redirect wellness/travel tenants away
+  // rather than rendering an inapplicable admin page for them.
+  if (isWellness || isTravel) {
+    return <Navigate to="/settings" replace />;
+  }
+
+  const resetCreateForm = () => {
+    setCreating(false);
+    setNewLabel("");
+    setNewFieldType("text");
+    setNewOptionsText("");
+    setNewTooltip("");
+    setNewPlaceholder("");
+    setNewRequired(false);
+  };
+
+  const handleCreate = async () => {
+    const trimmedLabel = newLabel.trim();
+    if (!trimmedLabel) {
+      notify.error("Label is required");
+      return;
+    }
+    if (FIELD_TYPES_WITH_OPTIONS.has(newFieldType)) {
+      const opts = newOptionsText.split(",").map((o) => o.trim()).filter(Boolean);
+      if (!opts.length) {
+        notify.error("Enter at least one option, separated by commas");
+        return;
+      }
+    }
+    setSavingNew(true);
+    try {
+      const body = {
+        label: trimmedLabel,
+        fieldType: newFieldType,
+        isRequired: newRequired,
+      };
+      if (FIELD_TYPES_WITH_OPTIONS.has(newFieldType)) {
+        body.options = newOptionsText.split(",").map((o) => o.trim()).filter(Boolean);
+      }
+      const tooltip = newTooltip.trim();
+      const placeholder = newPlaceholder.trim();
+      if (tooltip) body.tooltip = tooltip;
+      if (placeholder) body.placeholder = placeholder;
+      await fetchApi("/api/lead-custom-fields", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      notify.success("Field created");
+      resetCreateForm();
+      await load();
+    } catch (err) {
+      notify.error(err?.message || "Failed to create field");
+    } finally {
+      setSavingNew(false);
+    }
+  };
+
+  const handleDelete = async (field) => {
+    const ok = await notify.confirm({
+      title: "Delete this field?",
+      message: `The "${field.label}" field will be removed, along with any values stored for it on existing leads. This cannot be undone.`,
+      confirmText: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
+    setDeletingId(field.id);
+    try {
+      await fetchApi(`/api/lead-custom-fields/${field.id}`, { method: "DELETE" });
+      notify.success("Field deleted");
+      await load();
+    } catch (err) {
+      notify.error(err?.message || "Failed to delete field");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleToggleRequired = async (field) => {
+    try {
+      await fetchApi(`/api/lead-custom-fields/${field.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ isRequired: !field.isRequired }),
+      });
+      await load();
+    } catch (err) {
+      notify.error(err?.message || "Failed to update field");
+    }
+  };
+
+  // Swaps this field's displayOrder with its neighbour in `direction`
+  // (-1 = up, +1 = down). No bulk /reorder endpoint exists for this
+  // resource (unlike Pipeline Stages), so this swaps the two rows'
+  // displayOrder via two calls to the existing per-field PUT — fine at the
+  // scale a settings page like this operates at (a handful of fields).
+  // Optimistic UI update first so the row visibly moves immediately;
+  // reload() on failure undoes it and surfaces the error.
+  const handleMoveField = async (index, direction) => {
+    const swapIndex = index + direction;
+    if (swapIndex < 0 || swapIndex >= fields.length || reordering) return;
+    const a = fields[index];
+    const b = fields[swapIndex];
+    const reordered = [...fields];
+    [reordered[index], reordered[swapIndex]] = [reordered[swapIndex], reordered[index]];
+    setFields(reordered);
+    setReordering(true);
+    try {
+      await Promise.all([
+        fetchApi(`/api/lead-custom-fields/${a.id}`, { method: "PUT", body: JSON.stringify({ displayOrder: b.displayOrder }) }),
+        fetchApi(`/api/lead-custom-fields/${b.id}`, { method: "PUT", body: JSON.stringify({ displayOrder: a.displayOrder }) }),
+      ]);
+      await load();
+    } catch (err) {
+      notify.error(err?.message || "Failed to reorder fields");
+      await load();
+    } finally {
+      setReordering(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: "2rem", maxWidth: "860px", margin: "0 auto", animation: "fadeIn 0.3s ease" }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: "bold", marginBottom: "0.25rem" }}>Lead Fields</h1>
+      <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem", marginBottom: "1.5rem" }}>
+        Add extra fields to your Leads. Once created, a field appears on every lead&rsquo;s create/edit form and detail view for your organization only.
+      </p>
+
+      <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "1.5rem" }}>
+        <div style={{ padding: "1.25rem 1.25rem 0" }}>
+          <h3 style={{ margin: 0, fontSize: "1rem", fontWeight: 600 }}>Existing Fields</h3>
+        </div>
+        {loading ? (
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", color: "var(--text-secondary)", padding: "1.5rem" }}>
+            <Loader size={16} className="spin" /> Loading…
+          </div>
+        ) : fields.length === 0 ? (
+          <EmptyState
+            icon={<ListChecks size={40} />}
+            heading="No custom fields yet"
+            body="Add your first field below to start capturing extra details on every lead."
+          />
+        ) : (
+          <div style={{ overflowX: "auto", marginTop: "0.75rem" }}>
+            <table className="stable-table" style={{ borderCollapse: "collapse", width: "100%" }}>
+              <thead>
+                <tr style={{ background: "var(--subtle-bg)" }}>
+                  <th style={{ ...th, width: "72px" }}>Order</th>
+                  <th style={th}>Label</th>
+                  <th style={th}>Type</th>
+                  <th style={th}>Options</th>
+                  <th style={th}>Required</th>
+                  <th style={{ ...th, textAlign: "right" }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {fields.map((f, index) => (
+                  <tr key={f.id} style={{ borderTop: "1px solid var(--border-color)" }}>
+                    <td style={{ ...td, display: "flex", gap: "0.15rem" }}>
+                      <button
+                        onClick={() => handleMoveField(index, -1)}
+                        disabled={index === 0 || reordering}
+                        aria-label={`Move ${f.label} up`}
+                        title="Move up"
+                        style={{
+                          background: "none",
+                          border: "none",
+                          padding: "0.2rem",
+                          color: index === 0 ? "var(--border-color)" : "var(--text-secondary)",
+                          cursor: index === 0 ? "default" : "pointer",
+                        }}
+                      >
+                        <ArrowUp size={14} />
+                      </button>
+                      <button
+                        onClick={() => handleMoveField(index, 1)}
+                        disabled={index === fields.length - 1 || reordering}
+                        aria-label={`Move ${f.label} down`}
+                        title="Move down"
+                        style={{
+                          background: "none",
+                          border: "none",
+                          padding: "0.2rem",
+                          color: index === fields.length - 1 ? "var(--border-color)" : "var(--text-secondary)",
+                          cursor: index === fields.length - 1 ? "default" : "pointer",
+                        }}
+                      >
+                        <ArrowDown size={14} />
+                      </button>
+                    </td>
+                    <td style={{ ...td, fontWeight: 500 }}>{f.label}</td>
+                    <td style={td}>{FIELD_TYPE_LABELS[f.fieldType] || f.fieldType}</td>
+                    <td style={{ ...td, color: "var(--text-secondary)" }}>
+                      {Array.isArray(f.options) ? f.options.join(", ") : "—"}
+                    </td>
+                    <td style={td}>
+                      <input
+                        type="checkbox"
+                        checked={Boolean(f.isRequired)}
+                        onChange={() => handleToggleRequired(f)}
+                        style={{ cursor: "pointer" }}
+                      />
+                    </td>
+                    <td style={{ ...td, textAlign: "right" }}>
+                      <button
+                        onClick={() => handleDelete(f)}
+                        disabled={deletingId === f.id}
+                        aria-label={`Delete ${f.label}`}
+                        title="Delete field"
+                        style={{ ...iconBtn, color: "var(--danger-color, #ef4444)" }}
+                      >
+                        {deletingId === f.id ? <Loader size={14} className="spin" /> : <Trash2 size={14} />}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="card" style={{ padding: "1.25rem" }}>
+        {!creating ? (
+          <button
+            onClick={() => setCreating(true)}
+            className="btn-primary"
+            style={{ display: "inline-flex", alignItems: "center", gap: "0.5rem" }}
+          >
+            <Plus size={16} /> Add Field
+          </button>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "1.1rem" }}>
+            <h3 style={{ margin: 0, fontSize: "1rem", fontWeight: 600 }}>New Field</h3>
+
+            <FormField label="Label" htmlFor="lf-new-label">
+              <input
+                id="lf-new-label"
+                type="text"
+                className="input-field"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="e.g. Referral Source"
+                maxLength={80}
+              />
+            </FormField>
+
+            <FormField label="Field Type" htmlFor="lf-new-type">
+              <select
+                id="lf-new-type"
+                className="input-field"
+                value={newFieldType}
+                onChange={(e) => setNewFieldType(e.target.value)}
+              >
+                {FIELD_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </FormField>
+
+            {FIELD_TYPES_WITH_OPTIONS.has(newFieldType) && (
+              <FormField label="Options" hint="Comma-separated, e.g. Google, Referral, Event" htmlFor="lf-new-options">
+                <input
+                  id="lf-new-options"
+                  type="text"
+                  className="input-field"
+                  value={newOptionsText}
+                  onChange={(e) => setNewOptionsText(e.target.value)}
+                  placeholder="Google, Referral, Event"
+                />
+              </FormField>
+            )}
+
+            <FormField label="Tooltip" hint="Shown near the input to explain what this field is for" htmlFor="lf-new-tooltip">
+              <input
+                id="lf-new-tooltip"
+                type="text"
+                className="input-field"
+                value={newTooltip}
+                onChange={(e) => setNewTooltip(e.target.value)}
+                placeholder="e.g. Where did this lead first hear about us?"
+                maxLength={255}
+              />
+            </FormField>
+
+            <FormField label="Placeholder" hint="Hint text shown inside the input when empty" htmlFor="lf-new-placeholder">
+              <input
+                id="lf-new-placeholder"
+                type="text"
+                className="input-field"
+                value={newPlaceholder}
+                onChange={(e) => setNewPlaceholder(e.target.value)}
+                placeholder="e.g. Enter referral source"
+                maxLength={255}
+              />
+            </FormField>
+
+            <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", color: "var(--text-primary)" }}>
+              <input
+                type="checkbox"
+                checked={newRequired}
+                onChange={(e) => setNewRequired(e.target.checked)}
+                style={{ cursor: "pointer" }}
+              />
+              Required
+            </label>
+
+            <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.25rem" }}>
+              <button onClick={handleCreate} disabled={savingNew} className="btn-primary">
+                {savingNew ? "Saving…" : "Save Field"}
+              </button>
+              <button onClick={resetCreateForm} disabled={savingNew} className="btn-secondary">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/travel/FlightQuoteAgent.jsx
+++ b/frontend/src/pages/travel/FlightQuoteAgent.jsx
@@ -136,7 +136,7 @@ const SORT_OPTIONS = [
 function blankOption() {
   return {
     airline: "", flightNumber: "", from: "", to: "",
-    departAt: "", arriveAt: "", fare: "", fareClass: "Economy", baggage: "",
+    departAt: "", arriveAt: "", fare: "", fareClass: "Economy", baggage: "", returnLeg: null,
   };
 }
 
@@ -182,15 +182,20 @@ export default function FlightQuoteAgent() {
   // Searches real-ish flights via /api/travel/search/flights and lets the
   // advisor drop a result straight into an option row. Data source + freshness
   // are surfaced via the provider badge (TBO / AI estimate / sample).
-  const [searchForm, setSearchForm] = useState({ from: "", to: "", departDate: "", cabinClass: "Economy" });
+  const [searchForm, setSearchForm] = useState({ from: "", to: "", departDate: "", returnDate: "", cabinClass: "Economy", tripType: "oneWay" });
   const [searching, setSearching] = useState(false);
   const [searchResults, setSearchResults] = useState([]);
+  const [returnSearchResults, setReturnSearchResults] = useState([]);
+  const [activeSearchLeg, setActiveSearchLeg] = useState("outbound");
   const [searchMeta, setSearchMeta] = useState(null); // { provider, note }
   // Results-board filters/sort (GDS-style left rail + sort dropdown).
   const [stopsFilter, setStopsFilter] = useState("any");
   const [airlineSel, setAirlineSel] = useState(null); // Set of enabled codes; null = all
   const [sortBy, setSortBy] = useState("recommended");
   const [expandedIdx, setExpandedIdx] = useState(null); // which row's "Flight details" is open
+
+  const isRoundTrip = searchForm.tripType === "roundTrip";
+  const activeResults = activeSearchLeg === "return" ? returnSearchResults : searchResults;
 
   // ── result state ────────────────────────────────────────────────
   const [result, setResult] = useState(null); // { itineraryId, items, totalWithMarkup, currency, pdfUrl }
@@ -295,22 +300,34 @@ export default function FlightQuoteAgent() {
     if (!searchForm.departDate) { notify.error("Pick a departure date"); return; }
     setSearching(true);
     setSearchResults([]);
+    setReturnSearchResults([]);
     setSearchMeta(null);
     // Reset the board's filters/sort for the new result set.
     setStopsFilter("any");
     setSortBy("recommended");
     setExpandedIdx(null);
+    setActiveSearchLeg("outbound");
     try {
-      const res = await fetchApi("/api/travel/search/flights", {
+      if (isRoundTrip && !searchForm.returnDate) { notify.error("Pick a return date"); return; }
+      if (isRoundTrip && searchForm.returnDate < searchForm.departDate) {
+        notify.error("Return date must be on or after the departure date"); return;
+      }
+      const searchLeg = (legFrom, legTo, date) => fetchApi("/api/travel/search/flights", {
         method: "POST",
         body: JSON.stringify({
-          from, to, departDate: searchForm.departDate,
+          from: legFrom, to: legTo, departDate: date,
           cabinClass: searchForm.cabinClass,
           currency: currency.trim().toUpperCase() || "INR",
         }),
       });
+      const [res, returnRes] = await Promise.all([
+        searchLeg(from, to, searchForm.departDate),
+        isRoundTrip ? searchLeg(to, from, searchForm.returnDate) : Promise.resolve(null),
+      ]);
       const opts = Array.isArray(res?.options) ? res.options : [];
+      const returnOpts = Array.isArray(returnRes?.options) ? returnRes.options : [];
       setSearchResults(opts);
+      setReturnSearchResults(returnOpts);
       // Start with every airline in the result set selected (matches the
       // reference UI's "all checked" default).
       setAirlineSel(new Set(opts.map((o) => o.airline).filter(Boolean)));
@@ -337,6 +354,19 @@ export default function FlightQuoteAgent() {
       fareClass: o.fareClass || "Economy",
       baggage: o.baggage || "",
     };
+    if (isRoundTrip && activeSearchLeg === "return") {
+      setOptions((prev) => {
+        const target = prev.findIndex((p) => p.airline && !p.returnLeg);
+        if (target < 0) { notify.info?.("Select an outbound flight first"); return prev; }
+        return prev.map((p, i) => i === target ? {
+          ...p,
+          returnLeg: opt,
+          fare: String((Number(p.fare) || 0) + (Number(opt.fare) || 0)),
+        } : p);
+      });
+      notify.success?.(`Added return ${o.airline || "flight"} ${o.from}→${o.to}`);
+      return;
+    }
     setOptions((prev) => {
       const emptyIdx = prev.findIndex((p) => !p.airline && !p.from && !p.to && p.fare === "");
       if (emptyIdx >= 0) return prev.map((p, i) => (i === emptyIdx ? opt : p));
@@ -344,21 +374,22 @@ export default function FlightQuoteAgent() {
       return [...prev, opt];
     });
     notify.success?.(`Added ${o.airline || "flight"} ${o.from}→${o.to}`);
+    if (isRoundTrip) showSearchLeg("return");
   };
 
   // Distinct airlines in the current result set (for the left-rail checkboxes).
   const availableAirlines = useMemo(() => {
     const seen = new Map();
-    for (const o of searchResults) {
+    for (const o of activeResults) {
       if (o.airline && !seen.has(o.airline)) seen.set(o.airline, o.airlineName || o.airline);
     }
     return Array.from(seen, ([code, name]) => ({ code, name }));
-  }, [searchResults]);
+  }, [activeResults]);
 
   // Apply the stops + airline filters, then sort. "recommended" keeps the
   // backend's order (which leads with the cheapest non-stop-ish picks).
   const visibleResults = useMemo(() => {
-    const out = searchResults.filter((o) => {
+    const out = activeResults.filter((o) => {
       if (airlineSel && o.airline && !airlineSel.has(o.airline)) return false;
       if (stopsFilter === "any") return true;
       const max = parseInt(stopsFilter, 10);
@@ -370,7 +401,7 @@ export default function FlightQuoteAgent() {
       earliest: (a, b) => new Date(a.departAt || 0) - new Date(b.departAt || 0),
     };
     return by[sortBy] ? [...out].sort(by[sortBy]) : out;
-  }, [searchResults, airlineSel, stopsFilter, sortBy]);
+  }, [activeResults, airlineSel, stopsFilter, sortBy]);
 
   const toggleAirline = (code) =>
     setAirlineSel((prev) => {
@@ -380,6 +411,14 @@ export default function FlightQuoteAgent() {
     });
   const allAirlines = () => setAirlineSel(new Set(availableAirlines.map((a) => a.code)));
   const clearAirlines = () => setAirlineSel(new Set());
+  const showSearchLeg = (leg) => {
+    const legResults = leg === "return" ? returnSearchResults : searchResults;
+    setActiveSearchLeg(leg);
+    setAirlineSel(new Set(legResults.map((o) => o.airline).filter(Boolean)));
+    setStopsFilter("any");
+    setSortBy("recommended");
+    setExpandedIdx(null);
+  };
 
   const setOpt = (i, patch) =>
     setOptions((prev) => prev.map((o, idx) => (idx === i ? { ...o, ...patch } : o)));
@@ -409,6 +448,7 @@ export default function FlightQuoteAgent() {
       const o = options[i];
       if (!o.airline.trim()) { notify.error(`Option ${i + 1}: airline is required`); return; }
       if (!o.from.trim() || !o.to.trim()) { notify.error(`Option ${i + 1}: origin and destination are required`); return; }
+      if (isRoundTrip && !o.returnLeg) { notify.error(`Option ${i + 1}: select a return flight`); return; }
       const fare = Number(o.fare);
       if (o.fare === "" || !Number.isFinite(fare) || fare < 0) {
         notify.error(`Option ${i + 1}: fare must be a non-negative number`);
@@ -428,6 +468,11 @@ export default function FlightQuoteAgent() {
         departAt: o.departAt || undefined,
         arriveAt: o.arriveAt || undefined,
         baggage: o.baggage.trim() || undefined,
+        returnLeg: o.returnLeg ? {
+          airline: o.returnLeg.airline.trim().toUpperCase(), flightNumber: o.returnLeg.flightNumber.trim() || undefined,
+          fareClass: o.returnLeg.fareClass || undefined, route: { from: o.returnLeg.from.trim().toUpperCase(), to: o.returnLeg.to.trim().toUpperCase() },
+          departAt: o.returnLeg.departAt || undefined, arriveAt: o.returnLeg.arriveAt || undefined, baggage: o.returnLeg.baggage.trim() || undefined,
+        } : undefined,
       })),
     };
     if (forcedRuleId) body.markupRuleId = forcedRuleId;
@@ -671,6 +716,10 @@ export default function FlightQuoteAgent() {
               Pull live options and drop one into a row below. Uses TBO when configured, else an AI web
               estimate, else sample data.
             </p>
+            <div role="group" aria-label="Trip type" style={{ display: "flex", gap: 8, marginTop: 10 }}>
+              <button type="button" onClick={() => setSearchForm({ ...searchForm, tripType: "oneWay", returnDate: "" })} style={searchForm.tripType === "oneWay" ? primaryBtn : secondaryBtn}>One way</button>
+              <button type="button" onClick={() => setSearchForm({ ...searchForm, tripType: "roundTrip" })} style={isRoundTrip ? primaryBtn : secondaryBtn}>Round trip</button>
+            </div>
             <div style={{ marginTop: 10, display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 130px), 1fr))" }}>
               <input
                 placeholder="From — city or code (e.g. Delhi or DEL)" value={searchForm.from} maxLength={60}
@@ -687,6 +736,13 @@ export default function FlightQuoteAgent() {
                 onChange={(e) => setSearchForm({ ...searchForm, departDate: e.target.value })}
                 style={input} aria-label="Search departure date"
               />
+              {isRoundTrip && (
+                <input
+                  type="date" value={searchForm.returnDate} min={searchForm.departDate || undefined}
+                  onChange={(e) => setSearchForm({ ...searchForm, returnDate: e.target.value })}
+                  style={input} aria-label="Search return date"
+                />
+              )}
               <select
                 value={searchForm.cabinClass}
                 onChange={(e) => setSearchForm({ ...searchForm, cabinClass: e.target.value })}
@@ -712,12 +768,17 @@ export default function FlightQuoteAgent() {
               </p>
             )}
 
-            {searchResults.length > 0 && (
+            {(searchResults.length > 0 || (isRoundTrip && returnSearchResults.length > 0)) && (
               <div style={board}>
                 {/* Header bar: route + date + sort (mirrors "Select onward flight"). */}
                 <div style={boardHeader}>
                   <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                    <strong style={{ fontSize: 14 }}>Select onward flight</strong>
+                    {isRoundTrip ? (
+                      <div style={{ display: "flex", gap: 6 }}>
+                        <button type="button" onClick={() => showSearchLeg("outbound")} style={activeSearchLeg === "outbound" ? primaryBtn : secondaryBtn}>Going flights</button>
+                        <button type="button" onClick={() => showSearchLeg("return")} style={activeSearchLeg === "return" ? primaryBtn : secondaryBtn}>Return flights</button>
+                      </div>
+                    ) : <strong style={{ fontSize: 14 }}>Select onward flight</strong>}
                     <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 13, opacity: 0.92 }}>
                       {searchMeta?.resolved?.from?.iata || searchForm.from || "—"}
                       <Plane size={14} aria-hidden />
@@ -991,6 +1052,14 @@ export default function FlightQuoteAgent() {
                     aria-label={`Baggage (option ${i + 1})`}
                   />
                 </div>
+                {isRoundTrip && (
+                  <div style={{ marginTop: 12, padding: 10, border: "1px solid var(--border-color)", borderRadius: 8, fontSize: 13 }}>
+                    <strong>Return flight: </strong>
+                    {o.returnLeg
+                      ? `${o.returnLeg.airline} ${o.returnLeg.flightNumber || ""} · ${o.returnLeg.from} → ${o.returnLeg.to} · ${o.returnLeg.departAt || "time pending"}`
+                      : "Select a return flight from the Return flights tab."}
+                  </div>
+                )}
               </div>
             ))}
           </section>


### PR DESCRIPTION
Summary
This PR adds three main capabilities:
Generic CRM admins can define and manage custom lead fields, with typed values rendered across lead/contact views.
Wellness attendance punches now support clinic geofencing.
Travel flight quotes support round-trip search, paired outbound/return flight selection, and customer-facing round-trip details.
Changes
Added lead custom-field definitions and typed value storage in Prisma.
Added lead-field APIs and Settings → Lead Fields UI.
Displayed custom fields in Leads, Contacts, Contact Detail, and Converted Leads.
Added wellness-only attendance geofence evaluation using assigned locations, coordinates, accuracy, and location radius.
Added attendance geofence tests.
Enhanced flight search/provider handling and round-trip flight quote creation.
Added outbound/return flight pairing in the flight quote agent.
Stored and displayed round-trip flight metadata in the public itinerary flow.
Added Razorpay auto-capture handling and captured-payment validation.
Added/updated coverage for lead fields, attendance geofencing, flight/public payment flows, and flight search.