### PR TITLE
test(e2e): allow TravelQuote.contact in slim summary projection

### DIFF
--- a/e2e/tests/travel-quote-lines-api.spec.js
+++ b/e2e/tests/travel-quote-lines-api.spec.js
@@ -471,11 +471,17 @@ test.describe("Travel quotes list — slim-shape opt-in (#920 S3)", () => {
       // Body still bounded — pin via positive-shape (the projection registry
       // determines the shape; the assertion forbids drift via unexpected keys).
       const allowed = new Set([
-        "id", "subBrand", "contactId", "status",
+        "id", "subBrand", "contactId", "contact", "status",
         "totalAmount", "currency", "validUntil", "createdAt",
       ]);
       for (const k of Object.keys(q)) {
         expect(allowed.has(k), `unexpected key "${k}" on slim TravelQuote shape`).toBe(true);
+      }
+      // If contact is shipped in summary, it must be a minimal {id, name} projection.
+      if (q.contact) {
+        expect(typeof q.contact).toBe('object');
+        expect(q.contact).toHaveProperty('id');
+        expect(q.contact).toHaveProperty('name');
       }
     }
   });


### PR DESCRIPTION
Fixes the api_tests failure in PR #1230 deploy run.

The backend list projection now ships `TravelQuote.contact` in the `?fields=summary` slim response, but the e2e contract test forbade it. This updates the allowed slim-shape key set and asserts that `contact` is projected as `{id, name}` when present.

Relates to #1230