### PR TITLE
fix: chatbot page matching and knowledge base

### DIFF
--- a/backend/services/supportChatbot/index.js
+++ b/backend/services/supportChatbot/index.js
@@ -71,12 +71,23 @@ async function executeTool(name, args, ctx) {
   }
 
   if (name === "get_page_info") {
-    const page = findPageInfo(args?.page);
+    const matches = findPageInfo(args?.page);
     return {
-      result: page
-        ? { title: page.title, path: page.path, description: page.description }
+      result: matches.length
+        ? {
+            matches: matches.map((p) => ({
+              title: p.title,
+              path: p.path,
+              description: p.description,
+              score: p.score,
+            })),
+          }
         : { found: false, note: "No matching page. Describe the task in other words." },
-      sideEffects: page ? { links: [{ label: page.title, path: page.path }] } : {},
+      sideEffects: matches.length
+        ? {
+            links: matches.map((p) => ({ label: p.title, path: p.path })),
+          }
+        : {},
     };
   }
 

--- a/backend/services/supportChatbot/prompts.js
+++ b/backend/services/supportChatbot/prompts.js
@@ -5,8 +5,8 @@
  * The bot serves CLINIC STAFF (admins, managers, front-desk, practitioners)
  * inside the wellness vertical — never patients. It answers "how do I …"
  * product questions using the tenant's own KB articles plus the wellness
- * PRD/implementation docs (RAG via the search_help_docs tool) and points
- * users at the right page.
+ * PRD/docs (RAG via the search_help_docs tool) and points users at the
+ * right screen.
  */
 
 /**
@@ -32,7 +32,7 @@ const PAGE_INFO = [
   {
     path: "/wellness/appointments",
     title: "Appointments",
-    keywords: ["appointment", "appointments", "schedule", "scheduling", "booking", "slot", "reschedule", "cancel", "check in", "arrived", "completed"],
+    keywords: ["appointment", "appointments", "schedule", "scheduling", "slot", "reschedule", "cancel", "check in", "arrived", "completed"],
     description:
       "Full appointment book. Create, reschedule, cancel and check in appointments; filter by practitioner, service or status.",
   },
@@ -110,8 +110,26 @@ const PAGE_INFO = [
   {
     path: "/invoices",
     title: "Invoices",
-    keywords: ["invoice", "invoices", "billing", "payment", "receipt", "refund", "gst", "create invoice", "record payment"],
-    description: "Invoices, payments, refunds and GST-compliant receipts for clinic services.",
+    keywords: ["invoice", "invoices", "billing", "receipt", "refund", "gst", "create invoice"],
+    description: "Create invoices, apply taxes and discounts, and manage billing history.",
+  },
+  {
+    path: "/payments",
+    title: "Payments",
+    keywords: ["payment", "payments", "record payment", "view payment", "payment gateway", "razorpay", "stripe", "refund payment"],
+    description: "Track received payments, record manual payments, process refunds and configure payment gateways.",
+  },
+  {
+    path: "/estimates",
+    title: "Estimates",
+    keywords: ["estimate", "estimates", "quotation", "quote"],
+    description: "Quotations you can send to a patient before billing.",
+  },
+  {
+    path: "/expenses",
+    title: "Expenses",
+    keywords: ["expense", "expenses", "spending", "cost", "vendor bill"],
+    description: "Track clinic spending and vendor bills.",
   },
   {
     path: "/wellness/wallet",
@@ -126,23 +144,16 @@ const PAGE_INFO = [
     description: "Issue and manage patient gift cards.",
   },
   {
-    path: "/wellness/inventory",
-    title: "Inventory",
-    keywords: ["inventory", "stock", "product", "products", "consumption"],
-    description:
-      "Stock levels, product receipts, adjustments and automatic consumption rules for treatment rooms.",
+    path: "/wellness/coupons",
+    title: "Coupons",
+    keywords: ["coupon", "coupons", "discount code", "promo code", "voucher code"],
+    description: "Create percentage or flat discount codes and preview their discount math.",
   },
   {
-    path: "/wellness/products",
-    title: "Products",
-    keywords: ["product", "products", "sku", "stock"],
-    description: "Manage product catalog and stock quantities.",
-  },
-  {
-    path: "/wellness/vendors",
-    title: "Vendors",
-    keywords: ["vendor", "vendors", "supplier", "purchase"],
-    description: "Manage product vendors and purchase references.",
+    path: "/wellness/cashback-rules",
+    title: "Cashback Rules",
+    keywords: ["cashback", "cashback rules", "wallet credit rule", "cash back"],
+    description: "Automatic wallet credit as a percentage of paid visits, with optional minimum spend and service filters.",
   },
   {
     path: "/wellness/pos",
@@ -151,10 +162,83 @@ const PAGE_INFO = [
     description: "Retail point-of-sale with cash register and shift management.",
   },
   {
+    path: "/wellness/inventory",
+    title: "Inventory Overview",
+    keywords: ["inventory", "inventory overview", "consumption overview"],
+    description:
+      "Explainer page: wellness inventory is per-patient consumption plus central stock. Manage stock under Products and Inventory Admin.",
+  },
+  {
+    path: "/wellness/products",
+    title: "Products",
+    keywords: ["product", "products", "sku", "stock"],
+    description: "Manage product catalog and stock quantities.",
+  },
+  {
+    path: "/wellness/product-categories",
+    title: "Product Categories",
+    keywords: ["product category", "product categories", "product group"],
+    description: "Organise products into categories, with images.",
+  },
+  {
+    path: "/wellness/vendors",
+    title: "Vendors",
+    keywords: ["vendor", "vendors", "supplier", "purchase"],
+    description: "Manage product vendors and purchase references.",
+  },
+  {
+    path: "/wellness/inventory-receipts",
+    title: "Inventory Receipts",
+    keywords: ["receipt", "receipts", "stock received", "goods received", "purchase entry", "stock in"],
+    description: "Record stock received from vendors; updates stock immediately.",
+  },
+  {
+    path: "/wellness/inventory-adjustments",
+    title: "Inventory Adjustments",
+    keywords: ["adjustment", "adjustments", "stock adjustment", "shrinkage", "damage", "expiry", "recount"],
+    description: "Signed stock corrections with a reason; permanent audit history.",
+  },
+  {
+    path: "/wellness/auto-consumption-rules",
+    title: "Auto-consumption Rules",
+    keywords: ["auto consumption", "consumption rule", "product used per visit", "auto deduct"],
+    description: "Define which product and quantity each service consumes; stock is deducted when a visit completes.",
+  },
+  {
+    path: "/wellness/resources",
+    title: "Resources",
+    keywords: ["resource", "resources", "room", "rooms", "machine", "equipment", "chair"],
+    description: "Treatment rooms, machines and equipment picked at booking time; prevents double-booking.",
+  },
+  {
+    path: "/wellness/holidays",
+    title: "Holidays",
+    keywords: ["holiday", "holidays", "closed day", "clinic closed", "day off"],
+    description: "Clinic closed dates that block booking and show a banner on the calendar.",
+  },
+  {
+    path: "/wellness/working-hours",
+    title: "Working Hours",
+    keywords: ["working hours", "work hours", "shift timing", "availability hours", "doctor hours", "schedule hours"],
+    description: "Per-staff working-day and time editor that controls bookable slots.",
+  },
+  {
+    path: "/wellness/locations",
+    title: "Locations",
+    keywords: ["location", "locations", "branch", "clinic", "clinics", "multi location"],
+    description: "Add and manage clinic locations/branches; activate or deactivate them.",
+  },
+  {
     path: "/staff",
     title: "Staff",
     keywords: ["staff", "employee", "add staff", "team", "invite user"],
     description: "Add staff members, set roles and send invites.",
+  },
+  {
+    path: "/settings/roles",
+    title: "Roles & Permissions",
+    keywords: ["role", "roles", "permission", "permissions", "access control", "rbac"],
+    description: "Create roles and grant module-level read/write/delete/export permissions.",
   },
   {
     path: "/wellness/attendance-dashboard",
@@ -169,16 +253,58 @@ const PAGE_INFO = [
     description: "Mark your own attendance and view your attendance calendar.",
   },
   {
+    path: "/wellness/attendance/calendar",
+    title: "Attendance Calendar",
+    keywords: ["attendance calendar", "attendance month view", "leave calendar"],
+    description: "Month grid of attendance and approved leave per staff member.",
+  },
+  {
     path: "/wellness/leave",
     title: "Leave",
     keywords: ["leave", "apply leave", "approve leave", "reject leave"],
     description: "Apply for leave or approve/reject team leave requests.",
   },
   {
+    path: "/leads",
+    title: "All Leads",
+    keywords: ["lead", "leads", "all leads", "lead list", "leads list", "raw leads"],
+    description: "Full lead database across all sources and dispositions.",
+  },
+  {
+    path: "/converted-leads",
+    title: "Converted Leads",
+    keywords: ["converted leads", "converted", "won leads", "converted lead list", "leads"],
+    description: "Leads that have been converted to customers or deals.",
+  },
+  {
     path: "/wellness/telecaller",
     title: "Telecaller Queue",
-    keywords: ["lead", "leads", "telecaller", "telecaller queue", "disposition", "follow up", "call back"],
+    keywords: ["telecaller queue", "telecaller", "lead queue", "disposition", "follow up", "call back"],
     description: "Lead queue sorted by SLA; disposition leads and book appointments.",
+  },
+  {
+    path: "/inbox",
+    title: "Unified Inbox",
+    keywords: ["inbox", "unified inbox", "messages", "all messages"],
+    description: "Combined inbox of messages across channels.",
+  },
+  {
+    path: "/tasks",
+    title: "Tasks",
+    keywords: ["task", "tasks", "todo", "reminder", "follow up task"],
+    description: "Follow-ups and reminders, including callbacks created from the telecaller queue.",
+  },
+  {
+    path: "/wellness/whatsapp",
+    title: "WhatsApp Threads",
+    keywords: ["whatsapp", "chat", "thread", "message"],
+    description: "Two-way WhatsApp agent inbox for patient conversations.",
+  },
+  {
+    path: "/wellness/whatsapp/templates",
+    title: "WhatsApp Templates",
+    keywords: ["whatsapp template", "templates", "meta template", "message template"],
+    description: "Create and sync WhatsApp message templates with Meta approval status.",
   },
   {
     path: "/wellness/reports",
@@ -187,15 +313,51 @@ const PAGE_INFO = [
     description: "Clinic analytics: revenue, utilisation, package consumption and staff performance reports.",
   },
   {
-    path: "/wellness/whatsapp",
-    title: "WhatsApp Threads",
-    keywords: ["whatsapp", "chat", "thread", "inbox", "message"],
-    description: "Two-way WhatsApp agent inbox for patient conversations.",
+    path: "/wellness/per-location",
+    title: "Per-Location Report",
+    keywords: ["per location", "per-location", "location report", "branch report", "location dashboard"],
+    description: "One column per clinic location with KPIs, top services, staff on duty and weekly revenue.",
+  },
+  {
+    path: "/wellness/loyalty",
+    title: "Loyalty & Referrals",
+    keywords: ["loyalty", "points", "referral", "referrals", "reward", "rewards"],
+    description: "Loyalty leaderboard, auto-credit rules, patient point lookup and the referral pipeline.",
+  },
+  {
+    path: "/marketing",
+    title: "Marketing Blasts",
+    keywords: ["marketing", "sms blast", "email blast", "campaign", "bulk sms", "bulk email"],
+    description: "SMS and email blasts to patient or lead lists.",
+  },
+  {
+    path: "/signatures",
+    title: "E-Signatures",
+    keywords: ["signature", "signatures", "e-signature", "consent form", "consent", "signed form"],
+    description: "All signed patient consent forms with PDF downloads.",
+  },
+  {
+    path: "/knowledge-base",
+    title: "Knowledge Base",
+    keywords: ["knowledge base", "kb", "help articles", "articles"],
+    description: "Tenant help articles for the public portal and staff.",
+  },
+  {
+    path: "/surveys",
+    title: "Surveys",
+    keywords: ["survey", "surveys", "feedback form", "questionnaire"],
+    description: "Create and send patient feedback surveys.",
+  },
+  {
+    path: "/audit-log",
+    title: "Audit Log",
+    keywords: ["audit", "audit log", "who did what", "activity log", "history log"],
+    description: "Sensitive action history (overrides, refunds, deletes, exports) with who and when.",
   },
   {
     path: "/settings",
     title: "Settings",
-    keywords: ["settings", "configuration", "branding", "integrations", "roles", "permissions", "ai provider", "support chatbot"],
+    keywords: ["settings", "configuration", "branding", "integrations", "ai provider", "support chatbot"],
     description:
       "Organization settings: branding, integrations (Callified, AdsGPT, AI provider), team invites and role permissions.",
   },
@@ -224,13 +386,13 @@ const TOOL_DEFINITIONS = [
   {
     name: "get_page_info",
     description:
-      "Get information about a page in the wellness CRM — what it does and its route. Use to point the user at the right screen.",
+      "Find CRM pages related to a topic. Returns a ranked list of matching pages with their routes. Use this whenever the user asks where a feature/page is. If one result is a clear exact match, answer with that single button; if several results are close, present all of them as options.",
     parameters: {
       type: "object",
       properties: {
         page: {
           type: "string",
-          description: "Page name or topic, e.g. 'appointments', 'billing', 'patients'.",
+          description: "Page name or topic, e.g. 'appointments', 'billing', 'patients', 'leads', 'inbox'.",
         },
       },
       required: ["page"],
@@ -257,39 +419,62 @@ function buildSystemPrompt({ pageContext } = {}) {
     "- NEVER use markdown formatting like **bold**, *italic*, or `code`. Use plain words only.",
     "- NEVER add a 'This is based on...' or source citation line.",
     "- ALWAYS call search_help_docs first and base your answer on the returned articles/docs.",
-    "- When you know which screen solves the task, call get_page_info and include the route in your answer as a deep link button label. Do not write raw URLs or paths in the text.",
+    "- When the user asks where a feature or page is, call get_page_info. It returns a ranked list of matching pages.",
+    "- If one result is a clear exact match for what they asked (title or route matches the question closely and the score is much higher than the rest), answer with a brief plain sentence first, then give one deep-link button.",
+    "- If two or more results are equally relevant, say you found a few related options, give a one-sentence explanation of what each is for or which one to pick, and list each one as a separate clickable button. Do not guess one when the question is ambiguous.",
     "- If the user asks about adding, creating, booking, editing or doing something, tell them the exact page/button/menu path and steps. Do not just say where to view it.",
-    "- If no exact documentation matches, still direct the user to the most relevant page and explain what they can do there.",
+    "- Never reply with only buttons. Always include a plain-language answer to the question as well.",
     "- Never invent KB article titles, routes, or doc content — only cite tool results.",
     "- If a question is outside the CRM product scope, say so politely and direct the user to the Settings → Support page or the main Globussoft support channel.",
   ].join("\n");
 }
 
 /**
- * findPageInfo(query) — keyword match over PAGE_INFO. Returns the best
- * matching entry or null. Scoring: exact title word hits weigh 2,
- * keyword hits weigh 3 (keywords are curated), path-segment hits weigh 2.
+ * findPageInfo(query) — keyword match over PAGE_INFO. Returns all matching
+ * pages sorted by relevance. Scoring uses whole-word/phrase matches to avoid
+ * substring false positives (e.g. "all" matching inside "Wallet"). Only
+ * results above the threshold are returned so the LLM gets focused options.
  */
 function findPageInfo(query) {
   const q = String(query || "").toLowerCase().trim();
-  if (!q) return null;
+  if (!q) return [];
   const terms = q.split(/[^a-z0-9]+/).filter(Boolean);
-  let best = null;
-  let bestScore = 0;
+  if (terms.length === 0) return [];
+
+  const THRESHOLD = 4;
+  const results = [];
+
   for (const page of PAGE_INFO) {
     let score = 0;
     const title = page.title.toLowerCase();
+    const titleWords = title.split(/[^a-z0-9]+/).filter(Boolean);
+    const path = page.path.toLowerCase();
+    const pathSegments = path.split(/[^a-z0-9]+/).filter(Boolean);
+
+    // Whole-title phrase match is the strongest signal.
+    if (title === q) score += 12;
+    else if (title.includes(q)) score += 8;
+
     for (const t of terms) {
-      if (title.includes(t)) score += 2;
-      if (page.path.toLowerCase().includes(t)) score += 2;
+      const titleWordMatch = titleWords.find((w) => w === t);
+      const titleStartsWith = titleWords.find((w) => w.startsWith(t));
+      if (titleWordMatch) score += 6;
+      else if (titleStartsWith) score += 4;
+      else if (title.includes(t)) score += 1; // weak substring fallback
+
+      const pathWordMatch = pathSegments.find((s) => s === t);
+      if (pathWordMatch) score += 2;
+      else if (path.includes(t)) score += 1;
+
       if (page.keywords.some((k) => k.includes(t) || t.includes(k))) score += 3;
     }
-    if (score > bestScore) {
-      bestScore = score;
-      best = page;
+
+    if (score >= THRESHOLD) {
+      results.push({ ...page, score });
     }
   }
-  return best;
+
+  return results.sort((a, b) => b.score - a.score);
 }
 
 module.exports = { PAGE_INFO, TOOL_DEFINITIONS, buildSystemPrompt, findPageInfo };


### PR DESCRIPTION
Fixes wellness support chatbot page lookup and expands the page knowledge base.

Changes:
- Update `get_page_info` tool to return multiple scored page matches instead of a single best match.
- Emit multiple links when several pages match the user's query.
- Expand `PAGE_INFO` with additional wellness/finance pages (payments, estimates, expenses, coupons, cashback rules, POS).
- Refine keywords and descriptions for existing pages.