### PR TITLE
fix(ci): resolve post-PR #1233 deploy failures

### DIFF
--- a/backend/.audit-allowlist.json
+++ b/backend/.audit-allowlist.json
@@ -139,6 +139,51 @@
       "sunsetBy": "2026-09-16"
     },
     {
+      "ghsa": "GHSA-w8wr-v893-vjvp",
+      "package": "tar",
+      "severity": "critical",
+      "title": "node-tar arbitrary file creation/overwrite via insufficient symlink protection",
+      "reason": "Transitive via @mapbox/node-pre-gyp at install-time only; same mitigation as GHSA-34x7-hfp2-rc4v.",
+      "addedOn": "2026-07-21",
+      "sunsetBy": "2026-10-21"
+    },
+    {
+      "ghsa": "GHSA-23hp-3jrh-7fpw",
+      "package": "tar",
+      "severity": "critical",
+      "title": "node-tar arbitrary file creation/overwrite via insufficient absolute path protection",
+      "reason": "Transitive via @mapbox/node-pre-gyp at install-time only; same mitigation as GHSA-34x7-hfp2-rc4v.",
+      "addedOn": "2026-07-21",
+      "sunsetBy": "2026-10-21"
+    },
+    {
+      "ghsa": "GHSA-8x88-c5mf-7j5w",
+      "package": "tar",
+      "severity": "critical",
+      "title": "node-tar arbitrary file creation/overwrite via insufficient relative path protection",
+      "reason": "Transitive via @mapbox/node-pre-gyp at install-time only; same mitigation as GHSA-34x7-hfp2-rc4v.",
+      "addedOn": "2026-07-21",
+      "sunsetBy": "2026-10-21"
+    },
+    {
+      "ghsa": "GHSA-gvwx-54wh-qm9j",
+      "package": "tar",
+      "severity": "critical",
+      "title": "node-tar insufficient symlink protection allows arbitrary file creation/overwrite",
+      "reason": "Transitive via @mapbox/node-pre-gyp at install-time only; same mitigation as GHSA-34x7-hfp2-rc4v.",
+      "addedOn": "2026-07-21",
+      "sunsetBy": "2026-10-21"
+    },
+    {
+      "ghsa": null,
+      "package": "canvas",
+      "severity": "high",
+      "title": "Transitive: depends on vulnerable @mapbox/node-pre-gyp → tar",
+      "reason": "Install-time dependency of pdfjs-dist used to fetch prebuilt binaries. The underlying tar advisories are allowlisted above; runtime exposure is zero.",
+      "addedOn": "2026-07-21",
+      "sunsetBy": "2026-10-21"
+    },
+    {
       "ghsa": null,
       "package": "@mapbox/node-pre-gyp",
       "severity": "high",

--- a/backend/test/routes/attendance.test.js
+++ b/backend/test/routes/attendance.test.js
@@ -350,12 +350,12 @@ describe('Geo-tagged attendance (wellness only)', () => {
       expect(prisma.attendance.create).not.toHaveBeenCalled();
     });
 
-    test('wellness tenant, assigned + fuzzy GPS (accuracy > 100m) → 403 ACCURACY_TOO_LOW', async () => {
+    test('wellness tenant, assigned + fuzzy GPS (accuracy > 500m) → 403 ACCURACY_TOO_LOW', async () => {
       prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
       prisma.userLocation.findMany.mockResolvedValue([{ location: RANCHI_CLINIC }]);
 
       const res = await authedReq('post', '/api/attendance/clock-in').send({
-        latitude: NEARBY_COORDS.latitude, longitude: NEARBY_COORDS.longitude, accuracy: 500,
+        latitude: NEARBY_COORDS.latitude, longitude: NEARBY_COORDS.longitude, accuracy: 600,
       });
 
       expect(res.status).toBe(403);

--- a/backend/test/routes/sandbox.test.js
+++ b/backend/test/routes/sandbox.test.js
@@ -94,7 +94,7 @@ prisma.sandboxSnapshot = {
 const scopeModels = [
   'contact', 'deal', 'activity', 'task', 'invoice',
   'estimate', 'estimateLineItem', 'contract', 'quote', 'quoteLineItem',
-  'pipeline', 'pipelineStage', 'emailMessage',
+  'pipeline', 'pipelineStage', 'emailMessage', 'travelQuote',
 ];
 for (const m of scopeModels) {
   prisma[m] = prisma[m] || {};

--- a/frontend/.bundle-size-budget.json
+++ b/frontend/.bundle-size-budget.json
@@ -33,6 +33,11 @@
       "comment": "lucide-react icon barrel. Tree-shakable — bloat means someone imported the whole barrel instead of named icons."
     },
     {
+      "pattern": "xlsx-*.js",
+      "maxKB": 450,
+      "comment": "PR #1233 added xlsx (^0.18.5) for CSV/Excel import on Contacts/Leads/Travel pages. Tree-shaken chunk is ~419 KB; budget set with small headroom. Long-term: evaluate lighter alternatives (exceljs, papaparse for CSV-only) or lazy-load importers."
+    },
+    {
       "pattern": "index-*.js",
       "maxKB": 250,
       "comment": "Main SPA entry chunk. Critical-path; keep tight."
@@ -50,8 +55,8 @@
   ],
 
   "totals": {
-    "all-js-maxKB": 5700,
+    "all-js-maxKB": 6200,
     "all-css-maxKB": 300,
-    "comment": "Whole frontend/dist/assets/ JS + CSS. Catches the case where a new chunk pops in without being budgeted explicitly. Bumped 5200→5700 on 2026-07-06: PR #1199 React landing-page renderer (LandingPageBuilder ~243 KB, block renderers, travel blocks, parity tool, phase-2 validation suite, authenticated submission flow) pushed total JS to 5213.2 KB; bumping by 500 KB restores ~140 KB headroom. No accidental barrel import. Bumped 4700→5200 on 2026-06-26: PR #1184 travel feature wave (QuoteBuilder 77.7 KB, destination-photos cascade, payment-flow enrichments, Itinerary/Leads/Payments UI polish, WhatsApp + LLM-router changes) pushed total JS to 5056.9 KB; bumping by 500 KB restores ~140 KB headroom. No single chunk is anomalous — largest new chunk QuoteBuilder-P9RV4t-.js is 77.7 KB and is already lazy-loaded. Bumped 4400→4700 on 2026-06-17: the travel customer-portal feature wave (in-app notification bell + My-Bookings status filter & location search → TravelCustomerPortal 61→63.5 KB, visa-doc signed-view flow, staff sub-brand-access picker, Get Started email-OTP step) plus the RBAC-recovery merge pushed total JS to 4489.7 KB; bumping by 300 KB restores ~210 KB headroom (matches the prior bumps' convention). No accidental barrel import — vendor-icons is tree-shaken (107/120) and no single chunk is anomalous. Next lazy-load candidates remain leaflet (151 KB, map-only routes) + PatientDetail (78 KB). Bumped 4200→4400 on 2026-06-12: the v3.9.x OCR passport + travel accounting export + workload + share-links surfaces (commit 5b2317e) pushed total JS to 4218.6 KB. Prior bump 4096→4200 on 2026-06-11 absorbed S81/S82/S127 MapPreview + S93 PoiPicker + S128 EmbedAllowlist."
+    "comment": "Whole frontend/dist/assets/ JS + CSS. Catches the case where a new chunk pops in without being budgeted explicitly. Bumped 5700→6200 on 2026-07-21: PR #1233 added xlsx for CSV/Excel import; the xlsx chunk is ~419 KB and pushes total JS to ~5853 KB. Bumping by 500 KB restores ~140 KB headroom. Bumped 5200→5700 on 2026-07-06: PR #1199 React landing-page renderer..."
   }
 }


### PR DESCRIPTION
Fixes the three failures in the main deploy run after merging PR #1233 (Contacts/Leads overhaul + geofencing + xlsx imports).

Changes:
- **Unit tests (sandbox)** — add `travelQuote` to mocked scope models so the new sandbox wipe order does not throw on an unmocked `prisma.travelQuote.deleteMany`.
- **Unit tests (attendance)** — update the accuracy-too-low case to use 600m; the new `ACCURACY_THRESHOLD_M` is 500m.
- **npm audit** — allowlist newly classified critical tar advisories and the transitive `canvas` package. tar is install-time only via node-pre-gyp.
- **Bundle-size budget** — add budget entry for the new xlsx chunk (~419 KB) and bump total JS budget 5700→6200 KB.

All three fixes are additive/config-only; no runtime behaviour changes.