### PR TITLE
fix(tests): whitelist SavedContactViewMember junction table

### DIFF
--- a/backend/test/schema/schema-invariants.test.js
+++ b/backend/test/schema/schema-invariants.test.js
@@ -143,6 +143,11 @@ const NON_TENANT_MODELS = new Set([
   // between role.tenantId and version.tenantId) without strengthening
   // isolation, because every query path joins through Role.
   'RolePermissionVersion',
+  // SavedContactView↔Contact junction. Both parents (SavedContactView and
+  // Contact) carry tenantId and cascade on tenant delete; members are
+  // scoped through the parent joins. A redundant tenantId would risk
+  // drift from the parents.
+  'SavedContactViewMember',
   // Globally-shared templates (real-estate, healthcare, education, legal,
   // saas) — seeded once, read by all tenants when they pick an industry.
   // Read-only from a tenant's perspective; no tenant data lives here.


### PR DESCRIPTION
Fixes the post-PR #1233 deploy failure where `test/schema/schema-invariants.test.js` flagged `SavedContactViewMember` as missing `tenantId`.

**Change**
- Add `SavedContactViewMember` to `NON_TENANT_MODELS` in `backend/test/schema/schema-invariants.test.js`.

**Rationale**
`SavedContactViewMember` is a junction between `SavedContactView` and `Contact`, both of which carry `tenantId` and cascade on tenant delete. Tenant isolation flows through the parent joins; a redundant `tenantId` on the junction row would create drift risk rather than strengthen isolation.

**Verification**
- `npx vitest run test/schema/schema-invariants.test.js` passes locally.

This is a follow-up to PR #1234.