### PR TITLE
ci(deploy): install frontend deps before vite build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -916,6 +916,9 @@ jobs:
             export PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH"
             cd ~/globussoft-crm/frontend
 
+            echo "=== npm install ==="
+            npm install --no-audit --no-fund --loglevel=error 2>&1 | tail -5
+
             echo "=== vite build ==="
             npx vite build --logLevel=error 2>&1 | tail -8
             du -sh dist
@@ -1263,6 +1266,9 @@ jobs:
             set -euo pipefail
             export PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH"
             cd /home/empcloud-development/globussoft-crm/frontend
+
+            echo "=== npm install ==="
+            npm install --no-audit --no-fund --loglevel=error 2>&1 | tail -5
 
             echo "=== vite build ==="
             npx vite build --logLevel=error 2>&1 | tail -8


### PR DESCRIPTION
Fixes the staging deploy failure where the frontend Vite build failed with a dynamic-import resolution error after the backend deploy reset the working tree to origin/main.

**Problem**
- The backend deploy step runs git reset --hard origin/main, which updates both backend and frontend source.
- The frontend deploy step then ran npx vite build without first updating node_modules.
- Stale/transitive dependencies on the server caused Rollup to fail resolving a dynamic import (deploy run 29836966731).

**Change**
- Add npm install --no-audit --no-fund --loglevel=error before npx vite build in both the production and staging frontend deploy steps, matching the backend deploy step.

**Scope**
- .github/workflows/deploy.yml only.