### PR TITLE
fix(e2e): align brand-kit and prescription specs with PR #1237

### DIFF
--- a/e2e/tests/travel-microsites-brand-kit-api.spec.js
+++ b/e2e/tests/travel-microsites-brand-kit-api.spec.js
@@ -162,7 +162,7 @@ test.describe("Travel microsites — G095 brand-kit block", () => {
 test.describe("Travel branding — G092 public brand-kit endpoint", () => {
   test("GET /api/brand-kits/by-subbrand/tmc is reachable without auth", async ({ request }) => {
     const res = await retryOn5xx(() =>
-      request.get(`${BASE_URL}/api/brand-kits/by-subbrand/tmc`, { timeout: REQUEST_TIMEOUT }),
+      request.get(`${BASE_URL}/api/brand-kits/by-subbrand/tmc?tenantId=1`, { timeout: REQUEST_TIMEOUT }),
     );
     // 200 when a kit exists; 404 when not (BRAND_KIT_NOT_FOUND). Either
     // is a green test as long as the route is auth-free.

--- a/e2e/tests/wellness-clinical-api.spec.js
+++ b/e2e/tests/wellness-clinical-api.spec.js
@@ -1286,8 +1286,8 @@ test.describe('Wellness API — Prescriptions', () => {
     expect(res.status(), await res.text()).toBe(201);
     const body = await res.json();
     expect(body.id).toBeTruthy();
-    // drugs is JSON-stringified on the row.
-    const drugs = JSON.parse(body.drugs);
+    // drugs is now normalized to a real array on the way out; tolerate legacy JSON-string rows.
+    const drugs = Array.isArray(body.drugs) ? body.drugs : JSON.parse(body.drugs);
     expect(drugs[0].name).toBe('Amoxicillin 500mg');
   });
 


### PR DESCRIPTION
Fixes two API-only e2e regressions from #1237:
- /api/brand-kits/by-subbrand now requires an explicit ?tenantId query parameter.
- Prescription responses now normalize drugs to an array instead of a JSON string.

This is a test-only change; no production code is modified.