### PR TITLE
fix(e2e): normalize remaining drugs JSON.parse calls for #1237

### DIFF
--- a/e2e/tests/wellness-clinical-api.spec.js
+++ b/e2e/tests/wellness-clinical-api.spec.js
@@ -2833,8 +2833,8 @@ test.describe('Wellness clinical — #10 backlog extension (#114 #118 #159 #160 
       expect(row.instructions).not.toMatch(/^ENC:v1:/);
       expect(row.instructions).toContain('encrypt-test');
     }
-    // drugs is JSON-stringified; verify it parses + contains the drug.
-    const parsed = JSON.parse(row.drugs);
+    // drugs is JSON-stringified on the row but now normalized to a real array in the response.
+    const parsed = Array.isArray(row.drugs) ? row.drugs : JSON.parse(row.drugs);
     expect(parsed[0].name).toContain('Encrypt-Test');
   });
 

--- a/e2e/tests/wellness-deep.spec.js
+++ b/e2e/tests/wellness-deep.spec.js
@@ -55,7 +55,8 @@ test.describe.serial('Wellness deep — PDF content (Rx, Consent, Invoice)', () 
     // Find a Rx that has known-good drug data
     const list = await (await request.get(`${API}/wellness/prescriptions?limit=10`, { headers: auth() })).json();
     const rx = list.find((r) => {
-      try { return JSON.parse(r.drugs).length > 0; } catch { return false; }
+      const d = Array.isArray(r.drugs) ? r.drugs : (() => { try { return JSON.parse(r.drugs); } catch { return []; } })();
+      return d.length > 0;
     });
     if (!rx) test.skip(true, 'no prescription with parseable drugs');
 
@@ -71,7 +72,7 @@ test.describe.serial('Wellness deep — PDF content (Rx, Consent, Invoice)', () 
     expect(parsed.text.length).toBeGreaterThan(50);           // has rendered text
 
     // The Rx PDF should reference the patient and at least one drug
-    const drugs = JSON.parse(rx.drugs);
+    const drugs = Array.isArray(rx.drugs) ? rx.drugs : JSON.parse(rx.drugs);
     const firstDrugName = drugs[0]?.name || '';
     if (firstDrugName) {
       expect(parsed.text.toLowerCase()).toContain(firstDrugName.toLowerCase().split(' ')[0]);


### PR DESCRIPTION
Completes the e2e test updates for PR #1237. Prescription responses now return drugs as a parsed array, so remove assumptions that body.drugs / row.drugs is always a JSON string.