### PR TITLE
 add wellness landing sites and travel bulk import workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -231,6 +231,7 @@ jobs:
             tests/auth-security-regression-api.spec.js \
             tests/audit-coverage-api.spec.js \
             tests/public-booking-api.spec.js \
+            tests/wellness-public-enquiry-api.spec.js \
             tests/services-api.spec.js \
             tests/sequences-authoring-api.spec.js \
             tests/orchestrator-api.spec.js \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -426,6 +426,7 @@ jobs:
             tests/auth-security-regression-api.spec.js \
             tests/audit-coverage-api.spec.js \
             tests/public-booking-api.spec.js \
+            tests/wellness-public-enquiry-api.spec.js \
             tests/services-api.spec.js \
             tests/sequences-authoring-api.spec.js \
             tests/orchestrator-api.spec.js \
@@ -870,7 +871,8 @@ jobs:
               echo "=== seed-travel (always) ==="
               node prisma/seed-travel.js 2>&1 | tail -20
             fi
-            # Optional RBAC backfill. Keep this OFF for normal deploys so
+
+            # Optional RBAC backfill. Keep this OFF for normal deploys so
             # already-selected permissions remain unchanged across refreshes
             # and restarts. Operators can opt in only when they are
             # intentionally adding a newly-wide preset grant.
@@ -1263,7 +1265,8 @@ jobs:
               echo "=== seed-travel (always) ==="
               node prisma/seed-travel.js 2>&1 | tail -20
             fi
-            # Optional RBAC backfill. Keep this OFF for normal deploys so
+
+            # Optional RBAC backfill. Keep this OFF for normal deploys so
             # already-selected permissions remain unchanged across refreshes
             # and restarts. Operators can opt in only when they are
             # intentionally adding a newly-wide preset grant.

--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,9 @@ rbac-backup-tenant-*.json
 # CRM ↔ marketing-site handoff work but never pushed to this repo.
 drharors-wellness/
 
+# Local wellness landing folder used for API-only lead capture testing.
+well2-updated430pm/
+
 # WhatsApp Web (QR-scan) transport session data — whatsapp-web.js LocalAuth +
 # puppeteer cache. Per-tenant linked-device credentials live here; NEVER commit.
 backend/.wwebjs_auth/

--- a/backend/lib/pageCatalog.js
+++ b/backend/lib/pageCatalog.js
@@ -505,7 +505,7 @@ const PAGE_CATALOG = [
     label: 'Landing Sites',
     description: 'Sector-aware landing site builder',
     category: 'Marketing',
-    vertical: 'generic',
+    vertical: ['generic', 'wellness'],
     requiredPermissions: [{ module: 'marketing', action: 'read' }],
   },
   {
@@ -1466,7 +1466,7 @@ function getCatalog() {
  */
 function getCatalogForVertical(vertical) {
   return PAGE_CATALOG.filter((p) => {
-    if (p.vertical) return p.vertical === vertical;
+    if (p.vertical) return matchesVertical(p.vertical, vertical);
     const isWellness = p.path === '/wellness' || p.path.startsWith('/wellness/');
     if (isWellness) return vertical === 'wellness';
     const isTravel = p.path === '/travel' || p.path.startsWith('/travel/');
@@ -1484,6 +1484,13 @@ function getPage(path) {
 
 function isKnownPage(path) {
   return typeof path === 'string' && PAGES_BY_PATH.has(path);
+}
+
+function matchesVertical(pageVertical, vertical) {
+  if (Array.isArray(pageVertical)) {
+    return pageVertical.includes(vertical);
+  }
+  return pageVertical === vertical;
 }
 
 /**
@@ -1513,7 +1520,7 @@ function getAccessiblePages(permissionSet, opts = {}) {
   // full catalog (back-compat).
   const basePool = opts.vertical
     ? PAGE_CATALOG.filter((p) => {
-        if (p.vertical) return p.vertical === opts.vertical;
+        if (p.vertical) return matchesVertical(p.vertical, opts.vertical);
         const isWellness = p.path === '/wellness' || p.path.startsWith('/wellness/');
         if (isWellness) return opts.vertical === 'wellness';
         const isTravel = p.path === '/travel' || p.path.startsWith('/travel/');

--- a/backend/lib/travelInvoiceReconciliation.js
+++ b/backend/lib/travelInvoiceReconciliation.js
@@ -1,0 +1,222 @@
+"use strict";
+
+const { parseCsv, parseXlsxBuffer } = require("./csvIO");
+
+function isXlsxUpload(file) {
+  if (!file) return false;
+  const name = String(file.originalname || "").toLowerCase();
+  if (name.endsWith(".xlsx") || name.endsWith(".xls")) return true;
+  const mt = String(file.mimetype || "").toLowerCase();
+  return (
+    mt === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    mt === "application/vnd.ms-excel"
+  );
+}
+
+function parseSpreadsheetBuffer(buffer, file) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error("parseSpreadsheetBuffer: buffer is required");
+  }
+  return isXlsxUpload(file)
+    ? parseXlsxBuffer(buffer)
+    : parseCsv(buffer.toString("utf8"));
+}
+
+function normalizeHeader(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return "";
+  return String(value).trim();
+}
+
+function parseMoney(value) {
+  const text = normalizeText(value).replace(/,/g, "");
+  if (!text) return null;
+  const n = Number(text);
+  if (!Number.isFinite(n)) return null;
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function parseExcelRow(row) {
+  const mapped = {};
+  for (const [key, value] of Object.entries(row || {})) {
+    mapped[normalizeHeader(key)] = value;
+  }
+
+  const invoiceNum = normalizeText(
+    mapped.invoicenumber ||
+    mapped.invoicenum ||
+    mapped.vouchernumber ||
+    mapped.vouchernum ||
+    mapped.invoiceid,
+  );
+
+  if (!invoiceNum || invoiceNum.toLowerCase() === "total") {
+    return { skip: true };
+  }
+
+  const invoiceDate = normalizeText(mapped.invoicedate || mapped.date);
+  const customer = normalizeText(mapped.customer || mapped.customername || mapped.party);
+  const status = normalizeText(mapped.status);
+  const subBrand = normalizeText(mapped.subbrand || mapped.subbrandcode || mapped.subbrandname);
+  const invoiceTotal = parseMoney(
+    mapped.invoicetotal ||
+    mapped.invoiceamount ||
+    mapped.totalamount ||
+    mapped.total,
+  );
+
+  return {
+    row: {
+      invoiceNum,
+      invoiceDate,
+      customer,
+      status,
+      subBrand,
+      invoiceTotal,
+    },
+  };
+}
+
+function dateOnly(value) {
+  if (!value) return "";
+  const dt = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(dt.getTime())) return "";
+  return dt.toISOString().slice(0, 10);
+}
+
+function reconcileRows({ rows, invoices, contactsById }) {
+  const invoiceMap = new Map();
+  for (const inv of invoices || []) {
+    invoiceMap.set(normalizeText(inv.invoiceNum).toUpperCase(), inv);
+  }
+
+  const parsedRows = [];
+  const discrepancies = [];
+  let matchedRows = 0;
+  let mismatchedRows = 0;
+  let missingRows = 0;
+  let totalWorkbookAmount = 0;
+  let totalCrmAmount = 0;
+
+  for (const raw of rows || []) {
+    const parsed = parseExcelRow(raw);
+    if (parsed.skip) continue;
+    const row = parsed.row;
+    parsedRows.push(row);
+    if (Number.isFinite(row.invoiceTotal)) {
+      totalWorkbookAmount += row.invoiceTotal;
+    }
+
+    const invoice = invoiceMap.get(row.invoiceNum.toUpperCase()) || null;
+    if (!invoice) {
+      missingRows += 1;
+      discrepancies.push({
+        invoiceNum: row.invoiceNum,
+        issue: "MISSING_IN_CRM",
+        expected: null,
+        actual: {
+          invoiceNum: row.invoiceNum,
+          status: row.status || null,
+          invoiceTotal: row.invoiceTotal ?? null,
+          customer: row.customer || null,
+          subBrand: row.subBrand || null,
+          invoiceDate: row.invoiceDate || null,
+        },
+      });
+      continue;
+    }
+
+    matchedRows += 1;
+    const invoiceTotal = Math.round((Number(invoice.totalAmount) + Number.EPSILON) * 100) / 100;
+    totalCrmAmount += invoiceTotal;
+    const contactName = contactsById?.[invoice.contactId]?.name || null;
+    const rowMismatches = [];
+
+    if (row.status && row.status.toLowerCase() !== String(invoice.status || "").toLowerCase()) {
+      rowMismatches.push({
+        field: "status",
+        expected: invoice.status,
+        actual: row.status,
+      });
+    }
+    if (row.subBrand && row.subBrand.toLowerCase() !== String(invoice.subBrand || "").toLowerCase()) {
+      rowMismatches.push({
+        field: "subBrand",
+        expected: invoice.subBrand,
+        actual: row.subBrand,
+      });
+    }
+    if (row.customer && contactName && row.customer.toLowerCase() !== contactName.toLowerCase()) {
+      rowMismatches.push({
+        field: "customer",
+        expected: contactName,
+        actual: row.customer,
+      });
+    }
+    if (row.invoiceDate) {
+      const expectedDate = dateOnly(invoice.createdAt);
+      if (expectedDate && row.invoiceDate.slice(0, 10) !== expectedDate) {
+        rowMismatches.push({
+          field: "invoiceDate",
+          expected: expectedDate,
+          actual: row.invoiceDate,
+        });
+      }
+    }
+    if (Number.isFinite(row.invoiceTotal) && Math.abs(row.invoiceTotal - invoiceTotal) > 0.01) {
+      rowMismatches.push({
+        field: "invoiceTotal",
+        expected: invoiceTotal,
+        actual: row.invoiceTotal,
+      });
+    }
+
+    if (rowMismatches.length > 0) {
+      mismatchedRows += 1;
+      discrepancies.push({
+        invoiceId: invoice.id,
+        invoiceNum: invoice.invoiceNum,
+        issue: "MISMATCH",
+        expected: {
+          status: invoice.status,
+          subBrand: invoice.subBrand,
+          customer: contactName,
+          invoiceDate: dateOnly(invoice.createdAt),
+          invoiceTotal,
+        },
+        actual: {
+          status: row.status || null,
+          subBrand: row.subBrand || null,
+          customer: row.customer || null,
+          invoiceDate: row.invoiceDate || null,
+          invoiceTotal: row.invoiceTotal ?? null,
+        },
+        fields: rowMismatches,
+      });
+    }
+  }
+
+  return {
+    totalRows: parsedRows.length,
+    matchedRows,
+    mismatchedRows,
+    missingRows,
+    matchedAmount: Math.round(totalCrmAmount * 100) / 100,
+    workbookAmount: Math.round(totalWorkbookAmount * 100) / 100,
+    discrepancyCount: discrepancies.length,
+    discrepancies,
+  };
+}
+
+module.exports = {
+  isXlsxUpload,
+  parseSpreadsheetBuffer,
+  reconcileRows,
+  normalizeHeader,
+  parseMoney,
+};

--- a/backend/lib/travelTmcCatalogueImport.js
+++ b/backend/lib/travelTmcCatalogueImport.js
@@ -1,0 +1,273 @@
+"use strict";
+
+const { parseCsv, parseXlsxBuffer, toXlsxBuffer } = require("./csvIO");
+const { sanitizeText } = require("./sanitizeJson");
+
+const TEMPLATE_HEADERS = [
+  "tripId",
+  "title",
+  "tagline",
+  "tier",
+  "region",
+  "durationDays",
+  "durationNights",
+  "minGradeBand",
+  "maxGradeBand",
+  "boardsSupportedJson",
+  "minGroupSize",
+  "priceBand",
+  "indicativePricePerStudent",
+  "primaryOutcomesJson",
+  "skillsDevelopedJson",
+  "subjectsTouchedJson",
+  "anchorExperiencesJson",
+  "curriculumHooksJson",
+  "reportSkillBlurb",
+  "summaryForBrief",
+  "imageUrl",
+];
+
+const TEMPLATE_SAMPLE = {
+  tripId: "golden-triangle-school-heritage",
+  title: "Golden Triangle School Heritage Trail",
+  tagline: "Delhi, Agra, and Jaipur as one classroom.",
+  tier: "domestic",
+  region: "North India",
+  durationDays: 6,
+  durationNights: 5,
+  minGradeBand: "6-8",
+  maxGradeBand: "9-10",
+  boardsSupportedJson: "[\"CBSE\",\"ICSE\"]",
+  minGroupSize: 25,
+  priceBand: "30k-75k",
+  indicativePricePerStudent: 55000,
+  primaryOutcomesJson: "[\"cultural-immersion\",\"history-deep-dive\"]",
+  skillsDevelopedJson: "[\"communication\",\"collaboration\"]",
+  subjectsTouchedJson: "[\"History\",\"Geography\",\"Art\"]",
+  anchorExperiencesJson:
+    "[{\"name\":\"Taj Mahal sunrise\",\"what_students_do\":\"Sketching and discussion\",\"skill_link\":\"Cultural respect and inclusion\",\"subject_link\":\"History\"}]",
+  curriculumHooksJson:
+    "[{\"board\":\"CBSE\",\"grade_band\":\"9-10\",\"subject\":\"History\",\"topic\":\"Mughal India\",\"hook_text\":\"Direct alignment with medieval India topics\"}]",
+  reportSkillBlurb:
+    "Students build historical reasoning and cultural fluency through a structured three-city route.",
+  summaryForBrief:
+    "A school-focused heritage circuit that pairs cleanly with CBSE and ICSE middle-school history learning.",
+  imageUrl: "",
+};
+
+const REQUIRED_FIELDS = new Set([
+  "tripId",
+  "title",
+  "tier",
+  "durationDays",
+  "minGradeBand",
+  "maxGradeBand",
+  "boardsSupportedJson",
+  "minGroupSize",
+  "priceBand",
+  "primaryOutcomesJson",
+  "skillsDevelopedJson",
+  "subjectsTouchedJson",
+  "anchorExperiencesJson",
+  "curriculumHooksJson",
+  "reportSkillBlurb",
+  "summaryForBrief",
+]);
+
+const JSON_ARRAY_FIELDS = new Set([
+  "boardsSupportedJson",
+  "primaryOutcomesJson",
+  "skillsDevelopedJson",
+  "subjectsTouchedJson",
+  "anchorExperiencesJson",
+  "curriculumHooksJson",
+]);
+
+const OPTIONAL_NUMERIC_FIELDS = new Set([
+  "durationNights",
+  "indicativePricePerStudent",
+]);
+
+function isXlsxUpload(file) {
+  if (!file) return false;
+  const name = String(file.originalname || "").toLowerCase();
+  if (name.endsWith(".xlsx") || name.endsWith(".xls")) return true;
+  const mt = String(file.mimetype || "").toLowerCase();
+  return (
+    mt === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    mt === "application/vnd.ms-excel"
+  );
+}
+
+function parseSpreadsheetBuffer(buffer, file) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error("parseSpreadsheetBuffer: buffer is required");
+  }
+  return isXlsxUpload(file)
+    ? parseXlsxBuffer(buffer)
+    : parseCsv(buffer.toString("utf8"));
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return "";
+  return String(value).trim();
+}
+
+function parseNumericField(raw, fieldName, { allowZero = false } = {}) {
+  const text = normalizeText(raw);
+  if (!text) {
+    if (OPTIONAL_NUMERIC_FIELDS.has(fieldName)) return null;
+    return { error: `${fieldName} is required` };
+  }
+  const n = Number(text);
+  if (!Number.isInteger(n) || (allowZero ? n < 0 : n <= 0)) {
+    return {
+      error: `${fieldName} must be a ${allowZero ? "non-negative" : "positive"} integer`,
+    };
+  }
+  return n;
+}
+
+function parseJsonArrayField(raw, fieldName) {
+  const text = normalizeText(raw);
+  if (!text) {
+    return { error: `${fieldName} is required` };
+  }
+
+  if (text.startsWith("[") || text.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return JSON.stringify(parsed);
+      }
+      if (parsed && typeof parsed === "object") {
+        return JSON.stringify(parsed);
+      }
+    } catch {
+      return { error: `${fieldName} must be valid JSON or a comma-separated list` };
+    }
+  }
+
+  return JSON.stringify(
+    text
+      .split(",")
+      .map((item) => sanitizeText(item))
+      .filter((item) => item.length > 0),
+  );
+}
+
+function parseCatalogueImportRow(raw, rowNumber) {
+  const errors = [];
+  const data = {};
+
+  for (const field of REQUIRED_FIELDS) {
+    if (normalizeText(raw[field]).length === 0) {
+      errors.push({ rowNumber, reason: `${field} is required` });
+    }
+  }
+
+  const tripId = sanitizeText(normalizeText(raw.tripId));
+  if (tripId) data.tripId = tripId;
+
+  const title = sanitizeText(normalizeText(raw.title));
+  if (title) data.title = title;
+
+  const tagline = normalizeText(raw.tagline);
+  data.tagline = tagline ? sanitizeText(tagline) : null;
+
+  const tier = sanitizeText(normalizeText(raw.tier));
+  if (tier) data.tier = tier;
+
+  const region = normalizeText(raw.region);
+  data.region = region ? sanitizeText(region) : null;
+
+  const durationDays = parseNumericField(raw.durationDays, "durationDays", { allowZero: true });
+  if (durationDays && durationDays.error) errors.push({ rowNumber, reason: durationDays.error });
+  else if (durationDays !== null) data.durationDays = durationDays;
+
+  const durationNights = parseNumericField(raw.durationNights, "durationNights", { allowZero: true });
+  if (durationNights && durationNights.error) errors.push({ rowNumber, reason: durationNights.error });
+  else if (durationNights !== null) data.durationNights = durationNights;
+
+  const minGradeBand = sanitizeText(normalizeText(raw.minGradeBand));
+  if (minGradeBand) data.minGradeBand = minGradeBand;
+
+  const maxGradeBand = sanitizeText(normalizeText(raw.maxGradeBand));
+  if (maxGradeBand) data.maxGradeBand = maxGradeBand;
+
+  const boardsSupportedJson = parseJsonArrayField(raw.boardsSupportedJson, "boardsSupportedJson");
+  if (boardsSupportedJson && boardsSupportedJson.error) errors.push({ rowNumber, reason: boardsSupportedJson.error });
+  else if (boardsSupportedJson !== undefined) data.boardsSupportedJson = boardsSupportedJson;
+
+  const minGroupSize = parseNumericField(raw.minGroupSize, "minGroupSize");
+  if (minGroupSize && minGroupSize.error) errors.push({ rowNumber, reason: minGroupSize.error });
+  else if (minGroupSize !== null) data.minGroupSize = minGroupSize;
+
+  const priceBand = sanitizeText(normalizeText(raw.priceBand));
+  if (priceBand) data.priceBand = priceBand;
+
+  const indicativePricePerStudent = parseNumericField(raw.indicativePricePerStudent, "indicativePricePerStudent", {
+    allowZero: true,
+  });
+  if (indicativePricePerStudent && indicativePricePerStudent.error) {
+    errors.push({ rowNumber, reason: indicativePricePerStudent.error });
+  } else if (indicativePricePerStudent !== null) {
+    data.indicativePricePerStudent = indicativePricePerStudent;
+  }
+
+  for (const field of [
+    "primaryOutcomesJson",
+    "skillsDevelopedJson",
+    "subjectsTouchedJson",
+    "anchorExperiencesJson",
+    "curriculumHooksJson",
+  ]) {
+    const parsed = parseJsonArrayField(raw[field], field);
+    if (parsed && parsed.error) {
+      errors.push({ rowNumber, reason: parsed.error });
+    } else if (parsed !== undefined) {
+      data[field] = parsed;
+    }
+  }
+
+  const reportSkillBlurb = sanitizeText(normalizeText(raw.reportSkillBlurb));
+  if (reportSkillBlurb) data.reportSkillBlurb = reportSkillBlurb;
+
+  const summaryForBrief = sanitizeText(normalizeText(raw.summaryForBrief));
+  if (summaryForBrief) data.summaryForBrief = summaryForBrief;
+
+  const imageUrl = normalizeText(raw.imageUrl);
+  data.imageUrl = imageUrl ? sanitizeText(imageUrl) : null;
+
+  return {
+    errors,
+    data,
+    naturalKey: tripId ? tripId.toLowerCase() : "",
+    reviewLabel: "AI-classified, pending review",
+  };
+}
+
+function buildTemplateBuffer(format) {
+  const rows = [TEMPLATE_SAMPLE];
+  if (format === "xlsx") {
+    return toXlsxBuffer(TEMPLATE_HEADERS, rows, "TMC Catalogue");
+  }
+  const { serializeRows } = require("./csvHelpers");
+  return serializeRows(
+    TEMPLATE_HEADERS.map((header) => ({ key: header, header })),
+    rows,
+  );
+}
+
+module.exports = {
+  TEMPLATE_HEADERS,
+  TEMPLATE_SAMPLE,
+  REQUIRED_FIELDS,
+  isXlsxUpload,
+  parseSpreadsheetBuffer,
+  normalizeText,
+  parseNumericField,
+  parseJsonArrayField,
+  parseCatalogueImportRow,
+  buildTemplateBuffer,
+};

--- a/backend/lib/travelTmcImport.js
+++ b/backend/lib/travelTmcImport.js
@@ -1,0 +1,145 @@
+"use strict";
+
+const { parseCsv, parseXlsxBuffer } = require("./csvIO");
+const { toE164 } = require("../utils/deduplication");
+
+const PARTICIPANT_IMPORT_STATUS = new Set(["pending", "approved", "rejected", "waitlisted"]);
+
+function isXlsxUpload(file) {
+  if (!file) return false;
+  const name = String(file.originalname || "").toLowerCase();
+  if (name.endsWith(".xlsx") || name.endsWith(".xls")) return true;
+  const mt = String(file.mimetype || "").toLowerCase();
+  return (
+    mt === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    mt === "application/vnd.ms-excel"
+  );
+}
+
+function parseSpreadsheetBuffer(buffer, file) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error("parseSpreadsheetBuffer: buffer is required");
+  }
+  return isXlsxUpload(file)
+    ? parseXlsxBuffer(buffer)
+    : parseCsv(buffer.toString("utf8"));
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return "";
+  return String(value).trim();
+}
+
+function normalizeEmail(value) {
+  const text = normalizeText(value);
+  return text ? text.toLowerCase() : "";
+}
+
+function parseDateValue(value) {
+  const text = normalizeText(value);
+  if (!text) return null;
+  const dt = new Date(text);
+  if (!Number.isFinite(dt.getTime())) return { error: `invalid date: ${text}` };
+  return dt;
+}
+
+function normalizeApplicationStatus(value) {
+  const text = normalizeText(value).toLowerCase();
+  if (!text) return null;
+  if (!PARTICIPANT_IMPORT_STATUS.has(text)) {
+    return { error: `applicationStatus must be one of: ${Array.from(PARTICIPANT_IMPORT_STATUS).join(", ")}` };
+  }
+  return text;
+}
+
+function parseParticipantImportRow(raw, rowNumber) {
+  const errors = [];
+  const fullName = normalizeText(raw.fullName || raw.name);
+  if (!fullName) {
+    errors.push({ rowNumber, reason: "fullName is required" });
+  }
+
+  const parentName = normalizeText(raw.parentName);
+  const parentEmail = normalizeEmail(raw.parentEmail);
+
+  let parentPhone = normalizeText(raw.parentPhone);
+  if (parentPhone) {
+    const formatted = toE164(parentPhone);
+    if (!formatted) {
+      errors.push({ rowNumber, reason: "invalid parentPhone" });
+    } else {
+      parentPhone = formatted;
+    }
+  } else {
+    parentPhone = "";
+  }
+
+  let applicationStatus = normalizeApplicationStatus(raw.applicationStatus || raw.status);
+  if (applicationStatus && applicationStatus.error) {
+    errors.push({ rowNumber, reason: applicationStatus.error });
+    applicationStatus = null;
+  }
+
+  const consentCapturedAt = parseDateValue(raw.consentCapturedAt);
+  if (consentCapturedAt && consentCapturedAt.error) {
+    errors.push({ rowNumber, reason: consentCapturedAt.error });
+  }
+  const passportExtractedAt = parseDateValue(raw.passportExtractedAt);
+  if (passportExtractedAt && passportExtractedAt.error) {
+    errors.push({ rowNumber, reason: passportExtractedAt.error });
+  }
+  const passportVerifiedAt = parseDateValue(raw.passportVerifiedAt);
+  if (passportVerifiedAt && passportVerifiedAt.error) {
+    errors.push({ rowNumber, reason: passportVerifiedAt.error });
+  }
+  const passportRejectedAt = parseDateValue(raw.passportRejectedAt);
+  if (passportRejectedAt && passportRejectedAt.error) {
+    errors.push({ rowNumber, reason: passportRejectedAt.error });
+  }
+  const passportExpiry = parseDateValue(raw.passportExpiry);
+  if (passportExpiry && passportExpiry.error) {
+    errors.push({ rowNumber, reason: passportExpiry.error });
+  }
+
+  const aadhaarLast4 = normalizeText(raw.aadhaarLast4);
+  if (aadhaarLast4 && !/^\d{4}$/.test(aadhaarLast4)) {
+    errors.push({ rowNumber, reason: "aadhaarLast4 must be exactly 4 digits" });
+  }
+
+  const data = {};
+  if (fullName) data.fullName = fullName;
+  if (parentName) data.parentName = parentName;
+  if (parentPhone) data.parentPhone = parentPhone;
+  if (parentEmail) data.parentEmail = parentEmail;
+  if (applicationStatus) data.applicationStatus = applicationStatus;
+  if (consentCapturedAt && !consentCapturedAt.error) data.consentCapturedAt = consentCapturedAt;
+  if (passportExtractedAt && !passportExtractedAt.error) data.passportExtractedAt = passportExtractedAt;
+  if (passportVerifiedAt && !passportVerifiedAt.error) data.passportVerifiedAt = passportVerifiedAt;
+  if (passportRejectedAt && !passportRejectedAt.error) data.passportRejectedAt = passportRejectedAt;
+  if (passportExpiry && !passportExpiry.error) data.passportExpiry = passportExpiry;
+  if (aadhaarLast4) data.aadhaarLast4 = aadhaarLast4;
+  if (normalizeText(raw.passportNumber)) data.passportNumber = normalizeText(raw.passportNumber);
+  if (normalizeText(raw.passportDocId)) data.passportDocId = normalizeText(raw.passportDocId);
+  if (normalizeText(raw.medicalNotes)) data.medicalNotes = normalizeText(raw.medicalNotes);
+  if (normalizeText(raw.reviewNotes)) data.reviewNotes = normalizeText(raw.reviewNotes);
+
+  return {
+    errors,
+    data,
+    naturalKey: [
+      fullName.toLowerCase(),
+      parentPhone || "",
+      parentEmail || "",
+    ].join("|"),
+  };
+}
+
+module.exports = {
+  isXlsxUpload,
+  parseSpreadsheetBuffer,
+  normalizeText,
+  normalizeEmail,
+  parseDateValue,
+  normalizeApplicationStatus,
+  parseParticipantImportRow,
+};

--- a/backend/routes/landing_pages.js
+++ b/backend/routes/landing_pages.js
@@ -2683,6 +2683,33 @@ async function applyLeadRouting(formProps, tenantId, contactId) {
   }
   return null;
 }
+function extractLeadFieldsFromSubmission(req, page) {
+  const formFields = (req.body && typeof req.body.fields === "object" && req.body.fields) ? req.body.fields : {};
+  const pick = (key) => {
+    const value = formFields[key] !== undefined ? formFields[key] : req.body[key];
+    if (value === undefined || value === null) return null;
+    return typeof value === "string" ? value.trim() : value;
+  };
+
+  const email = pick("email") || pick("parentEmail") || pick("parent_email");
+  const firstName = pick("first_name") || pick("firstName");
+  const lastName = pick("last_name") || pick("lastName");
+  const splitName = [firstName, lastName].filter(Boolean).join(" ").trim();
+  const name = pick("name") || pick("parentName") || pick("parent_name") || pick("full_name") || pick("fullName") || splitName;
+  const phone = pick("phone") || pick("phone_number") || pick("phoneNumber") || pick("mobile") || pick("parentPhone") || pick("parent_phone");
+  const company = pick("company") || pick("companyName") || pick("company_name") || pick("studentSchool") || pick("student_school") || pick("school");
+  const serviceInterest = pick("service_interest") || pick("serviceInterest") || pick("service") || pick("treatmentOfInterest");
+
+  return {
+    formFields,
+    email,
+    phone,
+    company,
+    serviceInterest,
+    contactEmail: email || `lp-${page.slug}-${Date.now()}@anonymous.local`,
+    contactName: name || pick("studentName") || pick("student_name") || "Landing Page Lead",
+  };
+}
 
 // Resolves the registration-mode marker for the form block being
 // submitted. Two sources:
@@ -2975,23 +3002,12 @@ router.post("/:id/submit", verifyToken, express.json(), async (req, res) => {
       }
     }
 
-    // Extract form fields (supports both nested and flat structures)
-    const formFields = (req.body && typeof req.body.fields === "object" && req.body.fields) ? req.body.fields : {};
-    const pick = (key) => formFields[key] || req.body[key] || null;
-
-    const email = pick("email") || pick("parentEmail") || pick("parent_email");
-    const name = pick("name") || pick("parentName") || pick("parent_name") || pick("full_name") || pick("fullName");
-    const full_name = pick("full_name") || pick("fullName");
-    const phone = pick("phone") || pick("parentPhone") || pick("parent_phone");
-    const company = pick("company") || pick("companyName") || pick("company_name") || pick("studentSchool") || pick("student_school") || pick("school");
-    const company_name = pick("company_name") || pick("companyName");
-
+    // Extract form fields (supports nested `fields` and flat payloads).
+    const { formFields, phone, company, serviceInterest, contactEmail, contactName } = extractLeadFieldsFromSubmission(req, page);
     if (!isValidPhoneOrEmpty(phone)) {
       return res.status(400).json({ error: "Please enter a valid phone number (digits only, 10–15 digits)", code: "INVALID_PHONE" });
     }
 
-    const contactEmail = email || `lp-${page.slug}-${Date.now()}@anonymous.local`;
-    const contactName = name || full_name || pick("studentName") || pick("student_name") || "Landing Page Lead";
     const sourceSuffix = submittedAudience ? ` (${submittedAudience})` : "";
     const attributionLabel = `Landing Page: ${page.title}${sourceSuffix}`;
 
@@ -3006,17 +3022,22 @@ router.post("/:id/submit", verifyToken, express.json(), async (req, res) => {
       where: { email_tenantId: { email: contactEmail, tenantId } },
       update: {
         source: contactSource,
+        name: contactName,
+        phone: phone || null,
+        company: company || null,
+        treatmentOfInterest: serviceInterest || null,
         deletedAt: null,
       },
       create: {
         name: contactName,
         email: contactEmail,
         phone: phone || null,
-        company: company || company_name || null,
+        company: company || null,
         status: "Lead",
         source: contactSource,
         firstTouchSource: attributionLabel,
         subBrand: page.subBrand || (typeof req.body.subBrand === "string" ? req.body.subBrand : null),
+        treatmentOfInterest: serviceInterest || null,
         aiScore: 30,
         tenantId,
       },
@@ -3103,30 +3124,13 @@ publicRouter.post("/:slug/submit", express.json(), async (req, res) => {
       }
     }
 
-    // The Wanderlux template sends form values nested under `fields`
-    // (multi-step form aggregates all step inputs there); the older
-    // single-block form types post flat. Read from `fields` first so
-    // Wanderlux submissions land with real contact info instead of
-    // the anonymous `lp-{slug}-{ts}@anonymous.local` fallback. Falls
-    // back to the flat shape for back-compat with the older types.
-    const formFields = (req.body && typeof req.body.fields === "object" && req.body.fields) ? req.body.fields : {};
-    const pick = (key) => formFields[key] || req.body[key] || null;
-    // Student programmes capture the PARENT as the lead contact (the
-    // person we'll actually call back); student details land in the
-    // contact's notes / source so the sales team has the full picture.
-    const email = pick("email") || pick("parentEmail") || pick("parent_email");
-    const name = pick("name") || pick("parentName") || pick("parent_name") || pick("full_name") || pick("fullName");
-    const full_name = pick("full_name") || pick("fullName");
-    const phone = pick("phone") || pick("parentPhone") || pick("parent_phone");
-    const company = pick("company") || pick("companyName") || pick("company_name") || pick("studentSchool") || pick("student_school") || pick("school");
-    const company_name = pick("company_name") || pick("companyName");
-
+    // The generated wellness form posts first_name / last_name / service_interest;
+    // travel templates may post nested `fields` or parent/student aliases.
+    const { formFields, phone, company, serviceInterest, contactEmail, contactName } = extractLeadFieldsFromSubmission(req, page);
     if (!isValidPhoneOrEmpty(phone)) {
       return res.status(400).json({ error: "Please enter a valid phone number (digits only, 10–15 digits)", code: "INVALID_PHONE" });
     }
 
-    const contactEmail = email || `lp-${page.slug}-${Date.now()}@anonymous.local`;
-    const contactName = name || full_name || pick("studentName") || pick("student_name") || "Landing Page Lead";
     // Append the audience tag to the descriptive attribution so lead-routing
     // rules + manual triage can branch on it (e.g. "Landing Page: Bali
     // (tmc)" vs "Landing Page: Bali (rfu)"). Only appends when the body
@@ -3162,17 +3166,22 @@ publicRouter.post("/:slug/submit", express.json(), async (req, res) => {
         // new deal visible in leads lists. Without this, a visitor who registers,
         // gets deleted, then re-registers with the same email would match the
         // tombstoned row and the lead would stay hidden.
+        name: contactName,
+        phone: phone || null,
+        company: company || null,
+        treatmentOfInterest: serviceInterest || null,
         deletedAt: null,
       },
       create: {
         name: contactName,
         email: contactEmail,
         phone: phone || null,
-        company: company || company_name || null,
+        company: company || null,
         status: "Lead",
         source: contactSource,
         firstTouchSource: attributionLabel,
         subBrand: page.subBrand || (typeof req.body.subBrand === "string" ? req.body.subBrand : null),
+        treatmentOfInterest: serviceInterest || null,
         aiScore: 30,
         tenantId,
       },

--- a/backend/routes/landing_sites.js
+++ b/backend/routes/landing_sites.js
@@ -66,7 +66,7 @@ router.get('/sectors', verifyToken, async (_req, res) => {
 
 router.post('/generate', verifyToken, async (req, res) => {
   try {
-    const { sectorKey, sectorLabel, campaignName, campaignGoal, businessName, audience, location, tone, ctaText, imageMode, autoCreate = true } = req.body || {};
+    const { sectorKey, sectorLabel, campaignName, campaignGoal, businessName, audience, location, eventDate, eventTime, eventLocation, tone, ctaText, imageMode, autoCreate = true } = req.body || {};
     const normalizedSector = normalizeSectorKey(sectorKey);
     const result = await generateLandingSiteContent({
       tenantId: req.user.tenantId,
@@ -77,6 +77,9 @@ router.post('/generate', verifyToken, async (req, res) => {
       businessName,
       audience,
       location,
+      eventDate,
+      eventTime,
+      eventLocation,
       tone,
       ctaText,
       imageMode,

--- a/backend/routes/travel_invoices.js
+++ b/backend/routes/travel_invoices.js
@@ -18,6 +18,7 @@
  */
 
 const express = require("express");
+const multer = require("multer");
 const router = express.Router();
 const { verifyToken, verifyRole } = require("../middleware/auth");
 const { requirePermission } = require("../middleware/requirePermission");
@@ -89,10 +90,20 @@ const {
   buildCaCsv: buildTravelCaCsv,
   buildAccountingXlsx: buildTravelAccountingXlsx,
 } = require("../lib/travelAccountingExport");
+const {
+  parseSpreadsheetBuffer: parseInvoiceReconciliationSpreadsheet,
+  reconcileRows: reconcileInvoiceRows,
+  normalizeHeader: normalizeInvoiceHeader,
+  normalizeText: normalizeInvoiceText,
+} = require("../lib/travelInvoiceReconciliation");
 // Sub-brand → legal-entity / GSTIN resolution (Q21 config blob on Tenant).
 const { resolveForSubBrand } = require("../lib/subBrandConfig");
 
 const VALID_INVOICE_STATUSES = ["Draft", "Issued", "Partial", "Paid", "Voided"];
+const invoiceReconcileUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
 
 // Arc 2 #901 slice 11 — PRD_TRAVEL_BILLING FR-3.x doc-type taxonomy.
 // Travel verticals need to issue more than just a "TaxInvoice": Proforma
@@ -479,6 +490,99 @@ router.get(
       }
       console.error("[travel-invoices] list error:", e.message);
       res.status(500).json({ error: "Failed to list invoices" });
+    }
+  },
+);
+
+// POST /api/travel/invoices/reconcile/excel-software
+// Read-only reconciliation preview for workbook rows exported from the
+// accounting.xlsx bridge. The route never mutates CRM records; it only
+// compares uploaded rows against the current tenant invoices and returns a
+// discrepancy report so the operator can reconcile off-platform without any
+// DB risk.
+router.post(
+  "/invoices/reconcile/excel-software",
+  verifyToken,
+  verifyRole(["ADMIN", "MANAGER"]),
+  requireTravelTenant,
+  invoiceReconcileUpload.single("file"),
+  async (req, res) => {
+    try {
+      if (!req.file || !req.file.buffer || req.file.buffer.length === 0) {
+        return res.status(400).json({ error: "file field required (multipart)", code: "FILE_REQUIRED" });
+      }
+
+      let parsed;
+      try {
+        parsed = parseInvoiceReconciliationSpreadsheet(req.file.buffer, req.file);
+      } catch (parseErr) {
+        return res.status(400).json({ error: parseErr.message, code: "INVALID_FILE" });
+      }
+
+      const rows = Array.isArray(parsed.rows) ? parsed.rows : [];
+      if (rows.length === 0) {
+        return res.status(400).json({ error: "file is empty", code: "EMPTY_FILE" });
+      }
+
+      const invoiceNums = new Set();
+      for (const raw of rows) {
+        const mapped = {};
+        for (const [key, value] of Object.entries(raw || {})) {
+          mapped[normalizeInvoiceHeader(key)] = value;
+        }
+        const invoiceNum = normalizeInvoiceText(
+          mapped.invoicenumber ||
+          mapped.invoicenum ||
+          mapped.vouchernumber ||
+          mapped.invoiceid,
+        );
+        if (invoiceNum && invoiceNum.toLowerCase() !== "total") {
+          invoiceNums.add(invoiceNum.toUpperCase());
+        }
+      }
+      if (invoiceNums.size === 0) {
+        return res.status(400).json({ error: "No invoice numbers found in file", code: "MISSING_FIELDS" });
+      }
+
+      const where = {
+        tenantId: req.travelTenant.id,
+        invoiceNum: { in: Array.from(invoiceNums) },
+      };
+      if (req.query.subBrand) {
+        assertValidSubBrand(String(req.query.subBrand));
+        where.subBrand = String(req.query.subBrand);
+      }
+
+      const invoices = await prisma.travelInvoice.findMany({
+        where,
+        select: {
+          id: true,
+          invoiceNum: true,
+          totalAmount: true,
+          status: true,
+          subBrand: true,
+          contactId: true,
+          createdAt: true,
+        },
+      });
+      const contactIds = [...new Set(invoices.map((inv) => inv.contactId).filter((id) => Number.isFinite(Number(id))))];
+      const contacts = contactIds.length > 0
+        ? await prisma.contact.findMany({
+            where: { tenantId: req.travelTenant.id, id: { in: contactIds.map((id) => Number(id)) } },
+            select: { id: true, name: true },
+          })
+        : [];
+      const contactsById = Object.fromEntries(contacts.map((c) => [c.id, c]));
+
+      const report = reconcileInvoiceRows({ rows, invoices, contactsById });
+      report.scannedInvoices = invoices.length;
+      report.subBrand = req.query.subBrand ? String(req.query.subBrand) : null;
+
+      res.status(200).json(report);
+    } catch (e) {
+      if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+      console.error("[travel-invoices] excel-software reconciliation error:", e.message);
+      res.status(500).json({ error: "Failed to reconcile workbook" });
     }
   },
 );

--- a/backend/routes/travel_tmc_catalogue.js
+++ b/backend/routes/travel_tmc_catalogue.js
@@ -85,11 +85,17 @@
  */
 
 const express = require("express");
+const multer = require("multer");
 const router = express.Router();
 const { verifyToken, verifyRole } = require("../middleware/auth");
 const { requirePermission } = require("../middleware/requirePermission");
 const prisma = require("../lib/prisma");
 const { sanitizeText } = require("../lib/sanitizeJson");
+const {
+  parseSpreadsheetBuffer,
+  parseCatalogueImportRow,
+  buildTemplateBuffer,
+} = require("../lib/travelTmcCatalogueImport");
 
 // PRD §3.2 + schema default — every catalogue row is created archived; only
 // /promote-to-active (senior-role) flips it to active.
@@ -97,6 +103,11 @@ const STATUS_ACTIVE = "active";
 const STATUS_ARCHIVED = "archived";
 const VALID_STATUSES = new Set([STATUS_ACTIVE, STATUS_ARCHIVED]);
 const VALID_STATUS_FILTERS = new Set([STATUS_ACTIVE, STATUS_ARCHIVED, "all"]);
+
+const catalogueImportUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
 
 // JSON-string columns (Prisma `String @db.Text` storing JSON arrays).
 const JSON_ARRAY_FIELDS = [
@@ -344,6 +355,141 @@ router.post(
       if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
       console.error("[travel-tmc-catalogue] create error:", e.message);
       res.status(500).json({ error: "Failed to create catalogue entry" });
+    }
+  },
+);
+
+// ?????????????????????????????????????????????????????????????????????
+// GET /api/travel-tmc-catalogue/import-template
+//
+// Downloadable master template for the bulk import flow. The import route
+// expects the same field order as TEMPLATE_HEADERS, with the server forcing
+// review status on ingest so the file does not need a status column.
+// ?????????????????????????????????????????????????????????????????????
+router.get(
+  "/import-template",
+  verifyToken,
+  requirePermission("tmc_catalogue", "read"),
+  async (req, res) => {
+    try {
+      const format = (req.query.format || "csv").toString().toLowerCase();
+      if (format !== "csv" && format !== "xlsx") {
+        return res.status(400).json({ error: "format must be csv or xlsx", code: "INVALID_FORMAT" });
+      }
+      if (format === "xlsx") {
+        const buf = buildTemplateBuffer("xlsx");
+        res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        res.setHeader("Content-Disposition", 'attachment; filename="tmc-catalogue-template.xlsx"');
+        return res.end(buf);
+      }
+      const csv = buildTemplateBuffer("csv");
+      res.setHeader("Content-Type", "text/csv; charset=utf-8");
+      res.setHeader("Content-Disposition", 'attachment; filename="tmc-catalogue-template.csv"');
+      return res.end(csv);
+    } catch (e) {
+      console.error("[travel-tmc-catalogue] template error:", e.message);
+      res.status(500).json({ error: "Failed to build import template" });
+    }
+  },
+);
+
+// ?????????????????????????????????????????????????????????????????????
+// POST /api/travel-tmc-catalogue/import
+//
+// Bulk upload via CSV/XLSX. New rows land archived (review-pending) and
+// the response labels them as AI-classified so the UI can surface the
+// review queue immediately after ingest.
+// ?????????????????????????????????????????????????????????????????????
+const MAX_IMPORT_ROWS = 5000;
+router.post(
+  "/import",
+  verifyToken,
+  requirePermission("tmc_catalogue", "write"),
+  catalogueImportUpload.single("file"),
+  async (req, res) => {
+    try {
+      if (!req.file || !req.file.buffer || req.file.buffer.length === 0) {
+        return res.status(400).json({ error: "No CSV/Excel file uploaded", code: "NO_FILE" });
+      }
+      const parsed = parseSpreadsheetBuffer(req.file.buffer, req.file);
+      const rows = Array.isArray(parsed?.rows) ? parsed.rows : [];
+      if (rows.length === 0) {
+        return res.status(400).json({ error: "Spreadsheet is empty", code: "EMPTY_FILE" });
+      }
+      if (rows.length > MAX_IMPORT_ROWS) {
+        return res.status(413).json({ error: `Too many rows. Max ${MAX_IMPORT_ROWS}`, code: "TOO_MANY_ROWS" });
+      }
+
+      const errors = [];
+      const createdTripIds = [];
+      const updatedTripIds = [];
+      let imported = 0;
+      let updated = 0;
+      let skipped = 0;
+
+      for (let i = 0; i < rows.length; i += 1) {
+        const rowNumber = i + 2;
+        try {
+          const parsedRow = parseCatalogueImportRow(rows[i], rowNumber);
+          if (parsedRow.errors && parsedRow.errors.length > 0) {
+            errors.push(...parsedRow.errors);
+            skipped += 1;
+            continue;
+          }
+          const data = parsedRow.data || {};
+          const tripId = String(data.tripId || "").trim();
+          if (!tripId) {
+            errors.push({ rowNumber, reason: "tripId is required" });
+            skipped += 1;
+            continue;
+          }
+
+          const existing = await prisma.tmcTripCatalogue.findFirst({
+            where: { tenantId: req.user.tenantId, tripId },
+          });
+
+          if (existing) {
+            await prisma.tmcTripCatalogue.update({
+              where: { id: existing.id },
+              data: {
+                ...data,
+                status: existing.status || STATUS_ARCHIVED,
+              },
+            });
+            updated += 1;
+            updatedTripIds.push(tripId);
+          } else {
+            await prisma.tmcTripCatalogue.create({
+              data: {
+                ...data,
+                tenantId: req.user.tenantId,
+                status: STATUS_ARCHIVED,
+              },
+            });
+            imported += 1;
+            createdTripIds.push(tripId);
+          }
+        } catch (rowErr) {
+          skipped += 1;
+          errors.push({ rowNumber, reason: rowErr.message });
+        }
+      }
+
+      const reviewLabel = createdTripIds.length > 0 ? "AI-classified, pending review" : "Imported";
+      res.json({
+        imported,
+        updated,
+        skipped,
+        total: rows.length,
+        createdTripIds,
+        updatedTripIds,
+        reviewLabel,
+        errors,
+      });
+    } catch (e) {
+      if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+      console.error("[travel-tmc-catalogue] import error:", e.message);
+      res.status(500).json({ error: "Failed to import catalogue" });
     }
   },
 );

--- a/backend/routes/travel_trips.js
+++ b/backend/routes/travel_trips.js
@@ -41,6 +41,7 @@
 // stored (Q14 + Aadhaar Act §29 — see TRAVEL_CRM_RISKS.md R8).
 
 const express = require("express");
+const multer = require("multer");
 const router = express.Router();
 const { verifyToken, verifyRole } = require("../middleware/auth");
 const { requirePermission } = require("../middleware/requirePermission");
@@ -52,8 +53,16 @@ const visaDocStore = require("../lib/visaDocStore");
 const passportOcrClient = require("../services/passportOcrClient");
 const listProjection = require("../lib/listProjection");
 const { toE164 } = require("../utils/deduplication");
+const {
+  parseSpreadsheetBuffer,
+  parseParticipantImportRow,
+} = require("../lib/travelTmcImport");
 
 const VALID_TRIP_STATUSES = ["confirmed", "in-trip", "completed", "cancelled"];
+const tripImportUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
 
 // TMC-only access guard. Trips ARE tmc-only, so we just check that "tmc"
 // is in the allowed set (or that the user has full access).
@@ -1539,6 +1548,119 @@ async function loadTrip(req) {
   }
   return trip;
 }
+
+const PARTICIPANT_IMPORT_MAX_ROWS = 5000;
+
+// POST /api/travel/trips/:id/participants/import
+// Additive bulk import for TMC rosters / historical participant sheets.
+// Rows are upserted by a conservative natural key (fullName + parentPhone
+// + parentEmail) and never delete existing participants. Blank cells do not
+// clear stored values on update, so a partially-filled workbook cannot lose
+// data already captured in CRM.
+router.post(
+  "/trips/:id/participants/import",
+  verifyToken,
+  requireTravelTenant,
+  requireTmcAccess,
+  tripImportUpload.single("file"),
+  async (req, res) => {
+    try {
+      const trip = await loadTrip(req);
+      if (!req.file || !req.file.buffer || req.file.buffer.length === 0) {
+        return res.status(400).json({ error: "file field required (multipart)", code: "FILE_REQUIRED" });
+      }
+
+      let parsed;
+      try {
+        parsed = parseSpreadsheetBuffer(req.file.buffer, req.file);
+      } catch (parseErr) {
+        return res.status(400).json({ error: parseErr.message, code: "INVALID_FILE" });
+      }
+
+      const rows = Array.isArray(parsed.rows) ? parsed.rows : [];
+      if (rows.length === 0) {
+        return res.status(400).json({ error: "file is empty", code: "EMPTY_FILE" });
+      }
+      if (rows.length > PARTICIPANT_IMPORT_MAX_ROWS) {
+        return res.status(413).json({
+          error: `Too many rows. Max ${PARTICIPANT_IMPORT_MAX_ROWS}`,
+          code: "TOO_MANY_ROWS",
+        });
+      }
+
+      const seen = new Map();
+      const errors = [];
+      let inserted = 0;
+      let updated = 0;
+      let skipped = 0;
+
+      for (let i = 0; i < rows.length; i += 1) {
+        const raw = rows[i] || {};
+        const rowNumber = raw.__row || i + 2;
+        const parsedRow = parseParticipantImportRow(raw, rowNumber);
+        if (parsedRow.errors.length > 0) {
+          errors.push(...parsedRow.errors.map((err) => ({ row: err.rowNumber || rowNumber, reason: err.reason })));
+          skipped += 1;
+          continue;
+        }
+        if (seen.has(parsedRow.naturalKey)) {
+          errors.push({ row: rowNumber, reason: `duplicate of row ${seen.get(parsedRow.naturalKey)} (same natural key)` });
+          skipped += 1;
+          continue;
+        }
+        seen.set(parsedRow.naturalKey, rowNumber);
+
+        const existing = await prisma.tripParticipant.findFirst({
+          where: {
+            tripId: trip.id,
+            fullName: parsedRow.data.fullName,
+            parentPhone: parsedRow.data.parentPhone || null,
+            parentEmail: parsedRow.data.parentEmail || null,
+          },
+          select: { id: true },
+        });
+
+        if (existing) {
+          const data = {};
+          for (const [key, value] of Object.entries(parsedRow.data)) {
+            if (value === undefined || value === null || value === "") continue;
+            data[key] = value;
+          }
+          if (Object.keys(data).length === 0) {
+            skipped += 1;
+            continue;
+          }
+          await prisma.tripParticipant.update({
+            where: { id: existing.id },
+            data,
+          });
+          updated += 1;
+        } else {
+          await prisma.tripParticipant.create({
+            data: {
+              tenantId: req.travelTenant.id,
+              tripId: trip.id,
+              ...parsedRow.data,
+            },
+          });
+          inserted += 1;
+        }
+      }
+
+      res.status(200).json({
+        inserted,
+        updated,
+        skipped,
+        errors,
+        total: rows.length,
+      });
+    } catch (e) {
+      if (e.status) return res.status(e.status).json({ error: e.message, code: e.code });
+      console.error("[travel-trips] participant import error:", e.message);
+      res.status(500).json({ error: "Failed to import participants" });
+    }
+  },
+);
 
 // GET /api/travel/trips/:id/participants
 //

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -36,6 +36,7 @@ const {
   applyRupeeCapableFonts,
 } = require("../services/pdfRenderer");
 const { writeAudit, diffFields } = require("../lib/audit");
+const { sanitizeText } = require("../lib/sanitizeJson");
 const { sendEmail } = require("../lib/emailSender");
 const waWebClient = require("../services/whatsappWebClient");
 // #920 slice S42  wellness PHI list-endpoint slim projections.
@@ -106,6 +107,7 @@ const {
   requirePermission,
   userHasPermission,
 } = require("../middleware/requirePermission");
+const { findDuplicateContactFull } = require("../utils/deduplication");
 // #920 slice S59  canonical PHI-read gate factory. The original inline
 // declaration of `phiReadGate` (which lived just below the `phiReadGate`
 // JSDoc block ~line 365) has been replaced with this factory call so the
@@ -10969,6 +10971,117 @@ router.get("/prescriptions/:id/pdf", async (req, res) => {
 // renders an explanatory empty state ("Your patient profile isn't
 // linked yet  ask your clinic to link it") rather than treating
 // missing-link as an error.
+const _publicEnquiryIpMax = process.env.NODE_ENV === "test" ? 5000 : 20;
+const publicEnquiryLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: _publicEnquiryIpMax,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  keyGenerator: (req, res) => ipKeyGenerator(req, res),
+  message: {
+    error: "Too many enquiry requests from this network. Please try again in a minute.",
+    code: "RATE_LIMITED",
+  },
+});
+
+const cleanPublicLeadText = (value, maxLen = 191) => {
+  if (value == null) return "";
+  return sanitizeText(String(value)).trim().slice(0, maxLen);
+};
+
+const buildPublicLeadNote = ({ service, message }) => {
+  const parts = [
+    "Website enquiry",
+    service ? `Service: ${service}` : null,
+    message ? `Message: ${message}` : null,
+  ].filter(Boolean);
+  return parts.join(" | ");
+};
+
+router.post("/public/enquiry", publicEnquiryLimiter, async (req, res) => {
+  try {
+    const tenantSlug = cleanPublicLeadText(req.body?.tenantSlug, 80);
+    const firstName = cleanPublicLeadText(req.body?.firstName, 80);
+    const lastName = cleanPublicLeadText(req.body?.lastName, 80);
+    const bodyName = cleanPublicLeadText(req.body?.name, 160);
+    const name = bodyName || [firstName, lastName].filter(Boolean).join(" ").trim();
+    const email = cleanPublicLeadText(req.body?.email, 191);
+    const phone = cleanPublicLeadText(req.body?.phone, 24);
+    const service = cleanPublicLeadText(req.body?.service, 120);
+    const message = cleanPublicLeadText(req.body?.message, 2000);
+
+    if (!tenantSlug) {
+      return res.status(400).json({ error: "tenantSlug is required", code: "MISSING_TENANT" });
+    }
+    if (!name) {
+      return res.status(400).json({ error: "name is required", code: "MISSING_NAME" });
+    }
+    if (!email && !phone) {
+      return res.status(400).json({ error: "email or phone is required", code: "INSUFFICIENT_IDENTITY" });
+    }
+    if (phone && !/^(?:\+?91)?[6-9]\d{9}$/.test(phone.replace(/[\s-]/g, ""))) {
+      return res.status(400).json({ error: "phone must be a 10-digit Indian mobile number", code: "INVALID_PHONE" });
+    }
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return res.status(400).json({ error: "email is not a valid format", code: "INVALID_EMAIL" });
+    }
+
+    const tenant = await prisma.tenant.findUnique({
+      where: { slug: tenantSlug },
+      select: { id: true, slug: true, vertical: true, name: true },
+    });
+    if (!tenant || tenant.vertical !== "wellness") {
+      return res.status(404).json({ error: "Clinic not found", code: "TENANT_NOT_FOUND" });
+    }
+
+    const syntheticEmail = email || `wellness-enquiry-${tenant.slug}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@inbound.local`;
+    const note = buildPublicLeadNote({ service, message });
+
+    const duplicate = await findDuplicateContactFull({
+      email: email || null,
+      phone: phone || null,
+      tenantId: tenant.id,
+    });
+
+    if (duplicate) {
+      const existing = duplicate.contact;
+      const nextDescription = [existing.description, note].filter(Boolean).join("\n\n") || note;
+      await prisma.contact.update({
+        where: { id: existing.id },
+        data: {
+          status: "Lead",
+          name: existing.name || name,
+          email: existing.email || syntheticEmail,
+          phone: existing.phone || phone || null,
+          firstTouchSource: existing.firstTouchSource || "Dr. Enhance Wellness website enquiry",
+          description: nextDescription,
+        },
+      });
+      return res.json({ created: false, duplicate: true, contactId: existing.id, message: "Thanks - we'll be in touch shortly." });
+    }
+
+    const contact = await prisma.contact.create({
+      data: {
+        tenantId: tenant.id,
+        name,
+        email: syntheticEmail,
+        phone: phone || null,
+        status: "Lead",
+        source: "website",
+        firstTouchSource: "Dr. Enhance Wellness website enquiry",
+        description: note,
+        aiScore: 30,
+        aiScoreLastComputedAt: new Date(),
+      },
+    });
+
+    return res.status(201).json({ created: true, contactId: contact.id, message: "Thanks - we'll be in touch shortly." });
+  } catch (e) {
+    console.error("[wellness] public enquiry error:", e.message);
+    res.status(500).json({ error: "Failed to submit enquiry" });
+  }
+});
+
 router.get(
   "/my-prescriptions",
   requirePermission("my_prescriptions", "read"),

--- a/backend/server.js
+++ b/backend/server.js
@@ -157,6 +157,8 @@ const ALLOWED_ORIGINS = [
   // never gets to run.
   "http://127.0.0.1:5173",
   "http://127.0.0.1:5000",
+  "http://localhost:8000",
+  "http://127.0.0.1:8000",
   "https://globuscrm.globussoft.com",
   // Dr. Haror's external marketing site — consumes the public wellness
   // catalog + payment endpoints (POST /api/wellness/public/payment/order +
@@ -957,6 +959,7 @@ app.use("/api", (req, res, next) => {
     "/terms-and-conditions",
     "/legal",
     "/landing-pages/public",
+    "/landing-sites/public",
     "/landing-pages/wanderlux-static",
     "/brochure-assets",
     // Diagnostic PDFs are public by design (PRD §4.2) — the unguessable

--- a/backend/services/landingPageRenderer.js
+++ b/backend/services/landingPageRenderer.js
@@ -125,24 +125,38 @@ function renderComponent(component, slug) {
       const level = props.level || "h1";
       const align = props.align || "left";
       const color = props.color || "#1a1a1a";
-      return `<${level} style="color:${color};text-align:${align};margin:0 0 16px;">${escapeHtml(props.text || "")}</${level}>`;
+      const variant = props.variant || "";
+      let extra = "";
+      if (variant === "wellness-logo") extra = "font-size:0.92rem;text-transform:uppercase;letter-spacing:0.08em;font-weight:700;margin:0;";
+      else if (variant === "wellness-display") extra = "font-size:clamp(2rem,5vw,3.4rem);line-height:1.05;font-weight:800;margin:0 0 16px;";
+      else if (variant === "wellness-section-title" || variant === "wellness-card-title") extra = `font-size:${variant === "wellness-card-title" ? "1.25rem" : "1.35rem"};font-weight:800;margin:0 0 10px;`;
+      return `<${level} style="color:${color};text-align:${align};margin:0 0 16px;${extra}">${escapeHtml(props.text || "")}</${level}>`;
     }
 
     case "text": {
       const align = props.align || "left";
       const color = props.color || "#444";
       const fontSize = props.fontSize || "16px";
-      return `<p style="color:${color};text-align:${align};font-size:${fontSize};line-height:1.6;margin:0 0 16px;">${escapeHtml(props.text || "")}</p>`;
+      const variant = props.variant || "";
+      let extra = "";
+      let finalColor = color;
+      if (variant === "wellness-nav") extra = "text-transform:uppercase;letter-spacing:0.16em;font-weight:700;margin:10px 0 0;";
+      else if (variant === "wellness-eyebrow") extra = "text-transform:uppercase;letter-spacing:0.14em;font-weight:700;margin:0 0 14px;";
+      else if (variant === "wellness-detail") extra = "margin:0 0 10px;line-height:1.45;";
+      else if (variant === "wellness-footer") { extra = "margin:0;padding:22px 24px;background:#202a27;text-transform:uppercase;letter-spacing:0.04em;font-weight:700;"; finalColor = "#ffffff"; }
+      return `<p style="color:${finalColor};text-align:${align};font-size:${fontSize};line-height:1.6;margin:0 0 16px;${extra}">${escapeHtml(props.text || "")}</p>`;
     }
 
     case "image": {
       const width = props.width || "100%";
       const maxWidth = props.maxWidth || "100%";
       const alt = escapeHtml(props.alt || "");
-      // #447: scheme-allowlist via safeUrl before escapeHtml. Modern browsers
-      // don't execute javascript: on <img> but sanitization here is
-      // defense-in-depth — same string can flow into other sinks.
-      return `<div style="text-align:center;margin:0 0 16px;"><img src="${escapeHtml(safeUrl(props.src, 'image-src'))}" alt="${alt}" style="width:${width};max-width:${maxWidth};height:auto;border-radius:8px;" /></div>`;
+      const isWellnessEventImage = props.variant === "wellness-event-image";
+      const wrapperMargin = isWellnessEventImage ? "0" : "0 0 16px";
+      const height = isWellnessEventImage ? "height:330px;object-fit:cover;" : "height:auto;";
+      const radius = isWellnessEventImage ? "18px" : "8px";
+      const border = isWellnessEventImage ? "border:1px solid #d8d2c3;background:#f4f1e8;box-shadow:0 18px 45px rgba(31,47,44,0.12);" : "";
+      return `<div style="text-align:center;margin:${wrapperMargin};"><img src="${escapeHtml(safeUrl(props.src, 'image-src'))}" alt="${alt}" style="width:${width};max-width:${maxWidth};${height}border-radius:${radius};${border}" /></div>`;
     }
 
     case "button": {
@@ -162,31 +176,40 @@ function renderComponent(component, slug) {
       const submitText = escapeHtml(props.submitText || "Submit");
       const thankYouMessage = escapeHtml(props.thankYouMessage || "Thank you for your submission!");
       const formId = "form_" + Math.random().toString(36).substr(2, 8);
+      const isWellnessForm = props.variant === "wellness-consultation";
+      const controlStyle = isWellnessForm
+        ? "width:100%;padding:14px 16px;border:1px solid #c9c3b4;border-radius:8px;font-size:15px;box-sizing:border-box;background:#fffdf7;background-color:#fffdf7;color:#1f2937;opacity:1;color-scheme:light;-webkit-text-fill-color:#1f2937;"
+        : "width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:6px;font-size:15px;box-sizing:border-box;background:#ffffff;background-color:#ffffff;color:#1f2937;opacity:1;color-scheme:light;-webkit-text-fill-color:#1f2937;";
+      const labelStyle = isWellnessForm
+        ? "display:block;margin-bottom:8px;font-weight:600;color:#5e675f;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;"
+        : "display:block;margin-bottom:4px;font-weight:500;color:#333;font-size:14px;";
       let fieldsHtml = fields
         .map((f) => {
           const req = f.required ? "required" : "";
           const inputType = f.type || "text";
-          return `<div style="margin-bottom:12px;">
-            <label style="display:block;margin-bottom:4px;font-weight:500;color:#333;font-size:14px;">${escapeHtml(f.label || f.name)}</label>
-            <input type="${inputType}" name="${escapeHtml(f.name)}" ${req} style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:6px;font-size:15px;box-sizing:border-box;" />
-          </div>`;
+          const label = escapeHtml(f.label || f.name);
+          const requiredMark = f.required && isWellnessForm ? " *" : "";
+          const name = escapeHtml(f.name);
+          const placeholder = escapeHtml(f.placeholder || "");
+          const fieldShellStyle = isWellnessForm
+            ? `margin-bottom:18px;flex:${fields.indexOf(f) < 2 ? "1 1 calc(50% - 8px)" : "1 1 100%"};min-width:${fields.indexOf(f) < 2 ? "0" : "100%"};box-sizing:border-box;`
+            : "margin-bottom:12px;";
+          if (inputType === "textarea") {
+            return `<div style="${fieldShellStyle}"><label style="${labelStyle}">${label}${requiredMark}</label><textarea name="${name}" ${req} placeholder="${placeholder}" rows="4" style="${controlStyle}resize:vertical;min-height:98px;"></textarea></div>`;
+          }
+          if (inputType === "select") {
+            const options = (f.options || []).map((option) => `<option value="${escapeHtml(String(option))}">${escapeHtml(String(option))}</option>`).join("");
+            return `<div style="${fieldShellStyle}"><label style="${labelStyle}">${label}${requiredMark}</label><select name="${name}" ${req} style="${controlStyle}">${options}</select></div>`;
+          }
+          return `<div style="${fieldShellStyle}"><label style="${labelStyle}">${label}${requiredMark}</label><input type="${escapeHtml(inputType) }" name="${name}" ${req} placeholder="${placeholder}" style="${controlStyle}" /></div>`;
         })
         .join("\n");
 
-      // ── #451 — CAPTCHA / spam protection (Cloudflare Turnstile) ───
-      // Embedded only when props.enableCaptcha === true. We use Cloudflare
-      // Turnstile (free, no Google reCAPTCHA — Cloudflare already fronts
-      // crm.globusdemos.com so adding it is one extra SDK call).
-      // The site-key is read from props.turnstileSiteKey if provided
-      // (per-form override) and falls back to the env-var default; if
-      // neither is set we render the widget with a "test" site-key so
-      // dev environments don't 500. The submit handler verifies the
-      // token server-side.
       const enableCaptcha = !!props.enableCaptcha;
       const turnstileSiteKey =
         props.turnstileSiteKey ||
         process.env.TURNSTILE_SITE_KEY ||
-        "1x00000000000000000000AA"; // Cloudflare's "always-passes" test site-key.
+        "1x00000000000000000000AA";
       const captchaScript = enableCaptcha
         ? `<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>`
         : "";
@@ -194,39 +217,35 @@ function renderComponent(component, slug) {
         ? `<div class="cf-turnstile" data-sitekey="${escapeHtml(turnstileSiteKey)}" data-callback="${formId}_onTurnstile" style="margin:0 0 12px;"></div>`
         : "";
 
-      // ── #451 — successRedirectUrl ─────────────────────────────────
-      // If set, the submit-success handler redirects the visitor to this
-      // URL instead of revealing the static thank-you panel. Validation:
-      // accept http:// or https:// only (no javascript:, mailto:, file:,
-      // etc.). Falls back to thank-you-panel mode on invalid URL or any
-      // missing prop. The validation happens at render-time so a bad URL
-      // never reaches the browser's location.assign.
       let successRedirectUrl = "";
       if (typeof props.successRedirectUrl === "string" && props.successRedirectUrl.length > 0) {
         try {
           const u = new URL(props.successRedirectUrl);
-          if (u.protocol === "http:" || u.protocol === "https:") {
-            successRedirectUrl = props.successRedirectUrl;
-          }
+          if (u.protocol === "http:" || u.protocol === "https:") successRedirectUrl = props.successRedirectUrl;
         } catch (_e) {
           successRedirectUrl = "";
         }
       }
 
-      // The browser-side success branch: redirect if a valid
-      // successRedirectUrl is configured, otherwise reveal the
-      // thank-you panel.
       const successJs = successRedirectUrl
         ? `window.location.assign(${JSON.stringify(successRedirectUrl)});`
         : `form.querySelector("button[type=submit]").style.display = "none";
-            var fields = form.querySelectorAll("div > label, div > input");
+            var fields = form.querySelectorAll("div > label, div > input, div > textarea, div > select");
             fields.forEach(function(el){ el.parentElement.style.display = "none"; });
             document.getElementById("${formId}_thanks").style.display = "block";`;
+      const formTitle = props.title ? `<h2 style="margin:0 0 28px;color:#1f2f2c;font-family:Georgia,'Times New Roman',serif;font-size:1.75rem;font-weight:500;">${escapeHtml(props.title)}</h2>` : "";
+      const formStyle = isWellnessForm
+        ? "width:100%;max-width:520px;margin:0 auto 16px;padding:36px;background:#fbfaf4;border-radius:18px;border:1px solid #d8d2c3;border-top:2px solid #7c6f45;box-shadow:0 18px 55px rgba(31,47,44,0.08);box-sizing:border-box;"
+        : "max-width:480px;margin:0 auto 16px;padding:24px;background:#f9fafb;border-radius:10px;border:1px solid #e5e7eb;";
+      const buttonStyle = isWellnessForm
+        ? "width:100%;padding:16px;background:linear-gradient(90deg,#b7ad8c,#d1a083);color:#fff;border:none;border-radius:999px;font-size:15px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;cursor:pointer;"
+        : "width:100%;padding:12px;background:#2563eb;color:#fff;border:none;border-radius:6px;font-size:15px;font-weight:600;cursor:pointer;";
 
-      return `${captchaScript}<form id="${formId}" style="max-width:480px;margin:0 auto 16px;padding:24px;background:#f9fafb;border-radius:10px;border:1px solid #e5e7eb;" onsubmit="return false;">
-        ${fieldsHtml}
+      return `${captchaScript}<form id="${formId}" style="${formStyle}" onsubmit="return false;">
+        ${formTitle}
+        <div style="${isWellnessForm ? 'display:flex;flex-wrap:wrap;gap:0 16px;' : ''}">${fieldsHtml}</div>
         ${captchaHtml}
-        <button type="submit" style="width:100%;padding:12px;background:#2563eb;color:#fff;border:none;border-radius:6px;font-size:15px;font-weight:600;cursor:pointer;">${submitText}</button>
+        <button type="submit" style="${buttonStyle}">${submitText}</button>
         <div id="${formId}_thanks" style="display:none;text-align:center;padding:16px;color:#16a34a;font-weight:500;">${thankYouMessage}</div>
       </form>
       <script>
@@ -236,12 +255,12 @@ function renderComponent(component, slug) {
         form.addEventListener("submit", function(e){
           e.preventDefault();
           var data = {};
-          var inputs = form.querySelectorAll("input");
+          var inputs = form.querySelectorAll("input, textarea, select");
           inputs.forEach(function(inp){ data[inp.name] = inp.value; });
           var phoneInp = form.querySelector('input[type="tel"]');
           if(phoneInp && phoneInp.value.trim()){
             var digits = phoneInp.value.replace(/\\D/g,'');
-            if(digits.length < 10 || digits.length > 15){ alert('Please enter a valid phone number (10–15 digits).'); phoneInp.focus(); return; }
+            if(digits.length < 10 || digits.length > 15){ alert('Please enter a valid phone number (10-15 digits).'); phoneInp.focus(); return; }
           }
           ${enableCaptcha ? `data.cfTurnstileToken = turnstileToken; if (!turnstileToken) { alert("Please complete the CAPTCHA challenge."); return; }` : ""}
           fetch("/p/${escapeHtml(slug)}/submit", {
@@ -293,14 +312,35 @@ function renderComponent(component, slug) {
     case "columns": {
       const columns = props.columns || [];
       const gap = props.gap || "24px";
-      const _colWidth = columns.length > 0 ? `calc(${100 / columns.length}% - ${gap})` : "100%";
+      const variant = props.variant || "";
+      const isWellnessCampaignPage = variant === "wellness-campaign-page";
+      const isWellnessHeaderRow = variant === "wellness-header-row";
+      const isWellnessHeroRow = variant === "wellness-hero-row";
+      const isWellnessRegistrationRow = variant === "wellness-registration-row";
+      const isWellnessBenefitCards = variant === "wellness-benefit-cards";
+      const isWellnessConsultation = variant === "wellness-consultation";
+      const looksLikeWellnessSupporting = columns.some((col) => (col.components || []).some((child) => ["why-title", "after-title"].includes(child.id)));
+      const isWellnessSupporting = variant === "wellness-supporting" || looksLikeWellnessSupporting;
+      const isWellnessSection = isWellnessCampaignPage || isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards || isWellnessConsultation || isWellnessSupporting;
+      const isWellnessInnerRow = isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards;
+      const hasFullWidthSupport = isWellnessConsultation && columns.some((col) => col.fullWidth);
+      const containerStyle = isWellnessCampaignPage
+        ? `display:flex;flex-wrap:wrap;gap:${gap};align-items:stretch;width:1040px;max-width:1040px;min-width:960px;margin:0 auto 36px;padding:0;background:#fbfaf4;color:#1f2f2c;border-radius:18px;border:1px solid #d8d2c3;box-shadow:0 28px 80px rgba(31,47,44,0.14);box-sizing:border-box;overflow:hidden;`
+        : `display:flex;flex-wrap:wrap;gap:${gap};align-items:stretch;width:100%;max-width:${isWellnessSection ? "100%" : "none"};margin:${isWellnessInnerRow ? "0" : (isWellnessConsultation && !hasFullWidthSupport ? "0 auto 0" : (isWellnessSection ? "0 auto 36px" : "0 0 16px"))};padding:${isWellnessHeaderRow ? "26px 64px 20px" : isWellnessHeroRow ? "44px 64px 30px" : isWellnessRegistrationRow ? "20px 64px 54px" : isWellnessBenefitCards ? "0" : (isWellnessSection ? (isWellnessConsultation ? "36px" : "0 48px 40px") : "0")};background:${isWellnessInnerRow || isWellnessConsultation || isWellnessSupporting ? "#fbfaf4" : "transparent"};color:${isWellnessSection ? "#1f2f2c" : "inherit"};border-radius:${isWellnessConsultation ? (hasFullWidthSupport ? "18px" : "18px 18px 0 0") : (isWellnessSupporting ? "0 0 18px 18px" : "0")};box-sizing:border-box;overflow:hidden;`;
       const colsHtml = columns
-        .map((col) => {
+        .map((col, idx) => {
+          let flex = col.fullWidth ? "1 1 100%" : "1 1 0";
+          if (isWellnessHeroRow) flex = idx === 1 ? "0 1 420px" : "1 1 430px";
+          if (isWellnessRegistrationRow) flex = idx === 0 ? "0 1 500px" : "1 1 390px";
+          if (isWellnessBenefitCards) flex = "1 1 100%";
+          if (isWellnessConsultation && idx === 1) flex = "0 1 480px";
+          const cardStyle = isWellnessBenefitCards ? "padding:28px;background:#fffdf7;border:1px solid #d8d2c3;border-radius:18px;box-shadow:0 14px 35px rgba(31,47,44,0.06);justify-content:center;" : "padding:0;background:transparent;border:none;border-radius:0;box-shadow:none;";
+          const minWidth = col.fullWidth ? "100%" : (isWellnessHeroRow ? (idx === 1 ? "360px" : "430px") : isWellnessRegistrationRow ? (idx === 0 ? "500px" : "360px") : isWellnessSection ? "280px" : "250px");
           const innerHtml = (col.components || []).map((c) => renderComponent(c, slug)).join("\n");
-          return `<div style="flex:1;min-width:250px;">${innerHtml}</div>`;
+          return `<div style="flex:${flex};min-width:${minWidth};max-width:100%;box-sizing:border-box;display:flex;flex-direction:column;gap:${isWellnessBenefitCards ? "10px" : "16px"};${cardStyle}">${innerHtml}</div>`;
         })
         .join("\n");
-      return `<div style="display:flex;flex-wrap:wrap;gap:${gap};margin:0 0 16px;">${colsHtml}</div>`;
+      return `<div style="${containerStyle}">${colsHtml}</div>`;
     }
 
     // ── Travel destination blocks ────────────────────────────────────

--- a/backend/services/landingSiteGeneratorLLM.js
+++ b/backend/services/landingSiteGeneratorLLM.js
@@ -12,6 +12,8 @@ const {
   BASIC_BLOCK_TYPES,
   buildGenericLandingSitePrompt,
   buildGenericFallback,
+  buildWellnessRegistrationBlocks,
+  isWellnessSector,
   normalizeSectorKey,
 } = require('./landingSitePrompts');
 
@@ -84,17 +86,38 @@ function ensureBlockArray(blocks) {
     .filter(Boolean);
 }
 
+function collectBlocksByType(blocks, type) {
+  const found = [];
+  const visit = (items) => {
+    if (!Array.isArray(items)) return;
+    items.forEach((block) => {
+      if (!block || typeof block !== 'object') return;
+      if (block.type === type) found.push(block);
+      const columns = block.props && Array.isArray(block.props.columns) ? block.props.columns : [];
+      columns.forEach((column) => visit(column.components));
+    });
+  };
+  visit(blocks);
+  return found;
+}
+
 async function enrichWithImages(payload, input, options = {}) {
   const blocks = ensureBlockArray(payload.blocks);
   if (!blocks.length) return payload;
 
-  const imageBlocks = blocks.filter((block) => block.type === 'image');
+  const imageBlocks = collectBlocksByType(blocks, 'image');
   if (!imageBlocks.length) return { ...payload, blocks };
 
-  const queries = [
-    `${input.sectorLabel || input.sectorKey || 'business'} landing page`,
-    `${input.campaignName || input.businessName || input.sectorLabel || 'campaign'} marketing`,
-  ];
+  const wellnessPhotoQuery = [input.campaignName, input.campaignGoal, input.audience, input.location, input.sectorLabel || input.sectorKey, 'wellness healthcare community event'].filter(Boolean).join(' ');
+  const queries = isWellnessSector(input.sectorKey)
+    ? [
+        wellnessPhotoQuery,
+        [input.businessName, input.sectorLabel || input.sectorKey, 'wellness event registration'].filter(Boolean).join(' '),
+      ]
+    : [
+        `${input.sectorLabel || input.sectorKey || 'business'} landing page`,
+        `${input.campaignName || input.businessName || input.sectorLabel || 'campaign'} marketing`,
+      ];
 
   const fetched = [];
   for (const query of queries) {
@@ -177,6 +200,9 @@ async function generateLandingSiteContent(input = {}, options = {}) {
   if (!payload.blocks.length) payload = fallback;
 
   payload.blocks = ensureBlockArray(payload.blocks);
+  if (isWellnessSector(sectorKey)) {
+    payload.blocks = buildWellnessRegistrationBlocks({ ...input, sectorKey }, payload);
+  }
   payload = await enrichWithImages(payload, { ...input, sectorKey }, options);
   payload.blocks = ensureBlockArray(payload.blocks);
 

--- a/backend/services/landingSitePrompts.js
+++ b/backend/services/landingSitePrompts.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 const SECTORS = {
   general: { label: 'General', voice: 'Clear, flexible, and lead-focused.' },
@@ -16,31 +16,55 @@ const SECTORS = {
   finance: { label: 'Finance', voice: 'Trustworthy and compliant.' },
 };
 
+const WELLNESS_SECTOR_KEYS = new Set(['health', 'hospital', 'fitness']);
 const BASIC_BLOCK_TYPES = new Set(['heading', 'text', 'image', 'button', 'form', 'divider', 'spacer', 'columns']);
+
+function isWellnessSector(sectorKey) {
+  return WELLNESS_SECTOR_KEYS.has(String(sectorKey || '').trim().toLowerCase());
+}
 
 function normalizeSectorKey(value) {
   const key = String(value || 'general').trim().toLowerCase();
   return SECTORS[key] ? key : 'general';
 }
 
+function clean(value, fallback = '', max = 120) {
+  const text = String(value || '').trim();
+  return (text || fallback).slice(0, max);
+}
+
+function slugFor(sectorKey, campaignName) {
+  return `${sectorKey}-${campaignName}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 50) || `landing-${sectorKey}`;
+}
+
 function buildGenericLandingSitePrompt(input = {}) {
   const sectorKey = normalizeSectorKey(input.sectorKey);
   const sector = SECTORS[sectorKey];
-  const sectorLabel = String(input.sectorLabel || sector.label).trim().slice(0, 60);
-  const campaignName = String(input.campaignName || '').trim().slice(0, 120) || `${sectorLabel} Landing Site`;
-  const businessName = String(input.businessName || '').trim().slice(0, 120);
-  const campaignGoal = String(input.campaignGoal || '').trim().slice(0, 200) || 'capture leads';
-  const audience = String(input.audience || '').trim().slice(0, 200) || 'qualified visitors';
-  const location = String(input.location || '').trim().slice(0, 120);
-  const tone = String(input.tone || '').trim().slice(0, 120) || sector.voice;
-  const ctaText = String(input.ctaText || '').trim().slice(0, 40) || 'Get Started';
-  const imageMode = String(input.imageMode || 'auto').trim().toLowerCase();
+  const sectorLabel = clean(input.sectorLabel, sector.label, 60);
+  const campaignName = clean(input.campaignName, `${sectorLabel} Landing Site`, 120);
+  const businessName = clean(input.businessName, '', 120);
+  const campaignGoal = clean(input.campaignGoal, 'capture leads', 200);
+  const audience = clean(input.audience, 'qualified visitors', 200);
+  const location = clean(input.location, '', 120);
+  const eventDate = clean(input.eventDate, '', 80);
+  const eventTime = clean(input.eventTime, '', 80);
+  const eventLocation = clean(input.eventLocation || input.location, '', 120);
+  const tone = clean(input.tone, sector.voice, 120);
+  const ctaText = clean(input.ctaText, 'Get Started', 40);
+  const imageMode = clean(input.imageMode, 'auto', 20).toLowerCase();
+  const wellnessMode = isWellnessSector(sectorKey);
 
   const system = [
-    'You generate generic CRM landing-site content.',
+    'You generate CRM landing-site content.',
     'Return exactly one JSON object with no markdown, no fences, and no extra prose.',
     'Use only these block types: heading, text, image, button, form, divider, spacer, columns.',
-    'The page must feel complete: hero, supporting copy, one visual, a benefits section, and a lead form.',
+    wellnessMode
+      ? 'For health, hospital, and fitness campaigns, create a polished consultation/event registration page similar to a wellness clinic contact page: left column with event details and contact copy, right column with a lead form. Keep event date, time, and location near the top.'
+      : 'The page must feel complete: hero, supporting copy, one visual, a benefits section, and a lead form.',
     'Image URLs are optional. If you cannot produce a useful image, use an empty string for src.',
     '',
     'Return this shape:',
@@ -63,31 +87,204 @@ function buildGenericLandingSitePrompt(input = {}) {
     `Tone: ${tone}`,
     `CTA label: ${ctaText}`,
     `Image mode: ${imageMode}`,
+    wellnessMode ? `Event date: ${eventDate || '(not provided)'}` : '',
+    wellnessMode ? `Event time: ${eventTime || '(not provided)'}` : '',
+    wellnessMode ? `Event location: ${eventLocation || '(not provided)'}` : '',
     '',
-    'Write for a mobile-first landing site with a clear lead capture focus.',
-    'Include at least one image block, one columns block, one button block, and one form block.',
-    'The form should capture name, email, phone, and a short message.',
-    'Keep the page concise and practical.',
-  ].join('\n');
+    wellnessMode
+      ? 'The form must capture first name, last name, email, phone, service of interest, and a message. Use select for service of interest and textarea for the message.'
+      : 'The form should capture name, email, phone, and a short message.',
+  ].filter(Boolean).join('\n');
 
-  return { system, user, sectorKey, sectorLabel, campaignName, businessName, campaignGoal, audience, location, tone, ctaText, imageMode };
+  return { system, user, sectorKey, sectorLabel, campaignName, businessName, campaignGoal, audience, location, tone, ctaText, imageMode, eventDate, eventTime, eventLocation, wellnessMode };
+}
+
+function buildWellnessRegistrationBlocks(input = {}, sourcePayload = {}) {
+  const sectorKey = normalizeSectorKey(input.sectorKey);
+  const sector = SECTORS[sectorKey];
+  const sectorLabel = clean(input.sectorLabel, sector.label, 60);
+  const campaignName = clean(input.campaignName || sourcePayload.suggestedTitle, `${sectorLabel} Wellness Event`, 120);
+  const businessName = clean(input.businessName, 'Enhance Wellness', 120);
+  const campaignGoal = clean(input.campaignGoal || sourcePayload.description, 'invite the community to register and help the team collect qualified leads', 220);
+  const audience = clean(input.audience, 'interested visitors', 180);
+  const eventDate = clean(input.eventDate, 'Add the event date', 80);
+  const eventTime = clean(input.eventTime, 'Add the event time', 80);
+  const eventLocation = clean(input.eventLocation || input.location, 'Add the event venue', 160);
+  const ctaText = clean(input.ctaText, 'Get Started', 40);
+  const serviceLabel = clean(input.serviceLabel || sourcePayload.serviceLabel, sectorKey === 'fitness' ? 'Wellness Assessment' : sectorKey === 'hospital' ? 'Health Camp Registration' : 'Event Registration', 80);
+  const intro = `${businessName} invites ${audience} to register. ${campaignGoal}`;
+
+  return [
+    {
+      id: 'wellness-campaign-page',
+      type: 'columns',
+      props: {
+        gap: '0',
+        variant: 'wellness-campaign-page',
+        columns: [
+          {
+            fullWidth: true,
+            components: [
+              {
+                id: 'wellness-page-header',
+                type: 'columns',
+                props: {
+                  gap: '10px',
+                  variant: 'wellness-header-row',
+                  columns: [
+                    {
+                      fullWidth: true,
+                      components: [
+                        { id: 'wellness-logo', type: 'heading', props: { text: `${businessName} Initiative`, level: 'h3', align: 'center', color: '#1f2f2c', variant: 'wellness-logo' } },
+                        { id: 'wellness-nav', type: 'text', props: { text: 'HOME   EVENTS   ABOUT   DONATE   CONTACT', align: 'center', color: '#1f2f2c', fontSize: '0.78rem', variant: 'wellness-nav' } },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            fullWidth: true,
+            components: [
+              {
+                id: 'wellness-hero-row',
+                type: 'columns',
+                props: {
+                  gap: '36px',
+                  variant: 'wellness-hero-row',
+                  columns: [
+                    {
+                      components: [
+                        { id: 'wellness-eyebrow', type: 'text', props: { text: 'VISIT - CALL - WRITE', align: 'left', color: '#a88345', fontSize: '0.78rem', variant: 'wellness-eyebrow' } },
+                        { id: 'wellness-title', type: 'heading', props: { text: campaignName, level: 'h1', align: 'left', color: '#1f2f2c', variant: 'wellness-display' } },
+                        { id: 'wellness-intro', type: 'text', props: { text: intro, align: 'left', color: '#5f6c67', fontSize: '1.02rem', variant: 'wellness-body' } },
+                        { id: 'event-title', type: 'heading', props: { text: 'Event Details', level: 'h3', align: 'left', color: '#1f2f2c', variant: 'wellness-section-title' } },
+                        { id: 'event-date', type: 'text', props: { text: `Date: ${eventDate}`, align: 'left', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-detail' } },
+                        { id: 'event-time', type: 'text', props: { text: `Time: ${eventTime}`, align: 'left', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-detail' } },
+                        { id: 'event-location', type: 'text', props: { text: `Location: ${eventLocation}`, align: 'left', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-detail' } },
+                        { id: 'event-audience', type: 'text', props: { text: `For: ${audience}`, align: 'left', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-detail' } },
+                      ],
+                    },
+                    {
+                      components: [
+                        { id: 'event-photo', type: 'image', props: { src: '', alt: `${campaignName} event photo`, width: '100%', maxWidth: '420px', variant: 'wellness-event-image' } },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            fullWidth: true,
+            components: [
+              {
+                id: 'wellness-registration-row',
+                type: 'columns',
+                props: {
+                  gap: '36px',
+                  variant: 'wellness-registration-row',
+                  columns: [
+                    {
+                      components: [
+                        {
+                          id: 'lead-form',
+                          type: 'form',
+                          props: {
+                            title: 'Request a Consultation',
+                            fields: [
+                              { label: 'First Name', name: 'first_name', type: 'text', required: true, placeholder: 'e.g., John' },
+                              { label: 'Last Name', name: 'last_name', type: 'text', required: true, placeholder: 'e.g., Doe' },
+                              { label: 'Email Address', name: 'email', type: 'email', required: true, placeholder: 'e.g., name@example.com' },
+                              { label: 'Phone Number', name: 'phone', type: 'tel', required: true, placeholder: 'e.g., Phone Number' },
+                              { label: 'Service of Interest', name: 'service_interest', type: 'select', required: false, options: [serviceLabel, campaignName, 'General Enquiry'] },
+                              { label: 'Tell Us More', name: 'message', type: 'textarea', required: false, placeholder: 'Share any questions or concerns...' },
+                            ],
+                            submitText: ctaText,
+                            thankYouMessage: `Thanks. We have received your registration for ${campaignName}.`,
+                            enableCaptcha: false,
+                            leadRoutingRuleId: '',
+                            successRedirectUrl: '',
+                            variant: 'wellness-consultation',
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      components: [
+                        {
+                          id: 'wellness-benefit-cards',
+                          type: 'columns',
+                          props: {
+                            gap: '18px',
+                            variant: 'wellness-benefit-cards',
+                            columns: [
+                              {
+                                components: [
+                                  { id: 'contact-title', type: 'heading', props: { text: 'Need Help?', level: 'h3', align: 'center', color: '#1f2f2c', variant: 'wellness-card-title' } },
+                                  { id: 'contact-copy', type: 'text', props: { text: 'Share your details in the registration form. The team will follow up with confirmation and next steps.', align: 'center', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-body' } },
+                                ],
+                              },
+                              {
+                                components: [
+                                  { id: 'why-title', type: 'heading', props: { text: 'Why Attend', level: 'h3', align: 'center', color: '#1f2f2c', variant: 'wellness-card-title' } },
+                                  { id: 'why-copy', type: 'text', props: { text: 'Get clear guidance, event support, and a simple registration experience from the wellness team.', align: 'center', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-body' } },
+                                ],
+                              },
+                              {
+                                components: [
+                                  { id: 'after-title', type: 'heading', props: { text: 'After Registration', level: 'h3', align: 'center', color: '#1f2f2c', variant: 'wellness-card-title' } },
+                                  { id: 'after-copy', type: 'text', props: { text: 'Your enquiry is stored as a lead in the CRM so the team can follow up without missing the request.', align: 'center', color: '#4e5a55', fontSize: '0.98rem', variant: 'wellness-body' } },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            fullWidth: true,
+            components: [
+              { id: 'wellness-footer', type: 'text', props: { text: `Copyright ${new Date().getFullYear()} ${businessName}`, align: 'center', color: '#ffffff', fontSize: '0.82rem', variant: 'wellness-footer' } },
+            ],
+          },
+        ],
+      },
+    },
+  ];
 }
 
 function buildGenericFallback(input = {}) {
   const sectorKey = normalizeSectorKey(input.sectorKey);
   const sector = SECTORS[sectorKey];
-  const sectorLabel = String(input.sectorLabel || sector.label).trim().slice(0, 60);
-  const campaignName = String(input.campaignName || '').trim().slice(0, 120) || `${sectorLabel} Landing Site`;
-  const businessName = String(input.businessName || '').trim().slice(0, 120);
-  const campaignGoal = String(input.campaignGoal || '').trim().slice(0, 200) || 'capture leads';
-  const audience = String(input.audience || '').trim().slice(0, 200) || 'qualified visitors';
-  const location = String(input.location || '').trim().slice(0, 120);
-  const ctaText = String(input.ctaText || '').trim().slice(0, 40) || 'Get Started';
-  const slug = `${sectorKey}-${campaignName}`
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-    .slice(0, 50) || `landing-${sectorKey}`;
+  const sectorLabel = clean(input.sectorLabel, sector.label, 60);
+  const campaignName = clean(input.campaignName, `${sectorLabel} Landing Site`, 120);
+  const businessName = clean(input.businessName, '', 120);
+  const campaignGoal = clean(input.campaignGoal, 'capture leads', 200);
+  const audience = clean(input.audience, 'qualified visitors', 200);
+  const location = clean(input.location, '', 120);
+  const ctaText = clean(input.ctaText, 'Get Started', 40);
+  const wellnessMode = isWellnessSector(sectorKey);
+  const slug = slugFor(sectorKey, campaignName);
+
+  if (wellnessMode) {
+    return {
+      suggestedTitle: campaignName.slice(0, 80),
+      suggestedSlug: slug,
+      description: `${sectorLabel} event registration landing site for ${campaignGoal}`.slice(0, 200),
+      seoMeta: {
+        metaTitle: `${campaignName} | ${sectorLabel}`.slice(0, 60),
+        metaDescription: `${campaignGoal} for ${audience}.`.slice(0, 160),
+      },
+      blocks: buildWellnessRegistrationBlocks(input, { suggestedTitle: campaignName }),
+    };
+  }
 
   const heroTitle = location ? `${campaignName} in ${location}` : campaignName;
   const heroBody = businessName
@@ -136,7 +333,7 @@ function buildGenericFallback(input = {}) {
             { label: 'Name', name: 'name', type: 'text', required: true },
             { label: 'Email', name: 'email', type: 'email', required: true },
             { label: 'Phone', name: 'phone', type: 'tel', required: false },
-            { label: 'Message', name: 'message', type: 'text', required: false },
+            { label: 'Message', name: 'message', type: 'textarea', required: false },
           ],
           submitText: 'Submit',
           thankYouMessage: `Thanks. We will contact you about this ${sectorLabel.toLowerCase()} page soon.`,
@@ -156,4 +353,6 @@ module.exports = {
   normalizeSectorKey,
   buildGenericLandingSitePrompt,
   buildGenericFallback,
+  buildWellnessRegistrationBlocks,
+  isWellnessSector,
 };

--- a/backend/test/lib/pageCatalog.test.js
+++ b/backend/test/lib/pageCatalog.test.js
@@ -271,6 +271,7 @@ describe('getCatalogForVertical (vertical-aware filtering)', () => {
       expect(p.startsWith('/wellness')).toBe(false);
       expect(p.startsWith('/travel')).toBe(false);
     }
+    expect(paths).toContain('/landing-sites');
     expect(paths).not.toContain('/landing-pages');
   });
 
@@ -301,7 +302,7 @@ describe('getCatalogForVertical (vertical-aware filtering)', () => {
     expect(generic).not.toContain('/revenue-goals');
   });
 
-  it('Landing Pages is travel-only and stays out of generic/wellness catalogs', () => {
+  it('Landing Pages stays travel-only while Landing Sites is shared across generic + wellness', () => {
     const travel = getCatalogForVertical('travel').map((p) => p.path);
     const wellness = getCatalogForVertical('wellness').map((p) => p.path);
     const generic = getCatalogForVertical('generic').map((p) => p.path);
@@ -309,6 +310,10 @@ describe('getCatalogForVertical (vertical-aware filtering)', () => {
     expect(travel).toContain('/landing-pages');
     expect(wellness).not.toContain('/landing-pages');
     expect(generic).not.toContain('/landing-pages');
+
+    expect(travel).not.toContain('/landing-sites');
+    expect(wellness).toContain('/landing-sites');
+    expect(generic).toContain('/landing-sites');
   });
 
   it('unknown / null vertical falls back to the cross-vertical core only', () => {

--- a/backend/test/routes/landing-pages.test.js
+++ b/backend/test/routes/landing-pages.test.js
@@ -1108,6 +1108,45 @@ describe('POST /p/:slug/submit (public submission, no auth)', () => {
     );
   });
 
+  test('wellness-style public registration stores first/last name and service interest on the lead contact', async () => {
+    prisma.landingPage.findFirst.mockResolvedValue({
+      id: 52,
+      slug: 'blood-donation-bangalore-enhance-wellness',
+      status: 'PUBLISHED',
+      title: 'Enhance Wellness Blood Donation Drive',
+      content: JSON.stringify([{ type: 'form', props: {} }]),
+      tenantId: 2,
+      templateType: 'generic-site:wellness-registration-v1',
+    });
+    prisma.contact.upsert.mockResolvedValue({ id: 1200, email: 'asha@example.com', tenantId: 2 });
+    prisma.landingPage.update.mockResolvedValue({ id: 52, submissions: 1 });
+
+    const res = await request(makeApp())
+      .post('/p/blood-donation-bangalore-enhance-wellness/submit')
+      .send({
+        first_name: 'Asha',
+        last_name: 'Donor',
+        email: 'asha@example.com',
+        phone: '+919876543210',
+        service_interest: 'Event Registration',
+        message: 'I can donate in the morning.',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const upsertArgs = prisma.contact.upsert.mock.calls[0][0];
+    expect(upsertArgs.where.email_tenantId).toEqual({ email: 'asha@example.com', tenantId: 2 });
+    expect(upsertArgs.create).toMatchObject({
+      name: 'Asha Donor',
+      email: 'asha@example.com',
+      phone: '+919876543210',
+      status: 'Lead',
+      source: 'inbound:webform',
+      firstTouchSource: 'Landing Page: Enhance Wellness Blood Donation Drive',
+      treatmentOfInterest: 'Event Registration',
+      tenantId: 2,
+    });
+  });
   test('unknown slug → 404 (no contact/deal/analytics writes)', async () => {
     prisma.landingPage.findFirst.mockResolvedValue(null);
     const res = await request(makeApp())

--- a/backend/test/routes/travel-tmc-catalogue.test.js
+++ b/backend/test/routes/travel-tmc-catalogue.test.js
@@ -75,6 +75,9 @@ import jwt from 'jsonwebtoken';
 import { createRequire } from 'node:module';
 
 const requireCJS = createRequire(import.meta.url);
+const { serializeRows } = requireCJS('../../lib/csvHelpers');
+const { TEMPLATE_HEADERS } = requireCJS('../../lib/travelTmcCatalogueImport');
+const IMPORT_COLUMNS = TEMPLATE_HEADERS.map((key) => ({ key, header: key }));
 const JWT_SECRET = process.env.JWT_SECRET || 'enterprise_super_secret_key_2026';
 const catalogueRouter = requireCJS('../../routes/travel_tmc_catalogue');
 
@@ -95,6 +98,10 @@ function tokenFor(role = 'ADMIN', { userId = 7, tenantId = 1 } = {}) {
 
 // A minimal-valid POST body for the catalogue. Matches the schema's NOT NULL
 // columns. Tests that exercise create-with-overrides spread on top of this.
+function buildImportCsv(rows) {
+  return serializeRows(IMPORT_COLUMNS, rows);
+}
+
 function validCreateBody(overrides = {}) {
   return {
     tripId: 'golden-triangle-delhi-agra-jaipur',
@@ -449,6 +456,138 @@ describe('POST /api/travel-tmc-catalogue', () => {
 // ─────────────────────────────────────────────────────────────────────
 // PATCH /api/travel-tmc-catalogue/:id
 // ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/travel-tmc-catalogue/import-template', () => {
+  test('csv template downloads with the expected filename and headers', async () => {
+    const res = await request(makeApp())
+      .get('/api/travel-tmc-catalogue/import-template?format=csv')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    expect(res.headers['content-disposition']).toContain('tmc-catalogue-template.csv');
+    expect(res.text).toContain('tripId,title,tagline,tier,region');
+    expect(res.text).toContain('golden-triangle-school-heritage');
+  });
+
+  test('xlsx template downloads with the expected content type', async () => {
+    const res = await request(makeApp())
+      .get('/api/travel-tmc-catalogue/import-template?format=xlsx')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(res.headers['content-disposition']).toContain('tmc-catalogue-template.xlsx');
+    expect(Buffer.isBuffer(res.body) || res.body?.length > 0).toBe(true);
+  });
+});
+
+describe('POST /api/travel-tmc-catalogue/import', () => {
+  test('bulk upload creates new rows archived and updates existing ones', async () => {
+    const csv = buildImportCsv([
+      {
+        tripId: 'andaman-sea-explorer',
+        title: 'Andaman Sea Explorer',
+        tagline: 'Island science and ecology',
+        tier: 'domestic',
+        region: 'Andaman & Nicobar',
+        durationDays: 5,
+        durationNights: 4,
+        minGradeBand: '6-8',
+        maxGradeBand: '9-10',
+        boardsSupportedJson: 'CBSE, ICSE',
+        minGroupSize: 24,
+        priceBand: 'mid',
+        indicativePricePerStudent: 42000,
+        primaryOutcomesJson: 'marine literacy, collaboration',
+        skillsDevelopedJson: 'teamwork, observation',
+        subjectsTouchedJson: 'Science, Geography',
+        anchorExperiencesJson: '[{"name":"coral walk"}]',
+        curriculumHooksJson: '[{"board":"CBSE","topic":"ecosystems"}]',
+        reportSkillBlurb: 'Builds scientific inquiry and teamwork.',
+        summaryForBrief: 'A coastal science itinerary.',
+        imageUrl: '',
+      },
+      {
+        tripId: 'golden-triangle',
+        title: 'Golden Triangle Heritage Trail (Imported)',
+        tagline: 'Updated from Excel',
+        tier: 'domestic',
+        region: 'North India',
+        durationDays: 6,
+        durationNights: 5,
+        minGradeBand: '6-8',
+        maxGradeBand: '9-10',
+        boardsSupportedJson: 'CBSE, ICSE',
+        minGroupSize: 20,
+        priceBand: 'mid',
+        indicativePricePerStudent: 36000,
+        primaryOutcomesJson: 'history, cultural fluency',
+        skillsDevelopedJson: 'communication',
+        subjectsTouchedJson: 'History, Geography',
+        anchorExperiencesJson: '[{"name":"Taj Mahal sunrise"}]',
+        curriculumHooksJson: '[{"board":"CBSE","topic":"Mughal India"}]',
+        reportSkillBlurb: 'Historical reasoning with cross-cultural fluency.',
+        summaryForBrief: 'Updated itinerary brief.',
+        imageUrl: '',
+      },
+    ]);
+
+    prisma.tmcTripCatalogue.findFirst.mockImplementation(async ({ where }) => {
+      if (where.tripId === 'golden-triangle') {
+        return { id: 44, tenantId: 1, tripId: 'golden-triangle', status: 'active' };
+      }
+      return null;
+    });
+    prisma.tmcTripCatalogue.create.mockImplementation(async ({ data }) => ({
+      id: 77,
+      tenantId: 1,
+      ...data,
+    }));
+    prisma.tmcTripCatalogue.update.mockImplementation(async ({ data }) => ({
+      id: 44,
+      tenantId: 1,
+      tripId: 'golden-triangle',
+      status: 'active',
+      ...data,
+    }));
+
+    const res = await request(makeApp())
+      .post('/api/travel-tmc-catalogue/import')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .attach('file', Buffer.from(csv), 'tmc-catalogue.csv');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      imported: 1,
+      updated: 1,
+      skipped: 0,
+      total: 2,
+      reviewLabel: 'AI-classified, pending review',
+    });
+    expect(res.body.createdTripIds).toEqual(['andaman-sea-explorer']);
+    expect(res.body.updatedTripIds).toEqual(['golden-triangle']);
+
+    expect(prisma.tmcTripCatalogue.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tenantId: 1,
+          tripId: 'andaman-sea-explorer',
+          status: 'archived',
+        }),
+      }),
+    );
+    expect(prisma.tmcTripCatalogue.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 44 },
+        data: expect.objectContaining({
+          tripId: 'golden-triangle',
+          status: 'active',
+        }),
+      }),
+    );
+  });
+});
 
 describe('PATCH /api/travel-tmc-catalogue/:id', () => {
   test('happy path updates allowed fields', async () => {

--- a/backend/test/routes/travel-trips.test.js
+++ b/backend/test/routes/travel-trips.test.js
@@ -815,6 +815,64 @@ describe('Participants', () => {
     );
   });
 
+  test('POST /participants/import upserts rows additively without clearing blanks', async () => {
+    prisma.tripParticipant.findFirst
+      .mockResolvedValueOnce({ id: 77 })
+      .mockResolvedValueOnce(null);
+    prisma.tripParticipant.update.mockResolvedValue({ id: 77, tripId: 100, fullName: 'Anaya Sharma' });
+    prisma.tripParticipant.create.mockResolvedValue({ id: 88, tripId: 100, fullName: 'Ravi Mehta' });
+
+    const csv = [
+      'fullName,parentName,parentPhone,parentEmail,applicationStatus,consentCapturedAt,reviewNotes',
+      'Anaya Sharma,Riya Sharma,9876543210,parent@example.com,approved,2026-05-01T00:00:00.000Z,Imported row',
+      'Ravi Mehta,,,,waitlisted,,',
+    ].join('
+');
+
+    const res = await request(makeApp())
+      .post('/api/travel/trips/100/participants/import')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .attach('file', Buffer.from(csv, 'utf8'), 'participants.csv');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ inserted: 1, updated: 1, skipped: 0, total: 2 });
+    expect(prisma.tripParticipant.findFirst).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tripId: 100,
+          fullName: 'Anaya Sharma',
+          parentPhone: '+919876543210',
+          parentEmail: 'parent@example.com',
+        }),
+      }),
+    );
+    expect(prisma.tripParticipant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 77 },
+        data: expect.objectContaining({
+          fullName: 'Anaya Sharma',
+          parentName: 'Riya Sharma',
+          parentPhone: '+919876543210',
+          parentEmail: 'parent@example.com',
+          applicationStatus: 'approved',
+          reviewNotes: 'Imported row',
+          consentCapturedAt: expect.any(Date),
+        }),
+      }),
+    );
+    expect(prisma.tripParticipant.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tenantId: 1,
+          tripId: 100,
+          fullName: 'Ravi Mehta',
+          applicationStatus: 'waitlisted',
+        }),
+      }),
+    );
+  });
+
   test('POST participant returns 201 + persisted row', async () => {
     prisma.tripParticipant.create.mockResolvedValue({
       id: 50, tripId: 100, fullName: 'Bob Patel', aadhaarLast4: '1234',

--- a/backend/test/routes/travel-trips.test.js
+++ b/backend/test/routes/travel-trips.test.js
@@ -826,8 +826,7 @@ describe('Participants', () => {
       'fullName,parentName,parentPhone,parentEmail,applicationStatus,consentCapturedAt,reviewNotes',
       'Anaya Sharma,Riya Sharma,9876543210,parent@example.com,approved,2026-05-01T00:00:00.000Z,Imported row',
       'Ravi Mehta,,,,waitlisted,,',
-    ].join('
-');
+    ].join('\n');
 
     const res = await request(makeApp())
       .post('/api/travel/trips/100/participants/import')
@@ -1719,3 +1718,5 @@ describe('POST /api/travel/trips/:id/registrations/:rid/reject', () => {
     expect(res.body).toMatchObject({ code: 'REGISTRATION_NOT_FOUND' });
   });
 });
+
+

--- a/backend/test/routes/travel_invoices.test.js
+++ b/backend/test/routes/travel_invoices.test.js
@@ -72,6 +72,7 @@ prisma.revokedToken.findUnique = vi.fn().mockResolvedValue(null);
 // per-call to return null.
 prisma.contact = prisma.contact || {};
 prisma.contact.findFirst = vi.fn().mockResolvedValue({ id: 99, tenantId: 1 });
+prisma.contact.findMany = vi.fn().mockResolvedValue([{ id: 99, name: 'Acme School' }]);
 
 import express from 'express';
 import request from 'supertest';
@@ -121,6 +122,7 @@ beforeEach(() => {
   prisma.auditLog.create.mockReset().mockResolvedValue({ id: 1 });
   prisma.auditLog.findFirst.mockReset().mockResolvedValue(null);
   prisma.contact.findFirst.mockReset().mockResolvedValue({ id: 99, tenantId: 1 });
+  prisma.contact.findMany.mockReset().mockResolvedValue([{ id: 99, name: 'Acme School' }]);
 });
 
 describe('POST /api/travel/invoices', () => {
@@ -248,6 +250,72 @@ describe('POST /api/travel/invoices', () => {
       });
     expect(r2.status).toBe(201);
     expect(r2.body.invoiceNum).toBe(`TINV-${CURRENT_YEAR}-0002`);
+  });
+
+  test('POST /invoices/reconcile/excel-software returns mismatch summary without mutating DB', async () => {
+    prisma.travelInvoice.findMany.mockResolvedValue([
+      {
+        id: 1,
+        invoiceNum: `TINV-${CURRENT_YEAR}-0001`,
+        totalAmount: '100.00',
+        status: 'Issued',
+        subBrand: 'tmc',
+        contactId: 99,
+        createdAt: new Date('2026-05-20T00:00:00.000Z'),
+      },
+      {
+        id: 2,
+        invoiceNum: `TINV-${CURRENT_YEAR}-0002`,
+        totalAmount: '200.00',
+        status: 'Paid',
+        subBrand: 'tmc',
+        contactId: 99,
+        createdAt: new Date('2026-05-20T00:00:00.000Z'),
+      },
+    ]);
+    prisma.contact.findMany.mockResolvedValue([
+      { id: 99, name: 'Acme School' },
+    ]);
+
+    const csv = [
+      'Invoice Number,Invoice Date,Customer,Customer GSTIN,Sub-Brand,Legal Entity,Status,Taxable Value,CGST,SGST,IGST,TCS,Invoice Total',
+      `TINV-${CURRENT_YEAR}-0001,2026-05-20,Acme School,,tmc,tmc_nexus,Issued,100,0,0,0,0,100`,
+      `TINV-${CURRENT_YEAR}-0002,2026-05-20,Acme School,,tmc,tmc_nexus,Issued,200,0,0,0,0,250`,
+      'TOTAL,,,,,,,',
+    ].join('
+');
+
+    const res = await request(makeApp())
+      .post('/api/travel/invoices/reconcile/excel-software')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`)
+      .attach('file', Buffer.from(csv, 'utf8'), 'travel-accounting.csv');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      totalRows: 2,
+      scannedInvoices: 2,
+      matchedRows: 2,
+      mismatchedRows: 1,
+      missingRows: 0,
+      discrepancyCount: 1,
+    });
+    expect(res.body.discrepancies[0]).toMatchObject({
+      invoiceNum: `TINV-${CURRENT_YEAR}-0002`,
+      issue: 'MISMATCH',
+    });
+    expect(prisma.travelInvoice.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.contact.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.travelInvoice.update).not.toHaveBeenCalled();
+    expect(prisma.travelInvoice.delete).not.toHaveBeenCalled();
+  });
+
+  test('POST /invoices/reconcile/excel-software without file returns FILE_REQUIRED', async () => {
+    const res = await request(makeApp())
+      .post('/api/travel/invoices/reconcile/excel-software')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'FILE_REQUIRED' });
   });
 
   // #996 — Contact existence + draft-dedup guards.

--- a/backend/test/routes/travel_invoices.test.js
+++ b/backend/test/routes/travel_invoices.test.js
@@ -282,8 +282,7 @@ describe('POST /api/travel/invoices', () => {
       `TINV-${CURRENT_YEAR}-0001,2026-05-20,Acme School,,tmc,tmc_nexus,Issued,100,0,0,0,0,100`,
       `TINV-${CURRENT_YEAR}-0002,2026-05-20,Acme School,,tmc,tmc_nexus,Issued,200,0,0,0,0,250`,
       'TOTAL,,,,,,,',
-    ].join('
-');
+    ].join('\n');
 
     const res = await request(makeApp())
       .post('/api/travel/invoices/reconcile/excel-software')
@@ -553,3 +552,5 @@ describe('GET /api/travel/invoices/:id (cross-tenant isolation)', () => {
     );
   });
 });
+
+

--- a/backend/test/routes/wellness-public-enquiry.test.js
+++ b/backend/test/routes/wellness-public-enquiry.test.js
@@ -1,0 +1,201 @@
+// @ts-check
+/**
+ * Unit tests for the public wellness enquiry endpoint that accepts static
+ * site form submissions and stores them as wellness Contact leads.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import express from 'express';
+import request from 'supertest';
+
+import prisma from '../../lib/prisma.js';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+const authPath = requireCJS.resolve('../../middleware/auth.js');
+Module._cache[authPath] = {
+  id: authPath,
+  filename: authPath,
+  loaded: true,
+  exports: {
+    verifyToken: (_req, _res, next) => next(),
+    verifyRole: () => (_req, _res, next) => next(),
+    RBAC_DENIED_MESSAGE: 'denied',
+    RBAC_DENIED_CODE: 'RBAC_DENIED',
+  },
+};
+
+const requirePermissionPath = requireCJS.resolve('../../middleware/requirePermission.js');
+Module._cache[requirePermissionPath] = {
+  id: requirePermissionPath,
+  filename: requirePermissionPath,
+  loaded: true,
+  exports: {
+    requirePermission: () => (_req, _res, next) => next(),
+    userHasPermission: () => true,
+  },
+};
+
+const wellnessRolePath = requireCJS.resolve('../../middleware/wellnessRole.js');
+Module._cache[wellnessRolePath] = {
+  id: wellnessRolePath,
+  filename: wellnessRolePath,
+  loaded: true,
+  exports: {
+    verifyWellnessRole: () => (_req, _res, next) => next(),
+  },
+};
+
+const auditPath = requireCJS.resolve('../../lib/audit.js');
+Module._cache[auditPath] = {
+  id: auditPath,
+  filename: auditPath,
+  loaded: true,
+  exports: {
+    writeAudit: vi.fn().mockResolvedValue({ id: 1 }),
+    diffFields: vi.fn(() => []),
+  },
+};
+
+const dedupPath = requireCJS.resolve('../../utils/deduplication.js');
+const findDuplicateContactFullMock = vi.fn();
+Module._cache[dedupPath] = {
+  id: dedupPath,
+  filename: dedupPath,
+  loaded: true,
+  exports: {
+    findDuplicateContactFull: findDuplicateContactFullMock,
+    findDuplicateContact: vi.fn(),
+    findDuplicateContactByPassport: vi.fn(),
+    findDuplicateMarketplaceLead: vi.fn(),
+    normalizePhone: vi.fn(),
+    toE164: vi.fn(),
+    computeDuplicateGroupKey: vi.fn(),
+  },
+};
+
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn();
+prisma.contact = prisma.contact || {};
+prisma.contact.findUnique = vi.fn();
+prisma.contact.findMany = vi.fn();
+prisma.contact.create = vi.fn();
+prisma.contact.update = vi.fn();
+
+const prismaPath = requireCJS.resolve('../../lib/prisma.js');
+Module._cache[prismaPath] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: prisma,
+};
+
+const wellnessRouter = requireCJS('../../routes/wellness');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wellness', wellnessRouter);
+  return app;
+}
+
+beforeEach(() => {
+  prisma.tenant.findUnique.mockReset();
+    prisma.contact.findUnique.mockReset();
+  prisma.contact.findMany.mockReset();
+  prisma.contact.create.mockReset();
+  prisma.contact.update.mockReset();
+  findDuplicateContactFullMock.mockReset();
+});
+
+describe('POST /api/wellness/public/enquiry', () => {
+  test('rejects missing tenantSlug', async () => {
+    const res = await request(makeApp())
+      .post('/api/wellness/public/enquiry')
+      .send({ firstName: 'Asha', lastName: 'Iyer', email: 'asha@example.com', phone: '+919876543210' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'MISSING_TENANT' });
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+  });
+
+  test('creates a Lead contact for the wellness tenant', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({
+      id: 1,
+      slug: 'enhanced-wellness',
+      vertical: 'wellness',
+      name: 'Enhanced Wellness',
+    });
+    findDuplicateContactFullMock.mockResolvedValue(null);
+    prisma.contact.create.mockResolvedValue({ id: 42 });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/public/enquiry')
+      .send({
+        tenantSlug: 'enhanced-wellness',
+        firstName: 'Asha',
+        lastName: 'Iyer',
+        email: 'asha@example.com',
+        phone: '+919876543210',
+        service: 'Hair Restoration',
+        message: '<b>Need</b> a consult',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ created: true, contactId: 42 });
+    expect(prisma.contact.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        tenantId: 1,
+        name: 'Asha Iyer',
+        email: 'asha@example.com',
+        phone: '+919876543210',
+        status: 'Lead',
+        source: 'website',
+      }),
+    }));
+  });
+
+  test('dedupes by email and updates the existing contact', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({
+      id: 1,
+      slug: 'enhanced-wellness',
+      vertical: 'wellness',
+      name: 'Enhanced Wellness',
+    });
+    findDuplicateContactFullMock.mockResolvedValue({
+      contact: {
+        id: 77,
+        name: 'Asha Iyer',
+        email: 'asha@example.com',
+        phone: '+919876543210',
+        description: 'Existing note',
+        firstTouchSource: null,
+      },
+    });
+    prisma.contact.update.mockResolvedValue({ id: 77 });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/public/enquiry')
+      .send({
+        tenantSlug: 'enhanced-wellness',
+        firstName: 'Asha',
+        lastName: 'Iyer',
+        email: 'asha@example.com',
+        phone: '+919876543210',
+        service: 'Skin & Aesthetics',
+        message: 'Please call back',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ created: false, duplicate: true, contactId: 77 });
+    expect(prisma.contact.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 77 },
+      data: expect.objectContaining({
+        status: 'Lead',
+        name: 'Asha Iyer',
+      }),
+    }));
+  });
+});

--- a/e2e/tests/wellness-public-enquiry-api.spec.js
+++ b/e2e/tests/wellness-public-enquiry-api.spec.js
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:5000';
+const RUN_TAG = `wellness-public-enquiry-${Date.now()}`;
+
+test.describe.serial('Wellness public enquiry API', () => {
+  const uniquePhone = '9' + String(Date.now()).slice(-9);
+  const uniqueEmail = `${RUN_TAG}@example.com`;
+
+  test('POST /api/wellness/public/enquiry creates a wellness lead', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/wellness/public/enquiry`, {
+      data: {
+        tenantSlug: 'enhanced-wellness',
+        firstName: 'Asha',
+        lastName: 'Iyer',
+        email: uniqueEmail,
+        phone: uniquePhone,
+        service: 'Hair Restoration',
+        message: `${RUN_TAG} checking consultation availability`,
+      },
+    });
+
+    expect(res.ok(), `create enquiry: ${await res.text()}`).toBeTruthy();
+    const body = await res.json();
+    expect(body.created).toBe(true);
+    expect(typeof body.contactId).toBe('number');
+    expect(body.message).toMatch(/we'll be in touch/i);
+  });
+
+  test('duplicate enquiry returns duplicate:true instead of creating a second lead', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/wellness/public/enquiry`, {
+      data: {
+        tenantSlug: 'enhanced-wellness',
+        firstName: 'Asha',
+        lastName: 'Iyer',
+        email: uniqueEmail,
+        phone: uniquePhone,
+        service: 'Hair Restoration',
+        message: `${RUN_TAG} duplicate submission`,
+      },
+    });
+
+    expect(res.ok(), `duplicate enquiry: ${await res.text()}`).toBeTruthy();
+    const body = await res.json();
+    expect(body.created).toBe(false);
+    expect(body.duplicate).toBe(true);
+    expect(typeof body.contactId).toBe('number');
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -592,6 +592,14 @@ function GenericOnly({ children }) {
   return children;
 }
 
+function GenericOrWellnessOnly({ children }) {
+  const { tenant, user } = useContext(AuthContext);
+  if (tenant?.vertical === 'travel') {
+    return <Navigate to={landingFor(user, tenant)} replace />;
+  }
+  return children;
+}
+
 // #207/#214: doctor/telecaller landing on /wellness directly (e.g. clicking
 // the sidebar logo, typing the URL, or refreshing) would still see the Owner
 // Dashboard with org-wide P&L. Gate the Owner Dashboard route to ADMIN/MANAGER
@@ -1333,10 +1341,10 @@ export default function App() {
                       }
                     />
                     <Route path="landing-pages" element={<TravelOnly><LandingPages /></TravelOnly>} />
-                    <Route path="landing-sites" element={<GenericOnly><LandingSites /></GenericOnly>} />
+                    <Route path="landing-sites" element={<GenericOrWellnessOnly><LandingSites /></GenericOrWellnessOnly>} />
                     <Route
                       path="landing-sites/builder/:id"
-                      element={<GenericOnly><LandingPageBuilder /></GenericOnly>}
+                      element={<GenericOrWellnessOnly><LandingPageBuilder /></GenericOrWellnessOnly>}
                     />
                     <Route
                       path="landing-pages/builder/:id"

--- a/frontend/src/__tests__/App.authSync.test.jsx
+++ b/frontend/src/__tests__/App.authSync.test.jsx
@@ -97,6 +97,46 @@ describe("<App /> — auth-sync on mount", () => {
       headers: { Authorization: `Bearer ${token}` },
     });
   });
+  it("allows a wellness tenant to stay on /landing-sites", async () => {
+    const token = "wellness-token";
+    sessionStorage.setItem("token", token);
+    window.history.pushState({}, "landing-sites", "/landing-sites");
+
+    setupFetch((url) => {
+      if (url === "/api/auth/me") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              id: 31,
+              name: "Rishu (Owner)",
+              email: "rishu@enhancedwellness.in",
+              role: "ADMIN",
+              tenant: {
+                id: 2,
+                name: "Enhanced Wellness",
+                slug: "enhanced-wellness",
+                vertical: "wellness",
+              },
+            }),
+        });
+      }
+      if (url === "/api/subscriptions/status") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ daysRemaining: 30, status: "active" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByTestId("lazy-route")).toBeInTheDocument());
+    expect(window.location.pathname).toBe("/landing-sites");
+  });
+
 
   it("overwrites stale localStorage user/tenant with the server identity", async () => {
     const token = "travel-token";

--- a/frontend/src/__tests__/BlockRenderer.test.jsx
+++ b/frontend/src/__tests__/BlockRenderer.test.jsx
@@ -18,7 +18,7 @@
  * Pattern: vitest + React Testing Library with mocked Image constructor
  */
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import BlockRenderer from '../components/landing-page-renderers/BlockRenderer';
 
@@ -230,6 +230,35 @@ describe('<BlockRenderer /> — block rendering and pageId passing', () => {
     expect(img.src).toBe('https://example.com/image.jpg');
   });
 
+  test('wellness event images stretch to their column and keep auto height', () => {
+    render(
+      <MemoryRouter>
+        <BlockRenderer landingPage={{
+          id: 222,
+          slug: 'wellness-page',
+          title: 'Wellness Page',
+          content: [
+            {
+              id: 'img2',
+              type: 'image',
+              props: {
+                src: 'https://example.com/wellness.jpg',
+                alt: 'Wellness image',
+                variant: 'wellness-event-image',
+                maxWidth: '420px',
+              },
+            },
+          ],
+        }} />
+      </MemoryRouter>
+    );
+
+    const img = screen.getByAltText('Wellness image');
+    expect(img).toBeInTheDocument();
+    expect(img.style.width).toBe('100%');
+    expect(img.style.maxWidth).toBe('100%');
+    expect(img.style.height).toBe('310px');
+  });
   test('renders button block with link', () => {
     const pageWithButton = {
       id: 222,
@@ -398,6 +427,42 @@ describe('<BlockRenderer /> — block rendering and pageId passing', () => {
     expect(screen.getByText('Known block')).toBeInTheDocument();
     expect(screen.getByText('Another known block')).toBeInTheDocument();
     // Unknown block should not render, no error thrown
+  });
+
+  test('public landing-site forms submit through public API endpoint', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, message: 'OK' }),
+    });
+
+    render(
+      <MemoryRouter>
+        <BlockRenderer landingPage={{
+          id: 456,
+          slug: 'public-site',
+          title: 'Public Site',
+          publicSubmit: true,
+          content: [
+            {
+              id: 'form1',
+              type: 'form',
+              props: {
+                fields: [{ name: 'email', label: 'Email', type: 'email' }],
+                submitText: 'Send',
+              },
+            },
+          ],
+        }} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Send/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/pages/public-site/submit', expect.any(Object));
+    });
+    global.fetch = originalFetch;
   });
 
   test('pageId null falls back gracefully (old HTML renderer compatibility)', () => {

--- a/frontend/src/__tests__/InvoicesAdmin.test.jsx
+++ b/frontend/src/__tests__/InvoicesAdmin.test.jsx
@@ -303,6 +303,55 @@ describe('<InvoicesAdmin /> — page chrome', () => {
   });
 });
 
+describe('<InvoicesAdmin /> - Excel Software reconciliation', () => {
+  let originalFetch;
+  let fetchSpy;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchSpy = vi.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        totalRows: 1,
+        scannedInvoices: 1,
+        matchedRows: 1,
+        mismatchedRows: 0,
+        missingRows: 0,
+        discrepancyCount: 0,
+        discrepancies: [],
+        workbookAmount: 100,
+        matchedAmount: 100,
+      }),
+    }));
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('uploads a workbook as multipart/form-data and renders the summary', async () => {
+    renderPage();
+    await screen.findByText(/Travel Invoices/i);
+    const file = new File(['Invoice Number,Invoice Total\nTINV-2026-0001,100'], 'travel-accounting.csv', { type: 'text/csv' });
+    fireEvent.change(screen.getByLabelText(/Excel Software reconciliation file/i), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Run reconciliation/i }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toBe('/api/travel/invoices/reconcile/excel-software');
+    expect(opts?.method).toBe('POST');
+    expect(opts?.headers?.Authorization).toBe('Bearer test-token');
+    expect(opts?.body).toBeInstanceOf(FormData);
+    expect(await screen.findByTestId('excel-reconciliation-result')).toBeInTheDocument();
+    expect(notifySuccess).toHaveBeenCalledWith(expect.stringMatching(/Matched 1 invoices/i));
+  });
+});
+
 describe('<InvoicesAdmin /> — list fetch + filter chrome', () => {
   it('GETs /api/travel/invoices on mount (no querystring) + renders invoice rows', async () => {
     renderPage();

--- a/frontend/src/__tests__/LandingPageBuilder.test.jsx
+++ b/frontend/src/__tests__/LandingPageBuilder.test.jsx
@@ -70,6 +70,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { AuthContext } from "../App";
 
 const fetchApiMock = vi.fn();
 vi.mock("../utils/api", () => ({
@@ -130,13 +131,20 @@ function defaultFetch(url, opts) {
   return Promise.resolve([]);
 }
 
-function renderBuilder(initialPath = "/landing-pages/42") {
+function renderBuilder(initialPath = "/landing-pages/42", tenantVertical = "travel") {
+  const authValue = {
+    user: { tenant: { vertical: tenantVertical } },
+    tenant: { vertical: tenantVertical },
+    loading: false,
+  };
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Routes>
-        <Route path="/landing-pages/:id" element={<LandingPageBuilder />} />
-      </Routes>
-    </MemoryRouter>,
+    <AuthContext.Provider value={authValue}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/landing-pages/:id" element={<LandingPageBuilder />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
   );
 }
 
@@ -191,6 +199,24 @@ describe("<LandingPageBuilder /> — page surface", () => {
         (!opts || !opts.method || opts.method === "GET"),
     );
     expect(routingFetch).toBe(true);
+  });
+
+  it("generic tenants do not fetch /api/travel/trips or render the trip picker", async () => {
+    renderBuilder("/landing-pages/42", "generic");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Page title")).toBeInTheDocument();
+    });
+
+    expect(
+      fetchApiMock.mock.calls.some(
+        ([url, opts]) =>
+          url === "/api/travel/trips?limit=200" &&
+          (!opts || !opts.method || opts.method === "GET"),
+      ),
+    ).toBe(false);
+    expect(
+      screen.queryByLabelText(/Link landing page to TMC trip/i),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the top bar with title input + slug input + counter after load", async () => {
@@ -434,6 +460,36 @@ describe("<LandingPageBuilder /> — page surface", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────
+  it("wellness tenants can publish even when another page is already live", async () => {
+    const livePage = {
+      ...samplePagePublished,
+      id: 44,
+      title: "Community Wellness Camp",
+      slug: "community-wellness-camp",
+    };
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = (opts && opts.method) || "GET";
+      if (url === "/api/landing-pages/42" && method === "GET") return Promise.resolve(samplePageDraft);
+      if (url === "/api/landing-pages" && method === "GET") return Promise.resolve([livePage, samplePageDraft]);
+      if (url === "/api/lead-routing" && method === "GET") return Promise.resolve(sampleRules);
+      if (url === "/api/landing-pages/42/publish" && method === "POST") {
+        return Promise.resolve({ ...samplePageDraft, status: "PUBLISHED", publishedAt: new Date().toISOString() });
+      }
+      return Promise.resolve([]);
+    });
+
+    const user = userEvent.setup();
+    renderBuilder("/landing-pages/42", "wellness");
+    await waitFor(() => expect(screen.getByLabelText("Page title")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /^Publish/ }));
+
+    await waitFor(() => expect(fetchApiMock.mock.calls.some(([url, opts]) => url === "/api/landing-pages/42/publish" && opts?.method === "POST")).toBe(true));
+    expect(notifyInfo).toHaveBeenCalledWith(expect.stringContaining("Community Wellness Camp"));
+    await waitFor(() => expect(notifySuccess).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByRole("button", { name: /Unpublish/i })).toBeInTheDocument());
+  });
+
   // EXTENSION cases — added 2026-05-26 to cover block library variety,
   // property-editor mutation, remove / reorder block controls, save-state
   // transitions, body-shape edge cases, and form-block routing rules.

--- a/frontend/src/__tests__/Sidebar.test.jsx
+++ b/frontend/src/__tests__/Sidebar.test.jsx
@@ -170,6 +170,7 @@ const SAMPLE_WELLNESS_PAGES = [
   { category: 'Leads & Revenue', path: '/wellness/telecaller-queue', label: 'Telecaller Queue' },
   { category: 'Finance', path: '/wellness/pos', label: 'Point of Sale' },
   { category: 'Finance', path: '/wellness/invoices', label: 'Invoices' },
+  { category: 'Marketing', path: '/landing-sites', label: 'Landing Sites' },
   { category: 'Products', path: '/wellness/products', label: 'Products' },
   { category: 'Products', path: '/wellness/product-categories', label: 'Categories' },
   { category: 'Products', path: '/wellness/auto-consumption', label: 'Auto-consumption' },
@@ -298,6 +299,18 @@ describe('Sidebar — load-bearing render surface', () => {
       expect(screen.getByText('Attendance')).toBeTruthy();
       expect(screen.getByText('Unified Inbox')).toBeTruthy();
       expect(screen.getByText('Point of Sale')).toBeTruthy();
+    });
+
+    it('renders Landing Sites in the Marketing section for wellness tenants', async () => {
+      renderSidebar({
+        vertical: 'wellness',
+        role: 'ADMIN',
+        accessiblePages: [
+          { category: 'Marketing', path: '/landing-sites', label: 'Landing Sites' },
+        ],
+      });
+      await screen.findByText('Landing Sites');
+      expect(document.querySelector('a[href="/landing-sites"]')).toBeTruthy();
     });
 
     it('shows wellness submodules only while their module is hovered', async () => {

--- a/frontend/src/__tests__/TmcCatalogueAdmin.test.jsx
+++ b/frontend/src/__tests__/TmcCatalogueAdmin.test.jsx
@@ -37,14 +37,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 const fetchApiMock = vi.fn();
+const rawFetchMock = vi.fn();
 vi.mock('../utils/api', () => ({
   fetchApi: (...args) => fetchApiMock(...args),
   getAuthToken: () => 'test-token',
 }));
+
+vi.stubGlobal('fetch', (...args) => rawFetchMock(...args));
 
 const notifyError = vi.fn();
 const notifySuccess = vi.fn();
@@ -165,12 +168,24 @@ function renderPage(user = ADMIN_USER) {
 
 beforeEach(() => {
   fetchApiMock.mockReset();
+  rawFetchMock.mockReset();
   notifyError.mockReset();
   notifySuccess.mockReset();
   notifyInfo.mockReset();
   notifyConfirm.mockReset();
   notifyConfirm.mockResolvedValue(true);
+  if (typeof window !== 'undefined' && window.URL) {
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:mock'),
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  }
   installFetchMock();
+  vi.stubGlobal('fetch', (...args) => rawFetchMock(...args));
 });
 
 afterEach(() => {
@@ -527,5 +542,113 @@ describe('<TmcCatalogueAdmin /> — theme + role gating', () => {
     expect(
       screen.queryByRole('button', { name: /Promote USA STEM Immersion to active/i }),
     ).toBeNull();
+  });
+});
+
+
+describe('<TmcCatalogueAdmin /> - bulk import template + ingest flow', () => {
+  it('downloads the CSV template with bearer auth and triggers a file download', async () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    rawFetchMock.mockImplementation(async (url) => {
+      if (String(url).includes('/api/travel-tmc-catalogue/import-template?format=csv')) {
+        return {
+          ok: true,
+          status: 200,
+          blob: async () => new Blob(['tripId,title'], { type: 'text/csv' }),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderPage();
+    await screen.findByText('Golden Triangle Heritage Trail');
+
+    fireEvent.click(screen.getByRole('button', { name: /Download CSV template/i }));
+
+    await waitFor(() => {
+      expect(rawFetchMock).toHaveBeenCalled();
+    });
+
+    const [url, opts] = rawFetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/travel-tmc-catalogue/import-template?format=csv');
+    expect(opts?.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(clickSpy).toHaveBeenCalled();
+    expect(window.URL.createObjectURL).toHaveBeenCalled();
+    expect(notifySuccess).toHaveBeenCalledWith(expect.stringMatching(/Downloaded CSV template/i));
+  });
+
+  it('uploads a spreadsheet, shows the ingest summary, and marks imported rows as pending review', async () => {
+    installFetchMock({
+      archived: {
+        catalogue: [
+          ...ARCHIVED_ROWS,
+          makeRow({
+            id: 303,
+            tripId: 'andaman-sea-explorer',
+            title: 'Andaman Sea Explorer',
+            status: 'archived',
+          }),
+        ],
+        total: ARCHIVED_ROWS.length + 1,
+        limit: 100,
+        offset: 0,
+      },
+    });
+
+    rawFetchMock.mockImplementation(async (url, opts) => {
+      if (String(url) === '/api/travel-tmc-catalogue/import') {
+        const body = opts?.body;
+        const entries = body ? Array.from(body.entries()) : [];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            imported: 1,
+            updated: 1,
+            skipped: 0,
+            total: 2,
+            reviewLabel: 'AI-classified, pending review',
+            createdTripIds: ['andaman-sea-explorer'],
+            updatedTripIds: ['golden-triangle'],
+            errors: [],
+            _entries: entries,
+          }),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderPage();
+    await screen.findByText('Golden Triangle Heritage Trail');
+
+    const file = new File(['tripId,title'], 'tmc-catalogue.csv', { type: 'text/csv' });
+    fireEvent.change(screen.getByLabelText('Bulk import file'), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole('button', { name: /Upload & classify/i }));
+
+    await waitFor(() => {
+      expect(rawFetchMock).toHaveBeenCalledWith(
+        '/api/travel-tmc-catalogue/import',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    const importCall = rawFetchMock.mock.calls.find(([url]) => String(url) === '/api/travel-tmc-catalogue/import');
+    expect(importCall).toBeTruthy();
+    const [, importOpts] = importCall;
+    expect(importOpts?.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    const formEntries = Array.from(importOpts.body.entries());
+    expect(formEntries[0][0]).toBe('file');
+    expect(formEntries[0][1]).toBe(file);
+
+    expect(await screen.findByTestId('tmc-catalogue-bulk-import-result')).toBeInTheDocument();
+    expect(notifySuccess).toHaveBeenCalledWith(
+      expect.stringMatching(/AI-classified, pending review: 1 new, 1 updated/i),
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Archived/i }));
+    expect(await screen.findByText('Andaman Sea Explorer')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('tmc-pending-review-andaman-sea-explorer'),
+    ).toHaveTextContent(/AI-classified, pending review/i);
   });
 });

--- a/frontend/src/__tests__/TravelPipeline.test.jsx
+++ b/frontend/src/__tests__/TravelPipeline.test.jsx
@@ -102,7 +102,12 @@ function mockFetch(itins = DEFAULT_ITINS, contacts = []) {
   });
 }
 
-function renderPage(user = ADMIN_USER) {
+function setTheme(theme = "light") {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+function renderPage(user = ADMIN_USER, theme = "light") {
+  setTheme(theme);
   return render(
     <AuthContext.Provider value={{ user }}>
       <MemoryRouter>
@@ -119,6 +124,7 @@ describe("TravelPipeline", () => {
     vi.clearAllMocks();
     notifyObj.confirm.mockResolvedValue(true);
     mockFetch();
+    setTheme("light");
   });
 
   // 1. Page chrome
@@ -367,6 +373,48 @@ describe("TravelPipeline", () => {
     // TravelStall badge
     const tsLabel = screen.getAllByText("TravelStall");
     expect(tsLabel.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses softer tones in light mode", async () => {
+    renderPage(ADMIN_USER, "light");
+    await screen.findByText("Bali Honeymoon Special");
+
+    const tmcBadge = screen.getAllByText("TMC").find((el) => el.getAttribute("style"));
+    expect(tmcBadge).toBeTruthy();
+    expect(tmcBadge.getAttribute("style")).toContain("rgba(18, 38, 71, 0.06)");
+    expect(tmcBadge.getAttribute("style")).toContain("rgba(18, 38, 71, 0.12)");
+
+    const statusSelectLight = screen.getAllByLabelText("Change status")[0];
+    expect(statusSelectLight.getAttribute("style")).toContain("rgba(47, 122, 77, 0.12)");
+    expect(statusSelectLight.getAttribute("style")).toContain("rgba(47, 122, 77, 0.18)");
+  });
+
+  it("keeps richer tones in dark mode", async () => {
+    renderPage(ADMIN_USER, "dark");
+    await screen.findByText("Bali Honeymoon Special");
+
+    const darkTmcBadge = screen.getAllByText("TMC").find((el) => el.getAttribute("style"));
+    expect(darkTmcBadge).toBeTruthy();
+    expect(darkTmcBadge.getAttribute("style")).toContain("rgba(18, 38, 71, 0.72)");
+    expect(darkTmcBadge.getAttribute("style")).toContain("rgba(157, 183, 230, 0.18)");
+
+    const statusSelectDark = screen.getAllByLabelText("Change status")[0];
+    expect(statusSelectDark.getAttribute("style")).toContain("rgba(47, 122, 77, 0.22)");
+    expect(statusSelectDark.getAttribute("style")).toContain("rgba(47, 122, 77, 0.3)");
+  });
+
+  it("updates status styling immediately when the app theme toggles", async () => {
+    renderPage(ADMIN_USER, "light");
+    await screen.findByText("Bali Honeymoon Special");
+
+    const statusSelect = screen.getAllByLabelText("Change status")[0];
+    expect(statusSelect.getAttribute("style")).toContain("rgba(47, 122, 77, 0.12)");
+
+    setTheme("dark");
+    await waitFor(() => {
+      const updated = screen.getAllByLabelText("Change status")[0];
+      expect(updated.getAttribute("style")).toContain("rgba(47, 122, 77, 0.22)");
+    });
   });
 
   // Refresh button re-fetches

--- a/frontend/src/__tests__/TripDetail.test.jsx
+++ b/frontend/src/__tests__/TripDetail.test.jsx
@@ -103,6 +103,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 const fetchApiMock = vi.fn();
+const rawFetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
 vi.mock('../utils/api', () => ({
   fetchApi: (...args) => fetchApiMock(...args),
   getAuthToken: () => 'test-token',
@@ -270,6 +272,8 @@ function renderPage(tripId = 101) {
 
 beforeEach(() => {
   fetchApiMock.mockReset();
+  rawFetchMock.mockReset();
+  globalThis.fetch = rawFetchMock;
   notifyError.mockReset();
   notifySuccess.mockReset();
   notifyInfo.mockReset();
@@ -284,6 +288,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  globalThis.fetch = originalFetch;
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -475,6 +480,32 @@ describe('<TripDetail /> — Participants tab', () => {
       ([, o]) => o?.method === 'POST',
     );
     expect(posts.length).toBe(0);
+  });
+
+  it('bulk import panel posts multipart file and shows the summary', async () => {
+    rawFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ inserted: 1, updated: 1, skipped: 0, errors: [], total: 2 }),
+    });
+    renderPage();
+    await screen.findByText('TMC-AND-2026-MUMBAI-G7');
+    fireEvent.click(screen.getByRole('tab', { name: /Participants/i }));
+    await screen.findByText('Anaya Sharma');
+    const file = new File(['fullName,parentPhone\nKabir Mehta,9876543210'], 'participants.csv', { type: 'text/csv' });
+    fireEvent.change(screen.getByLabelText(/Bulk import participants file/i), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Import file/i }));
+    await waitFor(() => {
+      expect(rawFetchMock).toHaveBeenCalled();
+    });
+    const [url, opts] = rawFetchMock.mock.calls[0];
+    expect(url).toBe('/api/travel/trips/101/participants/import');
+    expect(opts?.method).toBe('POST');
+    expect(opts?.body).toBeInstanceOf(FormData);
+    expect(await screen.findByTestId('participant-bulk-import-result')).toBeInTheDocument();
+    expect(notifySuccess).toHaveBeenCalledWith(expect.stringMatching(/Imported 1, updated 1/i));
   });
 });
 

--- a/frontend/src/components/landing-blocks/BasicBlocks.jsx
+++ b/frontend/src/components/landing-blocks/BasicBlocks.jsx
@@ -11,14 +11,24 @@ export function HeadingBlock({ props = {} }) {
   const align = props.align || 'left';
   const color = props.color || '#1a1a1a';
   const text = props.text || '';
-
+  const variant = props.variant || '';
   const HeadingTag = level;
+
+  const variantStyle = variant === 'wellness-logo'
+    ? { fontSize: '0.92rem', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 700, margin: '0' }
+    : variant === 'wellness-display'
+      ? { fontSize: 'clamp(2rem, 5vw, 3.4rem)', lineHeight: 1.05, fontWeight: 800, margin: '0 0 16px 0' }
+      : variant === 'wellness-section-title' || variant === 'wellness-card-title'
+        ? { fontSize: variant === 'wellness-card-title' ? '1.25rem' : '1.35rem', fontWeight: 800, margin: '0 0 10px 0' }
+        : {};
+
   return (
     <HeadingTag
       style={{
         color,
         textAlign: align,
         margin: '0 0 16px 0',
+        ...variantStyle,
       }}
     >
       {text}
@@ -31,6 +41,17 @@ export function TextBlock({ props = {} }) {
   const color = props.color || '#444';
   const fontSize = props.fontSize || '16px';
   const text = props.text || '';
+  const variant = props.variant || '';
+
+  const variantStyle = variant === 'wellness-nav'
+    ? { textTransform: 'uppercase', letterSpacing: '0.16em', fontWeight: 700, margin: '10px 0 0' }
+    : variant === 'wellness-eyebrow'
+      ? { textTransform: 'uppercase', letterSpacing: '0.14em', fontWeight: 700, margin: '0 0 14px' }
+      : variant === 'wellness-detail'
+        ? { margin: '0 0 10px', lineHeight: 1.45 }
+        : variant === 'wellness-footer'
+          ? { margin: 0, padding: '22px 24px', background: '#202a27', color: '#ffffff', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 700 }
+          : {};
 
   return (
     <p
@@ -40,6 +61,7 @@ export function TextBlock({ props = {} }) {
         fontSize,
         lineHeight: '1.6',
         margin: '0 0 16px 0',
+        ...variantStyle,
       }}
     >
       {text}
@@ -49,20 +71,28 @@ export function TextBlock({ props = {} }) {
 
 export function ImageBlock({ props = {} }) {
   const width = props.width || '100%';
-  const maxWidth = props.maxWidth || '100%';
   const alt = props.alt || '';
   const src = safeUrl(props.src, 'image-src');
+  const variant = props.variant || '';
+  const isWellnessEventImage = variant === 'wellness-event-image';
+  const maxWidth = isWellnessEventImage ? '100%' : (props.maxWidth || '100%');
 
   return (
-    <div style={{ textAlign: 'center', margin: '0 0 16px 0' }}>
+    <div style={{ textAlign: 'center', margin: isWellnessEventImage ? '0' : '0 0 20px 0' }}>
       <img
         src={src}
         alt={alt}
         style={{
-          width,
+          width: isWellnessEventImage ? '100%' : width,
           maxWidth,
-          height: 'auto',
-          borderRadius: '8px',
+          height: isWellnessEventImage ? '310px' : 'auto',
+          objectFit: isWellnessEventImage ? 'cover' : undefined,
+          display: 'block',
+          margin: '0 auto',
+          borderRadius: isWellnessEventImage ? '18px' : '24px',
+          boxShadow: isWellnessEventImage ? '0 18px 45px rgba(31, 47, 44, 0.12)' : '0 24px 60px rgba(15, 23, 42, 0.10)',
+          border: isWellnessEventImage ? '1px solid #d8d2c3' : '1px solid rgba(148, 163, 184, 0.15)',
+          background: '#f4f1e8',
         }}
       />
     </div>
@@ -83,19 +113,22 @@ export function ButtonBlock({ props = {} }) {
     size === 'large' ? '18px' : size === 'small' ? '13px' : '15px';
 
   return (
-    <div style={{ textAlign: align, margin: '0 0 16px 0' }}>
+    <div style={{ textAlign: align, margin: '0 0 20px 0' }}>
       <a
         href={url}
         style={{
           display: 'inline-block',
           padding,
-          background: bgColor,
+          background: `linear-gradient(135deg, ${bgColor}, ${bgColor})`,
           color,
           textDecoration: 'none',
-          borderRadius: '6px',
+          borderRadius: '999px',
           fontSize,
-          fontWeight: '600',
+          fontWeight: '700',
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
           cursor: 'pointer',
+          boxShadow: '0 14px 28px rgba(15, 23, 42, 0.12)',
         }}
       >
         {text}
@@ -104,12 +137,14 @@ export function ButtonBlock({ props = {} }) {
   );
 }
 
-export function FormBlock({ props = {}, slug = '', pageId = null }) {
+export function FormBlock({ props = {}, slug = '', pageId = null, submitEndpoint = '' }) {
   const fields = props.fields || [];
   const submitText = props.submitText || 'Submit';
   const thankYouMessage = props.thankYouMessage || 'Thank you for your submission!';
   const enableCaptcha = !!props.enableCaptcha;
   const successRedirectUrl = props.successRedirectUrl || '';
+  const formTitle = props.title || '';
+  const formVariant = props.variant || '';
 
   const [formData, setFormData] = useState({});
   const [submitted, setSubmitted] = useState(false);
@@ -142,10 +177,9 @@ export function FormBlock({ props = {}, slug = '', pageId = null }) {
     }
 
     try {
-      // Use pageId if available (React renderer), fallback to slug (HTML renderer)
-      const endpoint = pageId
+      const endpoint = submitEndpoint || (pageId
         ? `/api/landing-pages/${pageId}/submit`
-        : `/p/${slug}/submit`;
+        : `/p/${slug}/submit`);
 
       const response = await fetch(endpoint, {
         method: 'POST',
@@ -216,49 +250,105 @@ export function FormBlock({ props = {}, slug = '', pageId = null }) {
         id={formId}
         onSubmit={handleSubmit}
         style={{
-          maxWidth: '480px',
-          margin: '0 auto 16px',
-          padding: '24px',
-          background: '#f9fafb',
-          borderRadius: '10px',
-          border: '1px solid #e5e7eb',
+          width: '100%',
+          maxWidth: formVariant === 'wellness-consultation' ? '100%' : '480px',
+          margin: formVariant === 'wellness-consultation' ? '0 0 20px' : '0 auto 20px',
+          padding: formVariant === 'wellness-consultation' ? '36px' : '28px',
+          background: formVariant === 'wellness-consultation' ? '#fbfaf4' : 'linear-gradient(180deg, #fffdf8 0%, #faf7ef 100%)',
+          borderRadius: formVariant === 'wellness-consultation' ? '18px' : '24px',
+          border: formVariant === 'wellness-consultation' ? '1px solid #d8d2c3' : '1px solid rgba(148, 163, 184, 0.22)',
+          borderTop: formVariant === 'wellness-consultation' ? '2px solid #7c6f45' : undefined,
+          boxShadow: formVariant === 'wellness-consultation' ? '0 18px 55px rgba(31, 47, 44, 0.08)' : '0 24px 80px rgba(15, 23, 42, 0.10)',
+          boxSizing: 'border-box',
         }}
       >
-        {fields.map((field) => {
+        {formTitle && (
+          <h2 style={{ margin: '0 0 28px', color: '#1f2f2c', fontFamily: "Georgia, 'Times New Roman', serif", fontSize: '1.75rem', fontWeight: 500 }}>
+            {formTitle}
+          </h2>
+        )}
+
+        <div style={{ display: formVariant === 'wellness-consultation' ? 'flex' : 'block', flexWrap: 'wrap', gap: formVariant === 'wellness-consultation' ? '0 16px' : 0 }}>
+        {fields.map((field, index) => {
           const fieldId = `${formId}_${field.name}`;
+          const fieldType = field.type || 'text';
+          const controlStyle = {
+            width: '100%',
+            padding: formVariant === 'wellness-consultation' ? '14px 16px' : '10px 12px',
+            border: formVariant === 'wellness-consultation' ? '1px solid #c9c3b4' : '1px solid #d1d5db',
+            borderRadius: formVariant === 'wellness-consultation' ? '8px' : '6px',
+            fontSize: '15px',
+            boxSizing: 'border-box',
+            background: formVariant === 'wellness-consultation' ? '#fffdf7' : '#ffffff',
+            backgroundColor: formVariant === 'wellness-consultation' ? '#fffdf7' : '#ffffff',
+            backgroundImage: 'none',
+            color: '#1f2937',
+            opacity: 1,
+            colorScheme: 'light',
+            WebkitTextFillColor: '#1f2937',
+            appearance: fieldType === 'select' ? 'auto' : undefined,
+            boxShadow: 'inset 0 0 0 9999px #fffdf7',
+          };
+          const isHalfWidth = formVariant === 'wellness-consultation' && index < 2;
           return (
-            <div key={field.name} style={{ marginBottom: '12px' }}>
+            <div key={field.name} style={{ marginBottom: formVariant === 'wellness-consultation' ? '18px' : '12px', flex: isHalfWidth ? '1 1 calc(50% - 8px)' : '1 1 100%', minWidth: isHalfWidth ? '0' : '100%', boxSizing: 'border-box' }}>
               <label
                 htmlFor={fieldId}
                 style={{
                   display: 'block',
-                  marginBottom: '4px',
-                  fontWeight: '500',
-                  color: '#333',
-                  fontSize: '14px',
+                  marginBottom: formVariant === 'wellness-consultation' ? '8px' : '4px',
+                  fontWeight: '600',
+                  color: formVariant === 'wellness-consultation' ? '#5e675f' : '#333',
+                  fontSize: formVariant === 'wellness-consultation' ? '12px' : '14px',
+                  letterSpacing: formVariant === 'wellness-consultation' ? '0.12em' : 0,
+                  textTransform: formVariant === 'wellness-consultation' ? 'uppercase' : 'none',
                 }}
               >
-                {field.label || field.name}
+                {field.label || field.name}{field.required && formVariant === 'wellness-consultation' ? ' *' : ''}
               </label>
-              <input
-                id={fieldId}
-                type={field.type || 'text'}
-                name={field.name}
-                value={formData[field.name] || ''}
-                onChange={handleChange}
-                required={field.required}
-                style={{
-                  width: '100%',
-                  padding: '10px 12px',
-                  border: '1px solid #d1d5db',
-                  borderRadius: '6px',
-                  fontSize: '15px',
-                  boxSizing: 'border-box',
-                }}
-              />
+              {fieldType === 'textarea' ? (
+                <textarea
+                  className={formVariant === 'wellness-consultation' ? 'wellness-form-control' : undefined}
+                  id={fieldId}
+                  name={field.name}
+                  value={formData[field.name] || ''}
+                  onChange={handleChange}
+                  required={field.required}
+                  placeholder={field.placeholder || ''}
+                  rows={4}
+                  style={{ ...controlStyle, resize: 'vertical', minHeight: '98px' }}
+                />
+              ) : fieldType === 'select' ? (
+                <select
+                  className={formVariant === 'wellness-consultation' ? 'wellness-form-control' : undefined}
+                  id={fieldId}
+                  name={field.name}
+                  value={formData[field.name] || ''}
+                  onChange={handleChange}
+                  required={field.required}
+                  style={controlStyle}
+                >
+                  {(field.options || []).map((option) => (
+                    <option key={String(option)} value={String(option)}>{String(option)}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  className={formVariant === 'wellness-consultation' ? 'wellness-form-control' : undefined}
+                  id={fieldId}
+                  type={fieldType}
+                  name={field.name}
+                  value={formData[field.name] || ''}
+                  onChange={handleChange}
+                  required={field.required}
+                  placeholder={field.placeholder || ''}
+                  style={controlStyle}
+                />
+              )}
             </div>
           );
         })}
+        </div>
 
         {enableCaptcha && (
           <div style={{ margin: '0 0 12px 0' }}>
@@ -281,13 +371,15 @@ export function FormBlock({ props = {}, slug = '', pageId = null }) {
           disabled={loading}
           style={{
             width: '100%',
-            padding: '12px',
-            background: '#2563eb',
+            padding: formVariant === 'wellness-consultation' ? '16px' : '12px',
+            background: formVariant === 'wellness-consultation' ? 'linear-gradient(90deg, #b7ad8c, #d1a083)' : '#2563eb',
             color: '#fff',
             border: 'none',
-            borderRadius: '6px',
+            borderRadius: formVariant === 'wellness-consultation' ? '999px' : '6px',
             fontSize: '15px',
-            fontWeight: '600',
+            fontWeight: '700',
+            letterSpacing: formVariant === 'wellness-consultation' ? '0.1em' : 0,
+            textTransform: formVariant === 'wellness-consultation' ? 'uppercase' : 'none',
             cursor: loading ? 'not-allowed' : 'pointer',
             opacity: loading ? 0.6 : 1,
           }}
@@ -370,24 +462,80 @@ export function VideoBlock({ props = {} }) {
 export function ColumnsBlock({ props = {}, renderBlock }) {
   const columns = props.columns || [];
   const gap = props.gap || '24px';
+  const variant = props.variant || '';
+  const isWellnessCampaignPage = variant === 'wellness-campaign-page';
+  const isWellnessHeaderRow = variant === 'wellness-header-row';
+  const isWellnessHeroRow = variant === 'wellness-hero-row';
+  const isWellnessRegistrationRow = variant === 'wellness-registration-row';
+  const isWellnessBenefitCards = variant === 'wellness-benefit-cards';
+  const isWellnessConsultation = variant === 'wellness-consultation';
+  const looksLikeWellnessSupporting = columns.some((col) => (col.components || []).some((child) => ['why-title', 'after-title'].includes(child.id)));
+  const isWellnessSupporting = variant === 'wellness-supporting' || looksLikeWellnessSupporting;
+  const isWellnessSection = isWellnessCampaignPage || isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards || isWellnessConsultation || isWellnessSupporting;
+  const isWellnessInnerRow = isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards;
+  const hasFullWidthSupport = isWellnessConsultation && columns.some((col) => col.fullWidth);
+
+  const containerStyle = isWellnessCampaignPage ? {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap,
+    alignItems: 'stretch',
+    width: '1040px',
+    maxWidth: '1040px',
+    minWidth: '960px',
+    margin: '0 auto 36px',
+    padding: 0,
+    background: '#fbfaf4',
+    color: '#1f2f2c',
+    borderRadius: '18px',
+    border: '1px solid #d8d2c3',
+    boxShadow: '0 28px 80px rgba(31, 47, 44, 0.14)',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+  } : {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap,
+    alignItems: 'stretch',
+    width: '100%',
+    maxWidth: isWellnessSection ? '100%' : undefined,
+    margin: isWellnessInnerRow ? 0 : (isWellnessConsultation && !hasFullWidthSupport ? '0 auto 0' : (isWellnessSection ? '0 auto 36px' : '0 0 20px 0')),
+    padding: isWellnessHeaderRow ? '24px 56px 18px' : isWellnessHeroRow ? '30px 52px 22px' : isWellnessRegistrationRow ? '18px 56px 46px' : isWellnessBenefitCards ? 0 : (isWellnessSection ? (isWellnessConsultation ? '36px' : '0 44px 36px') : 0),
+    background: isWellnessInnerRow || isWellnessConsultation || isWellnessSupporting ? '#fbfaf4' : 'transparent',
+    color: isWellnessSection ? '#1f2f2c' : undefined,
+    borderRadius: isWellnessConsultation ? (hasFullWidthSupport ? '18px' : '18px 18px 0 0') : (isWellnessSupporting ? '0 0 18px 18px' : 0),
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+  };
+
+  const columnStyle = (col, idx) => {
+    let flex = col.fullWidth ? '1 1 100%' : '1 1 0';
+    if (isWellnessHeroRow) flex = idx === 1 ? '1 1 0' : '1.35 1 0';
+    if (isWellnessRegistrationRow) flex = idx === 0 ? '1.15 1 0' : '0.85 1 0';
+    if (isWellnessBenefitCards) flex = '1 1 100%';
+    if (isWellnessConsultation && idx === 1) flex = '0 1 480px';
+
+    return {
+      flex,
+      minWidth: col.fullWidth ? '100%' : (isWellnessHeroRow ? (idx === 1 ? '340px' : '460px') : isWellnessRegistrationRow ? (idx === 0 ? '540px' : '360px') : isWellnessSection ? '280px' : '260px'),
+      maxWidth: '100%',
+      boxSizing: 'border-box',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: isWellnessBenefitCards ? '10px' : '16px',
+      padding: isWellnessBenefitCards ? '28px' : 0,
+      background: isWellnessBenefitCards ? '#fffdf7' : 'transparent',
+      border: isWellnessBenefitCards ? '1px solid #d8d2c3' : 'none',
+      borderRadius: isWellnessBenefitCards ? '18px' : 0,
+      boxShadow: isWellnessBenefitCards ? '0 14px 35px rgba(31, 47, 44, 0.06)' : 'none',
+      justifyContent: isWellnessBenefitCards ? 'center' : undefined,
+    };
+  };
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap,
-        margin: '0 0 16px 0',
-      }}
-    >
+    <div style={containerStyle}>
       {columns.map((col, idx) => (
-        <div
-          key={idx}
-          style={{
-            flex: 1,
-            minWidth: '250px',
-          }}
-        >
+        <div key={idx} style={columnStyle(col, idx)}>
           {col.components &&
             col.components.map((c, cidx) => (
               <div key={cidx}>{renderBlock ? renderBlock(c) : null}</div>

--- a/frontend/src/components/landing-page-renderers/BlockRenderer.jsx
+++ b/frontend/src/components/landing-page-renderers/BlockRenderer.jsx
@@ -35,7 +35,7 @@ import {
  * @param {number} pageId - Landing page ID for API submissions
  * @param {Function} renderBlockFn - Recursive render function for nested blocks
  */
-function renderBlock(block, slug, pageId, renderBlockFn) {
+function renderBlock(block, slug, pageId, renderBlockFn, submitEndpoint = '') {
   if (!block || !block.type) return null;
 
   const { type, props = {} } = block;
@@ -51,7 +51,7 @@ function renderBlock(block, slug, pageId, renderBlockFn) {
     case 'button':
       return <ButtonBlock key={block.id || Math.random()} props={props} />;
     case 'form':
-      return <FormBlock key={block.id || Math.random()} props={props} slug={slug} pageId={pageId} />;
+      return <FormBlock key={block.id || Math.random()} props={props} slug={slug} pageId={pageId} submitEndpoint={submitEndpoint} />;
     case 'divider':
       return <DividerBlock key={block.id || Math.random()} props={props} />;
     case 'spacer':
@@ -97,13 +97,103 @@ function renderBlock(block, slug, pageId, renderBlockFn) {
  * BlockRenderer — Renders a page from a block array.
  * The block array is stored in landingPage.content and parsed as JSON.
  */
+function cloneBlocks(blocks) {
+  try {
+    return JSON.parse(JSON.stringify(blocks));
+  } catch (_err) {
+    return Array.isArray(blocks) ? blocks : [];
+  }
+}
+
+function isCardishWellnessBlock(block) {
+  if (!block || block.type !== 'columns') return false;
+  const variant = block.props?.variant;
+  if (variant === 'wellness-benefit-cards' || variant === 'wellness-supporting') return true;
+  const ids = (block.props?.columns || [])
+    .flatMap((col) => (col.components || []).map((child) => child.id));
+  return ids.some((id) => ['contact-title', 'why-title', 'after-title'].includes(id));
+}
+
+function cardFromComponents(components) {
+  const title = components.find((child) => child.type === 'heading');
+  const copy = components.find((child) => child.type === 'text');
+  if (!title && !copy) return null;
+  return { components: [title, copy].filter(Boolean) };
+}
+
+function extractWellnessCards(block) {
+  if (!block || block.type !== 'columns') return [];
+  const cards = [];
+  (block.props?.columns || []).forEach((col) => {
+    const components = col.components || [];
+    const nested = components.find((child) => isCardishWellnessBlock(child));
+    if (nested) cards.push(...extractWellnessCards(nested));
+    const ownCard = cardFromComponents(components.filter((child) => !isCardishWellnessBlock(child)));
+    if (ownCard) cards.push(ownCard);
+  });
+  return cards;
+}
+
+function normalizeWellnessCampaignBlocks(blocks) {
+  const next = cloneBlocks(blocks);
+  const page = next.find((block) => block?.type === 'columns' && block.props?.variant === 'wellness-campaign-page');
+  if (!page) return next;
+  const extractedCards = [];
+  const pageColumns = page.props?.columns || [];
+  page.props.columns = pageColumns.filter((col) => {
+    const components = col.components || [];
+    const isRegistrationHolder = components.some((child) => child?.type === 'columns' && child.props?.variant === 'wellness-registration-row');
+    if (isRegistrationHolder) return true;
+    const cardBlocks = components.filter(isCardishWellnessBlock);
+    cardBlocks.forEach((block) => extractedCards.push(...extractWellnessCards(block)));
+    return cardBlocks.length === 0;
+  });
+
+  const registration = (page.props.columns || [])
+    .flatMap((col) => col.components || [])
+    .find((child) => child?.type === 'columns' && child.props?.variant === 'wellness-registration-row');
+  if (!registration) return next;
+
+  const regColumns = registration.props.columns || [];
+  const rightColumn = regColumns[1] || { components: [] };
+  const rightComponents = rightColumn.components || [];
+  const existingCardBlock = rightComponents.find(isCardishWellnessBlock);
+  const existingCards = existingCardBlock ? extractWellnessCards(existingCardBlock) : [];
+  const looseCard = cardFromComponents(rightComponents.filter((child) => !isCardishWellnessBlock(child)));
+  const cards = [...(looseCard ? [looseCard] : []), ...existingCards, ...extractedCards]
+    .filter((card, index, all) => {
+      const title = card.components?.[0]?.props?.text || '';
+      return title && all.findIndex((candidate) => candidate.components?.[0]?.props?.text === title) === index;
+    })
+    .slice(0, 3);
+
+  if (cards.length) {
+    registration.props.columns = [
+      regColumns[0] || { components: [] },
+      {
+        components: [
+          {
+            id: 'wellness-benefit-cards',
+            type: 'columns',
+            props: { gap: '18px', variant: 'wellness-benefit-cards', columns: cards },
+          },
+        ],
+      },
+    ];
+  }
+  return next;
+}
+
 export default function BlockRenderer({ landingPage = {} }) {
-  const blocks = Array.isArray(landingPage.content)
+  const rawBlocks = Array.isArray(landingPage.content)
     ? landingPage.content
     : [];
+  const blocks = normalizeWellnessCampaignBlocks(rawBlocks);
 
   const slug = landingPage.slug || '';
-  const pageId = landingPage.id || null;
+  const publicSubmit = !!landingPage.publicSubmit;
+  const pageId = publicSubmit ? null : (landingPage.id || null);
+  const submitEndpoint = publicSubmit && slug ? `/api/pages/${slug}/submit` : '';
 
   // Track analytics (page view)
   React.useEffect(() => {
@@ -112,7 +202,7 @@ export default function BlockRenderer({ landingPage = {} }) {
     }
   }, [slug]);
 
-  const renderBlockWithContext = (block) => renderBlock(block, slug, pageId, renderBlockWithContext);
+  const renderBlockWithContext = (block) => renderBlock(block, slug, pageId, renderBlockWithContext, submitEndpoint);
 
   return (
     <main className="landing-page block-renderer">
@@ -120,14 +210,47 @@ export default function BlockRenderer({ landingPage = {} }) {
         .landing-page {
           margin: 0;
           padding: 0;
+          min-height: 100vh;
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-          color: #333;
+          color: #243244;
           line-height: 1.6;
+          background:
+            radial-gradient(circle at top left, rgba(184, 137, 59, 0.08), transparent 34%),
+            linear-gradient(180deg, #fbf8f1 0%, #f8f5ed 28%, #ffffff 100%);
+        }
+
+
+        .landing-page .wellness-form-control,
+        .landing-page .wellness-form-control:disabled,
+        .landing-page .wellness-form-control:-webkit-autofill,
+        .landing-page .wellness-form-control:-webkit-autofill:hover,
+        .landing-page .wellness-form-control:-webkit-autofill:focus {
+          background: #fffdf7 !important;
+          background-color: #fffdf7 !important;
+          background-image: none !important;
+          color: #1f2937 !important;
+          -webkit-text-fill-color: #1f2937 !important;
+          opacity: 1 !important;
+          color-scheme: light !important;
+          box-shadow: inset 0 0 0 9999px #fffdf7 !important;
+        }
+
+        .landing-page .wellness-form-control::placeholder {
+          color: #7b807a !important;
+          opacity: 1 !important;
+        }
+
+        .landing-page .landing-page-content {
+          max-width: 1160px;
+          margin: 0 auto;
+          padding: 48px 20px 72px;
+          display: grid;
+          gap: 28px;
         }
 
         .landing-page section {
           margin: 0;
-          padding: 40px 20px;
+          padding: 0;
         }
 
         .landing-page h1,
@@ -135,11 +258,14 @@ export default function BlockRenderer({ landingPage = {} }) {
         .landing-page h3,
         .landing-page h4 {
           margin: 0 0 16px 0;
+          font-family: Georgia, 'Times New Roman', serif;
           font-weight: 600;
+          letter-spacing: -0.02em;
+          color: #1f2937;
         }
 
         .landing-page a {
-          color: #2563eb;
+          color: #8a6428;
           text-decoration: none;
         }
 

--- a/frontend/src/pages/LandingPageBuilder.jsx
+++ b/frontend/src/pages/LandingPageBuilder.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useReducer, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useReducer, useRef, useCallback, useContext } from 'react';
 import { useParams, useSearchParams, useLocation, Link } from 'react-router-dom';
 import { ArrowLeft, Save, Eye, Monitor, Smartphone, Plus, Trash2, ChevronUp, ChevronDown, Type, AlignLeft, Image, MousePointerClick, FileInput, Minus, Space, Video, Upload, Undo2, Redo2, Columns, MapPin, Building2, Sparkles, ListChecks, CalendarDays, IndianRupee, HelpCircle, MessageSquare, AlertCircle, CheckCircle2, Globe, Film, Shield, FileDown, PhoneCall, History, X, RotateCcw, UserPlus, Search, Copy, Star, ExternalLink } from 'lucide-react';
 import { fetchApi, getAuthToken } from '../utils/api';
@@ -9,6 +9,7 @@ import { PRESETS as REG_FORM_PRESETS, listPresets as listRegFormPresets, default
 import LandingPageTemplateEditor from './LandingPageTemplateEditor';
 import LandingPageWanderluxEditor, { LayoutPanel as WanderluxLayoutPanel } from './LandingPageWanderluxEditor';
 import { TeeDecisionPanel } from '../components/TeeDecisionPanel';
+import { AuthContext } from '../App';
 
 // Phase D1 — registered travel-page template ids. When a page's
 // templateType matches one of these, the builder mounts the
@@ -176,8 +177,10 @@ function formatVersionTimestamp(iso) {
 
 export default function LandingPageBuilder() {
   const notify = useNotify();
+  const auth = useContext(AuthContext) || {};
   const { id } = useParams();
   const location = useLocation();
+  const isTravelTenant = auth?.user?.tenant?.vertical === 'travel' || auth?.tenant?.vertical === 'travel';
   const isGenericLandingSites = location.pathname.startsWith('/landing-sites');
   // G094: sub-brand preview context. Admin lands at
   //   /landing-pages/<id>/builder?sub_brand=tmc
@@ -232,7 +235,7 @@ export default function LandingPageBuilder() {
   const [selectedVersion, setSelectedVersion] = useState(null);
   const [urlCopied, setUrlCopied] = useState(false);
   const [featuringPage, setFeaturingPage] = useState(false);
-  // Hard-block publish: track all pages so we can detect another live page.
+  // Track all pages so we can warn when another live page exists.
   const [allPages, setAllPages] = useState([]);
 
   // #449: hide the global app sidebar while the builder is mounted. The
@@ -277,7 +280,7 @@ export default function LandingPageBuilder() {
       .catch(() => setRoutingRules([]));
   }, []);
 
-  // Fetch all pages so we can hard-block publish when another page is live.
+  // Fetch all pages so we can warn when another page is live.
   useEffect(() => {
     fetchApi('/api/landing-pages')
       .then(res => setAllPages(Array.isArray(res) ? res : (res?.pages || [])))
@@ -289,10 +292,14 @@ export default function LandingPageBuilder() {
   // leave the picker empty so the toolbar renders without the dropdown
   // for generic users.
   useEffect(() => {
+    if (!isTravelTenant) {
+      setTmcTrips([]);
+      return;
+    }
     fetchApi('/api/travel/trips?limit=200')
       .then(res => Array.isArray(res?.trips) ? setTmcTrips(res.trips) : setTmcTrips([]))
       .catch(() => setTmcTrips([]));
-  }, []);
+  }, [isTravelTenant]);
   // Sync linking state with the page's persisted tripId so the
   // dropdown reflects "Linked to trip X" on load.
   useEffect(() => {
@@ -447,11 +454,12 @@ export default function LandingPageBuilder() {
 
   const handlePublish = async () => {
     if (!page?.id || publishing) return;
-    // Hard-block: only one page can be live at a time.
+    // We rely on the backend publish transaction to swap the featured/live
+    // page, so don't block wellness or generic pages here if another draft
+    // or live page already exists.
     const currentLive = allPages.find(p => p.status === 'PUBLISHED' && p.id !== page.id);
     if (currentLive) {
-      notify.error(`"${currentLive.title}" is currently live. Unpublish it before publishing this page. You can save this as a draft in the meantime.`);
-      return;
+      notify.info(`"${currentLive.title}" is currently live. Publishing this page will replace it.`);
     }
     setPublishing(true);
     try {
@@ -733,7 +741,7 @@ export default function LandingPageBuilder() {
             <Globe size={14} /> Open live
           </a>
         )}
-        {tmcTrips.length > 0 && (() => {
+        {isTravelTenant && tmcTrips.length > 0 && (() => {
           const selectedTrip = tmcTrips.find((t) => t.id === linkingTripId);
           const filteredTrips = tripSearch.trim()
             ? tmcTrips.filter((t) =>
@@ -834,19 +842,18 @@ export default function LandingPageBuilder() {
           </button>
         ) : (() => {
           const blockedBy = allPages.find((p) => p.status === 'PUBLISHED' && p.id !== page.id);
-          const isBlocked = !!blockedBy;
           return (
             <button
               onClick={handlePublish}
-              disabled={publishing || !slugIsValid || isBlocked}
+              disabled={publishing || !slugIsValid}
               title={
                 !slugIsValid
                   ? 'Fix the slug first'
-                  : isBlocked
-                    ? ('"' + blockedBy.title + '" is currently live - unpublish it first')
+                    : blockedBy
+                    ? ('"' + blockedBy.title + '" is currently live - publishing will replace it')
                     : 'Publish - runs the readiness check then makes the page public'
               }
-              style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', padding: '0.35rem 0.95rem', border: 'none', borderRadius: 6, background: (!slugIsValid || isBlocked) ? 'var(--subtle-bg)' : '#10b981', cursor: (publishing || !slugIsValid || isBlocked) ? 'not-allowed' : 'pointer', fontSize: '0.85rem', color: '#fff', fontWeight: 600, opacity: (publishing || isBlocked) ? 0.5 : 1 }}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', padding: '0.35rem 0.95rem', border: 'none', borderRadius: 6, background: !slugIsValid ? 'var(--subtle-bg)' : '#10b981', cursor: (publishing || !slugIsValid) ? 'not-allowed' : 'pointer', fontSize: '0.85rem', color: '#fff', fontWeight: 600, opacity: publishing ? 0.5 : 1 }}
             >
               <Globe size={13} /> {publishing ? 'Publishing...' : 'Publish'}
             </button>
@@ -1420,15 +1427,36 @@ const iconBarBtnStyle = (enabled) => ({
 function ComponentPreview({ comp }) {
   const p = comp.props;
   switch (comp.type) {
-    case 'heading': { const Tag = p.level || 'h2'; return <Tag style={{ textAlign: p.align, color: p.color, margin: '0.5rem 0' }}>{p.text}</Tag>; }
-    case 'text': return <p style={{ textAlign: p.align, color: p.color, fontSize: p.fontSize, margin: '0.5rem 0', lineHeight: 1.6 }}>{p.text}</p>;
+    case 'heading': {
+      const Tag = p.level || 'h2';
+      const variantStyle = p.variant === 'wellness-logo'
+        ? { fontSize: '0.92rem', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 700, margin: 0 }
+        : p.variant === 'wellness-display'
+          ? { fontSize: 'clamp(2rem, 5vw, 3.2rem)', lineHeight: 1.05, fontWeight: 800, margin: '0 0 1rem' }
+          : p.variant === 'wellness-section-title' || p.variant === 'wellness-card-title'
+            ? { fontSize: p.variant === 'wellness-card-title' ? '1.2rem' : '1.35rem', fontWeight: 800, margin: '0 0 0.6rem' }
+            : {};
+      return <Tag style={{ textAlign: p.align, color: p.color, margin: '0.5rem 0', ...variantStyle }}>{p.text}</Tag>;
+    }
+    case 'text': {
+      const variantStyle = p.variant === 'wellness-nav'
+        ? { textTransform: 'uppercase', letterSpacing: '0.16em', fontWeight: 700, margin: '0.7rem 0 0' }
+        : p.variant === 'wellness-eyebrow'
+          ? { textTransform: 'uppercase', letterSpacing: '0.14em', fontWeight: 700, margin: '0 0 0.8rem' }
+          : p.variant === 'wellness-detail'
+            ? { margin: '0 0 0.5rem', lineHeight: 1.45 }
+            : p.variant === 'wellness-footer'
+              ? { margin: 0, padding: '1.1rem', background: '#202a27', color: '#fff', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 700 }
+              : {};
+      return <p style={{ textAlign: p.align, color: p.color, fontSize: p.fontSize, margin: '0.5rem 0', lineHeight: 1.6, ...variantStyle }}>{p.text}</p>;
+    }
     case 'image': return (
       <div style={{ textAlign: 'center' }}>
         {/* Image preview with fallback */}
         <img
           src={p.src}
           alt={p.alt || 'Image failed to load'}
-          style={{ maxWidth: p.maxWidth || '100%', borderRadius: '6px', height: 'auto', minHeight: 80 }}
+          style={{ maxWidth: p.maxWidth || '100%', width: p.width || '100%', borderRadius: p.variant === 'wellness-event-image' ? '18px' : '6px', height: p.variant === 'wellness-event-image' ? 300 : 'auto', objectFit: p.variant === 'wellness-event-image' ? 'cover' : undefined, minHeight: 80, border: p.variant === 'wellness-event-image' ? '1px solid #d8d2c3' : undefined, background: '#f4f1e8' }}
           onError={(e) => {
             if (e.target.dataset.fallback === '1') return;
             e.target.dataset.fallback = '1';
@@ -1446,33 +1474,75 @@ function ComponentPreview({ comp }) {
     );
     case 'button': return <div style={{ textAlign: p.align }}><button style={{ padding: p.size === 'large' ? '1rem 2.5rem' : '0.75rem 1.5rem', background: p.bgColor, color: p.color, border: 'none', borderRadius: '6px', fontWeight: '600', fontSize: p.size === 'large' ? '1.1rem' : '1rem', cursor: 'pointer' }}>{p.text}</button></div>;
     case 'form': return (
-      <div style={{ maxWidth: '400px', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-        {(p.fields || []).map((f, i) => (
-          <div key={i}><label style={{ display: 'block', fontSize: '0.85rem', fontWeight: '500', marginBottom: '0.25rem', color: '#475569' }}>{f.label}{f.required && ' *'}</label>
-          <input type={f.type} style={{ width: '100%', padding: '0.6rem', border: '1px solid #cbd5e1', borderRadius: '6px' }} disabled /></div>
-        ))}
+      <div style={{ width: '100%', maxWidth: p.variant === 'wellness-consultation' ? '520px' : '400px', margin: '0 auto', padding: p.variant === 'wellness-consultation' ? '1.5rem' : 0, background: p.variant === 'wellness-consultation' ? '#fbfaf4' : 'transparent', border: p.variant === 'wellness-consultation' ? '1px solid #d8d2c3' : 'none', borderTop: p.variant === 'wellness-consultation' ? '2px solid #7c6f45' : 'none', borderRadius: p.variant === 'wellness-consultation' ? 14 : 0, display: 'flex', flexDirection: 'column', gap: '0.75rem', boxSizing: 'border-box', overflow: 'hidden' }}>
+        {p.title && <h2 style={{ margin: '0 0 0.8rem', color: '#1f2f2c', fontFamily: "Georgia, 'Times New Roman', serif", fontWeight: 500 }}>{p.title}</h2>}
+        <div style={{ display: p.variant === 'wellness-consultation' ? 'flex' : 'block', flexWrap: 'wrap', gap: p.variant === 'wellness-consultation' ? '0 0.9rem' : 0 }}>
+        {(p.fields || []).map((f, i) => {
+          const inputStyle = { width: '100%', padding: p.variant === 'wellness-consultation' ? '0.8rem 0.9rem' : '0.6rem', border: '1px solid #c9c3b4', borderRadius: '6px', background: '#fffdf7', backgroundColor: '#fffdf7', color: '#1f2937', boxSizing: 'border-box', opacity: 1, colorScheme: 'light', WebkitTextFillColor: '#1f2937' };
+          return (
+            <div key={i} style={{ flex: p.variant === 'wellness-consultation' && i < 2 ? '1 1 calc(50% - 0.45rem)' : '1 1 100%', minWidth: p.variant === 'wellness-consultation' && i < 2 ? 0 : '100%' }}>
+              <label style={{ display: 'block', fontSize: p.variant === 'wellness-consultation' ? '0.7rem' : '0.85rem', fontWeight: '600', marginBottom: '0.35rem', color: '#5e675f', letterSpacing: p.variant === 'wellness-consultation' ? '0.12em' : 0, textTransform: p.variant === 'wellness-consultation' ? 'uppercase' : 'none' }}>{f.label}{f.required && ' *'}</label>
+              {f.type === 'textarea' ? (
+                <textarea rows={4} style={{ ...inputStyle, resize: 'vertical' }} disabled />
+              ) : f.type === 'select' ? (
+                <select style={inputStyle} disabled>
+                  {(f.options || []).map((option) => <option key={String(option)}>{String(option)}</option>)}
+                </select>
+              ) : (
+                <input type={f.type || 'text'} style={inputStyle} disabled />
+              )}
+            </div>
+          );
+        })}
+        </div>
         {p.enableCaptcha && (
           <div style={{ padding: '0.6rem 0.8rem', background: 'rgba(59,130,246,0.08)', border: '1px dashed #3b82f6', borderRadius: '6px', fontSize: '0.8rem', color: '#2563eb', textAlign: 'center' }}>
             CAPTCHA: Cloudflare Turnstile (rendered live on the public page)
           </div>
         )}
-        <button style={{ padding: '0.75rem', background: '#3b82f6', color: '#fff', border: 'none', borderRadius: '6px', fontWeight: '600' }}>{p.submitText}</button>
+        <button style={{ padding: p.variant === 'wellness-consultation' ? '0.9rem' : '0.75rem', background: p.variant === 'wellness-consultation' ? 'linear-gradient(90deg, #b7ad8c, #d1a083)' : '#3b82f6', color: '#fff', border: 'none', borderRadius: p.variant === 'wellness-consultation' ? 999 : 6, fontWeight: '700', letterSpacing: p.variant === 'wellness-consultation' ? '0.08em' : 0, textTransform: p.variant === 'wellness-consultation' ? 'uppercase' : 'none' }}>{p.submitText}</button>
       </div>
     );
     case 'divider': return <hr style={{ border: 'none', borderTop: '1px solid ' + p.color, margin: p.margin }} />;
     case 'spacer': return <div style={{ height: p.height }} />;
     case 'video': return <GenericVideoPreview p={p} />;
-    case 'columns': return (
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: p.gap || '2rem' }}>
-        {(p.columns || []).map((col, i) => (
-          <div key={i} style={{ flex: 1, minWidth: '200px' }}>
-            {(col.components || []).map((child, j) => (
-              <ComponentPreview key={j} comp={child} />
-            ))}
-          </div>
-        ))}
-      </div>
-    );
+    case 'columns': {
+      const variant = p.variant || '';
+      const isWellnessCampaignPage = variant === 'wellness-campaign-page';
+      const isWellnessHeaderRow = variant === 'wellness-header-row';
+      const isWellnessHeroRow = variant === 'wellness-hero-row';
+      const isWellnessRegistrationRow = variant === 'wellness-registration-row';
+      const isWellnessBenefitCards = variant === 'wellness-benefit-cards';
+      const isWellnessConsultation = variant === 'wellness-consultation';
+      const looksLikeWellnessSupporting = (p.columns || []).some((col) => (col.components || []).some((child) => ['why-title', 'after-title'].includes(child.id)));
+      const isWellnessSupporting = variant === 'wellness-supporting' || looksLikeWellnessSupporting;
+      const isWellnessSection = isWellnessCampaignPage || isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards || isWellnessConsultation || isWellnessSupporting;
+      const isWellnessInnerRow = isWellnessHeaderRow || isWellnessHeroRow || isWellnessRegistrationRow || isWellnessBenefitCards;
+      const hasFullWidthSupport = isWellnessConsultation && (p.columns || []).some((col) => col.fullWidth);
+      const containerStyle = isWellnessCampaignPage ? {
+        display: 'flex', flexWrap: 'wrap', gap: p.gap || '0', width: '1040px', maxWidth: '1040px', minWidth: '960px', margin: '0 auto 1.5rem', padding: 0, background: '#fbfaf4', color: '#1f2f2c', border: '1px solid #d8d2c3', borderRadius: 16, boxSizing: 'border-box', overflow: 'hidden'
+      } : {
+        display: 'flex', flexWrap: 'wrap', gap: isWellnessSection ? (p.gap || (isWellnessBenefitCards ? '1rem' : '2rem')) : (p.gap || '2rem'), width: '100%', maxWidth: '100%', margin: isWellnessInnerRow ? 0 : (isWellnessConsultation && !hasFullWidthSupport ? '0 auto 0' : (isWellnessSection ? '0 auto 1.5rem' : 0)), padding: isWellnessHeaderRow ? '1.5rem 4rem 1.1rem' : isWellnessHeroRow ? '2.6rem 4rem 1.75rem' : isWellnessRegistrationRow ? '1.25rem 4rem 3.25rem' : isWellnessBenefitCards ? 0 : (isWellnessSection ? (isWellnessConsultation ? '1.5rem' : '0 1.75rem 1.5rem') : 0), background: isWellnessInnerRow || isWellnessConsultation || isWellnessSupporting ? '#fbfaf4' : 'transparent', color: isWellnessSection ? '#1f2f2c' : undefined, borderRadius: isWellnessConsultation ? (hasFullWidthSupport ? 14 : '14px 14px 0 0') : (isWellnessSupporting ? '0 0 14px 14px' : 0), boxSizing: 'border-box', overflow: 'hidden'
+      };
+      return (
+        <div style={containerStyle}>
+          {(p.columns || []).map((col, i) => {
+            let flex = col.fullWidth ? '1 1 100%' : '1 1 0';
+            if (isWellnessHeroRow) flex = i === 1 ? '0 1 420px' : '1 1 430px';
+            if (isWellnessRegistrationRow) flex = i === 0 ? '0 1 500px' : '1 1 390px';
+            if (isWellnessBenefitCards) flex = '1 1 100%';
+            if (isWellnessConsultation && i === 1) flex = '0 1 440px';
+            return (
+              <div key={i} style={{ flex, minWidth: col.fullWidth ? '100%' : (isWellnessHeroRow ? (i === 1 ? '360px' : '430px') : isWellnessRegistrationRow ? (i === 0 ? '500px' : '360px') : isWellnessSection ? '280px' : '200px'), maxWidth: '100%', boxSizing: 'border-box', padding: isWellnessBenefitCards ? '1.25rem' : 0, background: isWellnessBenefitCards ? '#fffdf7' : 'transparent', border: isWellnessBenefitCards ? '1px solid #d8d2c3' : 'none', borderRadius: isWellnessBenefitCards ? 14 : 0, display: isWellnessBenefitCards ? 'flex' : undefined, flexDirection: isWellnessBenefitCards ? 'column' : undefined, justifyContent: isWellnessBenefitCards ? 'center' : undefined }}>
+                {(col.components || []).map((child, j) => (
+                  <ComponentPreview key={j} comp={child} />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
     // Travel block previews
     case 'destinationHero': return <DestinationHeroPreview p={p} />;
     case 'cityCards': return <CityCardsPreview p={p} />;
@@ -2964,4 +3034,6 @@ function ContactFooterEditor({ p, updateProp, field }) {
       </div>
     </>
   );
-}// Travel block sub-components
+}
+// Travel block sub-components
+

--- a/frontend/src/pages/LandingSites.jsx
+++ b/frontend/src/pages/LandingSites.jsx
@@ -1,9 +1,10 @@
-﻿import React, { useEffect, useMemo, useState } from 'react';
+﻿import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { PanelTop, Plus, Copy, Trash2, Globe, FileEdit, BarChart3, Sparkles, ExternalLink, LayoutGrid, Megaphone } from 'lucide-react';
 import { fetchApi } from '../utils/api';
 import { formatPercent } from '../utils/percent';
 import { useNotify } from '../utils/notify';
+import { AuthContext } from '../App';
 
 const STATUS_COLORS = {
   DRAFT: { bg: 'rgba(59,130,246,0.1)', color: '#3b82f6' },
@@ -35,6 +36,37 @@ function blankBlocks() {
   ];
 }
 
+function buildStarterBlocks({ sectorKey = 'general', campaignName = 'Untitled Landing Site', audience = 'qualified visitors', location = '', isWellness = false }) {
+  if (!isWellness) return blankBlocks();
+  const eventSummary = [
+    'Date: Add the event date',
+    'Time: Add the event time',
+    location ? `Location: ${location}` : 'Location: Add the venue',
+    `Audience: ${audience}`,
+  ].join('\n');
+  return [
+    { id: `seed-${Date.now()}`, type: 'heading', props: { text: campaignName, level: 'h1', align: 'center', color: '#111827' } },
+    { id: `seed-${Date.now() + 1}`, type: 'text', props: { text: 'Use this landing page for a camp, consultation day, or community event. Keep the details clear and the registration form easy to complete.', align: 'center', color: '#4b5563', fontSize: '1rem' } },
+    { id: `seed-${Date.now() + 2}`, type: 'columns', props: { gap: '24px', columns: [
+      { components: [
+        { id: `seed-${Date.now() + 3}`, type: 'heading', props: { text: 'Event details', level: 'h3', align: 'left', color: '#111827' } },
+        { id: `seed-${Date.now() + 4}`, type: 'text', props: { text: eventSummary, align: 'left', color: '#4b5563', fontSize: '0.98rem' } },
+      ] },
+      { components: [
+        { id: `seed-${Date.now() + 5}`, type: 'form', props: { fields: [
+          { label: 'Full name', name: 'name', type: 'text', required: true },
+          { label: 'Email address', name: 'email', type: 'email', required: true },
+          { label: 'Phone number', name: 'phone', type: 'tel', required: true },
+          { label: 'Preferred time', name: 'preferred_time', type: 'text', required: false },
+          { label: 'Notes', name: 'message', type: 'text', required: false },
+        ], submitText: 'Register Now', thankYouMessage: `Thanks. We have received your registration for ${campaignName}.`, enableCaptcha: false, leadRoutingRuleId: '', successRedirectUrl: '' } },
+      ] },
+    ] } },
+    { id: `seed-${Date.now() + 6}`, type: 'image', props: { src: '', alt: `${sectorKey} campaign image`, maxWidth: '100%' } },
+    { id: `seed-${Date.now() + 7}`, type: 'divider', props: { color: '#e5e7eb', margin: '1.5rem' } },
+  ];
+}
+
 function buildTemplateType(sectorKey) {
   return `generic-site-${sectorKey}-v1`;
 }
@@ -42,23 +74,34 @@ function buildTemplateType(sectorKey) {
 export default function LandingSites() {
   const notify = useNotify();
   const navigate = useNavigate();
+  const auth = useContext(AuthContext) || {};
+  const tenantVertical = auth?.user?.tenant?.vertical || auth?.tenant?.vertical || 'generic';
+  const isWellnessTenant = tenantVertical === 'wellness';
   const [pages, setPages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showGenerateModal, setShowGenerateModal] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [genError, setGenError] = useState(null);
   const [copiedId, setCopiedId] = useState(null);
-  const [form, setForm] = useState({
-    sectorKey: 'general',
+  const defaultFormState = (wellness = false) => ({
+    sectorKey: wellness ? 'health' : 'general',
     campaignName: '',
     campaignGoal: '',
     businessName: '',
     audience: '',
     location: '',
+    eventDate: '',
+    eventTime: '',
+    eventLocation: '',
     tone: '',
     ctaText: 'Get Started',
     imageMode: 'auto',
   });
+  const [form, setForm] = useState(defaultFormState(isWellnessTenant));
+
+  React.useEffect(() => {
+    setForm((current) => ({ ...defaultFormState(isWellnessTenant), ...current }));
+  }, [isWellnessTenant]);
 
   const loadPages = () => {
     setLoading(true);
@@ -84,14 +127,15 @@ export default function LandingSites() {
 
   const handleCreateBlank = async () => {
     try {
+      const sectorKey = isWellnessTenant ? 'health' : 'general';
       const page = await fetchApi('/api/landing-pages', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: 'Untitled Landing Site',
-          templateType: buildTemplateType('general'),
-          content: JSON.stringify(blankBlocks()),
-          description: 'General landing site',
+          title: isWellnessTenant ? 'Untitled Wellness Event Landing Site' : 'Untitled Landing Site',
+          templateType: buildTemplateType(sectorKey),
+          content: JSON.stringify(buildStarterBlocks({ sectorKey, campaignName: isWellnessTenant ? 'Untitled Wellness Event' : 'Untitled Landing Site', isWellness: isWellnessTenant, audience: 'qualified visitors' })),
+          description: isWellnessTenant ? 'Wellness event landing site' : 'General landing site',
         }),
         silent: true,
       });
@@ -129,6 +173,9 @@ export default function LandingSites() {
           businessName: form.businessName.trim(),
           audience: form.audience.trim(),
           location: form.location.trim(),
+          eventDate: form.eventDate.trim(),
+          eventTime: form.eventTime.trim(),
+          eventLocation: form.eventLocation.trim() || form.location.trim(),
           tone: form.tone.trim(),
           ctaText: form.ctaText.trim(),
           imageMode: form.imageMode,
@@ -144,17 +191,7 @@ export default function LandingSites() {
         notify.success('AI draft created. Review the page before publishing.');
       }
       setShowGenerateModal(false);
-      setForm({
-        sectorKey: 'general',
-        campaignName: '',
-        campaignGoal: '',
-        businessName: '',
-        audience: '',
-        location: '',
-        tone: '',
-        ctaText: 'Get Started',
-        imageMode: 'auto',
-      });
+      setForm(defaultFormState(isWellnessTenant));
       navigate(`/landing-sites/builder/${res.page.id}?ai=1`);
     } catch (err) {
       if (err?.status === 429 && err?.code === 'LLM_BUDGET_EXCEEDED') {
@@ -339,6 +376,18 @@ export default function LandingSites() {
               <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
                 <span style={{ fontSize: '0.8rem', fontWeight: 700 }}>Location</span>
                 <input className="input-field" value={form.location} onChange={(e) => setForm((s) => ({ ...s, location: e.target.value }))} placeholder="Pune" />
+              </label>
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                <span style={{ fontSize: '0.8rem', fontWeight: 700 }}>Event date</span>
+                <input className="input-field" value={form.eventDate} onChange={(e) => setForm((s) => ({ ...s, eventDate: e.target.value }))} placeholder="12 August 2026" />
+              </label>
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                <span style={{ fontSize: '0.8rem', fontWeight: 700 }}>Event time</span>
+                <input className="input-field" value={form.eventTime} onChange={(e) => setForm((s) => ({ ...s, eventTime: e.target.value }))} placeholder="10:00 AM - 4:00 PM" />
+              </label>
+              <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                <span style={{ fontSize: '0.8rem', fontWeight: 700 }}>Event venue</span>
+                <input className="input-field" value={form.eventLocation} onChange={(e) => setForm((s) => ({ ...s, eventLocation: e.target.value }))} placeholder="Main clinic branch" />
               </label>
               <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
                 <span style={{ fontSize: '0.8rem', fontWeight: 700 }}>Tone</span>

--- a/frontend/src/pages/public/LandingSiteResolver.jsx
+++ b/frontend/src/pages/public/LandingSiteResolver.jsx
@@ -49,5 +49,5 @@ export default function LandingSiteResolver() {
     ? page.content
     : (() => { try { return JSON.parse(page.content || '[]'); } catch { return []; } })();
 
-  return <BlockRenderer landingPage={{ ...page, content }} />;
+  return <BlockRenderer landingPage={{ ...page, content, publicSubmit: true }} />;
 }

--- a/frontend/src/pages/travel/InvoicesAdmin.jsx
+++ b/frontend/src/pages/travel/InvoicesAdmin.jsx
@@ -717,6 +717,10 @@ export default function InvoicesAdmin() {
     tally: { path: "tally.xml", ext: "xml", label: "Tally XML" },
   };
   const [exporting, setExporting] = useState(null); // format key while in-flight
+  const [reconFile, setReconFile] = useState(null);
+  const [reconResult, setReconResult] = useState(null);
+  const [reconciling, setReconciling] = useState(false);
+  const reconInputRef = useRef(null);
 
   const downloadExport = async (formatKey) => {
     const fmt = EXPORT_FORMATS[formatKey];
@@ -743,6 +747,37 @@ export default function InvoicesAdmin() {
       notify.error(err?.message || `Failed to export ${fmt.label}`);
     } finally {
       setExporting(null);
+    }
+  };
+
+  const runReconciliation = async () => {
+    if (!reconFile) {
+      notify.error("Choose a CSV or XLSX file first");
+      return;
+    }
+    setReconciling(true);
+    try {
+      const token = getAuthToken();
+      const fd = new FormData();
+      fd.append("file", reconFile);
+      const qs = subBrand ? `?subBrand=${encodeURIComponent(subBrand)}` : "";
+      const resp = await fetch(`/api/travel/invoices/reconcile/excel-software${qs}`, {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: fd,
+      });
+      const data = await resp.json().catch(() => null);
+      if (!resp.ok) {
+        throw Object.assign(new Error(data?.error || "Failed to reconcile workbook"), { body: data, status: resp.status });
+      }
+      setReconResult(data || null);
+      setReconFile(null);
+      if (reconInputRef.current) reconInputRef.current.value = "";
+      notify.success(`Matched ${data?.matchedRows || 0} invoices`);
+    } catch (err) {
+      notify.error(err?.body?.error || err?.message || "Failed to reconcile workbook");
+    } finally {
+      setReconciling(false);
     }
   };
 
@@ -801,6 +836,55 @@ export default function InvoicesAdmin() {
           </div>
         )}
       </header>
+
+      {canWrite && (
+        <div className="glass" data-testid="excel-reconciliation-panel" style={{ padding: 14, marginBottom: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>Excel Software reconciliation</div>
+              <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                Upload a CSV or XLSX workbook and compare status, sub-brand, customer, and totals against CRM.
+              </div>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <input
+                ref={reconInputRef}
+                type="file"
+                accept=".csv,.xlsx,.xls,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                onChange={(e) => setReconFile(e.target.files && e.target.files[0] ? e.target.files[0] : null)}
+                style={{ maxWidth: 260 }}
+                aria-label="Excel Software reconciliation file"
+              />
+              <button
+                type="button"
+                onClick={runReconciliation}
+                disabled={reconciling}
+                style={{ ...secondaryBtn, opacity: reconciling ? 0.7 : 1, cursor: reconciling ? "wait" : "pointer" }}
+              >
+                <History size={14} /> {reconciling ? "Reconciling..." : "Run reconciliation"}
+              </button>
+            </div>
+          </div>
+          {reconResult && (
+            <div style={{ marginTop: 10, display: "grid", gap: 6 }} data-testid="excel-reconciliation-result">
+              <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                Checked {reconResult.totalRows || 0} rows against {reconResult.scannedInvoices || 0} invoices. Matched {reconResult.matchedRows || 0}, mismatched {reconResult.mismatchedRows || 0}, missing {reconResult.missingRows || 0}.
+              </div>
+              <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                Workbook total {reconResult.workbookAmount ?? 0} vs CRM total {reconResult.matchedAmount ?? 0}.
+              </div>
+              {Array.isArray(reconResult.discrepancies) && reconResult.discrepancies.length > 0 && (
+                <div style={{ display: "grid", gap: 4 }}>
+                  <div style={{ fontSize: 12, fontWeight: 600 }}>First discrepancy</div>
+                  <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                    {reconResult.discrepancies[0].invoiceNum || "Unknown invoice"} - {reconResult.discrepancies[0].issue || "Mismatch"}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       <div
         className="glass"

--- a/frontend/src/pages/travel/TmcCatalogueAdmin.jsx
+++ b/frontend/src/pages/travel/TmcCatalogueAdmin.jsx
@@ -30,7 +30,7 @@
 // isAdmin gates so non-write users see read-only chrome (no Create /
 // Edit / Delete / Promote buttons) but still browse the catalogue.
 
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   Edit2,
   Plus,
@@ -41,7 +41,7 @@ import {
   Calendar,
   Settings,
 } from "lucide-react";
-import { fetchApi } from "../../utils/api";
+import { fetchApi, getAuthToken } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
 import { AuthContext } from "../../App";
 
@@ -139,6 +139,11 @@ export default function TmcCatalogueAdmin() {
   const [saving, setSaving] = useState(false);
   const [promotingId, setPromotingId] = useState(null);
   const [deletingId, setDeletingId] = useState(null);
+  const [bulkFile, setBulkFile] = useState(null);
+  const [bulkImporting, setBulkImporting] = useState(false);
+  const [bulkImportResult, setBulkImportResult] = useState(null);
+  const [pendingReviewTripIds, setPendingReviewTripIds] = useState(() => new Set());
+  const bulkFileInputRef = useRef(null);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -353,12 +358,120 @@ export default function TmcCatalogueAdmin() {
       // Drop the promoted row from this tab's view; the user can flip to
       // Active to see it in its new home.
       setRows((prev) => prev.filter((r) => r.id !== row.id));
+      setPendingReviewTripIds((prev) => {
+        const next = new Set(prev);
+        next.delete(row.tripId);
+        return next;
+      });
     } catch (err) {
       notify.error(
         err?.body?.error || err?.message || "Failed to promote entry",
       );
     } finally {
       setPromotingId(null);
+    }
+  };
+
+  const handleBulkFileChange = (e) => {
+    const nextFile = e.target.files?.[0] || null;
+    setBulkFile(nextFile);
+  };
+
+  const downloadTemplate = async (format) => {
+    try {
+      const token = getAuthToken();
+      const response = await fetch(
+        `/api/travel-tmc-catalogue/import-template?format=${format}`,
+        {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        },
+      );
+      if (!response.ok) {
+        let message = "Failed to download template";
+        try {
+          const payload = await response.json();
+          message = payload?.error || message;
+        } catch {
+          // keep default copy
+        }
+        throw new Error(message);
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download =
+        format === "xlsx" ? "tmc-catalogue-template.xlsx" : "tmc-catalogue-template.csv";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+      notify.success(`Downloaded ${format.toUpperCase()} template`);
+    } catch (err) {
+      notify.error(err?.message || "Failed to download template");
+    }
+  };
+
+  const handleBulkImport = async () => {
+    if (!canWrite) {
+      notify.error("Bulk import requires ADMIN or MANAGER role.");
+      return;
+    }
+    if (!bulkFile) {
+      notify.error("Choose a CSV or Excel file first.");
+      return;
+    }
+
+    setBulkImporting(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", bulkFile);
+      const token = getAuthToken();
+      const response = await fetch("/api/travel-tmc-catalogue/import", {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        body: formData,
+      });
+      if (!response.ok) {
+        let message = "Failed to import catalogue";
+        try {
+          const payload = await response.json();
+          message = payload?.error || message;
+        } catch {
+          // keep default copy
+        }
+        throw new Error(message);
+      }
+
+      const result = await response.json();
+      setBulkImportResult(result);
+      const createdTripIds = Array.isArray(result?.createdTripIds) ? result.createdTripIds : [];
+      if (createdTripIds.length > 0) {
+        setPendingReviewTripIds((prev) => {
+          const next = new Set(prev);
+          for (const tripId of createdTripIds) next.add(tripId);
+          return next;
+        });
+      }
+      if (bulkFileInputRef.current) {
+        bulkFileInputRef.current.value = "";
+      }
+      setBulkFile(null);
+      notify.success(
+        result?.reviewLabel
+          ? `${result.reviewLabel}: ${result.imported || 0} new, ${result.updated || 0} updated`
+          : `Imported ${result?.imported || 0} new and ${result?.updated || 0} updated rows`,
+      );
+      if (createdTripIds.length > 0 && tab !== STATUS_ARCHIVED) {
+        setTab(STATUS_ARCHIVED);
+      } else {
+        load();
+      }
+    } catch (err) {
+      notify.error(err?.message || "Failed to import catalogue");
+    } finally {
+      setBulkImporting(false);
     }
   };
 
@@ -420,6 +533,101 @@ export default function TmcCatalogueAdmin() {
           (ADMIN+MANAGER for the standing-facts override; ADMIN-only for
           the booking-link save per backend gate). */}
       {canWrite && <TmcConfigPanel notify={notify} isAdmin={isAdmin} />}
+
+      {canWrite && (
+        <section
+          data-testid="tmc-catalogue-bulk-import"
+          style={{
+            background: "var(--surface-color)",
+            border: "1px solid var(--border-color)",
+            borderRadius: 12,
+            padding: 16,
+            marginBottom: 16,
+            display: "grid",
+            gap: 12,
+          }}
+        >
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 4 }}>
+              Bulk import catalogue
+            </div>
+            <div style={{ color: "var(--text-secondary)", fontSize: 13 }}>
+              Download the master template, fill it in, then upload CSV or XLSX.
+              New rows are ingested as <strong>AI-classified, pending review</strong>
+              and stay archived until an admin promotes them.
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            <button
+              type="button"
+              onClick={() => downloadTemplate("csv")}
+              style={secondaryBtn}
+            >
+              Download CSV template
+            </button>
+            <button
+              type="button"
+              onClick={() => downloadTemplate("xlsx")}
+              style={secondaryBtn}
+            >
+              Download XLSX template
+            </button>
+            <label
+              style={{
+                ...secondaryBtn,
+                cursor: "pointer",
+                margin: 0,
+              }}
+            >
+              <input
+                ref={bulkFileInputRef}
+                type="file"
+                accept=".csv,.xlsx,.xls"
+                onChange={handleBulkFileChange}
+                aria-label="Bulk import file"
+                style={{ display: "none" }}
+              />
+              {bulkFile ? bulkFile.name : "Choose file"}
+            </label>
+            <button
+              type="button"
+              onClick={handleBulkImport}
+              disabled={bulkImporting || !bulkFile}
+              style={bulkImporting || !bulkFile ? primaryBtnDisabled : primaryBtn}
+            >
+              {bulkImporting ? "Importing..." : "Upload & classify"}
+            </button>
+          </div>
+
+          {bulkImportResult && (
+            <div
+              data-testid="tmc-catalogue-bulk-import-result"
+              style={{
+                display: "grid",
+                gap: 6,
+                padding: 12,
+                borderRadius: 8,
+                border: "1px solid var(--border-color)",
+                background: "var(--bg-color)",
+                color: "var(--text-primary)",
+                fontSize: 13,
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>{bulkImportResult.reviewLabel}</div>
+              <div>
+                Imported {bulkImportResult.imported || 0} new, updated {bulkImportResult.updated || 0},
+                skipped {bulkImportResult.skipped || 0} of {bulkImportResult.total || 0}
+              </div>
+              {(bulkImportResult.errors || []).length > 0 && (
+                <div style={{ color: "var(--text-secondary)" }}>
+                  {bulkImportResult.errors.length} row(s) need review.
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+      )}
 
       {/* Tabs */}
       <div role="tablist" aria-label="Catalogue status tabs" style={tabRow}>
@@ -818,8 +1026,28 @@ export default function TmcCatalogueAdmin() {
               }}
             >
               <div>
-                <div style={{ fontWeight: 600, fontSize: 15 }}>
-                  {row.title || row.tripId}
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 600, fontSize: 15 }}>
+                    {row.title || row.tripId}
+                  </div>
+                  {pendingReviewTripIds.has(row.tripId) && (
+                    <span
+                      data-testid={`tmc-pending-review-${row.tripId}`}
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        padding: "2px 8px",
+                        borderRadius: 999,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        background: "rgba(245, 158, 11, 0.12)",
+                        color: "var(--warning-color)",
+                        border: "1px solid rgba(245, 158, 11, 0.3)",
+                      }}
+                    >
+                      AI-classified, pending review
+                    </span>
+                  )}
                 </div>
                 <div
                   style={{

--- a/frontend/src/pages/travel/TravelPipeline.jsx
+++ b/frontend/src/pages/travel/TravelPipeline.jsx
@@ -66,32 +66,6 @@ const EDITABLE_STATUSES = [
   { value: "expired", label: "Expired" },
 ];
 
-// Status → visual style (matched to reference: won=green, lost=red, achieved=blue, negotiation=amber, draft/new=gray)
-const STATUS_STYLE = {
-  draft:        { bg: "#20202a", color: "#9a9aa5" },
-  sent:         { bg: "#332a12", color: "#e8b34a" },
-  revised:      { bg: "#1a2033", color: "#5b6ef8" },
-  accepted:     { bg: "#123324", color: "#4fd48a" },
-  advance_paid: { bg: "#123324", color: "#4fd48a" },
-  fully_paid:   { bg: "#0d2a1a", color: "#2ecc71" },
-  rejected:     { bg: "#331515", color: "#f06a6a" },
-  expired:      { bg: "#20202a", color: "#9a9aa5" },
-  // legacy aliases used in some tenants
-  won:          { bg: "#123324", color: "#4fd48a" },
-  lost:         { bg: "#331515", color: "#f06a6a" },
-  achieved:     { bg: "#1a2033", color: "#fff",    solidBg: "#5b6ef8" },
-  negotiation:  { bg: "#332a12", color: "#e8b34a" },
-  new:          { bg: "#20202a", color: "#9a9aa5" },
-};
-
-// Sub-brand tag colors (reference: TMC=dark navy, TravelStall=amber/gold, RFU=gray)
-const SUB_BRAND_STYLE = {
-  tmc:         { bg: "#0f1a2e", color: "#6b8ecf",  label: "TMC" },
-  rfu:         { bg: "#1a1f1a", color: "#8aaa8a",  label: "RFU" },
-  travelstall: { bg: "#2a1f10", color: "#d9a552",  label: "TravelStall" },
-  visasure:    { bg: "#1a1228", color: "#a78bfa",  label: "Visa Sure" },
-};
-
 // "Won" = itineraries where money is committed (accepted or paid). Used
 // for the KPI tile labelled "Won / Accepted".
 const WON_STATUSES = new Set(["accepted", "advance_paid", "fully_paid"]);
@@ -100,7 +74,81 @@ const NEGOTIATION_STATUSES = new Set(["sent", "revised"]);
 // "Lost" = closed-negative.
 const LOST_STATUSES = new Set(["rejected", "expired"]);
 
-// ─── Helpers ──────────────────────────────────────────────────────────────
+const LIGHT_THEME = "light";
+const DARK_THEME = "dark";
+
+const STATUS_STYLE = {
+  light: {
+    neutral: { bg: "rgba(18, 38, 71, 0.06)", color: "#4F5569", border: "rgba(18, 38, 71, 0.12)" },
+    info: { bg: "rgba(91, 110, 248, 0.12)", color: "#3F54D0", border: "rgba(91, 110, 248, 0.18)" },
+    success: { bg: "rgba(47, 122, 77, 0.12)", color: "#2F7A4D", border: "rgba(47, 122, 77, 0.18)" },
+    warning: { bg: "rgba(200, 154, 78, 0.14)", color: "#8B5E20", border: "rgba(200, 154, 78, 0.22)" },
+    danger: { bg: "rgba(168, 50, 63, 0.12)", color: "#A8323F", border: "rgba(168, 50, 63, 0.18)" },
+  },
+  dark: {
+    neutral: { bg: "rgba(244, 239, 223, 0.08)", color: "#D7D1C3", border: "rgba(244, 239, 223, 0.14)" },
+    info: { bg: "rgba(91, 110, 248, 0.20)", color: "#C6CCFF", border: "rgba(91, 110, 248, 0.26)" },
+    success: { bg: "rgba(47, 122, 77, 0.22)", color: "#A8D8B9", border: "rgba(47, 122, 77, 0.30)" },
+    warning: { bg: "rgba(200, 154, 78, 0.20)", color: "#F0D7A4", border: "rgba(200, 154, 78, 0.28)" },
+    danger: { bg: "rgba(168, 50, 63, 0.20)", color: "#F7B0B7", border: "rgba(168, 50, 63, 0.28)" },
+  },
+};
+
+const SUB_BRAND_STYLE = {
+  light: {
+    tmc: { bg: "rgba(18, 38, 71, 0.06)", color: "#122647", border: "rgba(18, 38, 71, 0.12)", label: "TMC" },
+    rfu: { bg: "rgba(47, 122, 77, 0.08)", color: "#2F7A4D", border: "rgba(47, 122, 77, 0.14)", label: "RFU" },
+    travelstall: { bg: "rgba(200, 154, 78, 0.12)", color: "#8B5E20", border: "rgba(200, 154, 78, 0.20)", label: "TravelStall" },
+    visasure: { bg: "rgba(91, 110, 248, 0.12)", color: "#5B6EF8", border: "rgba(91, 110, 248, 0.20)", label: "Visa Sure" },
+  },
+  dark: {
+    tmc: { bg: "rgba(18, 38, 71, 0.72)", color: "#9DB7E6", border: "rgba(157, 183, 230, 0.18)", label: "TMC" },
+    rfu: { bg: "rgba(26, 31, 26, 0.82)", color: "#B6D3B6", border: "rgba(182, 211, 182, 0.16)", label: "RFU" },
+    travelstall: { bg: "rgba(42, 31, 16, 0.84)", color: "#F0D7A4", border: "rgba(240, 215, 164, 0.18)", label: "TravelStall" },
+    visasure: { bg: "rgba(26, 18, 40, 0.84)", color: "#D1C4FF", border: "rgba(209, 196, 255, 0.18)", label: "Visa Sure" },
+  },
+};
+
+function getThemeName() {
+  if (typeof document === "undefined") return LIGHT_THEME;
+  return document.documentElement.getAttribute("data-theme") === DARK_THEME ? DARK_THEME : LIGHT_THEME;
+}
+
+function useTravelTheme() {
+  const [theme, setTheme] = useState(() => getThemeName());
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof MutationObserver === "undefined") return () => {};
+
+    const root = document.documentElement;
+    const syncTheme = () => {
+      setTheme(root.getAttribute("data-theme") === DARK_THEME ? DARK_THEME : LIGHT_THEME);
+    };
+
+    syncTheme();
+    const observer = new MutationObserver(syncTheme);
+    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}
+
+function getStatusTone(theme, current) {
+  const palette = STATUS_STYLE[theme] || STATUS_STYLE.light;
+  if (["accepted", "advance_paid", "fully_paid", "won"].includes(current)) return palette.success;
+  if (["sent", "negotiation"].includes(current)) return palette.warning;
+  if (["revised", "achieved"].includes(current)) return palette.info;
+  if (["rejected", "lost"].includes(current)) return palette.danger;
+  return palette.neutral;
+}
+
+function getSubBrandTone(theme, value) {
+  const palette = SUB_BRAND_STYLE[theme] || SUB_BRAND_STYLE.light;
+  return palette[value] || { ...palette.tmc, label: value };
+}
+
+// ??? Helpers ??????????????????????????????????????????????????????????????
 
 function fmtMoney(amt, currency = "INR") {
   const n = Number(amt);
@@ -161,6 +209,7 @@ export default function TravelPipeline() {
   const { user } = useContext(AuthContext);
   const notify = useNotify();
   const navigate = useNavigate();
+  const theme = useTravelTheme();
 
   // Data
   const [itineraries, setItineraries] = useState([]);
@@ -362,13 +411,13 @@ export default function TravelPipeline() {
 
   // ── Sub-brand badge ─────────────────────────────────────────────────
   function SubBrandBadge({ value }) {
-    const style = SUB_BRAND_STYLE[value] || { bg: "#20202a", color: "#9a9aa5", label: value };
+    const style = getSubBrandTone(theme, value);
     const displayLabel = style.label || subBrandShortLabel(value) || value || "—";
     return (
       <span style={{
         display: "inline-block", padding: "3px 9px", borderRadius: 6,
         fontSize: 11.5, fontWeight: 700,
-        background: style.bg, color: style.color,
+        background: style.bg, color: style.color, border: `1px solid ${style.border}`,
         letterSpacing: "0.02em",
       }}>
         {displayLabel}
@@ -604,10 +653,12 @@ export default function TravelPipeline() {
                     {/* Status — inline editable dropdown */}
                     <td style={tdStyle}>
                       <StatusDropdown
+                        key={`${row.id}-${theme}`}
                         id={row.id}
                         current={row.status}
                         disabled={updatingId === row.id}
                         onChange={(newStatus) => updateStatus(row.id, newStatus)}
+                        theme={theme}
                       />
                     </td>
 
@@ -802,9 +853,8 @@ export default function TravelPipeline() {
 // Renders a styled <select> that matches the current status's colour pill.
 // When `disabled` is true (update in flight) it shows a spinner-like faded
 // state.
-function StatusDropdown({ id: _id, current, disabled, onChange }) {
-  const s = STATUS_STYLE[current] || { bg: "#20202a", color: "#9a9aa5" };
-  const bgColor = s.solidBg || s.bg;
+function StatusDropdown({ id: _id, current, disabled, onChange, theme }) {
+  const s = getStatusTone(theme, current);
   return (
     <select
       value={current || ""}
@@ -812,9 +862,9 @@ function StatusDropdown({ id: _id, current, disabled, onChange }) {
       onChange={(e) => onChange(e.target.value)}
       aria-label="Change status"
       style={{
-        background: bgColor,
+        background: s.bg,
         color: s.color,
-        border: `1px solid ${s.color}40`,
+        border: `1px solid ${s.border}`,
         borderRadius: 20,
         padding: "5px 28px 5px 10px",
         fontSize: 12,
@@ -823,15 +873,21 @@ function StatusDropdown({ id: _id, current, disabled, onChange }) {
         opacity: disabled ? 0.6 : 1,
         appearance: "none",
         WebkitAppearance: "none",
-        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='${encodeURIComponent(s.color)}'/%3E%3C/svg%3E")`,
+        backgroundImage: `linear-gradient(45deg, transparent 50%, ${s.color} 50%), linear-gradient(135deg, ${s.color} 50%, transparent 50%)`,
         backgroundRepeat: "no-repeat",
-        backgroundPosition: "right 8px center",
+        backgroundPosition: "calc(100% - 14px) calc(50% - 1px), calc(100% - 10px) calc(50% - 1px)",
+        backgroundSize: "4px 4px, 4px 4px",
         minWidth: 120,
       }}
     >
       {EDITABLE_STATUSES.map((o) => (
-        <option key={o.value} value={o.value}
-          style={{ background: "#16161d", color: "#f3f3f5" }}
+        <option
+          key={o.value}
+          value={o.value}
+          style={{
+            background: theme === DARK_THEME ? "#16161d" : "#FFFFFF",
+            color: theme === DARK_THEME ? "#F4EFDF" : "#1F1B14",
+          }}
         >
           {o.label}
         </option>

--- a/frontend/src/pages/travel/TripDetail.jsx
+++ b/frontend/src/pages/travel/TripDetail.jsx
@@ -72,15 +72,24 @@ export default function TripDetail() {
   const [tab, setTab] = useState("overview");
   const [trip, setTrip] = useState(null);
   const [loading, setLoading] = useState(true);
+  const hasLoadedRef = useRef(false);
 
   const load = useCallback(() => {
-    setLoading(true);
+    // Keep the current trip visible on refreshes so tab-local state
+    // (like the participants bulk-import summary) survives the refetch.
+    if (!hasLoadedRef.current) setLoading(true);
     fetchApi(`/api/travel/trips/${id}`)
       .then(setTrip)
       .catch((e) => notify.error(e?.body?.error || "Failed to load trip"))
-      .finally(() => setLoading(false));
+      .finally(() => {
+        hasLoadedRef.current = true;
+        setLoading(false);
+      });
   }, [id, notify]);
 
+  useEffect(() => {
+    hasLoadedRef.current = false;
+  }, [id]);
   useEffect(load, [load]);
 
   if (loading) return <div style={{ padding: 24 }}>Loading&hellip;</div>;

--- a/frontend/src/pages/travel/TripDetail.jsx
+++ b/frontend/src/pages/travel/TripDetail.jsx
@@ -562,6 +562,10 @@ function ParticipantsTab({ trip, onChange, notify }) {
   // an autoincrement keyspace.
   const [pendingRegs, setPendingRegs] = useState([]);
   const [decidingRegId, setDecidingRegId] = useState(null);
+  const [bulkFile, setBulkFile] = useState(null);
+  const [bulkImportResult, setBulkImportResult] = useState(null);
+  const [bulkImporting, setBulkImporting] = useState(false);
+  const importInputRef = useRef(null);
 
   const loadPendingRegs = useCallback(async () => {
     try {
@@ -576,6 +580,37 @@ function ParticipantsTab({ trip, onChange, notify }) {
   useEffect(() => {
     loadPendingRegs();
   }, [loadPendingRegs]);
+
+  const bulkImport = async () => {
+    if (!bulkFile) {
+      notify.error("Choose a CSV or XLSX file first");
+      return;
+    }
+    const fd = new FormData();
+    fd.append("file", bulkFile);
+    setBulkImporting(true);
+    try {
+      const token = getAuthToken();
+      const resp = await fetch(`/api/travel/trips/${trip.id}/participants/import`, {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: fd,
+      });
+      const data = await resp.json().catch(() => null);
+      if (!resp.ok) {
+        throw Object.assign(new Error(data?.error || "Failed to import participants"), { body: data, status: resp.status });
+      }
+      setBulkImportResult(data || null);
+      setBulkFile(null);
+      if (importInputRef.current) importInputRef.current.value = "";
+      notify.success(`Imported ${data?.inserted || 0}, updated ${data?.updated || 0}`);
+      onChange();
+    } catch (e) {
+      notify.error(e?.body?.error || e?.message || "Failed to import participants");
+    } finally {
+      setBulkImporting(false);
+    }
+  };
 
   const add = async () => {
     if (!form.fullName.trim()) {
@@ -751,6 +786,42 @@ function ParticipantsTab({ trip, onChange, notify }) {
           <button type="button" onClick={() => setAdding(true)} style={addBtn}>
             <Plus size={14} /> Add participant
           </button>
+        )}
+      </div>
+
+      <div className="glass" data-testid="participant-bulk-import" style={{ padding: 14, marginBottom: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>Bulk import participants</div>
+            <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+              Upload a CSV or XLSX file. Existing rows are updated additively, and blank cells never clear data already stored in CRM.
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".csv,.xlsx,.xls,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              onChange={(e) => setBulkFile(e.target.files && e.target.files[0] ? e.target.files[0] : null)}
+              style={{ maxWidth: 240 }}
+              aria-label="Bulk import participants file"
+            />
+            <button type="button" onClick={bulkImport} disabled={bulkImporting} style={{ ...secondaryBtn, opacity: bulkImporting ? 0.7 : 1, cursor: bulkImporting ? "wait" : "pointer" }}>
+              <Upload size={14} /> {bulkImporting ? "Importing..." : "Import file"}
+            </button>
+          </div>
+        </div>
+        {bulkImportResult && (
+          <div style={{ marginTop: 10, display: "grid", gap: 6 }} data-testid="participant-bulk-import-result">
+            <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+              Imported {bulkImportResult.inserted || 0}, updated {bulkImportResult.updated || 0}, skipped {bulkImportResult.skipped || 0}, errors {bulkImportResult.errors?.length || 0}.
+            </div>
+            {Array.isArray(bulkImportResult.errors) && bulkImportResult.errors.length > 0 && (
+              <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                First issue: row {bulkImportResult.errors[0].row || "?"} - {bulkImportResult.errors[0].reason || "Unknown error"}
+              </div>
+            )}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
Expanded Landing Sites to support the Wellness vertical with wellness-aware page generation, event-specific content, public rendering, and dedicated wellness block components.
Enhanced public landing page lead capture by improving contact enrichment, supporting additional lead fields, and updating existing contacts with richer profile information on repeat submissions.
Added Travel bulk operations including invoice reconciliation, TMC catalogue spreadsheet import/export, and trip participant bulk import with validation and safe upsert behavior.
Updated Travel admin interfaces with invoice reconciliation tools, catalogue import workflows, participant bulk import, and improved pipeline theme support.
Introduced a public Wellness Enquiry API to securely capture leads from external wellness websites with validation, deduplication, and CRM contact integration.
Updated routing and access control to expose Landing Sites for Generic and Wellness tenants while maintaining Travel isolation and supporting new public landing site routes.
Expanded CI and automated test coverage across landing sites, public enquiries, travel imports, invoice reconciliation, participant imports, routing, and related frontend workflows.