### PR TITLE
Feat/qrandcoupon

### DIFF
--- a/backend/lib/couponApply.js
+++ b/backend/lib/couponApply.js
@@ -1,0 +1,76 @@
+const prisma = require("./prisma");
+
+/**
+ * Resolve a coupon code for application/preview inside a tenant.
+ *
+ * Returns { coupon } on success, or { error, coupon? } on failure.
+ * The error shape is { status, code, message } ready to be returned
+ * directly from an Express route.
+ *
+ * tenantId is passed explicitly so callers without a req.user
+ * (anonymous public payment flows) can reuse this helper.
+ */
+async function loadCouponForApply(tenantId, code) {
+  const coupon = await prisma.coupon.findFirst({
+    where: {
+      tenantId,
+      code: String(code || "")
+        .trim()
+        .toUpperCase(),
+    },
+  });
+  if (!coupon)
+    return {
+      error: {
+        status: 404,
+        code: "COUPON_NOT_FOUND",
+        message: "Coupon not found",
+      },
+    };
+  if (!coupon.isActive)
+    return {
+      error: {
+        status: 409,
+        code: "COUPON_INACTIVE",
+        message: "Coupon is inactive",
+      },
+      coupon,
+    };
+  const now = Date.now();
+  if (coupon.validFrom && coupon.validFrom.getTime() > now) {
+    return {
+      error: {
+        status: 409,
+        code: "COUPON_NOT_YET_VALID",
+        message: "Coupon is not yet valid",
+      },
+      coupon,
+    };
+  }
+  if (coupon.validUntil && coupon.validUntil.getTime() < now) {
+    return {
+      error: {
+        status: 410,
+        code: "COUPON_EXPIRED",
+        message: "Coupon has expired",
+      },
+      coupon,
+    };
+  }
+  if (
+    coupon.maxRedemptions != null &&
+    coupon.redemptionCount >= coupon.maxRedemptions
+  ) {
+    return {
+      error: {
+        status: 409,
+        code: "COUPON_LIMIT_REACHED",
+        message: "Coupon redemption limit reached",
+      },
+      coupon,
+    };
+  }
+  return { coupon };
+}
+
+module.exports = { loadCouponForApply };

--- a/backend/lib/pageCatalog.js
+++ b/backend/lib/pageCatalog.js
@@ -474,6 +474,24 @@ const PAGE_CATALOG = [
     requiredPermissions: [{ module: 'marketing', action: 'read' }],
   },
 
+  //  Events Management (Wellness vertical) 
+  {
+    path: '/wellness/qr-generator',
+    label: 'QR Generator',
+    description: 'Create downloadable QR codes for clinic events, services, and offers',
+    category: 'Events Management',
+    vertical: 'wellness',
+    requiredPermissions: [{ module: 'marketing', action: 'read' }],
+  },
+  {
+    path: '/wellness/events-history',
+    label: 'History',
+    description: 'All QR codes organized by event',
+    category: 'Events Management',
+    vertical: 'wellness',
+    requiredPermissions: [{ module: 'marketing', action: 'read' }],
+  },
+
   //  Marketing 
   {
     path: '/marketing',
@@ -508,15 +526,6 @@ const PAGE_CATALOG = [
     vertical: 'generic',
     requiredPermissions: [{ module: 'marketing', action: 'read' }],
   },
-  {
-    path: '/wellness/qr-generator',
-    label: 'QR Generator',
-    description: 'Create downloadable QR codes for clinic public pages, services, and offers',
-    category: 'Marketing',
-    vertical: 'wellness',
-    requiredPermissions: [{ module: 'marketing', action: 'read' }],
-  },
-
   //  Reports + analytics 
   {
     path: '/wellness/reports',

--- a/backend/lib/walletCodes.js
+++ b/backend/lib/walletCodes.js
@@ -125,19 +125,21 @@ function lastFour(plaintext) {
  *     supplied AND not in the allowlist, the discount is zero. Empty / null
  *     allowlist = no restriction.
  *
- * Returns { discount, finalAmount, applied } so the call site can render
- * "₹50 off, you pay ₹950" without re-deriving math.
+ * Returns { discount, finalAmount, applied, excess } so the call site can render
+ * "₹50 off, you pay ₹950" without re-deriving math. For FLAT coupons whose
+ * value exceeds the bill, `excess` is the leftover amount that should be
+ * credited to the customer's wallet; PERCENT coupons never produce excess.
  *
  * @param {{ discountType: 'PERCENT'|'FLAT', discountValue: number, serviceIds?: string|null }} coupon
  * @param {number} baseAmount
  * @param {number|null} [serviceId]
- * @returns {{ discount: number, finalAmount: number, applied: boolean }}
+ * @returns {{ discount: number, finalAmount: number, applied: boolean, excess: number }}
  */
 function computeCouponDiscount(coupon, baseAmount, serviceId = null) {
   const base = Number.isFinite(Number(baseAmount)) ? Math.max(0, Number(baseAmount)) : 0;
   const valueRaw = Number.isFinite(Number(coupon?.discountValue)) ? Number(coupon.discountValue) : 0;
   if (base <= 0 || valueRaw <= 0) {
-    return { discount: 0, finalAmount: base, applied: false };
+    return { discount: 0, finalAmount: base, applied: false, excess: 0 };
   }
 
   // Service allowlist — null/empty = applies to all. If a non-empty allowlist
@@ -148,31 +150,33 @@ function computeCouponDiscount(coupon, baseAmount, serviceId = null) {
   const allowlist = parseJsonArray(coupon?.serviceIds);
   if (allowlist.length > 0) {
     if (serviceId == null) {
-      return { discount: 0, finalAmount: base, applied: false };
+      return { discount: 0, finalAmount: base, applied: false, excess: 0 };
     }
     const sid = parseInt(serviceId, 10);
     if (!allowlist.includes(sid)) {
-      return { discount: 0, finalAmount: base, applied: false };
+      return { discount: 0, finalAmount: base, applied: false, excess: 0 };
     }
   }
 
   let discount = 0;
+  let excess = 0;
   if (coupon.discountType === 'PERCENT') {
     const pct = Math.min(100, valueRaw);
     discount = (base * pct) / 100;
   } else if (coupon.discountType === 'FLAT') {
     discount = Math.min(valueRaw, base);
+    excess = round2(Math.max(0, valueRaw - discount));
   } else {
     // Unknown discountType — refuse to compute (zero discount). Route
     // handler returns 400 INVALID_DISCOUNT_TYPE before we get here, so
     // this is purely defensive.
-    return { discount: 0, finalAmount: base, applied: false };
+    return { discount: 0, finalAmount: base, applied: false, excess: 0 };
   }
 
   // Round to 2 decimal places to avoid floating-point dust like 199.99999.
   discount = round2(discount);
   const finalAmount = round2(Math.max(0, base - discount));
-  return { discount, finalAmount, applied: discount > 0 };
+  return { discount, finalAmount, applied: discount > 0, excess };
 }
 
 // ── Cashback earn computer ──────────────────────────────────────────

--- a/backend/lib/wellnessWallet.js
+++ b/backend/lib/wellnessWallet.js
@@ -1,0 +1,84 @@
+const prisma = require("./prisma");
+
+/**
+ * Append-only wallet ledger write used by the wellness wallet/gift-card/
+ * coupon/cashback route family. Updates Wallet.balance and creates a
+ * WalletTransaction row inside the same Prisma $transaction.
+ *
+ * Sign convention: credits positive, debits negative (mirrors QuickBooks).
+ * The `type` must start with `CREDIT_` or `DEBIT_`.
+ */
+async function writeWalletTransaction({
+  tenantId,
+  walletId,
+  type,
+  absAmount,
+  performedBy,
+  reason,
+  visitId = null,
+  invoiceId = null,
+  giftCardId = null,
+  couponId = null,
+}) {
+  const isCredit = String(type || "").startsWith("CREDIT_");
+  const isDebit = String(type || "").startsWith("DEBIT_");
+  if (!isCredit && !isDebit) {
+    throw new Error(`Invalid wallet transaction type: ${type}`);
+  }
+  const signed = isCredit ? Math.abs(absAmount) : -Math.abs(absAmount);
+  return prisma.$transaction(async (tx) => {
+    const wallet = await tx.wallet.findFirst({
+      where: { id: walletId, tenantId },
+    });
+    if (!wallet) throw new Error("WALLET_NOT_FOUND");
+    const newBalance = +(wallet.balance + signed).toFixed(2);
+    if (newBalance < 0) {
+      const e = new Error("INSUFFICIENT_BALANCE");
+      e.code = "INSUFFICIENT_BALANCE";
+      throw e;
+    }
+    await tx.wallet.update({
+      where: { id: walletId },
+      data: { balance: newBalance },
+    });
+    return tx.walletTransaction.create({
+      data: {
+        tenantId,
+        walletId,
+        type,
+        amount: signed,
+        reason: reason || null,
+        visitId,
+        invoiceId,
+        giftCardId,
+        couponId,
+        balanceAfter: newBalance,
+        performedBy,
+      },
+    });
+  });
+}
+
+/**
+ * Find an existing Wallet for a patient or create one in the tenant's
+ * default currency. Returns the wallet row.
+ */
+async function getOrCreateWallet(req, patientId) {
+  let wallet = await prisma.wallet.findFirst({
+    where: { tenantId: req.user.tenantId, patientId },
+  });
+  if (wallet) return wallet;
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: req.user.tenantId },
+    select: { defaultCurrency: true },
+  });
+  return prisma.wallet.create({
+    data: {
+      tenantId: req.user.tenantId,
+      patientId,
+      currency: tenant?.defaultCurrency || "INR",
+    },
+  });
+}
+
+module.exports = { writeWalletTransaction, getOrCreateWallet };

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3981,6 +3981,11 @@ model Visit {
   photosBefore  String?  @db.Text // JSON array of URLs
   photosAfter   String?  @db.Text // JSON array of URLs
   amountCharged Float?
+  // Coupon / locking-fee billing breakdown stored when a visit is completed
+  // with a coupon applied. JSON: { baseAmount, discount, lockingFee, balance,
+  // couponCode, excess }. Persisted so the Completed Visits UI can show the
+  // adjusted balance and so regenerating the payment link uses the same amount.
+  couponBreakdown String? @db.Text
 
   // Payment link generated when a visit is completed with a charge. Stored on
   // the visit so the front-end can render a "copy link" action without joining
@@ -9076,4 +9081,39 @@ model StatusDailySnapshot {
 
   @@unique([componentId, date])
   @@index([componentId, date])
+}
+
+// Wellness QR Generator — events and their generated QR configurations.
+// Both tables are tenant-scoped and record the creating user. QrCode rows
+// cascade-delete with their parent QrEvent.
+model QrEvent {
+  id        Int      @id @default(autoincrement())
+  name      String
+  tenantId  Int      @default(1)
+  createdBy Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  qrs QrCode[]
+
+  @@index([tenantId, createdAt])
+}
+
+model QrCode {
+  id         Int     @id @default(autoincrement())
+  eventId    Int
+  event      QrEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  name       String
+  text       String
+  size       Int
+  fgColor    String
+  bgColor    String
+  errorLevel String
+  tenantId   Int     @default(1)
+  createdBy  Int
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([eventId])
+  @@index([tenantId])
 }

--- a/backend/routes/pos.js
+++ b/backend/routes/pos.js
@@ -31,6 +31,12 @@ const express = require("express");
 const prisma = require("../lib/prisma");
 const { writeAudit, diffFields } = require("../lib/audit");
 const { verifyWellnessRole } = require("../middleware/wellnessRole");
+const { computeCouponDiscount } = require("../lib/walletCodes");
+const { loadCouponForApply } = require("../lib/couponApply");
+const {
+  getOrCreateWallet,
+  writeWalletTransaction,
+} = require("../lib/wellnessWallet");
 
 const router = express.Router();
 
@@ -1001,6 +1007,7 @@ router.post("/sales", cashierGate, async (req, res) => {
       paymentBreakdownJson,
       managerOverride,
       notes,
+      couponCode,
     } = req.body;
 
     // Validate shift
@@ -1360,6 +1367,52 @@ router.post("/sales", cashierGate, async (req, res) => {
     // loyalty hiccup can never roll back the sale itself. Anonymous sales
     // (no patientId) and non-COMPLETED states are no-ops.
     await maybeAutoCreditLoyaltyForSale(sale, req.user.tenantId);
+
+    // Wave 11 Agent FF — FLAT coupon excess lands in the patient's wallet.
+    // The coupon code was previewed by the UI (discount is already baked into
+    // discountTotal). If the FLAT face value exceeds the net basket, credit
+    // the leftover amount. Errors are logged but do NOT fail the sale.
+    if (couponCode && resolvedPatientId) {
+      try {
+        const lookup = await loadCouponForApply(
+          req.user.tenantId,
+          couponCode,
+        );
+        if (!lookup.error && lookup.coupon) {
+          const couponBase = Math.max(0, subtotal - lineDiscounts);
+          const couponResult = computeCouponDiscount(
+            lookup.coupon,
+            couponBase,
+          );
+          if (couponResult.applied) {
+            await prisma.coupon.update({
+              where: { id: lookup.coupon.id },
+              data: { redemptionCount: { increment: 1 } },
+            });
+          }
+          if (couponResult.excess > 0) {
+            const wallet = await getOrCreateWallet(
+              req,
+              resolvedPatientId,
+            );
+            await writeWalletTransaction({
+              tenantId: req.user.tenantId,
+              walletId: wallet.id,
+              type: "CREDIT_COUPON_EXCESS",
+              absAmount: couponResult.excess,
+              performedBy: req.user.userId,
+              reason: `Coupon ${lookup.coupon.code} excess credited`,
+              couponId: lookup.coupon.id,
+            });
+          }
+        }
+      } catch (couponErr) {
+        console.error(
+          "[pos] coupon post-sale handling failed:",
+          couponErr.message,
+        );
+      }
+    }
 
     // Wave 8b — emit sale.completed so the POS receipt dispatcher
     // (lib/posReceiptDispatcher.js) can queue an SMS (always) +

--- a/backend/routes/wellness.js
+++ b/backend/routes/wellness.js
@@ -846,7 +846,7 @@ async function findPaidBookingLockingFee(visitId) {
 
 // Compute the treatment balance due for a visit, given an optional coupon and
 // the already-paid non-refundable locking fee. Returns { baseAmount, discount,
-// lockingFee, balance, applied, coupon, error }.
+// excess, lockingFee, balance, applied, coupon, error }.
 async function computeTreatmentBalance({
   tenantId,
   baseAmount,
@@ -856,6 +856,7 @@ async function computeTreatmentBalance({
 }) {
   let discount = 0;
   let applied = false;
+  let excess = 0;
   let coupon = null;
   if (couponCode && String(couponCode).trim()) {
     const lookup = await loadCouponForApply(
@@ -863,12 +864,13 @@ async function computeTreatmentBalance({
       String(couponCode).trim().toUpperCase(),
     );
     if (lookup.error) {
-      return { error: lookup.error, baseAmount, discount: 0, lockingFee: 0, balance: baseAmount, applied: false };
+      return { error: lookup.error, baseAmount, discount: 0, excess: 0, lockingFee: 0, balance: baseAmount, applied: false };
     }
     coupon = lookup.coupon;
     const result = computeCouponDiscount(coupon, baseAmount, serviceId);
     discount = result.discount;
     applied = result.applied;
+    excess = result.excess;
   }
   const lockingFeePayment = await findPaidBookingLockingFee(visitId);
   const lockingFee = lockingFeePayment ? 200 : 0;
@@ -876,6 +878,7 @@ async function computeTreatmentBalance({
   return {
     baseAmount,
     discount,
+    excess,
     lockingFee,
     balance,
     applied,
@@ -883,8 +886,40 @@ async function computeTreatmentBalance({
   };
 }
 
+// Parse the JSON-text couponBreakdown column on a Visit row. Returns the parsed
+// object when valid, otherwise null. Kept defensive so callers can safely fall
+// back to visit.amountCharged.
+function parseVisitCouponBreakdown(visit) {
+  if (!visit || !visit.couponBreakdown) return null;
+  try {
+    const parsed = JSON.parse(visit.couponBreakdown);
+    if (parsed && typeof parsed === "object" && Number.isFinite(Number(parsed.balance))) {
+      return parsed;
+    }
+  } catch (_e) {
+    // ignore malformed JSON
+  }
+  return null;
+}
 
-async function sendVisitPaymentLink({ visit, tenantId, baseUrl }) {
+// Decorate one or more Visit rows for the frontend by parsing couponBreakdown
+// from its JSON-text column into an object. Mutates the row(s) in place.
+function attachCouponBreakdownToVisits(visits) {
+  if (!Array.isArray(visits)) {
+    if (visits && typeof visits === "object") {
+      const parsed = parseVisitCouponBreakdown(visits);
+      if (parsed) visits.couponBreakdown = parsed;
+    }
+    return visits;
+  }
+  for (const visit of visits) {
+    const parsed = parseVisitCouponBreakdown(visit);
+    if (parsed) visit.couponBreakdown = parsed;
+  }
+  return visits;
+}
+
+async function sendVisitPaymentLink({ visit, tenantId, baseUrl, amount }) {
   const patient = await prisma.patient.findUnique({
     where: { id: visit.patientId },
     select: { id: true, name: true, email: true, phone: true, contactId: true },
@@ -893,7 +928,7 @@ async function sendVisitPaymentLink({ visit, tenantId, baseUrl }) {
   const contact = await ensurePatientContact(patient, tenantId);
   const paymentLink = visit.paymentLinkUrl
     ? { url: visit.paymentLinkUrl, gateway: visit.paymentLinkGateway || "razorpay" }
-    : await generateVisitPaymentLink({ visit, tenantId, baseUrl });
+    : await generateVisitPaymentLink({ visit, tenantId, baseUrl, amount });
 
   if (paymentLink.error || !paymentLink.url) {
     return paymentLink;
@@ -2050,6 +2085,7 @@ router.get("/patients/:id/visits", phiReadGate, async (req, res) => {
       visits,
       req.user.tenantId,
     );
+    attachCouponBreakdownToVisits(visitsWithInvoiceState);
     // Audit-log the read same as the flat /visits list (PRD 11 clinical reads).
     // #534 (PERF-1): fire-and-forget  see PATIENT_LIST_READ above.
     writeAudit(
@@ -3027,6 +3063,9 @@ router.get("/visits", phiReadGate, async (req, res) => {
       visitFindArgs.select = listProjection("Visit", false);
     }
     const visits = await prisma.visit.findMany(visitFindArgs);
+    if (wantFullShape) {
+      attachCouponBreakdownToVisits(visits);
+    }
     // PRD 11 / T2.2: staff-side cross-patient visit list is a PHI read
     // (response includes patient name + phone on full path). One audit row
     // per request, with the filter params and result count  never the row
@@ -3103,6 +3142,7 @@ router.get("/visits/:id", phiReadGate, async (req, res) => {
     if (visit.prescriptions) {
       visit.prescriptions = visit.prescriptions.map(normalizePrescriptionDrugs);
     }
+    attachCouponBreakdownToVisits(visit);
     res.json(visit);
   } catch (e) {
     console.error("[wellness] get visit error:", e.message);
@@ -3594,6 +3634,7 @@ router.put("/visits/:id", phiWriteGate, async (req, res) => {
         billingBreakdown = {
           baseAmount: balanceCtx.baseAmount,
           discount: balanceCtx.discount,
+          excess: balanceCtx.excess,
           lockingFee: balanceCtx.lockingFee,
           balance: balanceCtx.balance,
           couponCode: balanceCtx.coupon?.code || null,
@@ -3604,6 +3645,27 @@ router.put("/visits/:id", phiWriteGate, async (req, res) => {
             where: { id: balanceCtx.coupon.id },
             data: { redemptionCount: { increment: 1 } },
           });
+        }
+
+        if (balanceCtx.excess > 0 && updated.patientId) {
+          try {
+            const wallet = await getOrCreateWallet(req, updated.patientId);
+            await writeWalletTransaction({
+              tenantId: req.user.tenantId,
+              walletId: wallet.id,
+              type: "CREDIT_COUPON_EXCESS",
+              absAmount: balanceCtx.excess,
+              performedBy: req.user.userId,
+              reason: `Coupon ${balanceCtx.coupon.code} excess credited`,
+              visitId: updated.id,
+              couponId: balanceCtx.coupon.id,
+            });
+          } catch (excessErr) {
+            console.error(
+              "[wellness] coupon excess wallet credit failed:",
+              excessErr.message,
+            );
+          }
         }
 
         if (balanceCtx.balance > 0) {
@@ -3655,16 +3717,30 @@ router.put("/visits/:id", phiWriteGate, async (req, res) => {
               data: {
                 paymentLinkUrl: link.url,
                 paymentLinkGeneratedAt: new Date(),
+                couponBreakdown: JSON.stringify(billingBreakdown),
               },
             });
             updated.paymentLinkUrl = finalVisit.paymentLinkUrl;
             updated.paymentLinkGeneratedAt = finalVisit.paymentLinkGeneratedAt;
+            updated.couponBreakdown = finalVisit.couponBreakdown;
           }
         } else if (balanceCtx.applied) {
           // Coupon + locking fee fully cover the bill; no link needed.
-          updated.paymentLinkUrl = null;
-          updated.paymentLinkGeneratedAt = null;
-          updated.paymentStatus = "paid";
+          // Persist the breakdown so the Completed Visits UI can show the
+          // discount even when nothing is due.
+          const finalVisit = await prisma.visit.update({
+            where: { id: updated.id },
+            data: {
+              paymentLinkUrl: null,
+              paymentLinkGeneratedAt: null,
+              paymentStatus: "paid",
+              couponBreakdown: JSON.stringify(billingBreakdown),
+            },
+          });
+          updated.paymentLinkUrl = finalVisit.paymentLinkUrl;
+          updated.paymentLinkGeneratedAt = finalVisit.paymentLinkGeneratedAt;
+          updated.paymentStatus = finalVisit.paymentStatus;
+          updated.couponBreakdown = finalVisit.couponBreakdown;
         }
       } catch (hookErr) {
         console.error(
@@ -3697,6 +3773,7 @@ router.put("/visits/:id", phiWriteGate, async (req, res) => {
       );
     }
 
+    attachCouponBreakdownToVisits(updated);
     res.json({ ...updated, billingBreakdown });
   } catch (e) {
     console.error("[wellness] update visit error:", e.message);
@@ -3726,10 +3803,12 @@ router.post("/visits/:id/payment-link", phiWriteGate, async (req, res) => {
       return res.status(400).json({ error: "Visit is already paid", code: "VISIT_ALREADY_PAID" });
 
     const { getFrontendUrlFromRequest } = require("../lib/requestOrigin");
+    const couponBreakdown = parseVisitCouponBreakdown(visit);
     const link = await generateVisitPaymentLink({
       visit,
       tenantId: req.user.tenantId,
       baseUrl: getFrontendUrlFromRequest(req),
+      amount: couponBreakdown ? couponBreakdown.balance : undefined,
     });
 
     if (link.error)
@@ -3769,10 +3848,12 @@ router.post("/visits/:id/payment-link/send", phiWriteGate, async (req, res) => {
     }
 
     const { getFrontendUrlFromRequest } = require("../lib/requestOrigin");
+    const couponBreakdown = parseVisitCouponBreakdown(visit);
     const result = await sendVisitPaymentLink({
       visit,
       tenantId: req.user.tenantId,
       baseUrl: getFrontendUrlFromRequest(req),
+      amount: couponBreakdown ? couponBreakdown.balance : undefined,
     });
     if (result.error) {
       return res.status(502).json({ error: result.error, code: result.code });
@@ -13765,75 +13846,11 @@ const {
   computeCouponDiscount,
   computeCashbackEarn,
 } = require("../lib/walletCodes");
-
-async function writeWalletTransaction({
-  tenantId,
-  walletId,
-  type,
-  absAmount,
-  performedBy,
-  reason,
-  visitId = null,
-  invoiceId = null,
-  giftCardId = null,
-  couponId = null,
-}) {
-  const isCredit = String(type || "").startsWith("CREDIT_");
-  const isDebit = String(type || "").startsWith("DEBIT_");
-  if (!isCredit && !isDebit) {
-    throw new Error(`Invalid wallet transaction type: ${type}`);
-  }
-  const signed = isCredit ? Math.abs(absAmount) : -Math.abs(absAmount);
-  return prisma.$transaction(async (tx) => {
-    const wallet = await tx.wallet.findFirst({
-      where: { id: walletId, tenantId },
-    });
-    if (!wallet) throw new Error("WALLET_NOT_FOUND");
-    const newBalance = +(wallet.balance + signed).toFixed(2);
-    if (newBalance < 0) {
-      const e = new Error("INSUFFICIENT_BALANCE");
-      e.code = "INSUFFICIENT_BALANCE";
-      throw e;
-    }
-    await tx.wallet.update({
-      where: { id: walletId },
-      data: { balance: newBalance },
-    });
-    return tx.walletTransaction.create({
-      data: {
-        tenantId,
-        walletId,
-        type,
-        amount: signed,
-        reason: reason || null,
-        visitId,
-        invoiceId,
-        giftCardId,
-        couponId,
-        balanceAfter: newBalance,
-        performedBy,
-      },
-    });
-  });
-}
-
-async function getOrCreateWallet(req, patientId) {
-  let wallet = await prisma.wallet.findFirst({
-    where: { tenantId: req.user.tenantId, patientId },
-  });
-  if (wallet) return wallet;
-  const tenant = await prisma.tenant.findUnique({
-    where: { id: req.user.tenantId },
-    select: { defaultCurrency: true },
-  });
-  return prisma.wallet.create({
-    data: {
-      tenantId: req.user.tenantId,
-      patientId,
-      currency: tenant?.defaultCurrency || "INR",
-    },
-  });
-}
+const { loadCouponForApply } = require("../lib/couponApply");
+const {
+  writeWalletTransaction,
+  getOrCreateWallet,
+} = require("../lib/wellnessWallet");
 
 router.get("/patients/:id/wallet", phiReadGate, async (req, res) => {
   try {
@@ -15668,71 +15685,6 @@ router.delete("/coupons/:id", verifyRole(["ADMIN"]), async (req, res) => {
   }
 });
 
-// tenantId is passed explicitly so callers without a req.user (anonymous public
-// payment flow) can reuse this. Existing auth'd callers pass req.user.tenantId.
-async function loadCouponForApply(tenantId, code) {
-  const coupon = await prisma.coupon.findFirst({
-    where: {
-      tenantId,
-      code: String(code || "")
-        .trim()
-        .toUpperCase(),
-    },
-  });
-  if (!coupon)
-    return {
-      error: {
-        status: 404,
-        code: "COUPON_NOT_FOUND",
-        message: "Coupon not found",
-      },
-    };
-  if (!coupon.isActive)
-    return {
-      error: {
-        status: 409,
-        code: "COUPON_INACTIVE",
-        message: "Coupon is inactive",
-      },
-      coupon,
-    };
-  const now = Date.now();
-  if (coupon.validFrom && coupon.validFrom.getTime() > now) {
-    return {
-      error: {
-        status: 409,
-        code: "COUPON_NOT_YET_VALID",
-        message: "Coupon is not yet valid",
-      },
-      coupon,
-    };
-  }
-  if (coupon.validUntil && coupon.validUntil.getTime() < now) {
-    return {
-      error: {
-        status: 410,
-        code: "COUPON_EXPIRED",
-        message: "Coupon has expired",
-      },
-      coupon,
-    };
-  }
-  if (
-    coupon.maxRedemptions != null &&
-    coupon.redemptionCount >= coupon.maxRedemptions
-  ) {
-    return {
-      error: {
-        status: 409,
-        code: "COUPON_LIMIT_REACHED",
-        message: "Coupon redemption limit reached",
-      },
-      coupon,
-    };
-  }
-  return { coupon };
-}
-
 router.post("/coupons/preview", async (req, res) => {
   try {
     const { code, baseAmount, serviceId, visitId } = req.body || {};
@@ -17130,6 +17082,175 @@ router.patch(
     }
   },
 );
+
+// -----------------------------------------------------------------------------
+// QR Events — Events Management QR generator persistence.
+// -----------------------------------------------------------------------------
+// Replaces the previous localStorage-only store with tenant-scoped Prisma
+// persistence. All endpoints below are staff-authed and isolated to
+// req.user.tenantId. QrCode rows cascade-delete with their parent QrEvent.
+
+router.get("/qr-events", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const events = await prisma.qrEvent.findMany({
+      where: { tenantId },
+      include: { qrs: { orderBy: { createdAt: "desc" } } },
+      orderBy: { createdAt: "desc" },
+    });
+    res.json({ events });
+  } catch (err) {
+    console.error("[wellness] GET /qr-events failed:", err.message);
+    res.status(500).json({ error: "Failed to load QR events", code: "QR_EVENTS_LOAD_FAILED" });
+  }
+});
+
+router.post("/qr-events", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    const userId = req.user.userId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const { name } = req.body || {};
+    const trimmed = String(name || "").trim();
+    if (!trimmed) {
+      return res.status(400).json({ error: "Event name is required", code: "QR_EVENT_NAME_REQUIRED" });
+    }
+    const event = await prisma.qrEvent.create({
+      data: { name: trimmed, tenantId, createdBy: userId },
+      include: { qrs: true },
+    });
+    writeAudit("QrEvent", "CREATE", event.id, userId, tenantId, { name: trimmed }).catch(
+      (auditErr) => console.warn("[wellness] audit QrEvent CREATE failed:", auditErr.message),
+    );
+    res.status(201).json(event);
+  } catch (err) {
+    console.error("[wellness] POST /qr-events failed:", err.message);
+    res.status(500).json({ error: "Failed to create QR event", code: "QR_EVENT_CREATE_FAILED" });
+  }
+});
+
+router.delete("/qr-events/:id", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    const userId = req.user.userId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const eventId = parseInt(req.params.id, 10);
+    const event = await prisma.qrEvent.findFirst({
+      where: { id: eventId, tenantId },
+      select: { id: true, name: true },
+    });
+    if (!event) {
+      return res.status(404).json({ error: "Event not found", code: "QR_EVENT_NOT_FOUND" });
+    }
+    await prisma.qrEvent.delete({ where: { id: eventId } });
+    writeAudit("QrEvent", "DELETE", event.id, userId, tenantId, { name: event.name }).catch(
+      (auditErr) => console.warn("[wellness] audit QrEvent DELETE failed:", auditErr.message),
+    );
+    res.json({ success: true });
+  } catch (err) {
+    console.error("[wellness] DELETE /qr-events/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to delete QR event", code: "QR_EVENT_DELETE_FAILED" });
+  }
+});
+
+router.post("/qr-events/:id/qrs", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    const userId = req.user.userId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const eventId = parseInt(req.params.id, 10);
+    const event = await prisma.qrEvent.findFirst({
+      where: { id: eventId, tenantId },
+      select: { id: true },
+    });
+    if (!event) {
+      return res.status(404).json({ error: "Event not found", code: "QR_EVENT_NOT_FOUND" });
+    }
+    const { name, text, size, fgColor, bgColor, errorLevel } = req.body || {};
+    const qr = await prisma.qrCode.create({
+      data: {
+        eventId,
+        tenantId,
+        createdBy: userId,
+        name: String(name || "").trim() || "Untitled QR",
+        text: String(text || "").trim(),
+        size: Number(size) || 256,
+        fgColor: String(fgColor || "#000000"),
+        bgColor: String(bgColor || "#ffffff"),
+        errorLevel: String(errorLevel || "M"),
+      },
+    });
+    res.status(201).json(qr);
+  } catch (err) {
+    console.error("[wellness] POST /qr-events/:id/qrs failed:", err.message);
+    res.status(500).json({ error: "Failed to add QR code", code: "QR_CODE_CREATE_FAILED" });
+  }
+});
+
+router.put("/qr-events/:id/qrs/:qrId", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const eventId = parseInt(req.params.id, 10);
+    const qrId = parseInt(req.params.qrId, 10);
+    const existing = await prisma.qrCode.findFirst({
+      where: { id: qrId, eventId, tenantId },
+    });
+    if (!existing) {
+      return res.status(404).json({ error: "QR code not found", code: "QR_CODE_NOT_FOUND" });
+    }
+    const { name, text, size, fgColor, bgColor, errorLevel } = req.body || {};
+    const data = {};
+    if (name !== undefined) data.name = String(name || "").trim() || existing.name || "Untitled QR";
+    if (text !== undefined) data.text = String(text || "").trim();
+    if (size !== undefined) data.size = Number(size) || existing.size;
+    if (fgColor !== undefined) data.fgColor = String(fgColor);
+    if (bgColor !== undefined) data.bgColor = String(bgColor);
+    if (errorLevel !== undefined) data.errorLevel = String(errorLevel);
+    const qr = await prisma.qrCode.update({
+      where: { id: qrId },
+      data,
+    });
+    res.json(qr);
+  } catch (err) {
+    console.error("[wellness] PUT /qr-events/:id/qrs/:qrId failed:", err.message);
+    res.status(500).json({ error: "Failed to update QR code", code: "QR_CODE_UPDATE_FAILED" });
+  }
+});
+
+router.delete("/qr-events/:id/qrs/:qrId", verifyToken, async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    if (!tenantId) {
+      return res.status(403).json({ error: "Tenant required", code: "TENANT_REQUIRED" });
+    }
+    const eventId = parseInt(req.params.id, 10);
+    const qrId = parseInt(req.params.qrId, 10);
+    const existing = await prisma.qrCode.findFirst({
+      where: { id: qrId, eventId, tenantId },
+      select: { id: true, name: true },
+    });
+    if (!existing) {
+      return res.status(404).json({ error: "QR code not found", code: "QR_CODE_NOT_FOUND" });
+    }
+    await prisma.qrCode.delete({ where: { id: qrId } });
+    res.json({ success: true });
+  } catch (err) {
+    console.error("[wellness] DELETE /qr-events/:id/qrs/:qrId failed:", err.message);
+    res.status(500).json({ error: "Failed to delete QR code", code: "QR_CODE_DELETE_FAILED" });
+  }
+});
 
 module.exports = router;
 

--- a/backend/test/lib/walletCodes.test.js
+++ b/backend/test/lib/walletCodes.test.js
@@ -177,7 +177,7 @@ describe('maskGiftCode + lastFour', () => {
 describe('computeCouponDiscount — PERCENT', () => {
   test('10% off ₹1,000 = ₹100 discount, ₹900 final', () => {
     const r = computeCouponDiscount({ discountType: 'PERCENT', discountValue: 10 }, 1000);
-    expect(r).toEqual({ discount: 100, finalAmount: 900, applied: true });
+    expect(r).toEqual({ discount: 100, finalAmount: 900, applied: true, excess: 0 });
   });
 
   test('caps PERCENT at 100% even if value is 150', () => {
@@ -185,22 +185,24 @@ describe('computeCouponDiscount — PERCENT', () => {
     expect(r.discount).toBe(500);
     expect(r.finalAmount).toBe(0);
     expect(r.applied).toBe(true);
+    expect(r.excess).toBe(0);
   });
 
   test('PERCENT 100% off → final 0', () => {
     const r = computeCouponDiscount({ discountType: 'PERCENT', discountValue: 100 }, 250);
-    expect(r).toEqual({ discount: 250, finalAmount: 0, applied: true });
+    expect(r).toEqual({ discount: 250, finalAmount: 0, applied: true, excess: 0 });
   });
 
   test('zero-base PERCENT → zero discount, applied=false', () => {
     const r = computeCouponDiscount({ discountType: 'PERCENT', discountValue: 50 }, 0);
-    expect(r).toEqual({ discount: 0, finalAmount: 0, applied: false });
+    expect(r).toEqual({ discount: 0, finalAmount: 0, applied: false, excess: 0 });
   });
 
   test('zero-pct PERCENT → zero discount', () => {
     const r = computeCouponDiscount({ discountType: 'PERCENT', discountValue: 0 }, 1000);
     expect(r.discount).toBe(0);
     expect(r.applied).toBe(false);
+    expect(r.excess).toBe(0);
   });
 
   test('PERCENT with float result rounds to 2dp', () => {
@@ -208,13 +210,14 @@ describe('computeCouponDiscount — PERCENT', () => {
     // 99 * 0.33 = 32.67 exact
     expect(r.discount).toBe(32.67);
     expect(r.finalAmount).toBe(66.33);
+    expect(r.excess).toBe(0);
   });
 });
 
 describe('computeCouponDiscount — FLAT', () => {
   test('₹50 off ₹1,000 = ₹50 discount, ₹950 final', () => {
     const r = computeCouponDiscount({ discountType: 'FLAT', discountValue: 50 }, 1000);
-    expect(r).toEqual({ discount: 50, finalAmount: 950, applied: true });
+    expect(r).toEqual({ discount: 50, finalAmount: 950, applied: true, excess: 0 });
   });
 
   test('FLAT discount cannot exceed baseAmount (₹500 off ₹200 → ₹200 off, never negative)', () => {
@@ -222,11 +225,17 @@ describe('computeCouponDiscount — FLAT', () => {
     expect(r.discount).toBe(200);
     expect(r.finalAmount).toBe(0);
     expect(r.applied).toBe(true);
+    expect(r.excess).toBe(300);
   });
 
   test('FLAT exactly equal to base → final 0', () => {
     const r = computeCouponDiscount({ discountType: 'FLAT', discountValue: 200 }, 200);
-    expect(r).toEqual({ discount: 200, finalAmount: 0, applied: true });
+    expect(r).toEqual({ discount: 200, finalAmount: 0, applied: true, excess: 0 });
+  });
+
+  test('FLAT value larger than base credits excess to wallet', () => {
+    const r = computeCouponDiscount({ discountType: 'FLAT', discountValue: 6000 }, 5000);
+    expect(r).toEqual({ discount: 5000, finalAmount: 0, applied: true, excess: 1000 });
   });
 });
 
@@ -248,7 +257,7 @@ describe('computeCouponDiscount — service allowlist', () => {
   test('serviceIds JSON array — service NOT in allowlist returns 0', () => {
     const c = { discountType: 'PERCENT', discountValue: 20, serviceIds: '[1,2,3]' };
     const r = computeCouponDiscount(c, 100, 99);
-    expect(r).toEqual({ discount: 0, finalAmount: 100, applied: false });
+    expect(r).toEqual({ discount: 0, finalAmount: 100, applied: false, excess: 0 });
   });
 
   test('serviceIds non-empty + serviceId null → zero (cannot prove the service is in the allowlist)', () => {
@@ -256,6 +265,7 @@ describe('computeCouponDiscount — service allowlist', () => {
     const r = computeCouponDiscount(c, 100, null);
     expect(r.discount).toBe(0);
     expect(r.applied).toBe(false);
+    expect(r.excess).toBe(0);
   });
 
   test('malformed serviceIds (not JSON) treated as empty allowlist', () => {
@@ -269,6 +279,7 @@ describe('computeCouponDiscount — defensive', () => {
     const r = computeCouponDiscount({ discountType: 'PERCENT', discountValue: 10 }, NaN);
     expect(r.discount).toBe(0);
     expect(r.applied).toBe(false);
+    expect(r.excess).toBe(0);
   });
 
   test('negative baseAmount → coerced to zero', () => {
@@ -278,13 +289,14 @@ describe('computeCouponDiscount — defensive', () => {
 
   test('unknown discountType returns zero discount', () => {
     const r = computeCouponDiscount({ discountType: 'BOGO', discountValue: 50 }, 100);
-    expect(r).toEqual({ discount: 0, finalAmount: 100, applied: false });
+    expect(r).toEqual({ discount: 0, finalAmount: 100, applied: false, excess: 0 });
   });
 
   test('null/undefined coupon does not throw', () => {
     expect(() => computeCouponDiscount(null, 100)).not.toThrow();
     const r = computeCouponDiscount(null, 100);
     expect(r.applied).toBe(false);
+    expect(r.excess).toBe(0);
   });
 });
 

--- a/backend/test/routes/pos-coupon-excess.test.js
+++ b/backend/test/routes/pos-coupon-excess.test.js
@@ -1,0 +1,246 @@
+// @ts-check
+/**
+ * Unit tests for the POS sale coupon-excess wallet credit added in Wave 11.
+ *
+ * When a FLAT coupon's face value exceeds the net basket total, the leftover
+ * amount must be credited to the patient's wallet as a CREDIT_COUPON_EXCESS
+ * transaction. The sale itself must complete successfully regardless of
+ * wallet-credit side effects.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+import prisma from '../../lib/prisma.js';
+
+// Sale-create path stubs.
+prisma.shift = prisma.shift || {};
+prisma.shift.findFirst = vi.fn();
+prisma.patient = prisma.patient || {};
+prisma.patient.findFirst = vi.fn();
+prisma.product = prisma.product || {};
+prisma.product.updateMany = vi.fn().mockResolvedValue({ count: 0 });
+prisma.sale = prisma.sale || {};
+prisma.sale.findFirst = vi.fn().mockResolvedValue(null);
+prisma.sale.create = vi.fn();
+prisma.invoiceCounter = prisma.invoiceCounter || {};
+prisma.invoiceCounter.upsert = vi.fn().mockResolvedValue({ nextSeq: 2 });
+prisma.loyaltyConfig = prisma.loyaltyConfig || {};
+prisma.loyaltyConfig.findUnique = vi.fn().mockResolvedValue(null);
+prisma.loyaltyTransaction = prisma.loyaltyTransaction || {};
+prisma.loyaltyTransaction.findFirst = vi.fn().mockResolvedValue(null);
+prisma.loyaltyTransaction.create = vi.fn().mockResolvedValue({});
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn().mockResolvedValue({ vertical: 'wellness', defaultCurrency: 'INR' });
+prisma.auditLog = prisma.auditLog || {};
+prisma.auditLog.create = vi.fn().mockResolvedValue({});
+prisma.auditLog.findFirst = vi.fn().mockResolvedValue(null);
+prisma.automationRule = prisma.automationRule || {};
+prisma.automationRule.findMany = vi.fn().mockResolvedValue([]);
+prisma.webhook = prisma.webhook || {};
+prisma.webhook.findMany = vi.fn().mockResolvedValue([]);
+
+// Coupon + wallet stubs for the excess credit path.
+prisma.coupon = prisma.coupon || {};
+prisma.coupon.findFirst = vi.fn();
+prisma.coupon.update = vi.fn();
+prisma.wallet = prisma.wallet || {};
+prisma.wallet.findFirst = vi.fn();
+prisma.wallet.create = vi.fn();
+prisma.wallet.update = vi.fn();
+prisma.walletTransaction = prisma.walletTransaction || {};
+prisma.walletTransaction.create = vi.fn();
+
+// $transaction passes the prisma client itself so tx.* resolves to prisma.* mocks.
+prisma.$transaction = vi.fn((fn) => fn(prisma));
+
+import express from 'express';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+const requireCJS = createRequire(import.meta.url);
+const posRouter = requireCJS('../../routes/pos');
+
+function makeApp({
+  tenantId = 1,
+  userId = 7,
+  role = 'ADMIN',
+  wellnessRole = 'admin',
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { userId, tenantId, role, wellnessRole };
+    next();
+  });
+  app.use('/api/pos', posRouter);
+  return app;
+}
+
+function basePayload(overrides = {}) {
+  return {
+    shiftId: 42,
+    paymentMethod: 'CASH',
+    lineItems: [
+      {
+        lineType: 'SERVICE',
+        refId: 1,
+        name: 'Consultation',
+        quantity: 1,
+        unitPrice: 100,
+      },
+    ],
+    patientId: 5,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  prisma.shift.findFirst.mockReset();
+  prisma.shift.findFirst.mockResolvedValue({
+    id: 42,
+    tenantId: 1,
+    status: 'OPEN',
+    userId: 7,
+    registerId: 3,
+  });
+  prisma.patient.findFirst.mockReset();
+  prisma.patient.findFirst.mockResolvedValue({ id: 5 });
+  prisma.sale.create.mockReset();
+  prisma.sale.create.mockImplementation(({ data }) =>
+    Promise.resolve({
+      id: 1234,
+      invoiceNumber: 'POS-2026-0001',
+      ...data,
+      lineItems: [],
+    }),
+  );
+  prisma.coupon.findFirst.mockReset();
+  prisma.coupon.update.mockReset();
+  prisma.wallet.findFirst.mockReset();
+  prisma.wallet.create.mockReset();
+  prisma.wallet.update.mockReset();
+  prisma.walletTransaction.create.mockReset();
+  prisma.auditLog.create.mockClear();
+  prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness', defaultCurrency: 'INR' });
+});
+
+describe('POST /api/pos/sales — FLAT coupon excess credit', () => {
+  test('credits excess to patient wallet when FLAT coupon exceeds basket total', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 9,
+      tenantId: 1,
+      code: 'FLAT6000',
+      isActive: true,
+      discountType: 'FLAT',
+      discountValue: 6000,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+    });
+    prisma.wallet.findFirst.mockResolvedValue({
+      id: 55,
+      tenantId: 1,
+      patientId: 5,
+      balance: 0,
+    });
+    prisma.coupon.update.mockResolvedValue({ id: 9, redemptionCount: 1 });
+    prisma.walletTransaction.create.mockResolvedValue({ id: 888, amount: 5900 });
+
+    const res = await request(makeApp())
+      .post('/api/pos/sales')
+      .send(basePayload({
+        discountTotal: 100,
+        paidAmount: 0,
+        couponCode: 'FLAT6000',
+      }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.coupon.update).toHaveBeenCalledTimes(1);
+    expect(prisma.coupon.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 9 },
+        data: { redemptionCount: { increment: 1 } },
+      }),
+    );
+    expect(prisma.walletTransaction.create).toHaveBeenCalledTimes(1);
+    const txCall = prisma.walletTransaction.create.mock.calls[0][0];
+    expect(txCall.data.type).toBe('CREDIT_COUPON_EXCESS');
+    expect(txCall.data.amount).toBe(5900);
+    expect(txCall.data.reason).toBe('Coupon FLAT6000 excess credited');
+    expect(txCall.data.couponId).toBe(9);
+  });
+
+  test('no wallet credit when coupon discount is less than basket total', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 10,
+      tenantId: 1,
+      code: 'FLAT50',
+      isActive: true,
+      discountType: 'FLAT',
+      discountValue: 50,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+    });
+    prisma.coupon.update.mockResolvedValue({ id: 10, redemptionCount: 1 });
+
+    const res = await request(makeApp())
+      .post('/api/pos/sales')
+      .send(basePayload({
+        discountTotal: 50,
+        paidAmount: 50,
+        couponCode: 'FLAT50',
+      }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.coupon.update).toHaveBeenCalledTimes(1);
+    expect(prisma.wallet.findFirst).not.toHaveBeenCalled();
+    expect(prisma.walletTransaction.create).not.toHaveBeenCalled();
+  });
+
+  test('no wallet credit for anonymous sale without patientId', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 11,
+      tenantId: 1,
+      code: 'FLAT6000',
+      isActive: true,
+      discountType: 'FLAT',
+      discountValue: 6000,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+    });
+    prisma.coupon.update.mockResolvedValue({ id: 11, redemptionCount: 1 });
+
+    const res = await request(makeApp())
+      .post('/api/pos/sales')
+      .send(basePayload({
+        patientId: null,
+        discountTotal: 0,
+        paidAmount: 0,
+        couponCode: 'FLAT6000',
+      }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.coupon.update).not.toHaveBeenCalled();
+    expect(prisma.wallet.findFirst).not.toHaveBeenCalled();
+  });
+
+  test('sale still succeeds when coupon lookup fails', async () => {
+    prisma.coupon.findFirst.mockResolvedValue(null);
+
+    const res = await request(makeApp())
+      .post('/api/pos/sales')
+      .send(basePayload({
+        discountTotal: 0,
+        paidAmount: 100,
+        couponCode: 'UNKNOWN',
+      }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.coupon.update).not.toHaveBeenCalled();
+    expect(prisma.wallet.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/routes/wellness-coupon-excess.test.js
+++ b/backend/test/routes/wellness-coupon-excess.test.js
@@ -1,0 +1,147 @@
+// @ts-check
+/**
+ * Route-level tests for the wellness coupon excess field.
+ *
+ * Pins that /api/wellness/coupons/preview and /api/wellness/coupons/apply
+ * both return the new `excess` field, and that `excess` is positive for
+ * FLAT coupons whose face value exceeds the base amount.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import prisma from '../../lib/prisma.js';
+
+prisma.coupon = prisma.coupon || {};
+prisma.coupon.findFirst = vi.fn();
+prisma.coupon.update = vi.fn();
+prisma.auditLog = prisma.auditLog || {};
+prisma.auditLog.create = vi.fn().mockResolvedValue({ id: 1 });
+prisma.auditLog.findFirst = vi.fn().mockResolvedValue(null);
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn().mockResolvedValue({ vertical: 'wellness' });
+prisma.automationRule = { findMany: vi.fn().mockResolvedValue([]) };
+prisma.webhook = { findMany: vi.fn().mockResolvedValue([]) };
+
+import express from 'express';
+import request from 'supertest';
+import { createRequire } from 'node:module';
+const requireCJS = createRequire(import.meta.url);
+const wellnessRouter = requireCJS('../../routes/wellness');
+
+function makeApp({
+  tenantId = 1,
+  userId = 7,
+  role = 'ADMIN',
+  wellnessRole = 'admin',
+  vertical = 'wellness',
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { userId, tenantId, role, wellnessRole, vertical };
+    next();
+  });
+  app.use('/api/wellness', wellnessRouter);
+  return app;
+}
+
+beforeEach(() => {
+  prisma.coupon.findFirst.mockReset();
+  prisma.coupon.update.mockReset();
+  prisma.auditLog.create.mockClear();
+});
+
+describe('POST /api/wellness/coupons/preview', () => {
+  test('returns excess for a FLAT coupon that exceeds the base amount', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      code: 'FLAT6000',
+      isActive: true,
+      discountType: 'FLAT',
+      discountValue: 6000,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+      serviceIds: null,
+    });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/coupons/preview')
+      .send({ code: 'FLAT6000', baseAmount: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      code: 'FLAT6000',
+      discountType: 'FLAT',
+      discountValue: 6000,
+      baseAmount: 5000,
+      discount: 5000,
+      finalAmount: 0,
+      applied: true,
+      excess: 1000,
+      balance: 0,
+      lockingFee: 0,
+    });
+  });
+
+  test('returns excess:0 for a PERCENT coupon', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 2,
+      tenantId: 1,
+      code: 'PERCENT10',
+      isActive: true,
+      discountType: 'PERCENT',
+      discountValue: 10,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+      serviceIds: null,
+    });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/coupons/preview')
+      .send({ code: 'PERCENT10', baseAmount: 1000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.excess).toBe(0);
+    expect(res.body.discount).toBe(100);
+  });
+});
+
+describe('POST /api/wellness/coupons/apply', () => {
+  test('returns excess for a FLAT coupon that exceeds the base amount', async () => {
+    prisma.coupon.findFirst.mockResolvedValue({
+      id: 3,
+      tenantId: 1,
+      code: 'FLAT6000',
+      isActive: true,
+      discountType: 'FLAT',
+      discountValue: 6000,
+      redemptionCount: 0,
+      maxRedemptions: null,
+      validFrom: null,
+      validUntil: null,
+      serviceIds: null,
+    });
+    prisma.coupon.update.mockResolvedValue({
+      id: 3,
+      redemptionCount: 1,
+    });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/coupons/apply')
+      .send({ code: 'FLAT6000', baseAmount: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      code: 'FLAT6000',
+      discount: 5000,
+      finalAmount: 0,
+      applied: true,
+      excess: 1000,
+      redemptionCount: 1,
+    });
+  });
+});

--- a/backend/test/routes/wellness-visits-payment-link.test.js
+++ b/backend/test/routes/wellness-visits-payment-link.test.js
@@ -13,6 +13,9 @@ const mockCreateInvoicePaymentLink = vi.fn();
 const mockSendEmail = vi.fn();
 const mockSendBestEffort = vi.fn();
 const mockCreatePatientNotification = vi.fn();
+const mockLoadCouponForApply = vi.fn();
+const mockGetOrCreateWallet = vi.fn();
+const mockWriteWalletTransaction = vi.fn();
 
 const requireCJS = createRequire(import.meta.url);
 const paymentLinkModulePath = requireCJS.resolve('../../lib/paymentLink');
@@ -62,6 +65,27 @@ requireCJS.cache[patientNotificationServiceModulePath] = {
   },
 };
 
+const couponApplyModulePath = requireCJS.resolve('../../lib/couponApply');
+requireCJS.cache[couponApplyModulePath] = {
+  id: couponApplyModulePath,
+  filename: couponApplyModulePath,
+  loaded: true,
+  exports: {
+    loadCouponForApply: (...args) => mockLoadCouponForApply(...args),
+  },
+};
+
+const wellnessWalletModulePath = requireCJS.resolve('../../lib/wellnessWallet');
+requireCJS.cache[wellnessWalletModulePath] = {
+  id: wellnessWalletModulePath,
+  filename: wellnessWalletModulePath,
+  loaded: true,
+  exports: {
+    getOrCreateWallet: (...args) => mockGetOrCreateWallet(...args),
+    writeWalletTransaction: (...args) => mockWriteWalletTransaction(...args),
+  },
+};
+
 prisma.visit = prisma.visit || {};
 prisma.visit.findFirst = vi.fn();
 prisma.visit.findUnique = vi.fn();
@@ -87,6 +111,9 @@ prisma.payment.update = vi.fn().mockResolvedValue({ id: 1 });
 
 prisma.tenant = prisma.tenant || {};
 prisma.tenant.findUnique = vi.fn();
+
+prisma.coupon = prisma.coupon || {};
+prisma.coupon.update = vi.fn();
 
 prisma.loyaltyConfig = prisma.loyaltyConfig || {};
 prisma.loyaltyConfig.findUnique = vi.fn().mockResolvedValue(null);
@@ -125,11 +152,17 @@ beforeEach(() => {
   mockSendEmail.mockReset();
   mockSendBestEffort.mockReset();
   mockCreatePatientNotification.mockReset();
+  mockLoadCouponForApply.mockReset();
+  mockGetOrCreateWallet.mockReset();
+  mockWriteWalletTransaction.mockReset();
   mockCreateInvoicePaymentLink.mockResolvedValue({
     url: 'https://rzp.io/l/test-visit-link',
     gateway: 'razorpay',
     paymentId: 99,
   });
+  mockLoadCouponForApply.mockResolvedValue({ error: { status: 404, code: 'COUPON_NOT_FOUND', message: 'Coupon not found' } });
+  mockGetOrCreateWallet.mockResolvedValue({ id: 5 });
+  mockWriteWalletTransaction.mockResolvedValue({ id: 6 });
 
   prisma.visit.findFirst.mockReset();
   prisma.visit.update.mockReset();
@@ -144,6 +177,7 @@ beforeEach(() => {
   prisma.payment.findFirst.mockReset();
   prisma.payment.update.mockReset();
   prisma.tenant.findUnique.mockReset();
+  prisma.coupon.update.mockReset();
 
   prisma.visit.update.mockResolvedValue({
     id: 1,
@@ -185,13 +219,16 @@ beforeEach(() => {
   });
 
   prisma.invoice.findFirst.mockResolvedValue(null);
-  prisma.invoice.create.mockResolvedValue({
-    id: 200,
-    tenantId: 1,
-    invoiceNum: 'WLV-1-1234567890123',
-    amount: 1500,
-    contactId: 100,
-    visitId: 1,
+  prisma.invoice.create.mockImplementation((args) => {
+    const amount = args?.data?.amount != null ? Number(args.data.amount) : 1500;
+    return Promise.resolve({
+      id: 200,
+      tenantId: 1,
+      invoiceNum: 'WLV-1-1234567890123',
+      amount,
+      contactId: args?.data?.contactId || 100,
+      visitId: args?.data?.visitId || 1,
+    });
   });
   prisma.payment.findMany.mockResolvedValue([]);
   prisma.payment.findFirst.mockResolvedValue(null);
@@ -319,6 +356,153 @@ describe('PUT /api/wellness/visits/:id payment link hook', () => {
       expect.objectContaining({ data: expect.objectContaining({ contactId: 101 }) }),
     );
   });
+
+  test('completing a visit with a coupon stores couponBreakdown and generates link for the adjusted balance', async () => {
+    prisma.visit.findFirst.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      patientId: 42,
+      serviceId: 10,
+      doctorId: 5,
+      status: 'booked',
+      amountCharged: 7500,
+    });
+    prisma.visit.update.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      patientId: 42,
+      serviceId: 10,
+      doctorId: 5,
+      status: 'completed',
+      amountCharged: 7500,
+      paymentLinkUrl: 'https://rzp.io/l/test-visit-link',
+      paymentLinkGeneratedAt: new Date('2026-07-21T07:00:00.000Z'),
+      couponBreakdown: JSON.stringify({
+        baseAmount: 7500,
+        discount: 2500,
+        excess: 0,
+        lockingFee: 0,
+        balance: 5000,
+        couponCode: 'FLAT2500',
+      }),
+    });
+    mockLoadCouponForApply.mockResolvedValue({
+      coupon: {
+        id: 77,
+        code: 'FLAT2500',
+        discountType: 'FLAT',
+        discountValue: 2500,
+        serviceIds: null,
+      },
+    });
+
+    const res = await request(makeApp())
+      .put('/api/wellness/visits/1')
+      .send({ status: 'completed', notes: '', amountCharged: 7500, couponCode: 'FLAT2500' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.couponBreakdown).toEqual({
+      baseAmount: 7500,
+      discount: 2500,
+      excess: 0,
+      lockingFee: 0,
+      balance: 5000,
+      couponCode: 'FLAT2500',
+    });
+    expect(prisma.visit.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: expect.objectContaining({
+          couponBreakdown: JSON.stringify({
+            baseAmount: 7500,
+            discount: 2500,
+            excess: 0,
+            lockingFee: 0,
+            balance: 5000,
+            couponCode: 'FLAT2500',
+          }),
+        }),
+      }),
+    );
+    expect(mockCreateInvoicePaymentLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: expect.objectContaining({ amount: 5000 }),
+      }),
+    );
+  });
+
+  test('completing a visit with a fully-covering coupon stores couponBreakdown and marks paid with no link', async () => {
+    prisma.visit.findFirst.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      patientId: 42,
+      serviceId: 10,
+      doctorId: 5,
+      status: 'booked',
+      amountCharged: 5500,
+    });
+    prisma.visit.update.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      patientId: 42,
+      serviceId: 10,
+      doctorId: 5,
+      status: 'completed',
+      amountCharged: 5500,
+      paymentLinkUrl: null,
+      paymentLinkGeneratedAt: null,
+      paymentStatus: 'paid',
+      couponBreakdown: JSON.stringify({
+        baseAmount: 5500,
+        discount: 5500,
+        excess: 4500,
+        lockingFee: 0,
+        balance: 0,
+        couponCode: 'TATA',
+      }),
+    });
+    mockLoadCouponForApply.mockResolvedValue({
+      coupon: {
+        id: 88,
+        code: 'TATA',
+        discountType: 'FLAT',
+        discountValue: 10000,
+        serviceIds: null,
+      },
+    });
+
+    const res = await request(makeApp())
+      .put('/api/wellness/visits/1')
+      .send({ status: 'completed', notes: '', amountCharged: 5500, couponCode: 'TATA' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.couponBreakdown).toEqual({
+      baseAmount: 5500,
+      discount: 5500,
+      excess: 4500,
+      lockingFee: 0,
+      balance: 0,
+      couponCode: 'TATA',
+    });
+    expect(res.body.paymentStatus).toBe('paid');
+    expect(mockCreateInvoicePaymentLink).not.toHaveBeenCalled();
+    expect(prisma.visit.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: expect.objectContaining({
+          paymentStatus: 'paid',
+          couponBreakdown: JSON.stringify({
+            baseAmount: 5500,
+            discount: 5500,
+            excess: 4500,
+            lockingFee: 0,
+            balance: 0,
+            couponCode: 'TATA',
+          }),
+        }),
+      }),
+    );
+  });
 });
 
 describe('POST /api/wellness/visits/:id/payment-link regeneration', () => {
@@ -433,6 +617,36 @@ describe('POST /api/wellness/visits/:id/payment-link regeneration', () => {
     expect(res.status).toBe(400);
     expect(res.body.code).toBe('VISIT_ALREADY_PAID');
     expect(mockCreateInvoicePaymentLink).not.toHaveBeenCalled();
+  });
+
+  test('regenerating a payment link uses the coupon-adjusted balance from couponBreakdown', async () => {
+    prisma.visit.findFirst.mockResolvedValue({
+      id: 1,
+      tenantId: 1,
+      patientId: 42,
+      status: 'completed',
+      amountCharged: 7500,
+      paymentStatus: 'unpaid',
+      couponBreakdown: JSON.stringify({
+        baseAmount: 7500,
+        discount: 2500,
+        excess: 0,
+        lockingFee: 0,
+        balance: 5000,
+        couponCode: 'FLAT2500',
+      }),
+    });
+
+    const res = await request(makeApp())
+      .post('/api/wellness/visits/1/payment-link')
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(mockCreateInvoicePaymentLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: expect.objectContaining({ amount: 5000 }),
+      }),
+    );
   });
 });
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -420,6 +420,7 @@ const WellnessCoupons = lazy(() => import("./pages/wellness/Coupons"));
 const WellnessCashbackRules = lazy(() => import("./pages/wellness/CashbackRules"));
 // Marketing QR Generator — create downloadable QR codes for clinic public pages/offers.
 const WellnessQRGenerator = lazy(() => import("./pages/wellness/QRGenerator"));
+const WellnessEventsHistory = lazy(() => import("./pages/wellness/EventsHistory"));
 const WellnessCalendar = lazy(() => import("./pages/wellness/Calendar"));
 const WellnessBookAppointment = lazy(() => import("./pages/wellness/BookAppointment"));
 const WellnessAppointments = lazy(() => import("./pages/wellness/Appointments"));
@@ -2076,6 +2077,18 @@ export default function App() {
                     lockedInPlace
                   >
                     <WellnessQRGenerator />
+                  </RoleGuard>
+                </WellnessOnly>
+              } />
+              {/* Events History — read-only list of QR codes grouped by event. */}
+              <Route path="wellness/events-history" element={
+                <WellnessOnly>
+                  <RoleGuard
+                    requiredPermission={{ module: 'marketing', action: 'read' }}
+                    feature="Events History"
+                    lockedInPlace
+                  >
+                    <WellnessEventsHistory />
                   </RoleGuard>
                 </WellnessOnly>
               } />

--- a/frontend/src/__tests__/QuoteAcceptLanding.test.jsx
+++ b/frontend/src/__tests__/QuoteAcceptLanding.test.jsx
@@ -108,10 +108,12 @@ describe('QuoteAcceptLanding — public customer landing (C9)', () => {
 
   it('2. quote envelope loads → renders id + customer + lines + total', async () => {
     renderPage();
+    // Wait for a loaded-state marker. "Your quote" is intentionally avoided
+    // because the loading spinner contains "Loading your quote…", so a regex
+    // match on /Your quote/i can succeed before the fetch resolves.
     await waitFor(() =>
-      expect(screen.getByText(/Your quote/i)).toBeInTheDocument(),
+      expect(screen.getByText(/Quote #42/i)).toBeInTheDocument(),
     );
-    expect(screen.getByText(/Quote #42/i)).toBeInTheDocument();
     expect(screen.getByText(/Aisha Khan/i)).toBeInTheDocument();
     expect(screen.getByText(/Hotel — 3 nights/i)).toBeInTheDocument();
     expect(screen.getByText(/Coach transfer/i)).toBeInTheDocument();
@@ -154,7 +156,7 @@ describe('QuoteAcceptLanding — public customer landing (C9)', () => {
 
   it('5. accept happy path → confirmation form → POST → thank-you', async () => {
     renderPage();
-    await waitFor(() => screen.getByText(/Your quote/i));
+    await waitFor(() => screen.getByText(/Your trip includes/i));
 
     fireEvent.click(screen.getByRole('button', { name: /Accept this quote/i }));
     await waitFor(() =>
@@ -185,7 +187,7 @@ describe('QuoteAcceptLanding — public customer landing (C9)', () => {
 
   it('6. reject requires reason — empty submit surfaces validation', async () => {
     renderPage();
-    await waitFor(() => screen.getByText(/Your quote/i));
+    await waitFor(() => screen.getByText(/Your trip includes/i));
 
     fireEvent.click(screen.getByRole('button', { name: /Decline/i }));
     await waitFor(() =>
@@ -202,7 +204,7 @@ describe('QuoteAcceptLanding — public customer landing (C9)', () => {
 
   it('7. 409 ALREADY_ACTIONED on accept → friendly message', async () => {
     renderPage();
-    await waitFor(() => screen.getByText(/Your quote/i));
+    await waitFor(() => screen.getByText(/Your trip includes/i));
 
     fireEvent.click(screen.getByRole('button', { name: /Accept this quote/i }));
     await waitFor(() =>

--- a/frontend/src/__tests__/wellness/EventsHistory.test.jsx
+++ b/frontend/src/__tests__/wellness/EventsHistory.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * EventsHistory.test.jsx — vitest + RTL coverage for the wellness
+ * Events History page.
+ *
+ * Scope:
+ *   1. Renders an empty state when no events exist.
+ *   2. Renders saved events and their QRs from the API.
+ *   3. Expands and collapses an event card.
+ *   4. Downloads a QR from history.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const toDataURLMock = vi.fn();
+vi.mock('qrcode', () => ({
+  default: {
+    toDataURL: (...args) => toDataURLMock(...args),
+    toCanvas: vi.fn(),
+  },
+}));
+
+const notifySuccess = vi.fn();
+const notifyError = vi.fn();
+const notifyObj = {
+  error: notifyError,
+  success: notifySuccess,
+  info: vi.fn(),
+  confirm: () => Promise.resolve(true),
+};
+vi.mock('../../utils/notify', () => ({
+  useNotify: () => notifyObj,
+}));
+
+vi.mock('../../utils/api', () => ({
+  fetchApi: vi.fn(),
+}));
+
+import EventsHistory from '../../pages/wellness/EventsHistory';
+import { AuthContext } from '../../App';
+import { fetchApi } from '../../utils/api';
+
+const TEST_TENANT_ID = 42;
+const QR_EVENTS_API = '/api/wellness/qr-events';
+
+let mockEvents = [];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={{ tenant: { id: TEST_TENANT_ID, slug: 'enhanced-wellness' }, user: { role: 'ADMIN' } }}>
+        <EventsHistory />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  toDataURLMock.mockResolvedValue('data:image/png;base64,MOCK');
+  notifySuccess.mockReset();
+  notifyError.mockReset();
+  mockEvents = [];
+
+  fetchApi.mockImplementation(async (url) => {
+    if (url === QR_EVENTS_API) {
+      return { events: mockEvents };
+    }
+    return {};
+  });
+});
+
+describe('EventsHistory', () => {
+  it('renders the page header and empty state', async () => {
+    renderPage();
+    expect(screen.getByText('Events History')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('No events yet')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('Create an event in the QR Generator to start collecting QR codes here.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders saved events and their QR counts from the API', async () => {
+    mockEvents = [
+      {
+        id: 1,
+        name: 'Summer Camp',
+        createdAt: new Date().toISOString(),
+        qrs: [
+          { id: 1, name: 'Check-in QR', text: 'https://example.com/checkin', size: 256, fgColor: '#000000', bgColor: '#ffffff', errorLevel: 'M', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+        ],
+      },
+      {
+        id: 2,
+        name: 'Membership Drive',
+        createdAt: new Date().toISOString(),
+        qrs: [],
+      },
+    ];
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Summer Camp')).toBeInTheDocument();
+    });
+    expect(screen.getByText('1 QR')).toBeInTheDocument();
+    expect(screen.getByText('Membership Drive')).toBeInTheDocument();
+    expect(screen.getByText('0 QRs')).toBeInTheDocument();
+  });
+
+  it('expands and collapses an event to show its QRs', async () => {
+    mockEvents = [
+      {
+        id: 1,
+        name: 'Summer Camp',
+        createdAt: new Date().toISOString(),
+        qrs: [
+          { id: 1, name: 'Check-in QR', text: 'https://example.com/checkin', size: 256, fgColor: '#000000', bgColor: '#ffffff', errorLevel: 'M', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+        ],
+      },
+    ];
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Check-in QR')).toBeInTheDocument();
+    });
+
+    const toggleButton = screen.getByRole('button', { name: /Summer Camp/i });
+    fireEvent.click(toggleButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Check-in QR')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(toggleButton);
+    await waitFor(() => {
+      expect(screen.getByText('Check-in QR')).toBeInTheDocument();
+    });
+  });
+
+  it('downloads a QR from history', async () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+    mockEvents = [
+      {
+        id: 1,
+        name: 'Summer Camp',
+        createdAt: new Date().toISOString(),
+        qrs: [
+          { id: 1, name: 'Check-in QR', text: 'https://example.com/checkin', size: 512, fgColor: '#123456', bgColor: '#abcdef', errorLevel: 'H', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+        ],
+      },
+    ];
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Check-in QR')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Download this QR'));
+
+    await waitFor(() => {
+      expect(toDataURLMock).toHaveBeenCalledWith(
+        'https://example.com/checkin',
+        expect.objectContaining({
+          width: 512,
+          color: { dark: '#123456', light: '#abcdef' },
+          errorCorrectionLevel: 'H',
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(notifySuccess).toHaveBeenCalledWith('QR code downloaded');
+    });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});

--- a/frontend/src/__tests__/wellness/LogVisitTab.test.jsx
+++ b/frontend/src/__tests__/wellness/LogVisitTab.test.jsx
@@ -333,6 +333,71 @@ describe('<wellness/LogVisitTab />  payment link surface', () => {
     expect(await screen.findByDisplayValue('https://rzp.io/l/visit-10')).toBeInTheDocument();
   });
 
+  it('renders the coupon-adjusted balance and coupon name when couponBreakdown is present', () => {
+    const patient = {
+      id: 1,
+      visits: [
+        {
+          id: 13,
+          status: 'completed',
+          visitDate: '2026-07-17T10:00:00.000Z',
+          serviceId: 1,
+          service: sampleServices[0],
+          doctor: { name: 'Anita Das' },
+          amountCharged: 7500,
+          paymentLinkUrl: 'https://rzp.io/l/visit-13',
+          couponBreakdown: {
+            baseAmount: 7500,
+            discount: 2500,
+            excess: 0,
+            lockingFee: 0,
+            balance: 5000,
+            couponCode: 'FLAT2500',
+          },
+        },
+      ],
+    };
+
+    renderTab({ patient });
+
+    expect(screen.getByText(/₹7,500/)).toBeInTheDocument();
+    expect(screen.getByText(/Coupon FLAT2500/)).toBeInTheDocument();
+    expect(screen.getByText(/₹2,500 deducted/)).toBeInTheDocument();
+    expect(screen.getByText(/Balance due:/)).toBeInTheDocument();
+    expect(screen.getByText(/₹5,000/)).toBeInTheDocument();
+  });
+
+  it('renders the coupon-adjusted balance from a string couponBreakdown payload', () => {
+    const patient = {
+      id: 1,
+      visits: [
+        {
+          id: 14,
+          status: 'completed',
+          visitDate: '2026-07-16T10:00:00.000Z',
+          serviceId: 1,
+          service: sampleServices[0],
+          doctor: { name: 'Anita Das' },
+          amountCharged: 7500,
+          paymentLinkUrl: 'https://rzp.io/l/visit-14',
+          couponBreakdown: JSON.stringify({
+            baseAmount: 7500,
+            discount: 2500,
+            excess: 0,
+            lockingFee: 0,
+            balance: 5000,
+            couponCode: 'FLAT2500',
+          }),
+        },
+      ],
+    };
+
+    renderTab({ patient });
+
+    expect(screen.getByText(/Coupon FLAT2500/)).toBeInTheDocument();
+    expect(screen.getByText(/Balance due:/)).toBeInTheDocument();
+  });
+
   it('shows a Paid badge and disables Copy for a paid completed visit', () => {
     const patient = {
       id: 1,

--- a/frontend/src/__tests__/wellness/QRGenerator.test.jsx
+++ b/frontend/src/__tests__/wellness/QRGenerator.test.jsx
@@ -1,19 +1,17 @@
 /**
- * QRGenerator.test.jsx — vitest + RTL coverage for the simplified wellness
- * marketing QR Generator page.
+ * QRGenerator.test.jsx — vitest + RTL coverage for the wellness
+ * Events Management QR Generator page.
  *
  * Scope:
- *   1. Renders the page header and source options.
- *   2. Generates a live QR preview via qrcode.toDataURL when the user types.
- *   3. Presets build correct URLs:
- *        - Public Booking Page -> /wellness/book-appointment
- *        - Buy Gift Cards     -> /wellness/buy-giftcards
- *   4. Generate QR button saves the current configuration to history.
- *   5. History items can be restored and deleted.
- *   6. Download button works once a QR preview exists.
+ *   1. Renders the page header and event selector.
+ *   2. Creates an event and auto-selects it.
+ *   3. Enters a URL + QR name and generates a QR under the selected event.
+ *   4. Editing a QR loads it back into the form and updates it.
+ *   5. Download buttons work once a QR preview exists.
+ *   6. Events and QRs persist across reloads (re-fetched from the API).
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -38,11 +36,28 @@ vi.mock('../../utils/notify', () => ({
   useNotify: () => notifyObj,
 }));
 
+vi.mock('../../utils/api', () => ({
+  fetchApi: vi.fn(),
+}));
+
 import QRGenerator from '../../pages/wellness/QRGenerator';
 import { AuthContext } from '../../App';
+import { fetchApi } from '../../utils/api';
 
-const TEST_ORIGIN = 'https://crm.example.com';
 const TEST_TENANT_ID = 42;
+const QR_EVENTS_API = '/api/wellness/qr-events';
+
+let mockEvents = [];
+let nextId = 1;
+
+function parseBody(options = {}) {
+  if (!options.body) return {};
+  try {
+    return JSON.parse(options.body);
+  } catch {
+    return {};
+  }
+}
 
 function renderPage() {
   return render(
@@ -54,173 +69,197 @@ function renderPage() {
   );
 }
 
+function openEventDropdown() {
+  fireEvent.click(screen.getByTestId('event-dropdown-trigger'));
+}
+
+function createEvent(name) {
+  fireEvent.click(screen.getByTestId('new-event-button'));
+  fireEvent.change(screen.getByPlaceholderText('e.g. Summer Camp 2026'), { target: { value: name } });
+  fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   toDataURLMock.mockResolvedValue('data:image/png;base64,MOCK');
   toCanvasMock.mockResolvedValue(undefined);
   notifySuccess.mockReset();
   notifyError.mockReset();
-  localStorage.clear();
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { origin: TEST_ORIGIN },
-    });
-  }
-});
+  mockEvents = [];
+  nextId = 1;
 
-afterEach(() => {
-  localStorage.clear();
+  fetchApi.mockImplementation(async (url, options = {}) => {
+    const method = options.method || 'GET';
+
+    if (url === QR_EVENTS_API && method === 'GET') {
+      return { events: mockEvents };
+    }
+
+    if (url === QR_EVENTS_API && method === 'POST') {
+      const body = parseBody(options);
+      const created = {
+        id: nextId++,
+        name: body.name,
+        createdAt: new Date().toISOString(),
+        qrs: [],
+      };
+      mockEvents = [created, ...mockEvents];
+      return created;
+    }
+
+    const qrCreateMatch = url.match(new RegExp(`^${QR_EVENTS_API}/(\\d+)/qrs$`));
+    if (qrCreateMatch && method === 'POST') {
+      const eventId = parseInt(qrCreateMatch[1], 10);
+      const body = parseBody(options);
+      const qr = {
+        id: nextId++,
+        eventId,
+        ...body,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      const event = mockEvents.find((e) => e.id === eventId);
+      if (event) event.qrs = [qr, ...event.qrs];
+      return qr;
+    }
+
+    const qrUpdateMatch = url.match(new RegExp(`^${QR_EVENTS_API}/(\\d+)/qrs/(\\d+)$`));
+    if (qrUpdateMatch && method === 'PUT') {
+      const eventId = parseInt(qrUpdateMatch[1], 10);
+      const qrId = parseInt(qrUpdateMatch[2], 10);
+      const body = parseBody(options);
+      const event = mockEvents.find((e) => e.id === eventId);
+      if (event) {
+        const idx = event.qrs.findIndex((q) => q.id === qrId);
+        if (idx !== -1) {
+          event.qrs[idx] = { ...event.qrs[idx], ...body, updatedAt: new Date().toISOString() };
+          return event.qrs[idx];
+        }
+      }
+      return { id: qrId, ...body };
+    }
+
+    const qrDeleteMatch = url.match(new RegExp(`^${QR_EVENTS_API}/(\\d+)/qrs/(\\d+)$`));
+    if (qrDeleteMatch && method === 'DELETE') {
+      const eventId = parseInt(qrDeleteMatch[1], 10);
+      const qrId = parseInt(qrDeleteMatch[2], 10);
+      const event = mockEvents.find((e) => e.id === eventId);
+      if (event) event.qrs = event.qrs.filter((q) => q.id !== qrId);
+      return true;
+    }
+
+    return {};
+  });
 });
 
 describe('QRGenerator', () => {
-  it('renders the page header and source options', () => {
+  it('renders the page header and event selector', async () => {
     renderPage();
     expect(screen.getByText('QR Generator')).toBeInTheDocument();
-    expect(screen.getByText('Custom URL / Text')).toBeInTheDocument();
-    expect(screen.getByText('Public Booking Page')).toBeInTheDocument();
-    expect(screen.getByText('Buy Gift Cards')).toBeInTheDocument();
+    expect(screen.getByTestId('event-dropdown-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('new-event-button')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter URL here')).toBeInTheDocument();
   });
 
-  it('generates a QR preview when the user enters custom text', async () => {
+  it('creates an event and auto-selects it', async () => {
     renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://example.com/offer' } });
+    createEvent('Health Camp 2026');
 
     await waitFor(() => {
-      expect(toDataURLMock).toHaveBeenCalledWith(
-        'https://example.com/offer',
-        expect.objectContaining({
-          width: 256,
-          margin: 2,
-          color: { dark: '#000000', light: '#ffffff' },
-          errorCorrectionLevel: 'M',
-        })
-      );
+      expect(screen.getByRole('button', { name: /Health Camp 2026/i })).toBeInTheDocument();
     });
 
-    expect(screen.getByAltText('QR code preview')).toBeInTheDocument();
+    expect(notifySuccess).toHaveBeenCalledWith('Event "Health Camp 2026" created');
   });
 
-  it('uses the authenticated booking page URL for the Public Booking Page preset', async () => {
+  it('selects an existing event from the dropdown', async () => {
+    mockEvents = [
+      { id: 1, name: 'Existing Event', createdAt: new Date().toISOString(), qrs: [] },
+    ];
     renderPage();
-    fireEvent.click(screen.getByText('Public Booking Page'));
 
     await waitFor(() => {
-      expect(toDataURLMock).toHaveBeenCalledWith(
-        `${TEST_ORIGIN}/wellness/book-appointment`,
-        expect.any(Object)
-      );
+      expect(screen.getByRole('button', { name: /Existing Event/i })).toBeInTheDocument();
     });
 
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    expect(input.value).toBe(`${TEST_ORIGIN}/wellness/book-appointment`);
-  });
-
-  it('uses the gift-card storefront URL for the Buy Gift Cards preset', async () => {
-    renderPage();
-    fireEvent.click(screen.getByText('Buy Gift Cards'));
+    openEventDropdown();
+    fireEvent.click(screen.getByRole('option', { name: /Existing Event/i }));
 
     await waitFor(() => {
-      expect(toDataURLMock).toHaveBeenCalledWith(
-        `${TEST_ORIGIN}/wellness/buy-giftcards`,
-        expect.any(Object)
-      );
+      expect(screen.getByRole('button', { name: /Existing Event/i })).toBeInTheDocument();
     });
-
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    expect(input.value).toBe(`${TEST_ORIGIN}/wellness/buy-giftcards`);
   });
 
-  it('saves the current configuration to history when Generate QR is clicked', async () => {
+  it('adds a generated QR to the selected event', async () => {
     renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://example.com/offer' } });
+    createEvent('Membership Drive');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Membership Drive/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Registration desk'), { target: { value: 'Sign-up QR' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://example.com/signup' } });
 
     await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
     fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
 
     await waitFor(() => {
-      expect(notifySuccess).toHaveBeenCalledWith('QR saved to history');
+      expect(notifySuccess).toHaveBeenCalledWith('QR added to event');
     });
 
-    expect(screen.getByText('History')).toBeInTheDocument();
-    const historySection = screen.getByText('History').closest('div').parentElement;
-    expect(historySection).toBeTruthy();
-    const historyUrl = historySection.querySelector('[style*="font-family: monospace"]');
-    expect(historyUrl.textContent).toBe('https://example.com/offer');
+    expect(screen.getByText('Membership Drive — Generated QRs')).toBeInTheDocument();
+    expect(screen.getByText('Sign-up QR')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/signup')).toBeInTheDocument();
   });
 
-  it('restores a history item when Restore is clicked', async () => {
+  it('edits an existing QR and updates it', async () => {
     renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://first.com' } });
-    await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
-    fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
-    await waitFor(() => expect(notifySuccess).toHaveBeenCalledWith('QR saved to history'));
+    createEvent('Yoga Workshop');
 
-    // Switch to a different source/text.
-    fireEvent.click(screen.getByText('Public Booking Page'));
     await waitFor(() => {
-      expect(input.value).toBe(`${TEST_ORIGIN}/wellness/book-appointment`);
+      expect(screen.getByRole('button', { name: /Yoga Workshop/i })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Restore/i }));
-    expect(input.value).toBe('https://first.com');
-  });
-
-  it('deletes a history item when the trash button is clicked', async () => {
-    renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://delete.me' } });
+    fireEvent.change(screen.getByPlaceholderText('e.g. Registration desk'), { target: { value: 'Initial QR' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://example.com/initial' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
     fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
-    await waitFor(() => expect(screen.getByText('History')).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: /Delete from history/i }));
-    expect(screen.queryByText('History')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Initial QR')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle('Edit this QR code'));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Initial QR')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('https://example.com/initial')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Registration desk'), { target: { value: 'Updated QR' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://example.com/updated' } });
+    fireEvent.click(screen.getByRole('button', { name: /Update QR/i }));
+
+    await waitFor(() => {
+      expect(notifySuccess).toHaveBeenCalledWith('QR updated');
+    });
+
+    expect(screen.getByText('Updated QR')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/updated')).toBeInTheDocument();
+    expect(screen.queryByText('Initial QR')).not.toBeInTheDocument();
   });
 
-  it('downloads a QR from history with the saved design settings', async () => {
+  it('downloads the preview QR code and shows a success toast', async () => {
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
     renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://history.com' } });
-    await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
-
-    fireEvent.change(screen.getByLabelText('Size (256px)'), { target: { value: '512' } });
-    fireEvent.change(screen.getByLabelText('QR foreground color'), { target: { value: '#123456' } });
-    fireEvent.change(screen.getByLabelText('QR background color'), { target: { value: '#abcdef' } });
-
-    fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
-    await waitFor(() => expect(screen.getByText('History')).toBeInTheDocument());
-
-    toDataURLMock.mockClear();
-    fireEvent.click(screen.getByTitle('Download this QR again'));
+    createEvent('Download Event');
 
     await waitFor(() => {
-      expect(toDataURLMock).toHaveBeenCalledWith(
-        'https://history.com',
-        expect.objectContaining({
-          width: 512,
-          color: { dark: '#123456', light: '#abcdef' },
-        })
-      );
+      expect(screen.getByRole('button', { name: /Download Event/i })).toBeInTheDocument();
     });
-    await waitFor(() => {
-      expect(notifySuccess).toHaveBeenCalledWith('QR code downloaded');
-    });
-    expect(clickSpy).toHaveBeenCalled();
-    clickSpy.mockRestore();
-  });
 
-  it('downloads the QR code and shows a success toast', async () => {
-    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
-    renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://example.com/offer' } });
-
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://example.com/offer' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /Download PNG/i })).not.toBeDisabled());
+
     fireEvent.click(screen.getByRole('button', { name: /Download PNG/i }));
 
     await waitFor(() => {
@@ -230,45 +269,71 @@ describe('QRGenerator', () => {
     clickSpy.mockRestore();
   });
 
-  it('updates the QR when design options change', async () => {
+  it('downloads a QR from the event list', async () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
     renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://example.com/offer' } });
-
-    await waitFor(() => expect(toDataURLMock).toHaveBeenCalled());
-    toDataURLMock.mockClear();
-
-    fireEvent.change(screen.getByLabelText('Size (256px)'), { target: { value: '512' } });
+    createEvent('List Download Event');
 
     await waitFor(() => {
-      expect(toDataURLMock).toHaveBeenCalledWith(
-        'https://example.com/offer',
-        expect.objectContaining({ width: 512 })
-      );
+      expect(screen.getByRole('button', { name: /List Download Event/i })).toBeInTheDocument();
     });
-  });
 
-  it('shows an error toast when Generate QR is clicked with empty text', async () => {
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
-    await waitFor(() => {
-      expect(notifyError).toHaveBeenCalledWith('Enter a URL or text before generating.');
-    });
-  });
-
-  it('persists history in localStorage across renders', async () => {
-    renderPage();
-    const input = screen.getByTitle('The URL or text encoded in the QR code.');
-    fireEvent.change(input, { target: { value: 'https://persist.com' } });
+    fireEvent.change(screen.getByPlaceholderText('e.g. Registration desk'), { target: { value: 'List QR' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://example.com/list' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
     fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
-    await waitFor(() => expect(screen.getByText('History')).toBeInTheDocument());
 
-    // Re-render simulating a page reload.
+    await waitFor(() => expect(screen.getByText('List QR')).toBeInTheDocument());
+
+    toDataURLMock.mockClear();
+    fireEvent.click(screen.getByTitle('Download this QR'));
+
+    await waitFor(() => {
+      expect(toDataURLMock).toHaveBeenCalledWith('https://example.com/list', expect.any(Object));
+    });
+    await waitFor(() => {
+      expect(notifySuccess).toHaveBeenCalledWith('QR code downloaded');
+    });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  it('shows an error toast when Generate QR is clicked without a URL', async () => {
     renderPage();
-    const historyItem = screen.getAllByText('https://persist.com').find((el) =>
-      el.closest('[style*="font-family: monospace"]')
-    );
-    expect(historyItem).toBeTruthy();
+    createEvent('Empty Event');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Empty Event/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
+    await waitFor(() => {
+      expect(notifyError).toHaveBeenCalledWith('Enter a URL before generating.');
+    });
+  });
+
+  it('persists events and QRs across renders via the API', async () => {
+    const { unmount } = renderPage();
+    createEvent('Persistent Event');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Persistent Event/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Registration desk'), { target: { value: 'Persistent QR' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter URL here'), { target: { value: 'https://persist.com' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Generate QR/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Generate QR/i }));
+
+    await waitFor(() => expect(screen.getByText('Persistent QR')).toBeInTheDocument());
+
+    // Re-render simulating a page reload; the component re-fetches from the API.
+    unmount();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Persistent Event/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText('Persistent QR')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -67,6 +67,7 @@ import {
   HeartPulse,
   Bell,
   Clock,
+  History,
   Crown,
   Wallet as WalletIcon,
   Gift,
@@ -1120,11 +1121,13 @@ const PAGE_ICON_BY_PATH = {
   "/wellness/my-transactions": Receipt,
   "/wellness/coupons": TicketPercent,
   "/wellness/cashback-rules": Coins,
+  // Events Management
+  "/wellness/qr-generator": QrCode,
+  "/wellness/events-history": History,
   // Marketing
   "/marketing": Send,
   "/sequences": Network,
   "/landing-pages": PanelTop,
-  "/wellness/qr-generator": QrCode,
   // Reports
   "/wellness/reports": BarChart3,
   "/wellness/per-location": Building2,
@@ -1175,6 +1178,7 @@ const WELLNESS_CATEGORY_ORDER = [
   "Staff",
   "Leads & Revenue",
   "Finance",
+  "Events Management",
   "Marketing",
   "Reports",
   "Appointments",
@@ -1205,6 +1209,7 @@ const WELLNESS_CATEGORY_ICON = {
   Staff: UsersRound,
   "Leads & Revenue": Target,
   Finance: IndianRupee,
+  "Events Management": Calendar,
   Marketing: Megaphone,
   Reports: BarChart3,
   Appointments: Calendar,

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1209,7 +1209,7 @@ const WELLNESS_CATEGORY_ICON = {
   Staff: UsersRound,
   "Leads & Revenue": Target,
   Finance: IndianRupee,
-  "Events Management": Calendar,
+  "Events Management": Ticket,
   Marketing: Megaphone,
   Reports: BarChart3,
   Appointments: Calendar,

--- a/frontend/src/pages/wellness/EventsHistory.jsx
+++ b/frontend/src/pages/wellness/EventsHistory.jsx
@@ -1,0 +1,210 @@
+// Wellness Events History — Events Management sidebar entry.
+//
+// Lists every saved event from the backend and, when expanded, shows all
+// QR codes generated for that event with a download button.
+import { useContext, useEffect, useState } from 'react';
+import {
+  History,
+  ChevronDown,
+  ChevronRight,
+  Download,
+  Calendar,
+} from 'lucide-react';
+import QRCode from 'qrcode';
+import { useNotify } from '../../utils/notify';
+import PageHeader from '../../components/PageHeader';
+import { AuthContext } from '../../App';
+import { loadEvents } from './QRGenerator';
+
+export default function EventsHistory() {
+  const notify = useNotify();
+  const { tenant } = useContext(AuthContext) || {};
+  const [events, setEvents] = useState([]);
+  const [expandedIds, setExpandedIds] = useState(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchEvents() {
+      try {
+        const data = await loadEvents();
+        const list = data?.events || [];
+        if (!cancelled) {
+          setEvents(list);
+          if (list.length > 0) {
+            setExpandedIds(new Set([list[0].id]));
+          }
+        }
+      } catch {
+        if (!cancelled) setEvents([]);
+      }
+    }
+    fetchEvents();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenant?.id]);
+
+  const toggleEvent = (id) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDownloadQr = async (qr) => {
+    try {
+      const url = await QRCode.toDataURL(qr.text, {
+        width: Math.max(64, Math.min(1024, Number(qr.size) || 256)),
+        margin: 2,
+        color: { dark: qr.fgColor, light: qr.bgColor },
+        errorCorrectionLevel: qr.errorLevel,
+      });
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `qr-${(qr.name || 'untitled').replace(/\s+/g, '-').toLowerCase()}-${Date.now()}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      notify.success('QR code downloaded');
+    } catch (err) {
+      console.error('[EventsHistory] Download QR failed:', err);
+      notify.error('Could not regenerate QR for download.');
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
+      <PageHeader
+        icon={History}
+        title="Events History"
+        description="All QR codes organized by event."
+      />
+
+      {events.length === 0 ? (
+        <div className="glass" style={emptyStateCard}>
+          <Calendar size={40} style={{ opacity: 0.5, marginBottom: '0.75rem' }} />
+          <h3 style={{ margin: '0 0 0.5rem', fontSize: '1.1rem' }}>No events yet</h3>
+          <p style={{ margin: 0, color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+            Create an event in the QR Generator to start collecting QR codes here.
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {events.map((event) => {
+            const isExpanded = expandedIds.has(event.id);
+            return (
+              <div key={event.id} className="glass" style={cardStyle}>
+                <button
+                  type="button"
+                  onClick={() => toggleEvent(event.id)}
+                  aria-expanded={isExpanded}
+                  style={eventHeader}
+                >
+                  {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+                  <span style={{ flex: 1, textAlign: 'left', fontWeight: 600, fontSize: '1rem' }}>
+                    {event.name}
+                  </span>
+                  <span style={{ color: 'var(--text-secondary)', fontSize: '0.8rem' }}>
+                    {event.qrs.length} QR{event.qrs.length === 1 ? '' : 's'}
+                  </span>
+                </button>
+
+                {isExpanded && (
+                  <div style={{ paddingTop: '1rem' }}>
+                    {event.qrs.length === 0 ? (
+                      <p style={{ margin: 0, color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+                        No QR codes for this event yet.
+                      </p>
+                    ) : (
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+                        {event.qrs.map((qr) => (
+                          <div
+                            key={qr.id}
+                            style={{
+                              padding: '0.75rem',
+                              border: '1px solid var(--border-color)',
+                              borderRadius: 8,
+                              background: 'rgba(255,255,255,0.03)',
+                            }}
+                          >
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
+                              <div style={{ minWidth: 0, flex: 1 }}>
+                                <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)', marginBottom: '0.25rem' }}>
+                                  {qr.name}
+                                </div>
+                                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '0.25rem' }}>
+                                  {new Date(qr.createdAt).toLocaleString()}
+                                </div>
+                                <div style={{ fontSize: '0.85rem', wordBreak: 'break-all', fontFamily: 'monospace' }}>
+                                  {qr.text}
+                                </div>
+                                <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
+                                  {qr.size}px · {qr.errorLevel}
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => handleDownloadQr(qr)}
+                                style={{ ...btnSecondary, padding: '0.35rem 0.6rem', fontSize: '0.75rem' }}
+                                title="Download this QR"
+                              >
+                                <Download size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const emptyStateCard = {
+  padding: '2rem',
+  borderRadius: 12,
+  border: '1px solid var(--border-color)',
+  textAlign: 'center',
+  color: 'var(--text-primary)',
+};
+
+const cardStyle = {
+  padding: '1rem 1.25rem',
+  borderRadius: 12,
+  border: '1px solid var(--border-color)',
+};
+
+const eventHeader = {
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '0.25rem',
+  background: 'transparent',
+  border: 'none',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+};
+
+const btnSecondary = {
+  padding: '0.6rem 1rem',
+  background: 'transparent',
+  color: 'var(--text-primary)',
+  border: '1px solid var(--border-color)',
+  borderRadius: 8,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.3rem',
+  fontSize: '0.9rem',
+};

--- a/frontend/src/pages/wellness/QRGenerator.jsx
+++ b/frontend/src/pages/wellness/QRGenerator.jsx
@@ -1,10 +1,9 @@
-// Wellness QR Generator — Marketing sidebar entry.
+// Wellness QR Generator — Events Management sidebar entry.
 //
 // Generates downloadable PNG QR codes client-side using the MIT `qrcode`
-// library. Supports custom URLs/text plus quick presets for the authenticated
-// wellness booking page and gift-card storefront. History is kept in
-// localStorage per tenant so generated QR configurations persist across
-// refreshes.
+// library. QR codes are organised by event; each event holds one or more
+// named QR configurations. Events and their QRs are persisted via the
+// /api/wellness/qr-events backend API so they survive refreshes.
 import {
   useCallback,
   useContext,
@@ -17,104 +16,115 @@ import {
   QrCode,
   Download,
   ExternalLink,
-  Type,
-  Gift,
-  CalendarDays,
   Palette,
   RotateCcw,
   Check,
   Clock,
   Trash2,
+  Plus,
+  Search,
+  ChevronDown,
+  Pencil,
 } from 'lucide-react';
 import QRCode from 'qrcode';
 import { useNotify } from '../../utils/notify';
+import { fetchApi } from '../../utils/api';
 import PageHeader from '../../components/PageHeader';
 import { AuthContext } from '../../App';
 
-const SOURCE_TYPES = [
-  {
-    key: 'custom',
-    label: 'Custom URL / Text',
-    icon: Type,
-    tooltip: 'Link to any website, form, or text you want.',
-  },
-  {
-    key: 'booking',
-    label: 'Public Booking Page',
-    icon: CalendarDays,
-    tooltip: 'Link to your authenticated appointment booking page.',
-  },
-  {
-    key: 'giftcards',
-    label: 'Buy Gift Cards',
-    icon: Gift,
-    tooltip: 'Link to the gift card purchase page.',
-  },
-];
-
 const ERROR_LEVELS = ['L', 'M', 'Q', 'H'];
 
-function historyKey(tenantId) {
-  return `wellness-qr-history-${tenantId || 'default'}`;
+/* eslint-disable react-refresh/only-export-components */
+const QR_EVENTS_API = '/api/wellness/qr-events';
+
+export async function loadEvents() {
+  const data = await fetchApi(QR_EVENTS_API);
+  return data || { events: [] };
 }
 
-function loadHistory(tenantId) {
-  try {
-    const raw = localStorage.getItem(historyKey(tenantId));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
+export async function createEvent(name) {
+  return fetchApi(QR_EVENTS_API, {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
 }
 
-function saveHistory(tenantId, history) {
-  try {
-    localStorage.setItem(historyKey(tenantId), JSON.stringify(history));
-  } catch {
-    // Ignore storage quota / private-mode errors.
-  }
+export async function deleteEvent(eventId) {
+  return fetchApi(`${QR_EVENTS_API}/${eventId}`, { method: 'DELETE' });
 }
+
+export async function createQr(eventId, fields) {
+  return fetchApi(`${QR_EVENTS_API}/${eventId}/qrs`, {
+    method: 'POST',
+    body: JSON.stringify(fields),
+  });
+}
+
+export async function updateQr(eventId, qrId, fields) {
+  return fetchApi(`${QR_EVENTS_API}/${eventId}/qrs/${qrId}`, {
+    method: 'PUT',
+    body: JSON.stringify(fields),
+  });
+}
+
+export async function deleteQr(eventId, qrId) {
+  return fetchApi(`${QR_EVENTS_API}/${eventId}/qrs/${qrId}`, { method: 'DELETE' });
+}
+/* eslint-enable react-refresh/only-export-components */
 
 export default function QRGenerator() {
   const notify = useNotify();
   const { tenant } = useContext(AuthContext) || {};
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
 
-  const [sourceType, setSourceType] = useState('custom');
+  const [events, setEvents] = useState([]);
+  const [selectedEventId, setSelectedEventId] = useState('');
+  const [qrName, setQrName] = useState('');
   const [text, setText] = useState('');
   const [size, setSize] = useState(256);
   const [fgColor, setFgColor] = useState('#000000');
   const [bgColor, setBgColor] = useState('#ffffff');
   const [errorLevel, setErrorLevel] = useState('M');
+  const [editingQrId, setEditingQrId] = useState(null);
   const [dataUrl, setDataUrl] = useState('');
   const [generating, setGenerating] = useState(false);
-  const [history, setHistory] = useState(() => loadHistory(tenant?.id));
 
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [creatingInline, setCreatingInline] = useState(false);
+  const [newEventName, setNewEventName] = useState('');
+
+  const dropdownRef = useRef(null);
   const canvasRef = useRef(null);
+  const selectedEvent = useMemo(
+    () => events.find((e) => e.id === selectedEventId) || null,
+    [events, selectedEventId],
+  );
 
-  // Build the canonical URL from the current source selection.
-  const computedUrl = useMemo(() => {
-    if (sourceType === 'custom') return text;
-    if (sourceType === 'booking') return `${origin}/wellness/book-appointment`;
-    if (sourceType === 'giftcards') return `${origin}/wellness/buy-giftcards`;
-    return '';
-  }, [sourceType, text, origin]);
-
-  // Sync the editable text when a preset changes so the user sees the target URL.
+  // Close the dropdown when clicking outside.
   useEffect(() => {
-    if (sourceType !== 'custom') {
-      setText(computedUrl);
+    if (!dropdownOpen) return undefined;
+    const onDocClick = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [dropdownOpen]);
+
+  // Auto-select the first event when data loads and nothing is selected.
+  useEffect(() => {
+    if (!selectedEventId && events.length > 0) {
+      setSelectedEventId(events[0].id);
     }
-  }, [computedUrl, sourceType]);
+  }, [events, selectedEventId]);
 
   // Generate the live QR preview whenever the text or design options change.
   useEffect(() => {
     let cancelled = false;
     if (!text.trim()) {
       setDataUrl('');
-      return;
+      return undefined;
     }
     setGenerating(true);
     QRCode.toDataURL(text, {
@@ -155,70 +165,156 @@ export default function QRGenerator() {
     }).catch(() => {});
   }, [text, size, fgColor, bgColor, errorLevel]);
 
+  const refreshEvents = useCallback(async () => {
+    try {
+      const data = await loadEvents();
+      setEvents(data?.events || []);
+    } catch {
+      // fetchApi already surfaces user-facing errors.
+    }
+  }, []);
+
+  // Load events from the backend on mount / tenant change.
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchEvents() {
+      try {
+        const data = await loadEvents();
+        if (!cancelled) setEvents(data?.events || []);
+      } catch {
+        if (!cancelled) setEvents([]);
+      }
+    }
+    fetchEvents();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenant?.id]);
+
+  const resetForm = useCallback(() => {
+    setQrName('');
+    setText('');
+    setSize(256);
+    setFgColor('#000000');
+    setBgColor('#ffffff');
+    setErrorLevel('M');
+    setEditingQrId(null);
+  }, []);
+
+  const handleCreateEvent = async () => {
+    const trimmed = newEventName.trim();
+    if (!trimmed) {
+      notify.error('Enter an event name.');
+      return;
+    }
+    try {
+      const created = await createEvent(trimmed);
+      await refreshEvents();
+      setSelectedEventId(created.id);
+      setNewEventName('');
+      setCreatingInline(false);
+      setDropdownOpen(false);
+      setSearchTerm('');
+      notify.success(`Event "${created.name}" created`);
+    } catch {
+      // fetchApi already surfaces user-facing errors.
+    }
+  };
+
+  const handleEventSelect = (value) => {
+    setSelectedEventId(value);
+    setDropdownOpen(false);
+    setSearchTerm('');
+  };
+
+  const handleGenerate = useCallback(async () => {
+    if (!text.trim()) {
+      notify.error('Enter a URL before generating.');
+      return;
+    }
+    if (!selectedEventId) {
+      notify.error('Select or create an event first.');
+      return;
+    }
+    const qrFields = { name: qrName, text, size, fgColor, bgColor, errorLevel };
+    try {
+      if (editingQrId) {
+        await updateQr(selectedEventId, editingQrId, qrFields);
+        notify.success('QR updated');
+      } else {
+        await createQr(selectedEventId, qrFields);
+        notify.success('QR added to event');
+      }
+      await refreshEvents();
+      resetForm();
+    } catch {
+      // fetchApi already surfaces user-facing errors.
+    }
+  }, [
+    text,
+    selectedEventId,
+    qrName,
+    size,
+    fgColor,
+    bgColor,
+    errorLevel,
+    editingQrId,
+    refreshEvents,
+    resetForm,
+    notify,
+  ]);
+
+  const handleEditQr = (qr) => {
+    setEditingQrId(qr.id);
+    setQrName(qr.name || '');
+    setText(qr.text || '');
+    setSize(qr.size ?? 256);
+    setFgColor(qr.fgColor || '#000000');
+    setBgColor(qr.bgColor || '#ffffff');
+    setErrorLevel(qr.errorLevel || 'M');
+  };
+
+  const handleDeleteQr = async (qrId) => {
+    try {
+      await deleteQr(selectedEventId, qrId);
+      await refreshEvents();
+      if (editingQrId === qrId) resetForm();
+    } catch {
+      // fetchApi already surfaces user-facing errors.
+    }
+  };
+
   const handleDownload = () => {
     if (!dataUrl) return;
+    const fileName = editingQrId
+      ? `qr-${(qrName || 'untitled').replace(/\s+/g, '-').toLowerCase()}-${Date.now()}.png`
+      : `qr-${Date.now()}.png`;
     const a = document.createElement('a');
     a.href = dataUrl;
-    a.download = `qr-${sourceType}-${Date.now()}.png`;
+    a.download = fileName;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     notify.success('QR code downloaded');
   };
 
-  const handleGenerate = useCallback(() => {
-    if (!text.trim()) {
-      notify.error('Enter a URL or text before generating.');
-      return;
-    }
-    const entry = {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      sourceType,
-      text,
-      size,
-      fgColor,
-      bgColor,
-      errorLevel,
-      createdAt: new Date().toISOString(),
-    };
-    const next = [entry, ...history].slice(0, 50);
-    setHistory(next);
-    saveHistory(tenant?.id, next);
-    notify.success('QR saved to history');
-  }, [text, sourceType, size, fgColor, bgColor, errorLevel, history, tenant?.id, notify]);
-
-  const restoreHistoryItem = (item) => {
-    setSourceType(item.sourceType);
-    setText(item.text);
-    setSize(item.size);
-    setFgColor(item.fgColor);
-    setBgColor(item.bgColor);
-    setErrorLevel(item.errorLevel);
-  };
-
-  const deleteHistoryItem = (id) => {
-    const next = history.filter((h) => h.id !== id);
-    setHistory(next);
-    saveHistory(tenant?.id, next);
-  };
-
-  const downloadHistoryItem = async (item) => {
+  const handleDownloadQr = async (qr) => {
     try {
-      const url = await QRCode.toDataURL(item.text, {
-        width: Math.max(64, Math.min(1024, Number(item.size) || 256)),
+      const url = await QRCode.toDataURL(qr.text, {
+        width: Math.max(64, Math.min(1024, Number(qr.size) || 256)),
         margin: 2,
-        color: { dark: item.fgColor, light: item.bgColor },
-        errorCorrectionLevel: item.errorLevel,
+        color: { dark: qr.fgColor, light: qr.bgColor },
+        errorCorrectionLevel: qr.errorLevel,
       });
       const a = document.createElement('a');
       a.href = url;
-      a.download = `qr-${item.sourceType}-${Date.now()}.png`;
+      a.download = `qr-${(qr.name || 'untitled').replace(/\s+/g, '-').toLowerCase()}-${Date.now()}.png`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       notify.success('QR code downloaded');
     } catch (err) {
-      console.error('[QRGenerator] Download from history failed:', err);
+      console.error('[QRGenerator] Download QR failed:', err);
       notify.error('Could not regenerate QR for download.');
     }
   };
@@ -228,16 +324,161 @@ export default function QRGenerator() {
     window.open(text, '_blank', 'noopener,noreferrer');
   };
 
-  const selectedSource = SOURCE_TYPES.find((s) => s.key === sourceType);
-  const SourceIcon = selectedSource?.icon || QrCode;
+  const filteredEvents = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) return events;
+    return events.filter((e) => e.name.toLowerCase().includes(term));
+  }, [events, searchTerm]);
+
+  const dropdownDisplay = selectedEvent ? selectedEvent.name : 'Select an event';
 
   return (
     <div style={{ padding: '2rem', animation: 'fadeIn 0.5s ease-out' }}>
       <PageHeader
         icon={QrCode}
         title="QR Generator"
-        description="Create downloadable QR codes for your clinic's booking page, gift cards, or any custom link."
+        description="Create downloadable QR codes for your clinic events."
       />
+
+      {/* Event selector */}
+      <div className="glass" style={{ ...cardStyle, marginBottom: '1.5rem', overflow: 'visible', position: 'relative', zIndex: 5 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem' }}>
+          <Palette size={18} />
+          <h3 style={{ margin: 0, fontSize: '1rem' }}>Event</h3>
+        </div>
+
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start', flexWrap: 'wrap' }}>
+          <div ref={dropdownRef} style={{ position: 'relative', flex: 1, minWidth: 220, maxWidth: 420 }}>
+            <button
+              type="button"
+              onClick={() => setDropdownOpen((open) => !open)}
+              data-testid="event-dropdown-trigger"
+              aria-haspopup="listbox"
+              aria-expanded={dropdownOpen}
+              style={{
+                ...inputStyle,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                textAlign: 'left',
+                cursor: 'pointer',
+              }}
+            >
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {dropdownDisplay}
+              </span>
+              <ChevronDown size={16} style={{ flexShrink: 0, marginLeft: '0.5rem' }} />
+            </button>
+
+            {dropdownOpen && (
+              <div
+                role="listbox"
+                data-testid="event-dropdown-panel"
+                style={{
+                  position: 'absolute',
+                  top: 'calc(100% + 4px)',
+                  left: 0,
+                  right: 0,
+                  maxHeight: 320,
+                  overflowY: 'auto',
+                  background: 'var(--surface-color, #fff)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: 8,
+                  zIndex: 100,
+                  boxShadow: 'var(--shadow-md, 0 4px 12px rgba(0,0,0,0.12))',
+                }}
+              >
+                <div style={{ padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                    <Search size={14} style={{ opacity: 0.6 }} />
+                    <input
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Search events"
+                      style={{
+                        border: 'none',
+                        background: 'transparent',
+                        outline: 'none',
+                        color: 'var(--text-primary)',
+                        fontSize: '0.9rem',
+                        width: '100%',
+                      }}
+                    />
+                  </div>
+                </div>
+                {filteredEvents.length === 0 && (
+                  <div style={{ padding: '0.75rem', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+                    No events found. Use <strong>+ New event</strong> to create one.
+                  </div>
+                )}
+                {filteredEvents.map((event) => (
+                  <button
+                    key={event.id}
+                    type="button"
+                    role="option"
+                    aria-selected={event.id === selectedEventId}
+                    onClick={() => handleEventSelect(event.id)}
+                    style={{
+                      ...dropdownItem,
+                      background: event.id === selectedEventId ? 'var(--subtle-bg-3, rgba(201,160,99,0.12))' : 'transparent',
+                    }}
+                  >
+                    {event.id === selectedEventId && <Check size={14} />}
+                    <span>{event.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            data-testid="new-event-button"
+            onClick={() => {
+              setDropdownOpen(false);
+              setCreatingInline(true);
+            }}
+            style={btnPrimary}
+            title="Create a new event"
+          >
+            <Plus size={16} /> New event
+          </button>
+        </div>
+
+        {creatingInline && (
+          <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+            <div style={{ flex: 1, minWidth: 200 }}>
+              <label style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>New event name</label>
+              <input
+                value={newEventName}
+                onChange={(e) => setNewEventName(e.target.value)}
+                placeholder="e.g. Summer Camp 2026"
+                autoFocus
+                style={{ ...inputStyle, marginTop: '0.35rem' }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateEvent();
+                  if (e.key === 'Escape') {
+                    setCreatingInline(false);
+                    setNewEventName('');
+                  }
+                }}
+              />
+            </div>
+            <button type="button" onClick={handleCreateEvent} style={btnPrimary}>
+              Create
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setCreatingInline(false);
+                setNewEventName('');
+              }}
+              style={btnSecondary}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
 
       <div
         style={{
@@ -247,65 +488,27 @@ export default function QRGenerator() {
           alignItems: 'start',
         }}
       >
-        {/* Left column — source + options */}
+        {/* Left column — inputs + design */}
         <div className="glass" style={cardStyle}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1.25rem' }}>
-            <SourceIcon size={20} />
-            <h3 style={{ margin: 0, fontSize: '1.1rem' }}>Source</h3>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>QR name</label>
+            <input
+              value={qrName}
+              onChange={(e) => setQrName(e.target.value)}
+              placeholder="e.g. Registration desk"
+              style={{ ...inputStyle, marginTop: '0.35rem' }}
+              title="A friendly name for this QR code."
+            />
           </div>
-
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '0.5rem', marginBottom: '1.25rem' }}>
-            {SOURCE_TYPES.map((source) => {
-              const Icon = source.icon;
-              const active = source.key === sourceType;
-              return (
-                <button
-                  key={source.key}
-                  type="button"
-                  title={source.tooltip}
-                  onClick={() => setSourceType(source.key)}
-                  style={{
-                    ...sourceChip,
-                    background: active ? 'var(--primary-color, var(--accent-color))' : 'transparent',
-                    color: active ? '#fff' : 'var(--text-primary)',
-                    borderColor: active ? 'var(--primary-color, var(--accent-color))' : 'var(--border-color)',
-                  }}
-                  aria-pressed={active}
-                >
-                  <Icon size={16} />
-                  <span>{source.label}</span>
-                  {active && <Check size={14} />}
-                </button>
-              );
-            })}
-          </div>
-
-          {sourceType === 'booking' && (
-            <div style={{ ...helperBox, marginBottom: '1rem' }}>
-              <CalendarDays size={16} />
-              <span>
-                QR will link to <strong>{origin}/wellness/book-appointment</strong>. Scanner must be logged in to book.
-              </span>
-            </div>
-          )}
-
-          {sourceType === 'giftcards' && (
-            <div style={{ ...helperBox, marginBottom: '1rem' }}>
-              <Gift size={16} />
-              <span>
-                QR will link to <strong>{origin}/wellness/buy-giftcards</strong>. Scanner must be logged in to purchase.
-              </span>
-            </div>
-          )}
 
           <div style={{ marginBottom: '0.75rem' }}>
+            <label style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>URL</label>
             <input
               value={text}
               onChange={(e) => setText(e.target.value)}
-              placeholder={sourceType === 'custom' ? '' : 'Generated link'}
-              disabled={sourceType !== 'custom'}
-              style={{ ...inputStyle, fontFamily: sourceType === 'custom' ? 'inherit' : 'monospace', fontSize: '0.9rem' }}
-              title="The URL or text encoded in the QR code."
+              placeholder="Enter URL here"
+              style={{ ...inputStyle, marginTop: '0.35rem', fontSize: '0.9rem' }}
+              title="The URL encoded in the QR code."
             />
           </div>
 
@@ -323,10 +526,20 @@ export default function QRGenerator() {
               type="button"
               onClick={handleGenerate}
               style={btnPrimary}
-              title="Generate the QR code and save it to history."
+              title={editingQrId ? 'Save changes to this QR code.' : 'Generate the QR code and add it to the selected event.'}
             >
-              <QrCode size={14} /> Generate QR
+              <QrCode size={14} /> {editingQrId ? 'Update QR' : 'Generate QR'}
             </button>
+            {editingQrId && (
+              <button
+                type="button"
+                onClick={resetForm}
+                style={btnSecondary}
+                title="Cancel editing and clear the form."
+              >
+                Cancel
+              </button>
+            )}
           </div>
 
           <hr style={{ border: 'none', borderTop: '1px solid var(--border-color)', margin: '1.25rem 0' }} />
@@ -441,7 +654,7 @@ export default function QRGenerator() {
           </div>
         </div>
 
-        {/* Right column — preview + history */}
+        {/* Right column — preview + event QR list */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
           <div className="glass" style={{ ...cardStyle, textAlign: 'center' }}>
             <h3 style={{ margin: '0 0 1rem', fontSize: '1.1rem', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}>
@@ -472,14 +685,14 @@ export default function QRGenerator() {
                 />
               ) : (
                 <div style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
-                  {generating ? 'Generating…' : 'Enter a URL or choose a source to preview the QR code.'}
+                  {generating ? 'Generating…' : 'Enter a URL to preview the QR code.'}
                 </div>
               )}
               <canvas ref={canvasRef} style={{ display: 'none' }} />
             </div>
 
             <div style={{ marginTop: '1rem', color: 'var(--text-secondary)', fontSize: '0.85rem', wordBreak: 'break-all' }}>
-              {text || 'No content selected'}
+              {text || 'No URL entered'}
             </div>
 
             <button
@@ -493,56 +706,60 @@ export default function QRGenerator() {
             </button>
           </div>
 
-          {history.length > 0 && (
+          {selectedEvent && selectedEvent.qrs.length > 0 && (
             <div className="glass" style={cardStyle}>
               <h3 style={{ margin: '0 0 1rem', fontSize: '1.1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                <Clock size={18} /> History
+                <Clock size={18} /> {selectedEvent.name} — Generated QRs
               </h3>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                {history.map((item) => (
+                {selectedEvent.qrs.map((qr) => (
                   <div
-                    key={item.id}
+                    key={qr.id}
                     style={{
                       padding: '0.75rem',
                       border: '1px solid var(--border-color)',
                       borderRadius: 8,
-                      background: 'rgba(255,255,255,0.03)',
+                      background: editingQrId === qr.id ? 'var(--subtle-bg-3, rgba(201,160,99,0.12))' : 'rgba(255,255,255,0.03)',
                     }}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
                       <div style={{ minWidth: 0, flex: 1 }}>
+                        <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)', marginBottom: '0.25rem' }}>
+                          {qr.name}
+                        </div>
                         <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '0.25rem' }}>
-                          {new Date(item.createdAt).toLocaleString()}
+                          {new Date(qr.createdAt).toLocaleString()}
+                          {qr.updatedAt && qr.updatedAt !== qr.createdAt && ` · edited`}
                         </div>
                         <div style={{ fontSize: '0.85rem', wordBreak: 'break-all', fontFamily: 'monospace' }}>
-                          {item.text}
+                          {qr.text}
                         </div>
                         <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
-                          {SOURCE_TYPES.find((s) => s.key === item.sourceType)?.label} · {item.size}px · {item.errorLevel}
+                          {qr.size}px · {qr.errorLevel}
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.35rem', flexShrink: 0 }}>
                         <button
                           type="button"
-                          onClick={() => restoreHistoryItem(item)}
+                          onClick={() => handleEditQr(qr)}
                           style={{ ...btnSecondary, padding: '0.35rem 0.6rem', fontSize: '0.75rem' }}
-                          title="Restore this configuration"
+                          title="Edit this QR code"
                         >
-                          Restore
+                          <Pencil size={14} />
                         </button>
                         <button
                           type="button"
-                          onClick={() => downloadHistoryItem(item)}
+                          onClick={() => handleDownloadQr(qr)}
                           style={{ ...btnSecondary, padding: '0.35rem 0.6rem', fontSize: '0.75rem' }}
-                          title="Download this QR again"
+                          title="Download this QR"
                         >
                           <Download size={14} />
                         </button>
                         <button
                           type="button"
-                          onClick={() => deleteHistoryItem(item.id)}
+                          onClick={() => handleDeleteQr(qr.id)}
                           style={{ ...btnSecondary, padding: '0.35rem 0.6rem', fontSize: '0.75rem' }}
-                          title="Delete from history"
+                          title="Delete from event"
                         >
                           <Trash2 size={14} />
                         </button>
@@ -575,22 +792,6 @@ const cardStyle = {
   border: '1px solid var(--border-color)',
 };
 
-const sourceChip = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: '0.4rem',
-  padding: '0.5rem 0.6rem',
-  border: '1px solid var(--border-color)',
-  borderRadius: 8,
-  background: 'transparent',
-  color: 'var(--text-primary)',
-  cursor: 'pointer',
-  fontSize: '0.8rem',
-  fontWeight: 500,
-  transition: 'all 0.15s ease',
-};
-
 const inputStyle = {
   width: '100%',
   padding: '0.55rem 0.75rem',
@@ -599,7 +800,6 @@ const inputStyle = {
   background: 'transparent',
   color: 'var(--text-primary)',
   fontSize: '0.9rem',
-  marginTop: '0.35rem',
   boxSizing: 'border-box',
 };
 
@@ -640,13 +840,17 @@ const btnSecondary = {
   fontSize: '0.9rem',
 };
 
-const helperBox = {
+const dropdownItem = {
+  width: '100%',
+  padding: '0.6rem 0.75rem',
+  background: 'transparent',
+  border: 'none',
+  borderBottom: '1px solid var(--border-color)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
   display: 'flex',
-  alignItems: 'flex-start',
-  gap: '0.5rem',
-  padding: '0.75rem',
-  borderRadius: 8,
-  background: 'rgba(255,255,255,0.05)',
-  color: 'var(--text-secondary)',
-  fontSize: '0.85rem',
+  alignItems: 'center',
+  gap: '0.4rem',
+  fontSize: '0.9rem',
+  textAlign: 'left',
 };

--- a/frontend/src/pages/wellness/patientDetail/tabs/LogVisitTab.jsx
+++ b/frontend/src/pages/wellness/patientDetail/tabs/LogVisitTab.jsx
@@ -24,8 +24,7 @@ export default function LogVisitTab({ patient, services, doctors: _doctors, onSa
   // the successful creation immediately.
   const [generatedLinks, setGeneratedLinks] = useState({});
   // Billing controls for the post-treatment payment link: staff can override the
-  // total bill and apply a coupon. The locking fee already paid during booking is
-  // deducted automatically by the backend.
+  // total bill and apply a coupon.
   const [amountCharged, setAmountCharged] = useState('');
   const [couponCode, setCouponCode] = useState('');
   const [appliedCoupon, setAppliedCoupon] = useState(null);
@@ -660,20 +659,8 @@ export default function LogVisitTab({ patient, services, doctors: _doctors, onSa
                   <span>-₹{((previewBreakdown || billingBreakdown).discount).toLocaleString('en-IN')}</span>
                 </div>
               )}
-              {billingBreakdown?.lockingFee > 0 && (
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem', color: 'var(--text-secondary)' }}>
-                  <span>Booking locking fee already paid</span>
-                  <span>-₹{billingBreakdown.lockingFee.toLocaleString('en-IN')}</span>
-                </div>
-              )}
-              {previewBreakdown?.lockingFee > 0 && (
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem', color: 'var(--text-secondary)' }}>
-                  <span>Booking locking fee already paid</span>
-                  <span>-₹{previewBreakdown.lockingFee.toLocaleString('en-IN')}</span>
-                </div>
-              )}
               <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid rgba(255,255,255,0.08)', fontWeight: 600 }}>
-                <span>{billingBreakdown ? 'Balance due' : 'Balance due (after locking fee)'}</span>
+                <span>Balance due</span>
                 <span>
                   ₹{(() => {
                     if (billingBreakdown) return billingBreakdown.balance;
@@ -682,11 +669,6 @@ export default function LogVisitTab({ patient, services, doctors: _doctors, onSa
                   })().toLocaleString('en-IN')}
                 </span>
               </div>
-              {!billingBreakdown && previewBreakdown?.lockingFee === 0 && (
-                <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '0.35rem' }}>
-                  No ₹200 booking locking fee has been paid for this appointment yet.
-                </div>
-              )}
             </div>
           )}
 

--- a/frontend/src/pages/wellness/patientDetail/tabs/LogVisitTab.jsx
+++ b/frontend/src/pages/wellness/patientDetail/tabs/LogVisitTab.jsx
@@ -525,15 +525,31 @@ export default function LogVisitTab({ patient, services, doctors: _doctors, onSa
                     {visit.amountCharged > 0 && (
                       <>
                         {' - '}
-                        {visit.invoice?.amount > 0 && visit.invoice.amount !== visit.amountCharged ? (
-                          <>
-                            <span style={{ textDecoration: 'line-through', opacity: 0.7 }}>₹{visit.amountCharged.toLocaleString('en-IN')}</span>
-                            {' → Balance due: '}
-                            <strong style={{ color: 'var(--success-color)' }}>₹{visit.invoice.amount.toLocaleString('en-IN')}</strong>
-                          </>
-                        ) : (
-                          <>Amount: <strong>₹{visit.amountCharged.toLocaleString('en-IN')}</strong></>
-                        )}
+                        {(() => {
+                          const breakdown = typeof visit.couponBreakdown === 'string'
+                            ? (() => { try { return JSON.parse(visit.couponBreakdown); } catch (_e) { return null; } })()
+                            : visit.couponBreakdown;
+                          if (breakdown && typeof breakdown === 'object' && Number.isFinite(Number(breakdown.balance))) {
+                            return (
+                              <>
+                                <span style={{ textDecoration: 'line-through', opacity: 0.7 }}>₹{Number(breakdown.baseAmount).toLocaleString('en-IN')}</span>
+                                {' — Coupon '}{breakdown.couponCode}{' — ₹'}{Number(breakdown.discount).toLocaleString('en-IN')}{' deducted — '}
+                                <span>Balance due: </span>
+                                <strong style={{ color: 'var(--success-color)' }}>₹{Number(breakdown.balance).toLocaleString('en-IN')}</strong>
+                              </>
+                            );
+                          }
+                          if (visit.invoice?.amount > 0 && visit.invoice.amount !== visit.amountCharged) {
+                            return (
+                              <>
+                                <span style={{ textDecoration: 'line-through', opacity: 0.7 }}>₹{visit.amountCharged.toLocaleString('en-IN')}</span>
+                                {' → Balance due: '}
+                                <strong style={{ color: 'var(--success-color)' }}>₹{visit.invoice.amount.toLocaleString('en-IN')}</strong>
+                              </>
+                            );
+                          }
+                          return <>Amount: <strong>₹{visit.amountCharged.toLocaleString('en-IN')}</strong></>;
+                        })()}
                       </>
                     )}
                   </div>


### PR DESCRIPTION
Adds QR event/code persistence for wellness marketing, fixes coupon redemption so excess amounts land in patient wallet and regenerated Razorpay links use the discounted total, and stabilizes the QuoteAcceptLanding frontend test that was flaking under CI memory regression.
Changes:
QR Generator
Added QrEvent and QrCode Prisma models with tenant scoping and cascade delete.
Added backend endpoints in backend/routes/wellness.js to create/list/delete QR events and their codes.
Added frontend/src/pages/wellness/QRGenerator.jsx and frontend/src/wellness/EventsHistory.jsx.
Added "Events Management" to the wellness sidebar with a ticket icon.
Coupon / visit billing
Coupon breakdown is now persisted on Visit.couponBreakdown as JSON.
Excess coupon value is to the patient wallet.
Completed Visits UI shows the coupon-adjusted amount.
Razorpay link regeneration uses the post-coupon balance.
Removed the booking locking-fee UI from the Log Visit payment area.