### PR TITLE
Added the leads and extension data

### DIFF
--- a/backend/controllers/audienceController.js
+++ b/backend/controllers/audienceController.js
@@ -152,6 +152,7 @@ exports.getContactsByStatus = async (req, res) => {
             where: {
                 status: status,
                 tenantId: req.user.tenantId,
+                ...(!["ADMIN", "MANAGER"].includes(req.user.role) ? { assignedToId: req.user.userId } : {}),
             },
             orderBy: {
                 createdAt: "desc",

--- a/backend/prisma/migrations/202607292130_task_notes_longtext/migration.sql
+++ b/backend/prisma/migrations/202607292130_task_notes_longtext/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Task` MODIFY `notes` LONGTEXT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1658,7 +1658,7 @@ model Task {
   dueDate   DateTime?
   status    String    @default("Pending") // Pending, Completed
   priority  String    @default("Medium") // Low, Medium, High, Critical
-  notes     String?
+  notes     String?   @db.LongText
   createdAt DateTime  @default(now())
   // #167: soft-delete column (see Contact).
   deletedAt DateTime?

--- a/backend/routes/contacts.js
+++ b/backend/routes/contacts.js
@@ -7,6 +7,7 @@ const { ensureEmail, ensureNumberInRange, ensureEnum, ensureStringLength, ensure
 const { writeAudit, diffFields } = require("../lib/audit");
 const { markFirstResponseIfNeeded } = require("../lib/leadSla");
 const { normalizePhone, computeDuplicateGroupKey, findDuplicateContactFull } = require("../utils/deduplication");
+const { notify } = require('../lib/notificationService');
 // #464: field-level permission enforcement. The fieldFilter middleware
 // existed but was never called from any route; rules saved via the
 // FieldPermissions UI had zero effect on read/write payloads. Default
@@ -110,6 +111,16 @@ function validateContactInput(body, { isUpdate = false } = {}) {
     if (annErr) return annErr;
   }
   return null;
+}
+
+function canViewAllLeads(req) {
+  return !!(req && req.user && ['ADMIN', 'MANAGER'].includes(req.user.role));
+}
+
+function canAccessLead(req, contact) {
+  if (!req || !req.user || !contact) return false;
+  if (canViewAllLeads(req)) return true;
+  return Number(contact.assignedToId) === Number(req.user.userId);
 }
 
 // PRD Gap §1.1e — walletBalance is a read-only computed surface. We strip
@@ -438,7 +449,7 @@ router.get('/', async (req, res) => {
     // from a USER is overridden by their own userId — a sales rep cannot
     // probe a colleague's book of business by URL. Total Contacts KPI on
     // /dashboard now reflects own-book size for sales reps.
-    if (req.user.role === 'USER') where.assignedToId = req.user.userId;
+    if (!canViewAllLeads(req)) where.assignedToId = req.user.userId;
     // ?count=1 — sidebar badge polls: return { total } only, skip full fetch.
     if (req.query.count === '1') {
       const total = await prisma.contact.count({ where });
@@ -501,6 +512,7 @@ router.get('/:id', async (req, res) => {
       include: { activities: { orderBy: { createdAt: 'desc' } }, tasks: true, deals: true, assignedTo: { select: { id: true, name: true, email: true } } }
     });
     if (!contact) return res.status(404).json({ error: 'Contact not found' });
+    if (!canAccessLead(req, contact)) return res.status(404).json({ error: 'Contact not found' });
     // #167: 404 soft-deleted rows unless caller opts in.
     if (contact.deletedAt && !includeDeleted) return res.status(404).json({ error: 'Contact not found' });
     // #464: strip read-restricted fields per the caller's role.
@@ -653,28 +665,65 @@ router.put('/bulk-assign', verifyRole(['ADMIN']), async (req, res) => {
     if (!Array.isArray(contactIds) || contactIds.length === 0) {
       return res.status(400).json({ error: 'No contact IDs provided' });
     }
-    const ids = contactIds.map(id => parseInt(id));
-    let assignableIds = ids;
-    let skipped = 0;
-    // Travel security guard — when assigning to a person, drop any brand-tagged
-    // lead the assignee can't access (rather than failing the whole batch).
-    // Generic/wellness leads have subBrand null → always assignable → unchanged.
-    if (assignedToId) {
-      const rows = await prisma.contact.findMany({
-        where: { id: { in: ids }, tenantId: req.user.tenantId },
-        select: { id: true, subBrand: true },
-      });
-      const { getSubBrandAccessSet, canAccessSubBrand } = require('../middleware/travelGuards');
-      const allowed = await getSubBrandAccessSet(parseInt(assignedToId));
-      const ok = rows.filter(r => !r.subBrand || canAccessSubBrand(allowed, r.subBrand)).map(r => r.id);
-      skipped = ids.length - ok.length;
-      assignableIds = ok;
-    }
-    await prisma.contact.updateMany({
-      where: { id: { in: assignableIds }, tenantId: req.user.tenantId },
-      data: { assignedToId: assignedToId ? parseInt(assignedToId) : null }
+    const ids = contactIds.map(id => parseInt(id)).filter(Number.isFinite);
+    const nextAssignedToId = assignedToId ? parseInt(assignedToId) : null;
+    const rows = await prisma.contact.findMany({
+      where: { id: { in: ids }, tenantId: req.user.tenantId },
+      select: { id: true, name: true, subBrand: true, assignedToId: true },
     });
-    res.json({ updated: assignableIds.length, skipped, assignedToId: assignedToId || null });
+
+    let assignableRows = rows;
+    let skippedRows = [];
+    if (nextAssignedToId) {
+      const { getSubBrandAccessSet, canAccessSubBrand } = require('../middleware/travelGuards');
+      const allowed = await getSubBrandAccessSet(nextAssignedToId);
+      assignableRows = rows.filter((r) => !r.subBrand || canAccessSubBrand(allowed, r.subBrand));
+      skippedRows = rows.filter((r) => r.subBrand && !canAccessSubBrand(allowed, r.subBrand));
+    }
+
+    const assignableIds = assignableRows.map((r) => r.id);
+    if (assignableIds.length > 0) {
+      await prisma.contact.updateMany({
+        where: { id: { in: assignableIds }, tenantId: req.user.tenantId },
+        data: { assignedToId: nextAssignedToId },
+      });
+    }
+
+    if (nextAssignedToId) {
+      const actorName = req.user?.name || req.user?.email || 'Admin';
+      for (const row of assignableRows) {
+        if (nextAssignedToId === row.assignedToId) continue;
+        try {
+          const leadName = row.name || ('#' + row.id);
+          await notify({
+            userId: nextAssignedToId,
+            tenantId: req.user.tenantId,
+            title: 'New lead assigned',
+            message: actorName + ' has assigned lead "' + leadName + '" to you. Please look into it.',
+            type: 'info',
+            category: 'lead',
+            entityType: 'lead',
+            entityId: row.id,
+            link: '/contacts/' + row.id,
+            io: req.io,
+          });
+        } catch (notifyErr) {
+          console.error('[contacts] bulk lead assignment notify failed:', notifyErr && notifyErr.message);
+        }
+      }
+    }
+
+    res.json({
+      updated: assignableIds.length,
+      skipped: skippedRows.length,
+      assignedToId: assignedToId || null,
+      skippedDetails: skippedRows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        subBrand: r.subBrand,
+        reason: 'ASSIGNEE_SUB_BRAND_ACCESS_MISMATCH',
+      })),
+    });
   } catch (_err) {
     res.status(500).json({ error: 'Failed to bulk assign agent' });
   }
@@ -684,6 +733,7 @@ router.post('/:id/activities', async (req, res) => {
   try {
     const contact = await prisma.contact.findFirst({ where: { id: parseInt(req.params.id), tenantId: req.user.tenantId } });
     if (!contact) return res.status(404).json({ error: 'Contact not found' });
+    if (!canAccessLead(req, contact)) return res.status(404).json({ error: 'Contact not found' });
     const { type, description } = req.body;
     const activity = await prisma.activity.create({
       data: { type, description, contactId: contact.id, userId: req.user ? req.user.userId : null, tenantId: req.user.tenantId }
@@ -706,6 +756,9 @@ router.post('/:id/summarize-chat', async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid contact ID' });
+    const existing = await prisma.contact.findFirst({ where: { id, tenantId: req.user.tenantId } });
+    if (!existing) return res.status(404).json({ error: 'Contact not found' });
+    if (!canAccessLead(req, existing)) return res.status(404).json({ error: 'Contact not found' });
     const leadConversationSummary = require('../lib/leadConversationSummary');
     const result = await leadConversationSummary.narrativeSummarizeContact({
       tenantId: req.user.tenantId,
@@ -758,6 +811,7 @@ router.put('/:id', async (req, res) => {
   try {
     const existing = await prisma.contact.findFirst({ where: { id: parseInt(req.params.id), tenantId: req.user.tenantId } });
     if (!existing) return res.status(404).json({ error: 'Contact not found' });
+    if (!canAccessLead(req, existing)) return res.status(404).json({ error: 'Contact not found' });
     // #464: strip write-restricted fields per the caller's role BEFORE
     // validation so blocked-field updates can't slip through.
     req.body = await filterWriteFields(req.body, req.user.role, "Contact", req.user.tenantId);
@@ -1039,11 +1093,32 @@ router.put('/:id/assign', verifyRole(['ADMIN']), async (req, res) => {
         return res.status(403).json({ error: "That staff member doesn't have access to this lead's sub-brand", code: 'SUB_BRAND_ASSIGN_DENIED' });
       }
     }
+    const nextAssignedToId = assignedToId ? parseInt(assignedToId) : null;
     const contact = await prisma.contact.update({
       where: { id: existing.id },
-      data: { assignedToId: assignedToId ? parseInt(assignedToId) : null },
+      data: { assignedToId: nextAssignedToId },
       include: { assignedTo: { select: { id: true, name: true, email: true } } }
     });
+    if (nextAssignedToId && nextAssignedToId !== existing.assignedToId) {
+      try {
+        const actorName = req.user?.name || req.user?.email || 'Admin';
+        const leadName = contact.name || ('#' + contact.id);
+        await notify({
+          userId: nextAssignedToId,
+          tenantId: req.user.tenantId,
+          title: 'New lead assigned',
+          message: actorName + ' has assigned lead "' + leadName + '" to you. Please look into it.',
+          type: 'info',
+          category: 'lead',
+          entityType: 'lead',
+          entityId: contact.id,
+          link: '/contacts/' + contact.id,
+          io: req.io,
+        });
+      } catch (notifyErr) {
+        console.error('[contacts] lead assignment notify failed:', notifyErr && notifyErr.message);
+      }
+    }
     // [GP-CRM integration] Notify registered webhooks (e.g. GlobusPhone) that
     // this contact/lead was re-assigned to a different agent. Fire-and-forget.
     try {
@@ -1391,6 +1466,7 @@ router.get('/:id/attachments', async (req, res) => {
   try {
     const contact = await prisma.contact.findFirst({ where: { id: parseInt(req.params.id), tenantId: req.user.tenantId } });
     if (!contact) return res.status(404).json({ error: 'Contact not found' });
+    if (!canAccessLead(req, contact)) return res.status(404).json({ error: 'Contact not found' });
     res.json(await prisma.contactAttachment.findMany({ where: { contactId: contact.id, tenantId: req.user.tenantId }, orderBy: { createdAt: 'desc' } }));
   } catch (_err) { res.status(500).json({ error: 'Failed to fetch attachments' }); }
 });

--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -1,10 +1,13 @@
 const express = require("express");
 const router = express.Router();
-const { verifyToken, verifyRole } = require("../middleware/auth");
+const { verifyToken } = require("../middleware/auth");
+const { requirePermission, userHasPermission } = require("../middleware/requirePermission");
 const prisma = require("../lib/prisma");
 const { ensureEnum, ensureDateInRange } = require("../lib/validators");
 const { writeAudit, diffFields } = require("../lib/audit");
 const { parseDateTimeLocalInTZ } = require("../lib/datetime");
+const { summarizeMessages } = require("../lib/leadConversationSummary");
+const { notify, notifyMany } = require("../lib/notificationService");
 
 const PRIORITY_ORDER = { Critical: 0, High: 1, Medium: 2, Low: 3 };
 
@@ -34,6 +37,127 @@ function parseTenantDateInput(input) {
 // silent coercion to "Pending".
 const ALLOWED_TASK_STATUSES = new Set(["Pending", "In Progress", "Completed", "Cancelled"]);
 const ALLOWED_TASK_PRIORITIES = new Set(["Low", "Medium", "High", "Critical"]);
+const VALID_EXTENSION_SOURCES = new Set(["gmail", "whatsapp"]);
+function canViewAllTasks(req) {
+  return ["ADMIN", "MANAGER", "OWNER"].includes(String(req.user?.role || "").toUpperCase());
+}
+
+async function notifyTaskAssignee({ task, actorId, tenantId, io, reassigned = false }) {
+  if (!task.userId || task.userId === actorId) return;
+  await notify({
+    userId: task.userId,
+    tenantId,
+    title: reassigned ? "Task reassigned to you" : "New task assigned",
+    message: (reassigned ? "A task was reassigned to you" : "A new task was assigned to you") + ": \"" + task.title + "\".",
+    type: "task",
+    priority: task.priority === "Critical" ? "high" : "normal",
+    link: "/tasks",
+    entityType: "Task",
+    entityId: task.id,
+    category: "task",
+    dedupWindowHours: 0,
+    io,
+  });
+}
+
+
+function compactTaskText(value, maxLength = 180) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 15).trimEnd()}...`;
+}
+
+function normalizeExtensionTaskMessages(body) {
+  const capturedAt = body.capturedAt ? new Date(body.capturedAt) : new Date();
+  const validCapturedAt = Number.isNaN(capturedAt.getTime()) ? new Date() : capturedAt;
+
+  if (body.source === "gmail") {
+    return [
+      {
+        direction: "INBOUND",
+        body: [body.subject ? `Subject: ${body.subject}` : null, body.body || ""]
+          .filter(Boolean)
+          .join("\n\n"),
+        createdAt: validCapturedAt,
+      },
+    ].filter((m) => m.body.trim());
+  }
+
+  return (Array.isArray(body.messages) ? body.messages : [])
+    .filter((m) => m && String(m.text || "").trim())
+    .map((m) => ({
+      direction: m.direction === "out" ? "OUTBOUND" : "INBOUND",
+      body: m.text,
+      createdAt: validCapturedAt,
+    }));
+}
+
+function extensionTaskCustomerName(body) {
+  if (body.source === "gmail") {
+    const senderRaw = String(body.sender || "").trim();
+    const m = senderRaw.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+    return (m && m[1] && m[1].trim()) || senderRaw || "Email sender";
+  }
+  return body.chatName || "WhatsApp chat";
+}
+
+function extensionTaskTitle(body) {
+  if (body.source === "gmail") return body.subject || "Follow up on captured email";
+  return body.chatName ? `Follow up: ${body.chatName}` : "Follow up on WhatsApp chat";
+}
+
+function taskNotesFromSummary(summary) {
+  const highlights = Array.isArray(summary.highlights) ? summary.highlights : [];
+  return [
+    summary.purpose,
+    highlights.length ? `Key: ${highlights.join("; ")}` : "",
+    summary.leadStage ? `Stage: ${summary.leadStage}` : "",
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}
+function taskResolutionNote(notes) {
+  const text = String(notes || "");
+  if (!text.startsWith("__task_meta__")) return "";
+  try {
+    const meta = JSON.parse(text.slice("__task_meta__".length));
+    return String(meta.r || "").trim();
+  } catch (_e) {
+    return "";
+  }
+}
+
+async function notifyTaskCompletionAdmins({ task, actorId, tenantId, io }) {
+  if (!prisma.user || typeof prisma.user.findMany !== "function") return;
+  const admins = await prisma.user.findMany({
+    where: {
+      tenantId,
+      OR: [
+        { role: { in: ["ADMIN", "MANAGER", "OWNER"] } },
+        { userType: "OWNER" },
+      ],
+    },
+    select: { id: true },
+  });
+  const userIds = admins.map((u) => u.id).filter((id) => id && id !== actorId);
+  if (!userIds.length) return;
+
+  const note = taskResolutionNote(task.notes);
+  await notifyMany({
+    userIds,
+    tenantId,
+    title: "Task resolved",
+    message: `Task "${task.title}" was resolved.${note ? ` Resolution note: ${note}` : ""}`,
+    type: "success",
+    priority: "normal",
+    link: "/tasks",
+    entityType: "Task",
+    entityId: task.id,
+    category: "task",
+    dedupWindowHours: 0,
+    io,
+  });
+}
 
 function validateTaskInput(body) {
   if (body.priority !== undefined && body.priority !== null && body.priority !== "") {
@@ -83,6 +207,7 @@ router.get("/", verifyToken, async (req, res) => {
     if (status) where.status = normalizeStatusFilter(status);
     if (priority) where.priority = priority;
     if (contactId) where.contactId = parseInt(contactId);
+    if (!canViewAllTasks(req)) where.userId = req.user.userId;
     if (overdue === "true") {
       where.dueDate = { lt: new Date() };
       where.status = "Pending";
@@ -155,8 +280,41 @@ router.get("/", verifyToken, async (req, res) => {
   }
 });
 
+
+// POST /api/tasks/extension-summary - summarize a browser-extension capture for task notes.
+router.post("/extension-summary", verifyToken, requirePermission("tasks", "write"), async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (!body.source || !VALID_EXTENSION_SOURCES.has(body.source)) {
+      return res.status(400).json({
+        error: `source must be one of: ${Array.from(VALID_EXTENSION_SOURCES).join(", ")}`,
+        code: "INVALID_SOURCE",
+      });
+    }
+
+    const messages = normalizeExtensionTaskMessages(body);
+    if (!messages.length) {
+      return res.status(400).json({ error: "Capture had no usable text content", code: "EMPTY_CAPTURE" });
+    }
+
+    const summary = await summarizeMessages({
+      tenantId: req.user.tenantId,
+      customerName: extensionTaskCustomerName(body),
+      messages,
+    });
+
+    return res.json({
+      title: compactTaskText(extensionTaskTitle(body), 120),
+      notes: taskNotesFromSummary(summary),
+      summary,
+    });
+  } catch (err) {
+    console.error("[tasks] extension-summary error:", err && err.message);
+    return res.status(500).json({ error: "Failed to summarize task", code: "TASK_SUMMARY_FAILED" });
+  }
+});
 // POST /api/tasks
-router.post("/", verifyToken, async (req, res) => {
+router.post("/", verifyToken, requirePermission("tasks", "write"), async (req, res) => {
   try {
     // #436: the global `stripDangerous` middleware (server.js:299, applied to
     // every route) deletes `userId` from req.body — that's the right thing
@@ -201,15 +359,23 @@ router.post("/", verifyToken, async (req, res) => {
       assignedTo: task.userId,
       contactId: task.contactId,
     });
+    try {
+      await notifyTaskAssignee({ task, actorId: req.user.userId, tenantId: req.user.tenantId, io: req.io });
+    } catch (notifyErr) {
+      console.warn("[tasks] assignee notification skipped:", notifyErr && notifyErr.message);
+    }
     res.status(201).json(task);
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: "Failed to create Task" });
+    console.error("[tasks] create failed:", err);
+    res.status(500).json({
+      error: "Failed to create Task",
+      detail: process.env.NODE_ENV === "production" ? undefined : (err && err.message),
+    });
   }
 });
 
 // PUT /api/tasks/:id — general update
-router.put("/:id", verifyToken, async (req, res) => {
+router.put("/:id", verifyToken, requirePermission("tasks", "update"), async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) return res.status(400).json({ error: "Invalid task ID" });
@@ -221,7 +387,7 @@ router.put("/:id", verifyToken, async (req, res) => {
     const inputErr = validateTaskInput(req.body);
     if (inputErr) return res.status(inputErr.status).json(inputErr);
 
-    const { title, notes, dueDate, priority, status } = req.body;
+    const { title, notes, dueDate, priority, status, targetUserId } = req.body;
     const data = {};
     if (title !== undefined) data.title = title;
     if (notes !== undefined) data.notes = notes;
@@ -229,6 +395,9 @@ router.put("/:id", verifyToken, async (req, res) => {
     if (dueDate !== undefined) data.dueDate = dueDate ? parseTenantDateInput(dueDate) : null;
     if (priority !== undefined) data.priority = priority;
     if (status !== undefined) data.status = status;
+    if (targetUserId !== undefined) {
+      data.userId = targetUserId !== null && targetUserId !== "" ? parseInt(targetUserId) : null;
+    }
 
     // gap #17: capture prior status BEFORE the update so task.completed can be
     // gated idempotently — re-saving an already-Completed task must not re-fire.
@@ -259,6 +428,14 @@ router.put("/:id", verifyToken, async (req, res) => {
     } catch (_e) {}
 
     // #179: audit only the keys that actually changed.
+    if (existing.userId !== task.userId) {
+      try {
+        await notifyTaskAssignee({ task, actorId: req.user.userId, tenantId: req.user.tenantId, io: req.io, reassigned: true });
+      } catch (notifyErr) {
+        console.warn("[tasks] reassignment notification skipped:", notifyErr && notifyErr.message);
+      }
+    }
+
     const changes = diffFields(existing, task, Object.keys(data));
     if (Object.keys(changes).length > 0) {
       await writeAudit('Task', 'UPDATE', task.id, req.user.userId, req.user.tenantId, { changedFields: changes });
@@ -280,12 +457,22 @@ router.put("/:id/complete", verifyToken, async (req, res) => {
     const existing = await prisma.task.findFirst({ where: { id, tenantId: req.user.tenantId } });
     if (!existing) return res.status(404).json({ error: "Task not found" });
 
-    // gap #17: same idempotency gate as PUT /:id — don't re-fire if already complete.
+    const isAssignedUser = existing.userId === req.user.userId;
+    const canCompleteAny = canViewAllTasks(req) || await userHasPermission(req.user, "tasks", "update");
+    if (!isAssignedUser && !canCompleteAny) {
+      return res.status(403).json({ error: "Only the assignee or a task manager can resolve this task" });
+    }
+
+    // gap #17: same idempotency gate as PUT /:id - don't re-fire if already complete.
     const wasCompleted = existing.status === "Completed";
+    const data = { status: "Completed" };
+    if (req.body && Object.prototype.hasOwnProperty.call(req.body, "notes")) {
+      data.notes = req.body.notes || null;
+    }
 
     const task = await prisma.task.update({
       where: { id: existing.id },
-      data: { status: "Completed" },
+      data,
     });
 
     try {
@@ -311,6 +498,11 @@ router.put("/:id/complete", verifyToken, async (req, res) => {
       await writeAudit('Task', 'COMPLETE', task.id, req.user.userId, req.user.tenantId, {
         title: existing.title,
       });
+      try {
+        await notifyTaskCompletionAdmins({ task, actorId: req.user.userId, tenantId: req.user.tenantId, io: req.io });
+      } catch (notifyErr) {
+        console.warn("[tasks] admin completion notification skipped:", notifyErr && notifyErr.message);
+      }
     }
 
     res.json(task);
@@ -321,7 +513,7 @@ router.put("/:id/complete", verifyToken, async (req, res) => {
 });
 
 // DELETE /api/tasks/:id — soft-delete (#167). ADMIN only. Idempotent.
-router.delete("/:id", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+router.delete("/:id", verifyToken, requirePermission("tasks", "delete"), async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) return res.status(400).json({ error: "Invalid task ID" });
@@ -347,7 +539,7 @@ router.delete("/:id", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
 });
 
 // POST /api/tasks/:id/restore — undo soft-delete (#167)
-router.post("/:id/restore", verifyToken, verifyRole(["ADMIN"]), async (req, res) => {
+router.post("/:id/restore", verifyToken, requirePermission("tasks", "delete"), async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) return res.status(400).json({ error: "Invalid task ID" });
@@ -364,7 +556,6 @@ router.post("/:id/restore", verifyToken, verifyRole(["ADMIN"]), async (req, res)
     const task = await prisma.task.update({
       where: { id: existing.id },
       data: { deletedAt: null },
-      include: { contact: true, user: true },
     });
     res.json({ ...task, restored: true });
   } catch (err) {
@@ -374,3 +565,5 @@ router.post("/:id/restore", verifyToken, verifyRole(["ADMIN"]), async (req, res)
 });
 
 module.exports = router;
+
+

--- a/frontend/src/__tests__/ContactDetail.test.jsx
+++ b/frontend/src/__tests__/ContactDetail.test.jsx
@@ -8,7 +8,9 @@
  * Endpoints consumed:
  *   - GET    /api/contacts/:id              -> contact + nested deals + activities
  *   - GET    /api/contacts/:id/attachments  -> attachment list
- *   - POST   /api/contacts/:id/attachments  -> upload attachment
+ *   - POST   /api/uploads/images            -> batch image upload to S3
+ *   - POST   /api/uploads/documents         -> batch document upload to S3
+ *   - POST   /api/contacts/:id/attachments  -> persist uploaded attachment metadata
  *   - DELETE /api/contacts/attachments/:id  -> remove attachment
  *
  * Mock stability: fetchApi is a stable vi.fn() reference; the per-test
@@ -29,9 +31,9 @@
  *   8. "Back to Contacts" link points to /contacts.
  *   9. Empty attachments shows "No files attached." copy.
  *  10. Attachment list renders one row per attachment with delete button.
- *  11. Clicking the Add button opens the upload form; Cancel closes it.
- *  12. Submitting the upload form POSTs to the attachments endpoint with
- *      the JSON body and re-fetches the attachment list.
+ *  11. Clicking the Add button opens the upload picker; Cancel closes it.
+ *  12. Submitting selected files uploads them to the shared S3 endpoints,
+ *      then POSTs attachment metadata and re-fetches the attachment list.
  *  13. Clicking the trash button DELETEs the attachment and re-fetches.
  *  14. Empty activity timeline renders the "No activities recorded yet." copy.
  *  15. Activity timeline renders one row per activity with type chip.
@@ -92,6 +94,8 @@ function makeFetchImpl(overrides = {}) {
     contact: { kind: "ok", data: BASE_CONTACT },
     attachments: { kind: "ok", data: ATTACHMENTS },
     upload: { kind: "ok", data: { id: 999 } },
+    uploadDocuments: { kind: "ok", data: { success: true, count: 1, urls: [{ url: "https://s3.example.com/msa-2026.pdf", fileName: "msa-2026.pdf", size: 7 }] } },
+    uploadImages: { kind: "ok", data: { success: true, count: 1, urls: [{ url: "https://s3.example.com/screenshot.png", fileName: "screenshot.png", size: 9 }] } },
     delete: { kind: "ok", data: { ok: true } },
     ...overrides,
   };
@@ -103,6 +107,8 @@ function makeFetchImpl(overrides = {}) {
     const method = (opts && opts.method) || "GET";
     if (/^\/api\/contacts\/\d+$/.test(url) && method === "GET") return handle(o.contact);
     if (/^\/api\/contacts\/\d+\/attachments$/.test(url) && method === "GET") return handle(o.attachments);
+    if (url === "/api/uploads/documents" && method === "POST") return handle(o.uploadDocuments);
+    if (url === "/api/uploads/images" && method === "POST") return handle(o.uploadImages);
     if (/^\/api\/contacts\/\d+\/attachments$/.test(url) && method === "POST") return handle(o.upload);
     if (/^\/api\/contacts\/attachments\/\d+$/.test(url) && method === "DELETE") return handle(o.delete);
     return Promise.resolve({});
@@ -242,41 +248,49 @@ describe("ContactDetail — page contract", () => {
     expect(firstLink.getAttribute("href")).toBe("https://files.example.com/501");
   });
 
-  it("opens the upload form when Add is clicked and closes via Cancel", async () => {
+  it("opens the upload picker when Add is clicked and closes via Cancel", async () => {
     fetchApiMock.mockImplementation(makeFetchImpl());
     const user = userEvent.setup();
     renderPage();
     await screen.findByText(/Priya Sharma/);
 
-    // Form fields are absent before Add is clicked.
-    expect(screen.queryByPlaceholderText(/File name/)).toBeNull();
+    // Picker is absent before Add is clicked.
+    expect(screen.queryByLabelText(/Upload files/)).toBeNull();
 
     const addBtn = screen.getByRole("button", { name: /Add/ });
     await user.click(addBtn);
 
-    expect(await screen.findByPlaceholderText(/File name/)).toBeTruthy();
-    expect(screen.getByPlaceholderText(/File URL/)).toBeTruthy();
+    expect(await screen.findByLabelText(/Upload files/)).toBeTruthy();
 
     const cancelBtn = screen.getByRole("button", { name: /Cancel/ });
     await user.click(cancelBtn);
 
     await waitFor(() => {
-      expect(screen.queryByPlaceholderText(/File name/)).toBeNull();
+      expect(screen.queryByLabelText(/Upload files/)).toBeNull();
     });
   });
 
-  it("submitting the upload form POSTs to /api/contacts/:id/attachments and re-fetches the list", async () => {
+  it("submitting selected files uploads to S3, persists attachment metadata, and re-fetches the list", async () => {
     fetchApiMock.mockImplementation(makeFetchImpl());
     const user = userEvent.setup();
     renderPage();
     await screen.findByText(/Priya Sharma/);
 
     await user.click(screen.getByRole("button", { name: /Add/ }));
-    await user.type(await screen.findByPlaceholderText(/File name/), "msa-2026.pdf");
-    await user.type(screen.getByPlaceholderText(/File URL/), "https://files.example.com/new");
+    const input = await screen.findByLabelText(/Upload files/);
+    const file = new File(["1234567"], "msa-2026.pdf", { type: "application/pdf" });
+    await user.upload(input, file);
 
     const beforeCalls = fetchApiMock.mock.calls.length;
-    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+    await user.click(screen.getByRole("button", { name: /^Upload$/ }));
+
+    await waitFor(() => {
+      const uploadCall = fetchApiMock.mock.calls.find(
+        (c) => c[0] === "/api/uploads/documents" && c[1] && c[1].method === "POST",
+      );
+      expect(uploadCall).toBeTruthy();
+      expect(uploadCall[1].body).toBeInstanceOf(FormData);
+    });
 
     await waitFor(() => {
       const postCall = fetchApiMock.mock.calls.find(
@@ -285,10 +299,10 @@ describe("ContactDetail — page contract", () => {
       expect(postCall).toBeTruthy();
       const body = JSON.parse(postCall[1].body);
       expect(body.filename).toBe("msa-2026.pdf");
-      expect(body.fileUrl).toBe("https://files.example.com/new");
+      expect(body.fileUrl).toBe("https://s3.example.com/msa-2026.pdf");
+      expect(body.mimeType).toBe("application/pdf");
     });
 
-    // Re-fetch should have followed the upload.
     await waitFor(() => {
       const refetch = fetchApiMock.mock.calls
         .slice(beforeCalls)

--- a/frontend/src/__tests__/Tasks.test.jsx
+++ b/frontend/src/__tests__/Tasks.test.jsx
@@ -52,11 +52,13 @@ vi.mock('../utils/api', () => ({
 const notifyError = vi.fn();
 const notifySuccess = vi.fn();
 const notifyInfo = vi.fn();
+const notifyPrompt = vi.fn().mockResolvedValue('Resolved via test');
 const notifyObj = {
   error: notifyError,
   info: notifyInfo,
   success: notifySuccess,
   confirm: () => Promise.resolve(true),
+  prompt: notifyPrompt,
 };
 vi.mock('../utils/notify', () => ({
   useNotify: () => notifyObj,
@@ -156,7 +158,11 @@ function defaultFetchMock(url, opts) {
 }
 
 function renderTasks() {
-  return render(<Tasks />);
+  return render(
+    <AuthContext.Provider value={{ user: { id: 1, role: 'ADMIN' }, tenant: { id: 1, vertical: 'generic' } }}>
+      <Tasks />
+    </AuthContext.Provider>,
+  );
 }
 
 // Travel-vertical render: wraps in the real AuthContext.Provider so
@@ -176,6 +182,8 @@ describe('<Tasks /> — page surface', () => {
     notifyError.mockReset();
     notifySuccess.mockReset();
     notifyInfo.mockReset();
+    notifyPrompt.mockReset();
+    notifyPrompt.mockResolvedValue('Resolved via test');
   });
 
   it('renders heading + Create Task CTA + priority-counter chips', async () => {
@@ -511,6 +519,8 @@ describe('<Tasks /> — travel "Assign to (staff)" dropdown', () => {
     notifyError.mockReset();
     notifySuccess.mockReset();
     notifyInfo.mockReset();
+    notifyPrompt.mockReset();
+    notifyPrompt.mockResolvedValue('Resolved via test');
   });
 
   it('travel vertical: fetches /api/staff and renders a staff assignee select', async () => {

--- a/frontend/src/__tests__/wave7-empty-state-warnings.test.jsx
+++ b/frontend/src/__tests__/wave7-empty-state-warnings.test.jsx
@@ -33,6 +33,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../App';
 
 const fetchApiMock = vi.fn();
 vi.mock('../utils/api', () => ({
@@ -160,6 +161,15 @@ describe('#608 Tasks — past dueDate shows non-blocking warning', () => {
     fireEvent.click(screen.getByRole('button', { name: /Create a new task/i }));
   };
 
+  const renderTasks = (TasksComponent) =>
+    render(
+      <MemoryRouter>
+        <AuthContext.Provider value={{ user: { id: 1, role: 'ADMIN' }, tenant: { id: 1, vertical: 'generic' } }}>
+          <TasksComponent />
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    );
+
   it('shows the warning when dueDate is in the past', async () => {
     const Tasks = (await import('../pages/Tasks')).default;
     fetchApiMock.mockImplementation((url) => {
@@ -168,11 +178,7 @@ describe('#608 Tasks — past dueDate shows non-blocking warning', () => {
       return Promise.resolve([]);
     });
 
-    render(
-      <MemoryRouter>
-        <Tasks />
-      </MemoryRouter>,
-    );
+    renderTasks(Tasks);
 
     await waitFor(() => expect(fetchApiMock).toHaveBeenCalled());
 
@@ -209,11 +215,7 @@ describe('#608 Tasks — past dueDate shows non-blocking warning', () => {
       return Promise.resolve([]);
     });
 
-    render(
-      <MemoryRouter>
-        <Tasks />
-      </MemoryRouter>,
-    );
+    renderTasks(Tasks);
 
     await waitFor(() => expect(fetchApiMock).toHaveBeenCalled());
 
@@ -241,11 +243,7 @@ describe('#608 Tasks — past dueDate shows non-blocking warning', () => {
       return Promise.resolve([]);
     });
 
-    render(
-      <MemoryRouter>
-        <Tasks />
-      </MemoryRouter>,
-    );
+    renderTasks(Tasks);
 
     await waitFor(() => expect(fetchApiMock).toHaveBeenCalled());
 
@@ -281,11 +279,7 @@ describe('#608 Tasks — past dueDate shows non-blocking warning', () => {
       return Promise.resolve([]);
     });
 
-    render(
-      <MemoryRouter>
-        <Tasks />
-      </MemoryRouter>,
-    );
+    renderTasks(Tasks);
 
     await waitFor(() => expect(fetchApiMock).toHaveBeenCalled());
 

--- a/frontend/src/pages/ContactDetail.jsx
+++ b/frontend/src/pages/ContactDetail.jsx
@@ -3,10 +3,21 @@ import { formatMoney } from '../utils/money';
 import { formatDate, formatDateTime } from '../utils/date';
 import React, { useContext, useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, Phone, Mail, Calendar, Paperclip, Upload, Trash2, FileText, Download, Target, Pencil, MessageSquareText, Sparkles } from 'lucide-react';
+import { ArrowLeft, Phone, Mail, Paperclip, Upload, Trash2, FileText, Target, Pencil, MessageSquareText, Sparkles } from 'lucide-react';
 import { AuthContext } from '../App';
 
 const PHONE_RE = /^\+?[\d\s\-().]{7,15}$/;
+const IMAGE_MIME_PREFIX = 'image/';
+const DOCUMENT_EXTENSIONS = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.csv'];
+
+function isImageFile(file) {
+  return String(file?.type || '').startsWith(IMAGE_MIME_PREFIX);
+}
+
+function isDocumentFile(file) {
+  const lowerName = String(file?.name || '').toLowerCase();
+  return DOCUMENT_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
+}
 
 const ContactDetail = () => {
   const { id } = useParams();
@@ -16,11 +27,13 @@ const ContactDetail = () => {
   const [contact, setContact] = useState(null);
   const [attachments, setAttachments] = useState([]);
   const [showUpload, setShowUpload] = useState(false);
-  const [uploadForm, setUploadForm] = useState({ filename: '', fileUrl: '' });
+  const [selectedFiles, setSelectedFiles] = useState([]);
+  const [uploadingFiles, setUploadingFiles] = useState(false);
+  const [uploadError, setUploadError] = useState('');
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [editError, setEditError] = useState('');
-  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', company: '', title: '', customFields: {} });
+  const [editForm, setEditForm] = useState({ name: '', email: '', phone: '', company: '', title: '', description: '', customFields: {} });
   // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
   const [customFieldDefs, setCustomFieldDefs] = useState([]);
 
@@ -187,6 +200,10 @@ const ContactDetail = () => {
   // only the already-summarized blocks already sitting in description.
   const [resummarizing, setResummarizing] = useState(false);
   const [resummarizeError, setResummarizeError] = useState('');
+  const [editingSummary, setEditingSummary] = useState(false);
+  const [summaryDraft, setSummaryDraft] = useState('');
+  const [summarySaving, setSummarySaving] = useState(false);
+  const [summaryError, setSummaryError] = useState('');
   const handleResummarizeCapture = async () => {
     setResummarizing(true);
     setResummarizeError('');
@@ -200,21 +217,101 @@ const ContactDetail = () => {
     }
   };
 
+  const openSummaryEdit = () => {
+    setSummaryDraft(contact?.description || '');
+    setSummaryError('');
+    setEditingSummary(true);
+  };
+
+  const handleSaveSummary = async () => {
+    setSummarySaving(true);
+    setSummaryError('');
+    try {
+      await fetchApi(`/api/contacts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: summaryDraft }),
+      });
+      setEditingSummary(false);
+      loadContact();
+    } catch (err) {
+      setSummaryError(err?.message || 'Could not save summary changes.');
+    } finally {
+      setSummarySaving(false);
+    }
+  };
+
   const loadAttachments = () => {
     fetchApi(`/api/contacts/${id}/attachments`).then(data => setAttachments(Array.isArray(data) ? data : [])).catch(() => {});
   };
 
   useEffect(() => { loadContact(); loadAttachments(); }, [id]);
 
+  const resetUploadState = () => {
+    setSelectedFiles([]);
+    setUploadError('');
+    setUploadingFiles(false);
+  };
+
+  const handleFilePick = (e) => {
+    const files = Array.from(e.target.files || []);
+    setSelectedFiles(files);
+    setUploadError('');
+  };
+
+  const uploadBatch = async (endpoint, fieldName, files) => {
+    if (!files.length) return [];
+    const form = new FormData();
+    files.forEach((file) => form.append(fieldName, file, file.name));
+    const result = await fetchApi(endpoint, { method: 'POST', body: form });
+    return Array.isArray(result?.urls) ? result.urls : [];
+  };
+
   const handleUpload = async (e) => {
     e.preventDefault();
-    await fetchApi(`/api/contacts/${id}/attachments`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(uploadForm)
-    });
-    setShowUpload(false);
-    setUploadForm({ filename: '', fileUrl: '' });
-    loadAttachments();
+    if (!selectedFiles.length) {
+      setUploadError('Select at least one file to upload.');
+      return;
+    }
+
+    const imageFiles = selectedFiles.filter(isImageFile);
+    const documentFiles = selectedFiles.filter((file) => !isImageFile(file) && isDocumentFile(file));
+    const unsupportedFiles = selectedFiles.filter((file) => !isImageFile(file) && !isDocumentFile(file));
+
+    if (unsupportedFiles.length > 0) {
+      setUploadError('Only images, PDF, DOC, DOCX, XLS, XLSX, and CSV files are supported.');
+      return;
+    }
+
+    setUploadingFiles(true);
+    setUploadError('');
+    try {
+      const [uploadedImages, uploadedDocuments] = await Promise.all([
+        uploadBatch('/api/uploads/images', 'images', imageFiles),
+        uploadBatch('/api/uploads/documents', 'documents', documentFiles),
+      ]);
+
+      const uploadedFiles = [...uploadedImages, ...uploadedDocuments];
+      await Promise.all(uploadedFiles.map((item) => {
+        const matchedFile = selectedFiles.find((file) => file.name === item.fileName && file.size === item.size);
+        return fetchApi(`/api/contacts/${id}/attachments`, {
+          method: 'POST',
+          body: JSON.stringify({
+            filename: item.fileName,
+            fileUrl: item.url,
+            fileSize: item.size,
+            mimeType: matchedFile?.type || null,
+          }),
+        });
+      }));
+
+      setShowUpload(false);
+      resetUploadState();
+      loadAttachments();
+    } catch (err) {
+      setUploadError(err?.message || 'Failed to upload files.');
+      setUploadingFiles(false);
+    }
   };
 
   const handleDeleteAttachment = async (attachId) => {
@@ -389,22 +486,78 @@ const ContactDetail = () => {
                 {resummarizeError && (
                   <p style={{ color: '#ef4444', fontSize: '0.75rem', margin: '0 0 0.5rem' }}>{resummarizeError}</p>
                 )}
-                {contact.description ? (
-                  <pre style={{
-                    margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-                    fontFamily: 'inherit', fontSize: '0.8rem', lineHeight: 1.6,
-                    color: 'var(--text-secondary)', maxHeight: 360, overflowY: 'auto',
-                  }}>
-                    {contact.description}
-                  </pre>
+                {summaryError && (
+                  <p style={{ color: '#ef4444', fontSize: '0.75rem', margin: '0 0 0.5rem' }}>{summaryError}</p>
+                )}
+                {editingSummary ? (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+                    <textarea
+                      className="input-field"
+                      rows={10}
+                      value={summaryDraft}
+                      onChange={(e) => setSummaryDraft(e.target.value)}
+                      style={{ padding: '0.65rem', fontSize: '0.85rem', resize: 'vertical' }}
+                    />
+                    <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+                      <button
+                        type="button"
+                        onClick={() => { setEditingSummary(false); setSummaryError(''); setSummaryDraft(contact.description || ''); }}
+                        disabled={summarySaving}
+                        className="btn-secondary"
+                        style={{ fontSize: '0.75rem', padding: '0.35rem 0.7rem' }}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSaveSummary}
+                        disabled={summarySaving}
+                        className="btn-primary"
+                        style={{ fontSize: '0.75rem', padding: '0.35rem 0.7rem' }}
+                      >
+                        {summarySaving ? 'Saving...' : 'Save summary'}
+                      </button>
+                    </div>
+                  </div>
+                ) : contact.description ? (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+                    <pre style={{
+                      margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                      fontFamily: 'inherit', fontSize: '0.8rem', lineHeight: 1.6,
+                      color: 'var(--text-secondary)', maxHeight: 360, overflowY: 'auto',
+                    }}>
+                      {contact.description}
+                    </pre>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      <button
+                        type="button"
+                        onClick={openSummaryEdit}
+                        className="btn-secondary"
+                        style={{ fontSize: '0.75rem', padding: '0.3rem 0.65rem', display: 'flex', alignItems: 'center', gap: 4 }}
+                      >
+                        <Pencil size={13} /> Edit summary
+                      </button>
+                    </div>
+                  </div>
                 ) : (
-                  <p style={{ margin: 0, fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
-                    No summary yet — click Summarize to generate one from the WhatsApp history.
-                  </p>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+                    <p style={{ margin: 0, fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                      No summary yet - click Summarize to generate one from the WhatsApp history.
+                    </p>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      <button
+                        type="button"
+                        onClick={openSummaryEdit}
+                        className="btn-secondary"
+                        style={{ fontSize: '0.75rem', padding: '0.3rem 0.65rem', display: 'flex', alignItems: 'center', gap: 4 }}
+                      >
+                        <Pencil size={13} /> Add summary manually
+                      </button>
+                    </div>
+                  </div>
                 )}
               </div>
             )}
-
             {/* Deals */}
             {contact.deals && contact.deals.length > 0 && (
               <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: '1rem', marginTop: '1rem' }}>
@@ -455,11 +608,32 @@ const ContactDetail = () => {
 
             {showUpload && (
               <form onSubmit={handleUpload} style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', background: 'var(--subtle-bg)', borderRadius: '6px' }}>
-                <input className="input-field" placeholder="File name" required value={uploadForm.filename} onChange={e => setUploadForm({ ...uploadForm, filename: e.target.value })} style={{ padding: '0.4rem', fontSize: '0.8rem' }} />
-                <input className="input-field" placeholder="File URL" required value={uploadForm.fileUrl} onChange={e => setUploadForm({ ...uploadForm, fileUrl: e.target.value })} style={{ padding: '0.4rem', fontSize: '0.8rem' }} />
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                  Upload files
+                  <input
+                    className="input-field"
+                    type="file"
+                    multiple
+                    accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.csv"
+                    onChange={handleFilePick}
+                    style={{ padding: '0.4rem', fontSize: '0.8rem' }}
+                  />
+                </label>
+                {selectedFiles.length > 0 && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+                    {selectedFiles.map((file) => (
+                      <span key={`${file.name}-${file.size}-${file.lastModified}`} style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+                        {file.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {uploadError && (
+                  <p style={{ margin: 0, fontSize: '0.75rem', color: '#ef4444' }}>{uploadError}</p>
+                )}
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
-                  <button type="submit" className="btn-primary" style={{ padding: '0.3rem 0.75rem', fontSize: '0.8rem' }}>Save</button>
-                  <button type="button" onClick={() => setShowUpload(false)} style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.8rem' }}>Cancel</button>
+                  <button type="submit" className="btn-primary" disabled={uploadingFiles} style={{ padding: '0.3rem 0.75rem', fontSize: '0.8rem' }}>{uploadingFiles ? 'Uploading...' : 'Upload'}</button>
+                  <button type="button" onClick={() => { setShowUpload(false); resetUploadState(); }} disabled={uploadingFiles} style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.8rem' }}>Cancel</button>
                 </div>
               </form>
             )}

--- a/frontend/src/pages/Contacts.jsx
+++ b/frontend/src/pages/Contacts.jsx
@@ -12,7 +12,7 @@ import ScrollableSelect from '../components/ScrollableSelect';
 import InlineCellEditor from '../components/InlineCellEditor';
 import EditContactModal from '../components/EditContactModal';
 import { AuthContext } from '../App';
-import { accessibleSubBrands } from '../utils/travelSubBrand';
+import { accessibleSubBrands, subBrandShortLabel } from '../utils/travelSubBrand';
 
 const parseCSV = (text) => {
   const lines = text.split(/\r?\n/).filter(l => l.trim());
@@ -143,6 +143,12 @@ const Contacts = () => {
     if (isWellness || isTravel || visibleColumns === null) return true;
     return visibleColumns.includes(key);
   };
+  const staffBrandSuffix = (member) => {
+    if (!isTravel) return '';
+    const brands = accessibleSubBrands(member).map(subBrandShortLabel);
+    return brands.length ? ' (' + brands.join(', ') + ')' : '';
+  };
+  const staffOptionLabel = (member) => (member.name || member.email) + staffBrandSuffix(member);
   const assignableStaff = (contact) => {
     if (!isTravel || !contact?.subBrand) return staff;
     return staff.filter(
@@ -292,11 +298,29 @@ const Contacts = () => {
 
   const handleBulkAssign = async () => {
     if (selectedContacts.length === 0) return;
-    await fetchApi('/api/contacts/bulk-assign', {
+    const result = await fetchApi('/api/contacts/bulk-assign', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ contactIds: selectedContacts, assignedToId: bulkAgent || null }),
     });
+    if (result?.updated > 0) {
+      notify.success?.(
+        result.updated === 1
+          ? 'Assigned 1 lead successfully'
+          : 'Assigned ' + result.updated + ' leads successfully'
+      );
+    }
+    if (result?.skipped > 0) {
+      const firstSkipped = result.skippedDetails?.[0];
+      const why = firstSkipped?.subBrand
+        ? ' because ' + firstSkipped.subBrand.toUpperCase() + ' is not allowed for the selected staff'
+        : '';
+      notify.info?.(
+        result.skipped === 1
+          ? '1 lead was skipped' + why + '.'
+          : result.skipped + ' leads were skipped' + why + '.'
+      );
+    }
     setSelectedContacts([]);
     setBulkAgent('');
     fetchContacts();
@@ -518,7 +542,7 @@ const Contacts = () => {
           >
             <option value="">Unassign</option>
             {staff.map(s => (
-              <option key={s.id} value={s.id}>{s.name || s.email}</option>
+              <option key={s.id} value={s.id}>{staffOptionLabel(s)}</option>
             ))}
           </select>
           <button className="btn-primary" onClick={handleBulkAssign} style={{ padding: '0.5rem 1rem', fontSize: '0.875rem' }}>
@@ -571,7 +595,7 @@ const Contacts = () => {
             options={[
               { value: '', label: 'All Assignees' },
               { value: 'unassigned', label: 'Unassigned' },
-              ...staff.map(s => ({ value: String(s.id), label: s.name || s.email })),
+              ...staff.map(s => ({ value: String(s.id), label: staffOptionLabel(s) })),
             ]}
           />
           <select
@@ -774,7 +798,7 @@ const Contacts = () => {
                       >
                         <option value="">Unassigned</option>
                         {assignableStaff(contact).map(s => (
-                          <option key={s.id} value={s.id}>{s.name || s.email}</option>
+                          <option key={s.id} value={s.id}>{staffOptionLabel(s)}</option>
                         ))}
                       </select>
                     ) : (

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect, useContext, useRef } from 'react';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
 import { AuthContext } from '../App';
+import { usePermissions } from '../hooks/usePermissions';
 import { accessibleSubBrands, subBrandShortLabel } from '../utils/travelSubBrand';
 import { useActiveSubBrand } from '../utils/subBrand';
-import { CheckCircle2, Phone, Calendar, Search, Plus, AlertTriangle, Clock, Flame, X, ChevronDown } from 'lucide-react';
+import { CheckCircle2, Phone, Calendar, Search, Plus, AlertTriangle, Clock, Flame, X, ChevronDown, Eye, Edit3, Trash2, Save, UserRound } from 'lucide-react';
 import TagPickerPopover from './wellness/patients/TagPickerPopover';
 import { tagChipStyle, chipRemoveStyle, modalInputStyle, filterLabelStyle } from './wellness/patients/styles';
 import { tagColour } from './wellness/patients/constants';
@@ -65,22 +66,30 @@ function isPastDate(localDateTimeStr) {
   return picked.getTime() < Date.now();
 }
 
+function formatDateTimeLocal(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 // Tags + description are encoded together in the Task.notes field so the
 // schema needs no migration. Format: JSON prefix sentinel + envelope.
 // Falls back gracefully for old plain-text notes.
 const NOTES_TAG = '__task_meta__';
-function encodeNotes(tagIds, description) {
-  if (!tagIds || tagIds.length === 0) return description || null;
-  return `${NOTES_TAG}${JSON.stringify({ t: tagIds, d: description || '' })}`;
+function encodeNotes(tagIds, description, resolutionNote = '') {
+  if ((!tagIds || tagIds.length === 0) && !resolutionNote) return description || null;
+  return `${NOTES_TAG}${JSON.stringify({ t: tagIds || [], d: description || '', r: resolutionNote || '' })}`;
 }
 function decodeNotes(raw) {
-  if (!raw) return { tagIds: [], description: '' };
-  if (!raw.startsWith(NOTES_TAG)) return { tagIds: [], description: raw };
+  if (!raw) return { tagIds: [], description: '', resolutionNote: '' };
+  if (!raw.startsWith(NOTES_TAG)) return { tagIds: [], description: raw, resolutionNote: '' };
   try {
-    const { t, d } = JSON.parse(raw.slice(NOTES_TAG.length));
-    return { tagIds: Array.isArray(t) ? t : [], description: d || '' };
+    const { t, d, r } = JSON.parse(raw.slice(NOTES_TAG.length));
+    return { tagIds: Array.isArray(t) ? t : [], description: d || '', resolutionNote: r || '' };
   } catch {
-    return { tagIds: [], description: raw };
+    return { tagIds: [], description: raw, resolutionNote: '' };
   }
 }
 
@@ -93,10 +102,12 @@ const EMPTY_FORM = {
   assignedToId: '',
   tagIds: [],
   description: '',
+  resolutionNote: '',
 };
 
 export default function Tasks() {
   const notify = useNotify();
+  const { hasPermission, isReady: permsReady } = usePermissions();
   const [tasks, setTasks] = useState([]);
   const [contacts, setContacts] = useState([]);
   const [staff, setStaff] = useState([]);
@@ -109,9 +120,15 @@ export default function Tasks() {
   // to the active sub-brand so e.g. an RFU-only operator isn't offered TMC
   // agents. Generic / wellness tenants don't render the staff dropdown at all,
   // so their Tasks form is unchanged.
-  const { tenant } = useContext(AuthContext) || {};
+  const { tenant, user } = useContext(AuthContext) || {};
   const isTravel = tenant?.vertical === 'travel';
   const isWellness = tenant?.vertical === 'wellness';
+  const role = String(user?.role || '').toUpperCase();
+  const currentUserId = user?.userId || user?.id || null;
+  const roleFallbackCanManage = ['ADMIN', 'MANAGER', 'OWNER'].includes(role);
+  const canCreateTasks = roleFallbackCanManage || !permsReady || hasPermission('tasks', 'write');
+  const canUpdateTasks = roleFallbackCanManage || !permsReady || hasPermission('tasks', 'update') || hasPermission('tasks', 'write');
+  const canDeleteTasks = roleFallbackCanManage || (permsReady && hasPermission('tasks', 'delete'));
   const { activeSubBrand } = useActiveSubBrand();
   const assignableStaff = !isTravel
     ? staff
@@ -123,6 +140,9 @@ export default function Tasks() {
   // c031ba0 pattern: header "+ Create Task" CTA opens this drawer; close on
   // X / ESC / outside-click; submit handler is preserved verbatim.
   const [creating, setCreating] = useState(false);
+  const [selectedTask, setSelectedTask] = useState(null);
+  const [editingTask, setEditingTask] = useState(false);
+  const [editTask, setEditTask] = useState(EMPTY_FORM);
 
   useEffect(() => { loadData(); }, []);
 
@@ -148,11 +168,15 @@ export default function Tasks() {
 
   // #893: ESC closes the drawer to match the c031ba0 Travel-page convention.
   useEffect(() => {
-    if (!creating) return undefined;
-    const onKey = (e) => { if (e.key === 'Escape') { setCreating(false); setShowTagPicker(false); } };
+    if (!creating && !selectedTask) return undefined;
+    const onKey = (e) => {
+      if (e.key !== 'Escape') return;
+      if (creating) { setCreating(false); setShowTagPicker(false); }
+      if (selectedTask) { setSelectedTask(null); setEditingTask(false); }
+    };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [creating]);
+  }, [creating, selectedTask]);
 
   const loadData = async () => {
     try {
@@ -193,7 +217,7 @@ export default function Tasks() {
         dueDate: newTask.dueDate ? new Date(newTask.dueDate).toISOString() : null,
         // Tags + description are packed into the notes field using a sentinel
         // prefix so no schema migration is needed.
-        notes: encodeNotes(newTask.tagIds, newTask.description),
+        notes: encodeNotes(newTask.tagIds, newTask.description, newTask.resolutionNote),
         contactId: newTask.contactId || undefined,
         // Backend reads `targetUserId` → Task.userId (stripDangerous deletes a
         // raw `userId` from the body). Only send when an assignee was picked.
@@ -211,16 +235,33 @@ export default function Tasks() {
     }
   };
 
-  const markComplete = async (id) => {
+  const markComplete = async (taskOrId) => {
+    const task = typeof taskOrId === 'object' ? taskOrId : tasks.find((t) => t.id === taskOrId) || selectedTask;
+    const id = typeof taskOrId === 'object' ? taskOrId.id : taskOrId;
+    const decoded = decodeNotes(task?.notes || '');
+    const resolutionNote = await notify.prompt({
+      title: 'Resolve task',
+      message: 'Add a short resolution note before marking this task complete.',
+      defaultValue: decoded.resolutionNote || '',
+      placeholder: 'What was done / outcome?',
+      confirmText: 'Resolve',
+    });
+    if (resolutionNote === null) return;
     try {
-      await fetchApi(`/api/tasks/${id}/complete`, { method: 'PUT' });
-      loadData();
-      // #625: invalidate sidebar counters — backend has no `task_completed`
-      // socket emit today, so the polling fallback alone left the badge
-      // stale until the next 60s tick.
+      const notes = encodeNotes(decoded.tagIds, decoded.description, String(resolutionNote || '').trim());
+      const updated = await fetchApi(`/api/tasks/${id}/complete`, {
+        method: 'PUT',
+        body: JSON.stringify({ notes }),
+      });
+      if (selectedTask?.id === id) {
+        setSelectedTask(updated || { ...selectedTask, status: 'Completed', notes });
+      }
+      await loadData();
       window.dispatchEvent(new CustomEvent('sidebar:counts-changed'));
+      notify.success('Task resolved');
     } catch (err) {
       console.error(err);
+      notify.error('Failed to resolve task');
     }
   };
 
@@ -259,6 +300,78 @@ export default function Tasks() {
     setNewTask((prev) => ({ ...prev, tagIds: prev.tagIds.filter((id) => id !== tagId) }));
   };
 
+  const assigneeName = (task) => task?.user?.name || task?.user?.email || 'Unassigned';
+  const canResolveTask = (task) => canUpdateTasks || (task?.userId && Number(task.userId) === Number(currentUserId));
+
+  const openTaskDetails = (task) => {
+    const decoded = decodeNotes(task.notes);
+    setSelectedTask(task);
+    setEditingTask(false);
+    setEditTask({
+      title: task.title || '',
+      status: task.status || 'Pending',
+      priority: normalizePriority(task.priority),
+      dueDate: formatDateTimeLocal(task.dueDate),
+      completedAt: '',
+      assignedToId: task.userId ? String(task.userId) : '',
+      tagIds: decoded.tagIds,
+      description: decoded.description,
+      resolutionNote: decoded.resolutionNote,
+    });
+  };
+
+  const closeTaskDetails = () => {
+    setSelectedTask(null);
+    setEditingTask(false);
+  };
+
+  const saveTaskChanges = async () => {
+    if (!selectedTask) return;
+    try {
+      const payload = {
+        title: editTask.title,
+        status: editTask.status,
+        priority: editTask.priority,
+        dueDate: editTask.dueDate ? new Date(editTask.dueDate).toISOString() : null,
+        notes: encodeNotes(editTask.tagIds, editTask.description, editTask.resolutionNote),
+        targetUserId: editTask.assignedToId || '',
+      };
+      const updated = await fetchApi(`/api/tasks/${selectedTask.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      });
+      setSelectedTask(updated);
+      setEditingTask(false);
+      await loadData();
+      window.dispatchEvent(new CustomEvent('sidebar:counts-changed'));
+      notify.success('Task updated');
+    } catch (err) {
+      console.error(err);
+      notify.error('Failed to update task');
+    }
+  };
+
+  const deleteTask = async () => {
+    if (!selectedTask) return;
+    const ok = await notify.confirm({
+      title: 'Delete task?',
+      message: `Delete "${selectedTask.title}" from the queue?`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await fetchApi(`/api/tasks/${selectedTask.id}`, { method: 'DELETE' });
+      closeTaskDetails();
+      await loadData();
+      window.dispatchEvent(new CustomEvent('sidebar:counts-changed'));
+      notify.success('Task deleted');
+    } catch (err) {
+      console.error(err);
+      notify.error('Failed to delete task');
+    }
+  };
+
   const selectedTags = allTags.filter((t) => newTask.tagIds.includes(t.id));
 
   const PRIORITY_ORDER = { Critical: 0, High: 1, Medium: 2, Low: 3 };
@@ -290,6 +403,7 @@ export default function Tasks() {
             Prioritized daily follow-ups and outbound activity directives.
           </p>
         </div>
+        {canCreateTasks && (
         <button
           id="open-create-task-btn"
           type="button"
@@ -306,6 +420,7 @@ export default function Tasks() {
         >
           <Plus size={14} /> Create Task
         </button>
+        )}
       </header>
 
       {/* Stats bar */}
@@ -349,6 +464,7 @@ export default function Tasks() {
             ) : activeTasks.map(t => {
               const cfg = PRIORITY_CONFIG[t.priority] || PRIORITY_CONFIG.Medium;
               const overdue = isOverdue(t);
+              const decoded = decodeNotes(t.notes);
               return (
                 <div key={t.id} style={{
                   display: 'flex', justifyContent: 'space-between', alignItems: 'center',
@@ -377,15 +493,32 @@ export default function Tasks() {
                         <Clock size={12} /> {new Date(t.dueDate).toLocaleString()}
                       </p>
                     )}
+                    <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '0.4rem', margin: '0.2rem 0 0' }}>
+                      <UserRound size={12} /> Assigned to {assigneeName(t)}
+                    </p>
+                    {decoded.description && (
+                      <p style={{ fontSize: '0.82rem', color: 'var(--text-secondary)', margin: '0.45rem 0 0', maxWidth: 760, lineHeight: 1.45 }}>
+                        {decoded.description.length > 170 ? `${decoded.description.slice(0, 170).trimEnd()}...` : decoded.description}
+                      </p>
+                    )}
                   </div>
                   <div style={{ display: 'flex', gap: '0.5rem', marginLeft: '1rem', flexShrink: 0 }}>
                     <button
-                      onClick={() => markComplete(t.id)}
+                      onClick={() => openTaskDetails(t)}
+                      className="btn-secondary"
+                      style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.5rem 0.9rem', fontSize: '0.8rem', position: 'relative', zIndex: 10, pointerEvents: 'all' }}
+                    >
+                      <Eye size={14} /> Details
+                    </button>
+                    {canResolveTask(t) && (
+                    <button
+                      onClick={() => markComplete(t)}
                       className="btn-secondary"
                       style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', background: 'var(--success-color)', color: '#fff', border: 'none', padding: '0.5rem 0.9rem', fontSize: '0.8rem', position: 'relative', zIndex: 10, pointerEvents: 'all' }}
                     >
                       <CheckCircle2 size={14} /> Resolve
                     </button>
+                    )}
                   </div>
                 </div>
               );
@@ -401,18 +534,215 @@ export default function Tasks() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
             {completedTasks.length === 0 ? (
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>No completed tasks yet.</p>
-            ) : completedTasks.slice(0, 8).map(t => (
-              <div key={t.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.65rem 1rem', background: 'rgba(255,255,255,0.01)', borderRadius: '4px' }}>
-                <span style={{ textDecoration: 'line-through', color: 'var(--text-secondary)', fontSize: '0.875rem' }}>{t.title}</span>
-                <span style={{ fontSize: '0.7rem', color: 'var(--success-color)', display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                  <CheckCircle2 size={10} /> Resolved
-                </span>
+            ) : completedTasks.slice(0, 8).map(t => {
+              const decoded = decodeNotes(t.notes);
+              return (
+              <div key={t.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', padding: '0.65rem 1rem', background: 'rgba(255,255,255,0.01)', borderRadius: '4px' }}>
+                <div style={{ minWidth: 0 }}>
+                  <span style={{ textDecoration: 'line-through', color: 'var(--text-secondary)', fontSize: '0.875rem' }}>{t.title}</span>
+                  {decoded.resolutionNote && (
+                    <p style={{ margin: '0.25rem 0 0', color: 'var(--text-secondary)', fontSize: '0.78rem', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 720 }}>
+                      Note: {decoded.resolutionNote}
+                    </p>
+                  )}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexShrink: 0 }}>
+                  <span style={{ fontSize: '0.7rem', color: 'var(--success-color)', display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <CheckCircle2 size={10} /> Resolved
+                  </span>
+                  <button type="button" onClick={() => openTaskDetails(t)} className="btn-secondary" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '0.35rem 0.65rem', fontSize: '0.75rem' }}>
+                    <Eye size={12} /> Details
+                  </button>
+                </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         </div>
 
       </div>
+
+
+      {selectedTask && (
+        <div
+          onClick={(e) => { if (e.target === e.currentTarget) closeTaskDetails(); }}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.62)',
+            backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            zIndex: 1000, padding: '1rem',
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Task details"
+            style={{
+              background: 'var(--bg-color, #f5f0e8)',
+              color: 'var(--text-primary)',
+              width: '100%',
+              maxWidth: 620,
+              maxHeight: '92vh',
+              overflowY: 'auto',
+              padding: '1.5rem',
+              borderRadius: 16,
+              boxShadow: '0 24px 64px rgba(0,0,0,0.3)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1rem',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+              <div style={{ flex: 1 }}>
+                <p style={{ margin: '0 0 0.25rem', color: 'var(--text-secondary)', fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Task details</p>
+                {editingTask ? (
+                  <input
+                    value={editTask.title}
+                    onChange={(e) => setEditTask({ ...editTask, title: e.target.value })}
+                    style={{ ...modalInputStyle, fontSize: '1.05rem', fontWeight: 700 }}
+                  />
+                ) : (
+                  <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{selectedTask.title}</h2>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={closeTaskDetails}
+                aria-label="Close"
+                style={{ background: 'transparent', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', padding: 4, display: 'flex', alignItems: 'center', borderRadius: 6 }}
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {editingTask ? (
+              <>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                    Status
+                    <select value={editTask.status} onChange={(e) => setEditTask({ ...editTask, status: e.target.value })} style={modalInputStyle}>
+                      <option value="Pending">Pending</option>
+                      <option value="In Progress">In Progress</option>
+                      <option value="Completed">Completed</option>
+                      <option value="Cancelled">Cancelled</option>
+                    </select>
+                  </label>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                    Priority
+                    <select value={editTask.priority} onChange={(e) => setEditTask({ ...editTask, priority: e.target.value })} style={modalInputStyle}>
+                      <option value="Critical">Critical</option>
+                      <option value="High">High</option>
+                      <option value="Medium">Medium</option>
+                      <option value="Low">Low</option>
+                    </select>
+                  </label>
+                </div>
+                <div style={{ display: 'grid', gridTemplateColumns: isTravel ? '1fr 1fr' : '1fr', gap: '0.75rem' }}>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                    Due date
+                    <input type="datetime-local" value={editTask.dueDate} onChange={(e) => setEditTask({ ...editTask, dueDate: e.target.value })} style={modalInputStyle} />
+                  </label>
+                  {isTravel && (
+                    <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                      Reassign to
+                      <select value={editTask.assignedToId} onChange={(e) => setEditTask({ ...editTask, assignedToId: e.target.value })} style={modalInputStyle}>
+                        <option value="">Unassigned</option>
+                        {assignableStaff.map((s) => {
+                          const brands = accessibleSubBrands(s);
+                          const scope = brands.length && brands.length < 4 ? ` (${brands.map(subBrandShortLabel).join('/')})` : '';
+                          return <option key={s.id} value={s.id}>{s.name}{scope}</option>;
+                        })}
+                      </select>
+                    </label>
+                  )}
+                </div>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                  Description
+                  <textarea
+                    rows="7"
+                    value={editTask.description}
+                    onChange={(e) => setEditTask({ ...editTask, description: e.target.value })}
+                    style={{ ...modalInputStyle, resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.45 }}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
+                  Resolution note
+                  <textarea
+                    rows="4"
+                    value={editTask.resolutionNote}
+                    onChange={(e) => setEditTask({ ...editTask, resolutionNote: e.target.value })}
+                    placeholder="Visible after the task is resolved"
+                    style={{ ...modalInputStyle, resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.45 }}
+                  />
+                </label>
+              </>
+            ) : (
+              <>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
+                  <PriorityBadge priority={selectedTask.priority} />
+                  <span style={{ padding: '0.2rem 0.6rem', borderRadius: 999, fontSize: '0.72rem', border: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>{selectedTask.status}</span>
+                  <span style={{ padding: '0.2rem 0.6rem', borderRadius: 999, fontSize: '0.72rem', border: '1px solid var(--border-color)', color: 'var(--text-secondary)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                    <UserRound size={12} /> {assigneeName(selectedTask)}
+                  </span>
+                </div>
+                {selectedTask.dueDate && (
+                  <p style={{ margin: 0, color: isOverdue(selectedTask) ? '#ef4444' : 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
+                    <Clock size={14} /> {new Date(selectedTask.dueDate).toLocaleString()}
+                  </p>
+                )}
+                {selectedTask.contact && (
+                  <p style={{ margin: 0, color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
+                    <Search size={14} /> {selectedTask.contact.name}{selectedTask.contact.email ? ` - ${selectedTask.contact.email}` : ''}
+                  </p>
+                )}
+                <section style={{ borderTop: '1px solid var(--border-color)', paddingTop: '1rem' }}>
+                  <h3 style={{ margin: '0 0 0.5rem', fontSize: '0.95rem' }}>Description</h3>
+                  <p style={{ margin: 0, whiteSpace: 'pre-wrap', lineHeight: 1.55, color: 'var(--text-secondary)' }}>
+                    {decodeNotes(selectedTask.notes).description || 'No description added.'}
+                  </p>
+                </section>
+                {decodeNotes(selectedTask.notes).resolutionNote && (
+                  <section style={{ borderTop: '1px solid var(--border-color)', paddingTop: '1rem' }}>
+                    <h3 style={{ margin: '0 0 0.5rem', fontSize: '0.95rem' }}>Resolution note</h3>
+                    <p style={{ margin: 0, whiteSpace: 'pre-wrap', lineHeight: 1.55, color: 'var(--text-secondary)' }}>
+                      {decodeNotes(selectedTask.notes).resolutionNote}
+                    </p>
+                  </section>
+                )}
+              </>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', flexWrap: 'wrap', paddingTop: '0.25rem' }}>
+              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                {canDeleteTasks && (
+                  <button type="button" onClick={deleteTask} className="btn-secondary" style={{ color: '#ef4444', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                    <Trash2 size={14} /> Delete
+                  </button>
+                )}
+                {canResolveTask(selectedTask) && selectedTask.status !== 'Completed' && !editingTask && (
+                  <button type="button" onClick={() => markComplete(selectedTask)} className="btn-secondary" style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                    <CheckCircle2 size={14} /> Resolve
+                  </button>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                {editingTask ? (
+                  <>
+                    <button type="button" onClick={() => setEditingTask(false)} className="btn-secondary">Cancel</button>
+                    <button type="button" onClick={saveTaskChanges} className="btn-primary" style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                      <Save size={14} /> Save
+                    </button>
+                  </>
+                ) : canUpdateTasks ? (
+                  <button type="button" onClick={() => setEditingTask(true)} className="btn-secondary" style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                    <Edit3 size={14} /> Edit
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Add Todo modal — matches the reference design */}
       {creating && (

--- a/frontend/src/pages/travel/CommissionProfilesAdmin.jsx
+++ b/frontend/src/pages/travel/CommissionProfilesAdmin.jsx
@@ -110,6 +110,30 @@ const PROFILE_TYPE_BADGE_BG = {
   hybrid: "rgba(168, 85, 247, 0.18)",
 };
 
+function hexToRgb(hex) {
+  const raw = String(hex || '').trim().replace(/^#/, '');
+  if (!/^[0-9a-f]{6}$/i.test(raw)) return null;
+  return {
+    r: parseInt(raw.slice(0, 2), 16),
+    g: parseInt(raw.slice(2, 4), 16),
+    b: parseInt(raw.slice(4, 6), 16),
+  };
+}
+
+function brandedButtonTextColor(background) {
+  const rgb = hexToRgb(background);
+  if (!rgb) return 'var(--accent-text, #fff)';
+  const luminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b;
+  return luminance < 160 ? '#F5F1E8' : '#1F2220';
+}
+
+function brandedButtonBorder(background) {
+  const rgb = hexToRgb(background);
+  if (!rgb) return 'none';
+  const luminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b;
+  return luminance < 220 ? 'none' : '1px solid rgba(31, 34, 32, 0.18)';
+}
+
 const EMPTY_FORM = {
   name: "",
   subBrand: "",
@@ -250,7 +274,13 @@ export default function CommissionProfilesAdmin() {
   const { activeSubBrand } = useActiveSubBrand();
   // G102: BrandKit lookup for primary-CTA tint.
   const { brandKit } = useBrandKit(activeSubBrand);
-  const primaryBtnBranded = { ...primaryBtn, background: brandPrimaryColor(brandKit) };
+  const brandCtaColor = brandPrimaryColor(brandKit);
+  const primaryBtnBranded = {
+    ...primaryBtn,
+    background: brandCtaColor,
+    color: brandedButtonTextColor(brandCtaColor),
+    border: brandedButtonBorder(brandCtaColor),
+  };
   const canWrite = user?.role === "ADMIN" || user?.role === "MANAGER";
   const canDelete = user?.role === "ADMIN";
 


### PR DESCRIPTION
Lead/contact assignment flow was improved so Admin/Manager can see all leads, while staff/users only see assigned leads.
Lead assignment now notifies the assigned staff member with a message asking them to look into the lead.
Bulk assignment now returns assigned/skipped counts and skipped details when staff sub-brand access does not match the lead.
Assignment dropdowns now show staff scope like (RFU/TMC) so admins can assign correctly by sub-brand.
Lead full-detail view now supports editing the AI/plugin-generated summary separately from the main contact edit modal.
Lead file upload in full view was changed from manual file URL entry to upload-based flow for images/documents, using the CRM upload endpoints/S3-backed storage path.
Plugin capture flow was extended so captured content can be sent as a task, not only as a lead.
Task creation from plugin capture supports AI summary generation for task notes.
Task notes storage was expanded to LongText so full AI/plugin summaries and resolution notes are preserved.
Task queue now has a detailed task view with description, assignee, priority, status, due date, edit, delete, reassign, and resolve actions based on permissions.
Assigned staff can now see their assigned tasks and resolve them from their account.
Resolve flow asks for a resolution note.
Resolved tasks remain visible in the completed log for both Admin/Manager and the assigned staff member.
Admin/Manager/Owner users are notified when an assigned staff member completes a task.