### PR TITLE
Sync prod_release with main (#1267 CORS + test fixes)

### DIFF
--- a/backend/middleware/originCheck.js
+++ b/backend/middleware/originCheck.js
@@ -80,6 +80,9 @@ function buildAllowlist() {
     "http://127.0.0.1:5173",
     "http://127.0.0.1:5000",
     "https://globuscrm.globussoft.com",
+    "https://empcloud.com",
+    "https://www.empcloud.com",
+    "https://app.empcloud.com",
   ];
   const envOne = process.env.FRONTEND_URL ? [process.env.FRONTEND_URL] : [];
   const envMany = process.env.CORS_ALLOWED_ORIGINS

--- a/backend/server.js
+++ b/backend/server.js
@@ -160,6 +160,10 @@ const ALLOWED_ORIGINS = [
   "http://localhost:8000",
   "http://127.0.0.1:8000",
   "https://globuscrm.globussoft.com",
+  // EMP Cloud frontend — browser API calls into the CRM.
+  "https://empcloud.com",
+  "https://www.empcloud.com",
+  "https://app.empcloud.com",
   // Dr. Haror's external marketing site — consumes the public wellness
   // catalog + payment endpoints (POST /api/wellness/public/payment/order +
   // /confirm). Hardcoded because it's part of the product surface, not a

--- a/backend/test/middleware/originCheck.test.js
+++ b/backend/test/middleware/originCheck.test.js
@@ -435,6 +435,9 @@ describe('buildAllowlist', () => {
     expect(list).toContain('http://127.0.0.1:5173');
     expect(list).toContain('http://127.0.0.1:5000');
     expect(list).toContain('https://globuscrm.globussoft.com');
+    expect(list).toContain('https://empcloud.com');
+    expect(list).toContain('https://www.empcloud.com');
+    expect(list).toContain('https://app.empcloud.com');
   });
 
   test('extends with FRONTEND_URL env var', () => {

--- a/backend/test/routes/staff-commission-profiles.test.js
+++ b/backend/test/routes/staff-commission-profiles.test.js
@@ -85,6 +85,10 @@ describe('GET /api/staff/commission-profiles', () => {
 
 describe('POST /api/staff/commission-profiles', () => {
   test('persists period + periodStart/periodEnd on create', async () => {
+    const today = new Date();
+    const periodStart = formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1));
+    const periodEnd = formatDateInput(new Date(today.getFullYear(), today.getMonth() + 1, 1));
+
     prisma.commissionProfile.create.mockResolvedValue({
       id: 22,
       tenantId: 1,
@@ -93,8 +97,8 @@ describe('POST /api/staff/commission-profiles', () => {
       percentage: '12.5',
       flatAmount: null,
       period: 'MONTHLY',
-      periodStart: new Date('2026-07-01T00:00:00.000Z'),
-      periodEnd: new Date('2026-08-01T00:00:00.000Z'),
+      periodStart: new Date(periodStart),
+      periodEnd: new Date(periodEnd),
       appliesToCategory: null,
       appliesToProduct: null,
       isActive: true,
@@ -108,8 +112,8 @@ describe('POST /api/staff/commission-profiles', () => {
         flatAmount: null,
         basis: 'REVENUE_PERCENT',
         period: 'MONTHLY',
-        periodStart: '2026-07-01',
-        periodEnd: '2026-08-01',
+        periodStart,
+        periodEnd,
         appliesToProduct: null,
         isActive: true,
       });
@@ -120,8 +124,8 @@ describe('POST /api/staff/commission-profiles', () => {
         data: expect.objectContaining({
           name: 'Monthly Bonus',
           period: 'MONTHLY',
-          periodStart: new Date('2026-07-01'),
-          periodEnd: new Date('2026-08-01'),
+          periodStart: new Date(periodStart),
+          periodEnd: new Date(periodEnd),
         }),
       }),
     );
@@ -131,6 +135,10 @@ describe('POST /api/staff/commission-profiles', () => {
 
 describe('PUT /api/staff/commission-profiles/:id', () => {
   test('persists period + periodStart/periodEnd on update', async () => {
+    const today = new Date();
+    const periodStart = formatDateInput(new Date(today.getFullYear(), today.getMonth(), 1));
+    const periodEnd = formatDateInput(new Date(today.getFullYear(), today.getMonth() + 3, 1));
+
     prisma.commissionProfile.findFirst.mockResolvedValue({
       id: 22,
       tenantId: 1,
@@ -153,8 +161,8 @@ describe('PUT /api/staff/commission-profiles/:id', () => {
       percentage: '15',
       flatAmount: null,
       period: 'QUARTERLY',
-      periodStart: new Date('2026-07-01T00:00:00.000Z'),
-      periodEnd: new Date('2026-10-01T00:00:00.000Z'),
+      periodStart: new Date(periodStart),
+      periodEnd: new Date(periodEnd),
       appliesToCategory: null,
       appliesToProduct: null,
       isActive: true,
@@ -165,8 +173,8 @@ describe('PUT /api/staff/commission-profiles/:id', () => {
       .send({
         percentage: 15,
         period: 'QUARTERLY',
-        periodStart: '2026-07-01',
-        periodEnd: '2026-10-01',
+        periodStart,
+        periodEnd,
       });
 
     expect(res.status).toBe(200);
@@ -175,8 +183,8 @@ describe('PUT /api/staff/commission-profiles/:id', () => {
         where: { id: 22 },
         data: expect.objectContaining({
           period: 'QUARTERLY',
-          periodStart: new Date('2026-07-01'),
-          periodEnd: new Date('2026-10-01'),
+          periodStart: new Date(periodStart),
+          periodEnd: new Date(periodEnd),
         }),
       }),
     );

--- a/frontend/src/__tests__/CommissionProfiles.test.jsx
+++ b/frontend/src/__tests__/CommissionProfiles.test.jsx
@@ -44,13 +44,15 @@
  *      fires.
  */
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 const fetchApiMock = vi.fn();
 vi.mock('../utils/api', () => ({
   fetchApi: (...args) => fetchApiMock(...args),
 }));
+
+let consoleErrorSpy;
 
 // Stable notify object — see the 2026-05-RTL "stable mock object references
 // for hooks" standing rule. Re-creating { error: vi.fn(), confirm: vi.fn() }
@@ -149,6 +151,20 @@ describe('<CommissionProfiles /> — Commission Profiles admin page surface', ()
     notifyConfirm.mockReset();
     notifyConfirm.mockImplementation(() => Promise.resolve(true));
     fetchApiMock.mockImplementation(defaultFetchMock);
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      const firstArg = String(args[0] ?? '');
+      if (
+        firstArg.includes('Warning: An update to CommissionProfiles inside a test was not wrapped in act') ||
+        firstArg.includes('When testing, code that causes React state updates should be wrapped into act')
+      ) {
+        return;
+      }
+      console.warn(...args);
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
   });
 
   it('mounts and fires GET /api/staff/commission-profiles', async () => {
@@ -430,6 +446,8 @@ describe('<CommissionProfiles /> — Commission Profiles admin page surface', ()
         return Promise.resolve({ id: 11 });
       }
       if (url === COMMISSION_URL) return Promise.resolve(sampleRows);
+      if (url === COMMISSION_DATA_URL) return Promise.resolve(sampleCommissionData);
+      if (url === '/api/wellness/products') return Promise.resolve([]);
       return Promise.resolve(null);
     });
 
@@ -447,6 +465,11 @@ describe('<CommissionProfiles /> — Commission Profiles admin page surface', ()
     expect(screen.getByTestId('profile-form-name')).toHaveValue('Senior Doctor Cut');
     expect(screen.getByDisplayValue('Monthly')).toBeInTheDocument();
 
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    const { currentMonthStart, defaultMonthEnd } = getCommissionWindowBounds();
+    fireEvent.change(dateInputs[0], { target: { value: currentMonthStart } });
+    fireEvent.change(dateInputs[1], { target: { value: defaultMonthEnd } });
+
     // Bump the percentage to 30.
     const numberInputs = document.querySelectorAll('input[type="number"]');
     fireEvent.change(numberInputs[0], { target: { value: '30' } });
@@ -460,8 +483,8 @@ describe('<CommissionProfiles /> — Commission Profiles admin page surface', ()
     expect(putBody.percentage).toBe(30);
     expect(putBody.basis).toBe('REVENUE_PERCENT');
     expect(putBody.period).toBe('MONTHLY');
-    expect(putBody.periodStart).toBe('2026-07-01T00:00:00.000Z');
-    expect(putBody.periodEnd).toBe('2026-08-01T00:00:00.000Z');
+    expect(putBody.periodStart).toBe(`${currentMonthStart}T00:00:00.000Z`);
+    expect(putBody.periodEnd).toBe(`${defaultMonthEnd}T00:00:00.000Z`);
     expect(putBody.isActive).toBe(true);
   });
 

--- a/frontend/src/__tests__/LandingSites.test.jsx
+++ b/frontend/src/__tests__/LandingSites.test.jsx
@@ -28,6 +28,19 @@ vi.mock('../utils/notify', () => ({ useNotify: () => notifyObj }));
 
 import LandingSites from '../pages/LandingSites';
 
+function isoAtLocalMonthOffset(monthOffset, day = 1) {
+  const now = new Date();
+  return new Date(
+    now.getFullYear(),
+    now.getMonth() + monthOffset,
+    day,
+    10,
+    0,
+    0,
+    0,
+  ).toISOString();
+}
+
 function defaultFetchMock(url, opts) {
   const method = (opts && opts.method) || 'GET';
   if (url === '/api/landing-sites' && method === 'GET') return Promise.resolve([]);
@@ -47,9 +60,9 @@ const LANDING_SITE_FIXTURE = [
     submissions: 18,
     templateType: 'generic-site-wellness-v1',
     description: 'Live wellness landing site',
-    createdAt: '2026-07-01T10:00:00.000Z',
-    updatedAt: '2026-07-02T10:00:00.000Z',
-    publishedAt: '2026-07-03T10:00:00.000Z',
+    createdAt: isoAtLocalMonthOffset(0, 1),
+    updatedAt: isoAtLocalMonthOffset(0, 2),
+    publishedAt: isoAtLocalMonthOffset(0, 3),
   },
   {
     id: 11,
@@ -60,8 +73,8 @@ const LANDING_SITE_FIXTURE = [
     submissions: 2,
     templateType: 'generic-site-wellness-v1',
     description: 'Draft wellness landing site',
-    createdAt: '2026-06-04T10:00:00.000Z',
-    updatedAt: '2026-06-05T10:00:00.000Z',
+    createdAt: isoAtLocalMonthOffset(-1, 4),
+    updatedAt: isoAtLocalMonthOffset(-1, 5),
     publishedAt: null,
   },
 ];

--- a/frontend/src/__tests__/Sidebar.test.jsx
+++ b/frontend/src/__tests__/Sidebar.test.jsx
@@ -34,7 +34,7 @@
  *   - useNotify returns a STABLE object reference (per the 2026-05-23
  *     standing rule on RTL hook mocks).
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
@@ -152,6 +152,7 @@ const { fetchApiMock } = vi.hoisted(() => ({
   fetchApiMock: vi.fn(),
 }));
 vi.mock('../utils/api', () => ({ fetchApi: fetchApiMock }));
+let consoleErrorSpy;
 
 // Sample page catalog used by the wellness-vertical tests that exercise
 // renderWellnessNav. Every entry mirrors the server's shape
@@ -228,6 +229,18 @@ function renderSidebar({
 }
 
 beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    const first = String(args[0] ?? '');
+    if (
+      first.includes('Warning: An update to Sidebar inside a test was not wrapped in act')
+      || first.includes('When testing, code that causes React state updates should be wrapped into act')
+    ) {
+      return;
+    }
+    // Preserve every other console.error so real regressions still surface.
+    // eslint-disable-next-line no-console
+    console.warn(...args);
+  });
   notifyObj.error.mockReset();
   notifyObj.success.mockReset();
   notifyObj.info.mockReset();
@@ -247,6 +260,10 @@ beforeEach(() => {
     }
     return Promise.resolve([]);
   });
+});
+
+afterEach(() => {
+  consoleErrorSpy?.mockRestore();
 });
 
 describe('Sidebar — load-bearing render surface', () => {


### PR DESCRIPTION
Sync latest main into prod_release.\n\nIncludes:\n- #1267 — CORS allowlist for empcloud.com origins\n- Frontend test stability fixes for CommissionProfiles, LandingSites, Sidebar\n\nAll checks passed on main.