### PR TITLE
Sync prod_release with main (#1269 #1270 #1271 + fixes)

### DIFF
--- a/backend/cron/leadScoringEngine.js
+++ b/backend/cron/leadScoringEngine.js
@@ -387,6 +387,75 @@ function computeScore(contact) {
 const RECOMPUTE_WINDOW_HOURS = 24;
 
 /**
+ * Score a specific list of contacts sequentially.
+ *
+ * Used by the generic CRM Leads page Refresh action. Sequential updates
+ * avoid the connection-pool saturation that the old cron caused when it
+ * fired one update per contact in parallel across every active tenant.
+ */
+async function scoreContactsByIds(tenantId, contactIds, io) {
+  if (!tenantId || !Array.isArray(contactIds) || contactIds.length === 0) {
+    return { scored: 0, errors: 0 };
+  }
+
+  const ids = [...new Set(contactIds.map((id) => Number(id)).filter(Number.isFinite))].slice(0, 100);
+  if (ids.length === 0) {
+    return { scored: 0, errors: 0 };
+  }
+
+  const contacts = await prisma.contact.findMany({
+    where: {
+      tenantId,
+      id: { in: ids },
+    },
+    include: {
+      deals: true,
+      activities: true,
+      sequenceEnrollments: true,
+      emails: { select: { direction: true, sentimentScore: true, createdAt: true } },
+      callLogs: { select: { createdAt: true } },
+      touchpoints: { select: { channel: true } },
+      whatsappMessages: { select: { direction: true, status: true, createdAt: true } },
+    },
+  });
+
+  const tickStart = new Date();
+  let scored = 0;
+  let errors = 0;
+
+  for (const contact of contacts) {
+    try {
+      let newScore = null;
+      if (aiModel) {
+        newScore = await scoreWithGemini(contact);
+      }
+      if (newScore === null) {
+        newScore = computeScore(contact);
+      }
+      await prisma.contact.update({
+        where: { id: contact.id },
+        data: {
+          aiScore: newScore,
+          aiScoreLastComputedAt: tickStart,
+        },
+      });
+      scored += 1;
+    } catch (err) {
+      console.error(`[LeadScoring] scoreContactsByIds update failed for contact ${contact.id}: ${err.message}`);
+      errors += 1;
+    }
+  }
+
+  console.log(`[LeadScoring] scoreContactsByIds: scored=${scored}, errors=${errors} for tenant=${tenantId}`);
+
+  if (io && scored > 0) {
+    io.emit('lead_scores_updated', { count: scored, ts: new Date() });
+  }
+
+  return { scored, errors };
+}
+
+/**
  * Core scoring tick — called by cron and by the debug endpoint.
  *
  * #421 — three architectural fixes vs the original sweep:
@@ -514,18 +583,15 @@ async function tickLeadScoringEngine(io) {
  * take effect without a server restart. `io` is captured by closure since
  * cronRegistry's tickFn contract takes no arguments. runImmediately
  * reproduces the historical "run once at startup" behavior.
+ *
+ * #<new> — automatic cron registration is disabled. The old background sweep
+ * was saturating the Prisma connection pool by parallelising updates across
+ * all tenants. aiScore is now recomputed on demand via the generic CRM
+ * Leads page Refresh action (POST /api/ai_scoring/contacts), which uses
+ * scoreContactsByIds and updates contacts sequentially.
  */
-function initLeadScoringCron(io) {
-  cronRegistry.register({
-    name: 'leadScoringEngine',
-    description: 'Recomputes Contact.aiScore for stale/unscored contacts (multi-factor formula + Gemini)',
-    defaultSchedule: '*/10 * * * *',
-    runImmediately: true,
-    tickFn: () => {
-      console.log('[LeadScoring] Cron tick — rescoring all contacts...');
-      return tickLeadScoringEngine(io);
-    },
-  }).catch((e) => console.error('[LeadScoring] cronRegistry registration failed:', e.message));
+function initLeadScoringCron(_io) {
+  console.log('[LeadScoring] Automatic cron disabled; scoring is now on-demand via /api/ai_scoring/contacts');
 }
 
-module.exports = { initLeadScoringCron, tickLeadScoringEngine, computeScore };
+module.exports = { initLeadScoringCron, tickLeadScoringEngine, computeScore, scoreContactsByIds };

--- a/backend/cron/webCheckinAutomation.js
+++ b/backend/cron/webCheckinAutomation.js
@@ -352,14 +352,14 @@ async function runWebCheckinAutomationTick(now = new Date(), deps = {}) {
 }
 
 function initWebCheckinAutomationCron() {
-  // Every 15 min, off-cluster (mirrors scheduler's jitter but offset by a few
-  // minutes so automation claims `reminded` rows before the scheduler's
-  // +30-min stall sweep can flip them to fallback-agent).
+  // Automation is disabled by default; this vertical is manual-only for now.
+  // The route /travel/automation-health and its sidebar entry are hidden.
   cronRegistry.register({
     name: "webCheckinAutomation",
     description: "Performs airline web check-in for reminded/retry-eligible bookings (every 15 min)",
     defaultSchedule: "8,23,38,53 * * * *",
     tickFn: runWebCheckinAutomationTick,
+    defaultEnabled: false,
   }).catch((e) => console.error("[WebCheckinAutomation] cronRegistry registration failed:", e.message));
 }
 

--- a/backend/cron/webCheckinEngine.js
+++ b/backend/cron/webCheckinEngine.js
@@ -31,7 +31,6 @@ const { safeNotifyTravelCustomer } = require("../lib/travelPortalNotificationSer
 
 const { MILESTONES, milestoneTag, dueMilestone } = content;
 const PAID_STATUSES = ["advance_paid", "fully_paid"];
-const ACTIVE_WC_STATUSES = ["pending", "reminded"]; // skip done/in-progress/fallback-agent/failed
 const HORIZON_HOURS = Math.max(...MILESTONES) + 1; // 37h scan window upper bound
 const PORTAL_BASE = process.env.PUBLIC_BASE_URL || "https://crm.globusdemos.com";
 const PORTAL_URL = `${PORTAL_BASE}/travel/portal`;
@@ -52,7 +51,7 @@ async function runWebCheckinTick(now = new Date()) {
 
   const rows = await prisma.webCheckin.findMany({
     where: {
-      status: { in: ACTIVE_WC_STATUSES },
+      status: "pending",
       departureAt: { gte: now, lte: horizon },
       itineraryId: { not: null },
     },

--- a/backend/cron/webCheckinScheduler.js
+++ b/backend/cron/webCheckinScheduler.js
@@ -1,62 +1,42 @@
 // Travel CRM — web check-in scheduler cron (PRD §4.6 + §6.3 row 1).
 //
-// Every 15 minutes. Manages the WebCheckin lifecycle through its
-// status enum:
+// Every 15 minutes. The WebCheckin status model is intentionally binary:
+//   pending  → not yet checked in / boarding pass not uploaded
+//   done     → boarding pass uploaded or customer confirmed
 //
-//   pending → reminded         when windowOpenAt ≤ now (the T-48h or
-//                              T-24h window has opened)
-//   reminded → fallback-agent  if status hasn't moved to 'done' or
-//                              'in-progress' within 30 min after the
-//                              window opened (per PRD §4.6 "2 failed
-//                              retries within 30 min → agent task")
+// The cron has ONE job: notify the responsible operator(s) when a pending
+// check-in's departureAt is within the next 24 hours. The notification is
+// deduped per user per WebCheckin row for 24h so the 15-minute tick does not
+// spam.
 //
-// Each transition creates one Notification row tagged on the WebCheckin
-// so the advisor dashboard surfaces the action. Idempotency: dedupe by
-// (entityType='WebCheckin', entityId, type). One reminder notification
-// + at most one fallback notification per WebCheckin lifecycle.
+// Notification targets:
+//   - If WebCheckin.assignedAgentId is set → that user only.
+//   - Otherwise → every ADMIN and MANAGER in the tenant.
 //
-// Source rows: this Phase 1 ship operates on EXISTING WebCheckin rows.
-// The row-creation step (scanning ItineraryItem flight details to spawn
-// WebCheckin rows at T-48h) is a separate concern — once a route or
-// upstream cron creates the WebCheckin in 'pending' status, this
-// scheduler picks it up. Airline browser-automation (P1B) is explicitly
-// out of scope for the autonomous loop.
-//
-// Dispatch: WhatsApp/email reminder send is stubbed (console.log)
-// pending Wati BSP creds (Q9). The Notification + status transition
-// are the visible Phase 1 outputs.
+// No status transitions, no automation, no fallback-agent flow — check-ins
+// are handled manually via the Web Check-ins queue.
 
 const cronRegistry = require("../lib/cronRegistry");
 const prisma = require("../lib/prisma");
-const { resolveForSubBrand } = require("../lib/subBrandConfig");
-// WhatsApp transport swap (Q9): Wati REST is COMMENTED OUT (kept on disk, not removed);
-// travel now dispatches over WhatsApp Web (QR-scan) via a drop-in client.
-// const watiClient = require("../services/watiClient"); // legacy Wati REST (disabled)
-const watiClient = require("../services/whatsappWebClient");
+const { notify } = require("../lib/notificationService");
 
-const FALLBACK_STALL_MIN = 30;
-const FUTURE_LOOK_AHEAD_DAYS = 7;
+const T24H_MS = 24 * 60 * 60 * 1000;
 const PORTAL_BASE = process.env.PUBLIC_BASE_URL || "https://crm.globusdemos.com";
 
 /**
  * Run the scheduler for one travel tenant.
  * @param {number} tenantId
- * @returns {Promise<{ reminded: number, fallback: number }>}
+ * @returns {Promise<{ notifiedUsers: number }>}
  */
 async function runWebCheckinSchedulerForTenant(tenantId) {
-  const now = Date.now();
-  const lookAhead = new Date(now + FUTURE_LOOK_AHEAD_DAYS * 86400_000);
-  const fallbackCutoff = new Date(now - FALLBACK_STALL_MIN * 60 * 1000);
+  const now = new Date();
+  const horizon = new Date(now.getTime() + T24H_MS);
 
-  // Pull pending + reminded rows whose window has opened (or will open
-  // within the look-ahead). Future-window rows are inspected so the
-  // scheduler can flip them at the exact moment their window opens
-  // without waiting a full cron cycle.
   const rows = await prisma.webCheckin.findMany({
     where: {
       tenantId,
-      status: { in: ["pending", "reminded"] },
-      windowOpenAt: { lte: lookAhead },
+      status: "pending",
+      departureAt: { gte: now, lte: horizon },
     },
     select: {
       id: true,
@@ -64,162 +44,72 @@ async function runWebCheckinSchedulerForTenant(tenantId) {
       airlineCode: true,
       flightNumber: true,
       passengerName: true,
-      windowOpenAt: true,
-      status: true,
-      updatedAt: true,
-      itineraryId: true,
+      departureAt: true,
+      assignedAgentId: true,
     },
     take: 500,
   });
 
-  // One tenant row read per pass for the Q9 cut-over plumbing. WebCheckin
-  // has no subBrand of its own — it inherits from the parent itinerary.
-  // Pre-fetch the itinerary.subBrand map in a single query so the inner
-  // loop doesn't N+1.
-  const tenant = await prisma.tenant.findUnique({
-    where: { id: tenantId },
-    select: { subBrandConfigJson: true },
-  });
-  const itinIds = [...new Set(rows.map((r) => r.itineraryId).filter(Boolean))];
-  let subBrandByItin = {};
-  let contactByItin = {};
-  if (itinIds.length > 0) {
-    const itins = await prisma.itinerary.findMany({
-      where: { id: { in: itinIds }, tenantId },
-      select: { id: true, subBrand: true, contactId: true },
-    });
-    subBrandByItin = Object.fromEntries(itins.map((i) => [i.id, i.subBrand]));
-    // Contact phones for the WhatsApp dispatch leg (Q9) — one batched read.
-    const contactIds = [...new Set(itins.map((i) => i.contactId).filter(Boolean))];
-    if (contactIds.length > 0) {
-      const contacts = await prisma.contact.findMany({
-        where: { id: { in: contactIds } },
-        select: { id: true, phone: true, name: true },
-      });
-      const byId = Object.fromEntries(contacts.map((c) => [c.id, c]));
-      contactByItin = Object.fromEntries(
-        itins.filter((i) => i.contactId).map((i) => [i.id, byId[i.contactId] || null]),
-      );
-    }
+  if (rows.length === 0) {
+    return { notifiedUsers: 0 };
   }
 
-  let reminded = 0;
-  let fallback = 0;
+  let notifiedUsers = 0;
 
   for (const row of rows) {
-    const windowAt = new Date(row.windowOpenAt).getTime();
-    if (Number.isNaN(windowAt)) continue;
+    const userIds = await resolveNotifyUserIds(tenantId, row.assignedAgentId);
+    if (userIds.length === 0) continue;
 
-    // Phase 1: window has just opened → flip pending → reminded.
-    if (row.status === "pending" && windowAt <= now) {
-      const existing = await prisma.notification.findFirst({
-        where: { tenantId, entityType: "WebCheckin", entityId: row.id, type: "info" },
-        select: { id: true },
-      });
+    const title = `Web check-in pending: ${row.airlineCode} ${row.flightNumber}`;
+    const message =
+      `${row.passengerName} — PNR ${row.pnr}. ` +
+      `Flight departs ${new Date(row.departureAt).toLocaleString()} and check-in is still pending.`;
+
+    for (const userId of userIds) {
       try {
-        await prisma.webCheckin.update({
-          where: { id: row.id },
-          data: { status: "reminded" },
+        const n = await notify({
+          userId,
+          tenantId,
+          title,
+          message,
+          type: "warning",
+          priority: "high",
+          entityType: "WebCheckin",
+          entityId: row.id,
+          link: `${PORTAL_BASE}/travel/web-checkins`,
+          dedupWindowHours: 24,
         });
-        if (!existing) {
-          await prisma.notification.create({
-            data: {
-              tenantId,
-              title: `Web check-in open: ${row.airlineCode} ${row.flightNumber}`,
-              message:
-                `${row.passengerName} — PNR ${row.pnr}. ` +
-                `Check-in window opened. Reminder dispatch queued (pending Wati creds). ` +
-                `Advisor link: ${PORTAL_BASE}/travel/trips`,
-              type: "info",
-              priority: "normal",
-              entityType: "WebCheckin",
-              entityId: row.id,
-            },
-          });
-        }
-        const subBrand = subBrandByItin[row.itineraryId] || null;
-        const cfg = subBrand ? resolveForSubBrand(tenant, subBrand) : {};
-        console.log(
-          `[WebCheckinScheduler] tenant ${tenantId} checkin ${row.id} ` +
-            `(${row.airlineCode} ${row.flightNumber}/${row.pnr}) → reminded ` +
-            `(WhatsApp dispatch via watiClient — ` +
-            `subBrand=${subBrand || "(none)"} wabaId=${cfg.wabaId || "(no-config)"})`,
-        );
-        // WhatsApp dispatch via watiClient (Q9) — stub when creds absent.
-        const contact = row.itineraryId ? contactByItin[row.itineraryId] : null;
-        if (contact && contact.phone) {
-          await watiClient.sendBestEffort({
-            tenantId,
-            subBrand,
-            toPhone: contact.phone,
-            contactId: contact.id,
-            templateName: process.env.WATI_WEB_CHECKIN_TEMPLATE || "web_checkin_nudge",
-            parameters: [
-              { name: "name", value: contact.name || row.passengerName || "there" },
-              { name: "flight", value: `${row.airlineCode} ${row.flightNumber}` },
-              { name: "pnr", value: row.pnr || "" },
-            ],
-            broadcastName: "travel-web-checkin-nudges",
-            fallbackText:
-              `Web check-in is now open for ${row.passengerName} — flight ` +
-              `${row.airlineCode} ${row.flightNumber}, PNR ${row.pnr}. Please complete check-in.`,
-          });
-        }
-        reminded++;
+        if (n) notifiedUsers += 1;
       } catch (e) {
         console.error(
-          `[WebCheckinScheduler] tenant ${tenantId} checkin ${row.id} reminded-transition error:`,
-          e.message,
-        );
-      }
-      continue;
-    }
-
-    // Phase 2: reminded but stalled past the 30-min fallback cutoff
-    // → escalate to agent. PRD §4.6 "2 failed retries within 30 min →
-    // agent task." The retry logic is in the (deferred) automation
-    // cron; this scheduler just flips status when the wall-clock says
-    // it's stalled.
-    if (row.status === "reminded" && new Date(row.updatedAt) < fallbackCutoff) {
-      const existing = await prisma.notification.findFirst({
-        where: { tenantId, entityType: "WebCheckin", entityId: row.id, type: "warning" },
-        select: { id: true },
-      });
-      if (existing) continue;
-      try {
-        await prisma.webCheckin.update({
-          where: { id: row.id },
-          data: { status: "fallback-agent" },
-        });
-        await prisma.notification.create({
-          data: {
-            tenantId,
-            title: `Web check-in escalated to agent: ${row.airlineCode} ${row.flightNumber}`,
-            message:
-              `${row.passengerName} — PNR ${row.pnr}. ` +
-              `No completion 30+ min after window opened — please manually check in via the ` +
-              `airline portal and upload the boarding pass.`,
-            type: "warning",
-            priority: "high",
-            entityType: "WebCheckin",
-            entityId: row.id,
-          },
-        });
-        console.log(
-          `[WebCheckinScheduler] tenant ${tenantId} checkin ${row.id} ` +
-            `(${row.airlineCode} ${row.flightNumber}/${row.pnr}) → fallback-agent (stalled 30m+)`,
-        );
-        fallback++;
-      } catch (e) {
-        console.error(
-          `[WebCheckinScheduler] tenant ${tenantId} checkin ${row.id} fallback-transition error:`,
+          `[WebCheckinScheduler] tenant ${tenantId} checkin ${row.id} notify fail for user ${userId}:`,
           e.message,
         );
       }
     }
   }
 
-  return { reminded, fallback };
+  return { notifiedUsers };
+}
+
+async function resolveNotifyUserIds(tenantId, assignedAgentId) {
+  if (assignedAgentId) {
+    const user = await prisma.user.findUnique({
+      where: { id: assignedAgentId },
+      select: { id: true, tenantId: true },
+    });
+    // Only notify the assigned agent if they still belong to this tenant.
+    return user && user.tenantId === tenantId ? [user.id] : [];
+  }
+
+  const managers = await prisma.user.findMany({
+    where: {
+      tenantId,
+      role: { in: ["ADMIN", "MANAGER"] },
+    },
+    select: { id: true },
+  });
+  return managers.map((u) => u.id);
 }
 
 async function runWebCheckinSchedulerForAllTravelTenants() {
@@ -227,30 +117,28 @@ async function runWebCheckinSchedulerForAllTravelTenants() {
     where: { vertical: "travel", isActive: true },
     select: { id: true, slug: true },
   });
-  let totalReminded = 0;
-  let totalFallback = 0;
+  let totalNotified = 0;
   for (const t of tenants) {
     try {
-      const { reminded, fallback } = await runWebCheckinSchedulerForTenant(t.id);
-      totalReminded += reminded;
-      totalFallback += fallback;
-      if (reminded || fallback) {
+      const { notifiedUsers } = await runWebCheckinSchedulerForTenant(t.id);
+      totalNotified += notifiedUsers;
+      if (notifiedUsers) {
         console.log(
-          `[WebCheckinScheduler] tenant ${t.slug}: ${reminded} reminded, ${fallback} fallback-agent`,
+          `[WebCheckinScheduler] tenant ${t.slug}: ${notifiedUsers} user notification(s)`,
         );
       }
     } catch (e) {
       console.error("[WebCheckinScheduler] tenant fail:", t.slug, e.message);
     }
   }
-  return { reminded: totalReminded, fallback: totalFallback };
+  return { notifiedUsers: totalNotified };
 }
 
 function initWebCheckinSchedulerCron() {
   // Every 15 minutes. PRD §6.3 row 1 specifies "every 15 min."
   cronRegistry.register({
     name: "webCheckinScheduler",
-    description: "Flips WebCheckin status pending→reminded→fallback-agent on window/stall triggers (every 15 min)",
+    description: "Notifies operators of pending web check-ins departing within 24h (every 15 min)",
     defaultSchedule: "13,28,43,58 * * * *",
     tickFn: runWebCheckinSchedulerForAllTravelTenants,
   }).catch((e) => console.error("[WebCheckinScheduler] cronRegistry registration failed:", e.message));

--- a/backend/lib/gmailMessage.js
+++ b/backend/lib/gmailMessage.js
@@ -68,7 +68,7 @@ function buildRawMessage(opts = {}) {
   const stamp = `${Date.now().toString(36)}_${Math.floor(Math.random() * 1e9).toString(36)}`;
 
   // Inner body section: single-part or multipart/alternative
-  let bodyContentType, bodyEncoding, bodyContent, bodyIsMultipart;
+  let bodyContentType, bodyContent, bodyIsMultipart;
   if (hasHtml && hasText) {
     const altBound = `alt_${stamp}`;
     const textPart = `Content-Type: text/plain; charset="UTF-8"\r\nContent-Transfer-Encoding: base64\r\n\r\n${Buffer.from(text, "utf8").toString("base64")}`;
@@ -78,12 +78,10 @@ function buildRawMessage(opts = {}) {
     bodyIsMultipart = true;
   } else if (hasHtml) {
     bodyContentType = 'text/html; charset="UTF-8"';
-    bodyEncoding = "base64";
     bodyContent = Buffer.from(html, "utf8").toString("base64");
     bodyIsMultipart = false;
   } else {
     bodyContentType = 'text/plain; charset="UTF-8"';
-    bodyEncoding = "base64";
     bodyContent = Buffer.from(hasText ? text : "", "utf8").toString("base64");
     bodyIsMultipart = false;
   }
@@ -167,6 +165,39 @@ function extractBody(payload) {
 }
 
 /**
+ * Walk a Gmail payload and collect attachment metadata (parts with an
+ * attachmentId). Gmail keeps attachment *data* out of the message.get('full')
+ * payload; callers must fetch each attachment via users.messages.attachments.get.
+ *
+ * @param {object} payload
+ * @returns {Array<{filename:string, mimeType:string, size:number, attachmentId:string}>}
+ */
+function extractAttachments(payload) {
+  const attachments = [];
+  const seen = new Set();
+  const walk = (part) => {
+    if (!part || typeof part !== "object") return;
+    const body = part.body || {};
+    const hasAttachmentId = typeof body.attachmentId === "string" && body.attachmentId.length > 0;
+    if (hasAttachmentId) {
+      const key = `${part.filename || ""}|${body.attachmentId}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        attachments.push({
+          filename: part.filename || `attachment-${attachments.length + 1}`,
+          mimeType: part.mimeType || "application/octet-stream",
+          size: Number.isFinite(body.size) ? body.size : 0,
+          attachmentId: body.attachmentId,
+        });
+      }
+    }
+    if (Array.isArray(part.parts)) part.parts.forEach(walk);
+  };
+  walk(payload);
+  return attachments;
+}
+
+/**
  * Flatten a gmail.users.messages.get response into a CRM-friendly shape.
  *
  * @param {object} apiMsg
@@ -191,6 +222,7 @@ function parseGmailMessage(apiMsg) {
     text,
     html,
     body: text || html || snippet || "",
+    attachments: extractAttachments(payload),
   };
 }
 
@@ -211,4 +243,5 @@ module.exports = {
   headerValue,
   parseGmailMessage,
   extractEmailAddress,
+  extractAttachments,
 };

--- a/backend/lib/leadCustomFieldValues.js
+++ b/backend/lib/leadCustomFieldValues.js
@@ -1,0 +1,76 @@
+function isValidUrl(str) {
+  try {
+    const url = new URL(str);
+    return ["http:", "https:", "mailto:"].includes(url.protocol);
+  } catch (_e) {
+    return false;
+  }
+}
+
+function coerceCustomFieldValue(def, raw) {
+  if (raw === null || raw === undefined || raw === "") return null;
+
+  if (def.fieldType === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? { valueNumber: n } : null;
+  }
+  if (def.fieldType === "date") {
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : { valueDate: d };
+  }
+  if (def.fieldType === "checkbox") {
+    return { valueBool: Boolean(raw) };
+  }
+  if (def.fieldType === "multiselect") {
+    const arr = Array.isArray(raw) ? raw : [raw];
+    const clean = arr.map((o) => String(o).trim()).filter(Boolean);
+    return clean.length ? { valueText: JSON.stringify(clean) } : null;
+  }
+  if (def.fieldType === "radio") {
+    const s = String(raw).trim();
+    return s ? { valueText: s } : null;
+  }
+  if (def.fieldType === "url") {
+    const s = String(raw).trim();
+    return s && isValidUrl(s) ? { valueText: s } : null;
+  }
+  const s = String(raw).trim();
+  return s ? { valueText: s.slice(0, 2000) } : null;
+}
+
+async function writeLeadCustomFieldValues(contactId, tenantId, customFields) {
+  const prisma = require("./prisma");
+  if (!customFields || typeof customFields !== "object") return;
+  const keys = Object.keys(customFields);
+  if (!keys.length) return;
+  try {
+    const definitions = await prisma.leadCustomFieldDefinition.findMany({
+      where: { tenantId, fieldKey: { in: keys } },
+    });
+    const byKey = new Map(definitions.map((d) => [d.fieldKey, d]));
+    for (const key of keys) {
+      const def = byKey.get(key);
+      if (!def) continue;
+      const raw = customFields[key];
+      const clearData = { valueText: null, valueNumber: null, valueDate: null, valueBool: null };
+      const typed = raw === null || raw === undefined || raw === "" ? null : coerceCustomFieldValue(def, raw);
+      if (!typed) {
+        await prisma.leadCustomFieldValue.upsert({
+          where: { contactId_fieldId: { contactId, fieldId: def.id } },
+          create: { contactId, fieldId: def.id, tenantId, ...clearData },
+          update: clearData,
+        });
+      } else {
+        await prisma.leadCustomFieldValue.upsert({
+          where: { contactId_fieldId: { contactId, fieldId: def.id } },
+          create: { contactId, fieldId: def.id, tenantId, ...clearData, ...typed },
+          update: typed,
+        });
+      }
+    }
+  } catch (e) {
+    console.error("[lead-custom-fields] writeLeadCustomFieldValues failed (non-fatal):", e && e.message);
+  }
+}
+
+module.exports = { writeLeadCustomFieldValues };

--- a/backend/lib/llmRouter.js
+++ b/backend/lib/llmRouter.js
@@ -77,8 +77,9 @@ const TASK_ROUTING = {
   "call-summary": { primary: "gemini-flash", fallback: null },
   // Callified AI call transcript classification for CRM leads (2026-07-31).
   // Reads the latest call transcript + review and decides whether the lead
-  // is hot, cold, or yet to call. Small JSON in/out → flash-lite primary.
-  "callified-lead-status": { primary: "gemini-flash-lite", fallback: "gemini-flash" },
+  // is hot, cold, or yet to call. Small JSON in/out → flash primary.
+  // NOTE: gemini-2.5-flash-lite was retired by Google; use gemini-flash.
+  "callified-lead-status": { primary: "gemini-flash", fallback: "gpt-4" },
   // Itinerary-suggest (PRD_TRAVEL_ITINERARY_UPGRADES FR-3.6 + AI_SURFACES §3
   // table). 2K in / 4K out — larger out than bulk-text because the full
   // itinerary JSON shape (daySplit + poiSuggestions + thematicNotes) lands
@@ -643,7 +644,7 @@ const MODEL_ID_ENV = {
   // Web-search-enabled OpenAI model (browses the live web at query time).
   "gpt-4o-search": ["LLM_MODEL_GPT_SEARCH", "gpt-4o-search-preview"],
   "gemini-flash": ["LLM_MODEL_GEMINI", "gemini-2.5-flash"],
-  "gemini-flash-lite": ["LLM_MODEL_GEMINI_FLASH_LITE", "gemini-2.5-flash-lite"],
+  "gemini-flash-lite": ["LLM_MODEL_GEMINI_FLASH_LITE", "gemini-2.0-flash"],
   "perplexity-sonar": ["LLM_MODEL_PERPLEXITY", "sonar"],
 };
 
@@ -834,7 +835,7 @@ function geminiModelChain(primaryId) {
   const raw = process.env.LLM_GEMINI_FALLBACK_MODELS;
   const fallbacks = raw && raw.trim()
     ? raw.split(",").map((s) => s.trim()).filter(Boolean)
-    : ["gemini-2.5-flash-lite", "gemini-2.0-flash"];
+    : ["gemini-2.0-flash"];
   return [primaryId, ...fallbacks].filter((m, i, a) => m && a.indexOf(m) === i);
 }
 

--- a/backend/lib/tenantSettings.js
+++ b/backend/lib/tenantSettings.js
@@ -101,6 +101,8 @@ const KEYS = {
   // as a sensible starting point; ops can tune per-tenant.
   IMAGE_LLM_MONTHLY_CAP_USD_CENTS:       "budgetCap_image_llm_monthly_usd_cents",
   BOOKING_EXPEDIA_MONTHLY_CAP_USD_CENTS: "budgetCap_booking_expedia_monthly_usd_cents",
+  // Generic CRM Leads page — AI transcript classification for Callified calls.
+  CALLIFIED_AI_TRANSCRIPT_ENABLED:       "feature.callified.ai_transcript.enabled",
   // Cron / operational settings (§4.5 hardcoded-value fixes)
   ORCHESTRATOR_DEFAULT_WORKING_MINUTES:  "orchestrator.defaultWorkingMinutes",
   SMS_DEDUP_PHRASE_24H:                  "sms.dedupPhrase24h",
@@ -144,6 +146,8 @@ const DEFAULTS = {
     Number(process.env.IMAGE_LLM_MONTHLY_CAP_USD_CENTS ?? 10000),
   [KEYS.BOOKING_EXPEDIA_MONTHLY_CAP_USD_CENTS]:
     Number(process.env.BOOKING_EXPEDIA_MONTHLY_CAP_USD_CENTS ?? 10000),
+  // Generic CRM Leads page — AI transcript classification enabled by default.
+  [KEYS.CALLIFIED_AI_TRANSCRIPT_ENABLED]: "true",
   // Cron / operational defaults (§4.5 hardcoded-value fixes)
   [KEYS.ORCHESTRATOR_DEFAULT_WORKING_MINUTES]: 660,
   [KEYS.SMS_DEDUP_PHRASE_24H]: "tomorrow at",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -852,6 +852,12 @@ model Contact {
   // backend/lib/leadConversationSummary.js.
   description String? @db.Text
 
+  // Raw external intake snapshot (JSON string). Stores the full partner
+  // payload so arbitrary keys survive even when they do not map to a native
+  // Contact column or a defined lead custom field. Kept separate from
+  // description because this is structured intake data, not a narrative.
+  externalPayloadJson String? @db.LongText
+
   createdAt DateTime  @default(now())
   // #167: soft-delete column. Routes filter `deletedAt: null` on list/detail.
   // DELETE flips this column instead of hard-deleting; restore endpoint clears it.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6817,7 +6817,7 @@ model WebCheckin {
   passengerName      String
   seatPref           String?
   mealPref           String?
-  status             String    @default("pending") // pending | reminded | in-progress | done | fallback-agent | failed
+  status             String    @default("pending") // pending | done
   attemptsJson       String?   @db.Text // [{at, result, errorReason}]
   // Customer-facing web check-in reminder EMAILS sent by cron/webCheckinEngine.js
   // (2026-06-16) — distinct from the scheduler's WhatsApp/status lifecycle.

--- a/backend/routes/ai_scoring.js
+++ b/backend/routes/ai_scoring.js
@@ -107,6 +107,29 @@ router.get("/contact/:contactId", verifyToken, async (req, res) => {
   }
 });
 
+// ─── Batch contact scoring ────────────────────────────────────────────────
+// POST /api/ai_scoring/contacts
+// Body: { contactIds: number[] }
+// Scores up to 100 contacts sequentially for the current tenant.
+router.post("/contacts", verifyToken, async (req, res) => {
+  try {
+    const { contactIds } = req.body || {};
+    if (!Array.isArray(contactIds) || contactIds.length === 0) {
+      return res.status(400).json({ error: "contactIds array is required", code: "MISSING_CONTACT_IDS" });
+    }
+    if (contactIds.length > 100) {
+      return res.status(400).json({ error: "At most 100 contacts can be scored at once", code: "TOO_MANY_CONTACT_IDS" });
+    }
+
+    const { scoreContactsByIds } = require("../cron/leadScoringEngine");
+    const result = await scoreContactsByIds(req.user.tenantId, contactIds, req.io);
+    res.json({ success: true, ...result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to score contacts" });
+  }
+});
+
 // ─── Debug trigger endpoint ─────────────────────────────────────────────────
 router.post("/trigger", async (req, res) => {
   try {

--- a/backend/routes/callified.js
+++ b/backend/routes/callified.js
@@ -25,6 +25,7 @@ const { writeAudit } = require("../lib/audit");
 const { resolveSubBrand } = require("../lib/subBrandResolve");
 const prisma = require("../lib/prisma");
 const { routeRequest, llmEnabled } = require("../lib/llmRouter");
+const { getSetting, KEYS } = require("../lib/tenantSettings");
 const { notify } = require("../lib/notificationService");
 
 // Sub-brand isolation guard imported from ../lib/subBrandResolve (tick #106
@@ -606,7 +607,7 @@ function fallbackClassify(review) {
   return { status: "cold", reason: `Neutral Callified score ${score}/5.` };
 }
 
-async function classifyLeadStatus(tenantId, contactId) {
+async function classifyLeadStatus(tenantId, contactId, { userId = null } = {}) {
   const { hasCall, review, transcript } = await fetchLatestCallReviewForContact(tenantId, contactId);
   if (!hasCall) {
     return {
@@ -625,6 +626,15 @@ async function classifyLeadStatus(tenantId, contactId) {
   // It acts as the source of truth when Gemini is unavailable, and as a guard
   // rail when Gemini returns a result that contradicts hard signals.
   const fallback = fallbackClassify(review);
+
+  // If the tenant has disabled AI transcript classification, use the fallback.
+  const aiTranscriptEnabled = await getSetting(tenantId, KEYS.CALLIFIED_AI_TRANSCRIPT_ENABLED, {
+    coerce: (v) => String(v).toLowerCase() !== "false",
+  });
+  if (!aiTranscriptEnabled) {
+    console.log(`[callified] AI transcript classification disabled for tenant ${tenantId}; using score/appointment fallback for contact ${contactId}.`);
+    return { status: fallback.status, source: "score", reason: fallback.reason };
+  }
 
   // If no Gemini key is configured, use the score/appointment fallback directly.
   const geminiReady = await llmEnabled("callified-lead-status", tenantId).catch((e) => {
@@ -651,6 +661,8 @@ async function classifyLeadStatus(tenantId, contactId) {
     review: reviewPayload,
     hasTranscript: !!transcriptText,
     hasReview: !!reviewPayload,
+    __surface: "leads-callified-transcript",
+    __userId: userId,
   };
 
   try {
@@ -699,6 +711,9 @@ async function assignHotLeadRoundRobin(tenantId, contactId, status, options = {}
   const { force = false } = options;
 
   try {
+    // Bump interactive transaction timeout: under load the staff lookup +
+    // tenant update can exceed Prisma's 5s default, causing the assignment to
+    // roll back and leaving the hot lead unassigned.
     const result = await prisma.$transaction(async (tx) => {
       const contact = await tx.contact.findFirst({
         where: { id: Number(contactId), tenantId },
@@ -769,7 +784,7 @@ async function assignHotLeadRoundRobin(tenantId, contactId, status, options = {}
       });
 
       return { assignedToId: nextUser.id, reason: "assigned" };
-    });
+    }, { timeout: 15000 });
 
     const assignedToId = result.assignedToId;
     if (!assignedToId) return null;
@@ -818,7 +833,7 @@ router.post("/leads/:leadId/classify", verifyToken, async (req, res) => {
     });
     if (!contact) return res.status(404).json({ error: "Lead not found" });
 
-    const classification = await classifyLeadStatus(req.user.tenantId, leadId);
+    const classification = await classifyLeadStatus(req.user.tenantId, leadId, { userId: req.user.userId });
     const updateData = {
       callifiedLeadStatus: classification.status,
       callifiedLeadStatusSource: classification.source,
@@ -831,21 +846,29 @@ router.post("/leads/:leadId/classify", verifyToken, async (req, res) => {
       if (assignedToId) updateData.assignedToId = assignedToId;
     }
 
-    const updated = await prisma.contact.update({
-      where: { id: leadId },
-      data: updateData,
-      include: { assignedTo: { select: { id: true, name: true, email: true } } },
-    });
+    try {
+      const updated = await prisma.contact.update({
+        where: { id: leadId },
+        data: updateData,
+        include: { assignedTo: { select: { id: true, name: true, email: true } } },
+      });
 
-    res.json({
-      id: updated.id,
-      callifiedLeadStatus: updated.callifiedLeadStatus,
-      callifiedLeadStatusSource: updated.callifiedLeadStatusSource,
-      callifiedLeadStatusUpdatedAt: updated.callifiedLeadStatusUpdatedAt,
-      assignedToId: updated.assignedToId,
-      assignedTo: updated.assignedTo,
-      reason: classification.reason,
-    });
+      res.json({
+        id: updated.id,
+        callifiedLeadStatus: updated.callifiedLeadStatus,
+        callifiedLeadStatusSource: updated.callifiedLeadStatusSource,
+        callifiedLeadStatusUpdatedAt: updated.callifiedLeadStatusUpdatedAt,
+        assignedToId: updated.assignedToId,
+        assignedTo: updated.assignedTo,
+        reason: classification.reason,
+      });
+    } catch (updateErr) {
+      if (updateErr.code === "P2025") {
+        console.error(`[callified] leads/:leadId/classify contact ${leadId} not found during update`);
+        return res.status(404).json({ error: "Lead not found", code: "LEAD_NOT_FOUND" });
+      }
+      throw updateErr;
+    }
   } catch (e) {
     console.error("[callified] leads/:leadId/classify error:", e.message);
     res.status(500).json({ error: "Failed to classify lead" });

--- a/backend/routes/contacts.js
+++ b/backend/routes/contacts.js
@@ -548,6 +548,8 @@ router.post('/', async (req, res) => {
     // LeadCustomFieldValue AFTER the contact create succeeds (see below).
     const customFields = req.body.customFields;
     delete req.body.customFields;
+    const skipInitialAssignee = req.body.skipInitialAssignee === true;
+    delete req.body.skipInitialAssignee;
     // #600 / #557 follow-up: the Leads form sends wellness-only optional fields
     // as empty strings even in the generic vertical. Prisma Int? / DateTime? /
     // String? columns reject "" where they expect null / a valid shape, so
@@ -573,11 +575,16 @@ router.post('/', async (req, res) => {
     if (typeof normalised.birthDate === "string" && normalised.birthDate !== "") {
       normalised.birthDate = new Date(normalised.birthDate);
     }
-    // #588: default assignedToId to the creator so USER-role list scoping
-    // (which filters by assignedToId = req.user.userId) actually surfaces
-    // the contact they just created. Mirrors POST /api/deals which sets
-    // ownerId = req.user.userId. Explicit body.assignedToId still wins.
-    if (normalised.assignedToId == null) normalised.assignedToId = req.user.userId;
+    // Generic CRM Callified leads stay unassigned until the call produces a real status.
+    // Explicit assignedToId still wins, and non-generic contact creation keeps the existing creator default.
+    const isGenericLeadAwaitingCall =
+      (req.user.vertical || 'generic') === 'generic' &&
+      normalised.status === 'Lead' &&
+      (!normalised.callifiedLeadStatus || normalised.callifiedLeadStatus === 'yet_to_call');
+    const shouldSkipInitialAssignee = isGenericLeadAwaitingCall || (skipInitialAssignee && normalised.status === 'Lead');
+    if (normalised.assignedToId == null && !shouldSkipInitialAssignee) {
+      normalised.assignedToId = req.user.userId;
+    }
 
     // Auto-assign new Leads to the tenant's default Callified campaign when set
     // and no campaign was supplied explicitly. Covers manual create, import,

--- a/backend/routes/external.js
+++ b/backend/routes/external.js
@@ -22,6 +22,7 @@ const externalAuth = require("../middleware/externalAuth");
 const { classifyLead } = require("../lib/leadJunkFilter");
 const { pickAssignee } = require("../lib/leadAutoRouter");
 const { computeFirstResponseDueAt } = require("../lib/leadSla");
+const { writeLeadCustomFieldValues } = require("../lib/leadCustomFieldValues");
 
 const router = express.Router();
 
@@ -58,22 +59,59 @@ const phoneMatches = (input) => {
   if (!suf) return null;
   return { contains: suf };
 };
-
 const parseLimit = (v, def = 50, max = 200) => Math.min(parseInt(v) || def, max);
 const parseOffset = (v) => parseInt(v) || 0;
 
-const LEAD_BODY_KEYS = new Set(["name", "phone", "email", "source", "note", "utm", "externalId"]);
+const LEAD_BODY_KEYS = new Set([
+  "name", "phone", "email", "source", "submitSource", "submittedSource",
+  "submit_source", "leadSource", "lead_source", "note", "utm",
+  "externalId", "callifiedCampaignId", "customFields",
+]);
+const CUSTOM_FIELD_PREFIX = "cf_";
+
+function normalizeSubmittedSource(value) {
+  if (value === null || value === undefined) return null;
+  const text = String(value).trim();
+  return text ? text.slice(0, 128) : null;
+}
+
+function resolveSubmittedSource(body) {
+  if (!body || typeof body !== "object") return null;
+  return normalizeSubmittedSource(body.source)
+    || normalizeSubmittedSource(body.submitSource)
+    || normalizeSubmittedSource(body.submittedSource)
+    || normalizeSubmittedSource(body.submit_source)
+    || normalizeSubmittedSource(body.leadSource)
+    || normalizeSubmittedSource(body.lead_source)
+    || normalizeSubmittedSource(body.utm?.source)
+    || normalizeSubmittedSource(body.utm?.utm_source);
+}
 
 function splitCustomLeadFields(body) {
-  if (!body || typeof body !== "object") return {};
-  const customFields = {};
+  if (!body || typeof body !== "object") return { rawCustomFields: {}, storageCustomFields: {} };
+  const rawCustomFields = {};
+  const storageCustomFields = {};
   for (const [key, value] of Object.entries(body)) {
-    if (!LEAD_BODY_KEYS.has(key)) {
-      customFields[key] = value;
+    if (LEAD_BODY_KEYS.has(key)) continue;
+    rawCustomFields[key] = value;
+    const storageKey = key.startsWith(CUSTOM_FIELD_PREFIX) ? key.slice(CUSTOM_FIELD_PREFIX.length) : key;
+    if (storageKey) storageCustomFields[storageKey] = value;
+  }
+  return { rawCustomFields, storageCustomFields };
+}
+
+const EXTERNAL_CONTACT_FIELD_KEYS = ["company", "title", "industry", "companySize", "linkedin", "website", "treatmentOfInterest", "stateCode", "billingStateCode"];
+function extractExternalContactFieldUpdates(body) {
+  const updates = {};
+  for (const key of EXTERNAL_CONTACT_FIELD_KEYS) {
+    if (body && body[key] !== undefined && body[key] !== null && body[key] !== "") {
+      updates[key] = body[key];
     }
   }
-  return customFields;
+  return updates;
 }
+
+// ── Tenant info ──────────────────────────────────────────────────
 
 // ── Tenant info ────────────────────────────────────────────────────
 
@@ -276,24 +314,39 @@ router.get("/leads", async (req, res) => {
 
 router.post("/leads", async (req, res) => {
   try {
-    const { name, phone, email, source, note, utm, externalId } = req.body;
-    const customFields = splitCustomLeadFields(req.body);
+    const { name, phone, email, note, utm, externalId } = req.body;
+    const submittedSource = resolveSubmittedSource(req.body);
+    const { rawCustomFields, storageCustomFields } = splitCustomLeadFields(req.body);
+    const externalPayloadJson = JSON.stringify(req.body);
+    const contactFieldUpdates = extractExternalContactFieldUpdates(req.body);
     if (!name && !phone && !email) {
       return res.status(400).json({ error: "name, phone, or email required", code: "INSUFFICIENT_IDENTITY" });
     }
 
+    let tenantCfg = null;
+    try {
+      tenantCfg = await prisma.tenant.findUnique({
+        where: { id: req.tenantId },
+        select: { vertical: true, callifiedAutoCampaignId: true },
+      });
+    } catch (e) {
+      console.error("[external] tenant config lookup failed:", e.message);
+    }
+    const isGenericLeadAwaitingCall = (tenantCfg?.vertical || "generic") === "generic";
+
     // Run the junk filter before persisting (rules + optional Gemini AI)
     const verdict = await classifyLead({
       tenantId: req.tenantId,
-      name, phone, email, source,
+      name, phone, email, source: submittedSource,
     });
 
-    // Auto-route to a specialist / telecaller (skip junk leads — they go nowhere)
-    let assignee = { userId: null, reason: "junk skipped routing" };
-    if (!verdict.isJunk) {
+    // Generic CRM Callified leads stay unassigned until a call result marks them hot.
+    // Wellness/travel routing keeps the existing intake-time behavior.
+    let assignee = { userId: null, reason: verdict.isJunk ? "junk skipped routing" : "awaiting_call_status" };
+    if (!verdict.isJunk && !isGenericLeadAwaitingCall) {
       assignee = await pickAssignee({
         tenantId: req.tenantId,
-        name, phone, email, source, note,
+        name, phone, email, source: submittedSource, note,
       });
     }
 
@@ -302,7 +355,7 @@ router.post("/leads", async (req, res) => {
     // → SLA minutes is hardcoded in lib/leadSla.js. Junk leads still get a
     // due date — it's harmless (cron won't notify on Junk-status rows because
     // the breach query gates on status='Lead').
-    const slaText = [name, source, note].filter(Boolean).join(" ");
+    const slaText = [name, submittedSource, note].filter(Boolean).join(" ");
     let firstResponseDueAt = null;
     let slaMeta = null;
     try {
@@ -325,9 +378,18 @@ router.post("/leads", async (req, res) => {
       name: name || (phone ? `Caller ${phone}` : "Unknown caller"),
       email: resolvedEmail,
       phone: phone || null,
+      company: req.body.company || null,
+      title: req.body.title || null,
+      industry: req.body.industry || null,
+      companySize: req.body.companySize || null,
+      linkedin: req.body.linkedin || null,
+      website: req.body.website || null,
+      treatmentOfInterest: req.body.treatmentOfInterest || null,
+      stateCode: req.body.stateCode || null,
+      billingStateCode: req.body.billingStateCode || null,
       status: verdict.isJunk ? "Junk" : "Lead",
-      source: source || "callified",
-      firstTouchSource: source || "callified",
+      source: submittedSource,
+      firstTouchSource: submittedSource,
       aiScore: verdict.score,
       assignedToId: assignee.userId,
       firstResponseDueAt,
@@ -341,16 +403,8 @@ router.post("/leads", async (req, res) => {
     // and no campaign was supplied explicitly. Mirrors the logic in contacts.js
     // so external API leads are dialable by Callified just like manually added leads.
     if (contactData.status === "Lead" && req.body.callifiedCampaignId == null) {
-      try {
-        const tenantCfg = await prisma.tenant.findUnique({
-          where: { id: req.tenantId },
-          select: { callifiedAutoCampaignId: true },
-        });
-        if (tenantCfg?.callifiedAutoCampaignId) {
-          contactData.callifiedCampaignId = tenantCfg.callifiedAutoCampaignId;
-        }
-      } catch (e) {
-        console.error("[external] auto-campaign lookup failed:", e.message);
+      if (tenantCfg?.callifiedAutoCampaignId) {
+        contactData.callifiedCampaignId = tenantCfg.callifiedAutoCampaignId;
       }
     } else if (req.body.callifiedCampaignId != null) {
       contactData.callifiedCampaignId = Number(req.body.callifiedCampaignId);
@@ -380,9 +434,23 @@ router.post("/leads", async (req, res) => {
         deduped = true;
       }
     }
-    if (!contact) {
-      contact = await prisma.contact.create({ data: contactData });
+    if (contact) {
+      const dedupeUpdates = { externalPayloadJson };
+      for (const [key, value] of Object.entries(contactFieldUpdates)) {
+        if (contact[key] == null || contact[key] === "") {
+          dedupeUpdates[key] = value;
+        }
+      }
+      if (Object.keys(dedupeUpdates).length > 1) {
+        contact = await prisma.contact.update({ where: { id: contact.id }, data: dedupeUpdates });
+      }
+    } else {
+      contact = await prisma.contact.create({ data: { ...contactData, ...contactFieldUpdates, externalPayloadJson } });
     }
+    if (Object.keys(storageCustomFields).length) {
+      await writeLeadCustomFieldValues(contact.id, req.tenantId, storageCustomFields);
+    }
+
 
     // Attach an activity so the CRM's inbox shows the origin + junk verdict.
     // NOTE: this is a *system* activity, not a real human first-response —
@@ -392,7 +460,7 @@ router.post("/leads", async (req, res) => {
     const activityBits = [
       note,
       utm && `utm=${JSON.stringify(utm)}`,
-      Object.keys(customFields).length ? `customFields=${JSON.stringify(customFields)}` : null,
+      Object.keys(rawCustomFields).length ? `customFields=${JSON.stringify(rawCustomFields)}` : null,
       verdict.reasons.length && `junk-filter: ${verdict.reasons.join("; ")}`,
     ].filter(Boolean);
     if (activityBits.length) {
@@ -406,12 +474,13 @@ router.post("/leads", async (req, res) => {
       });
     }
 
+    const { externalPayloadJson: _externalPayloadJson, ...publicContact } = contact;
     res.status(deduped ? 200 : 201).json({
-      ...contact,
+      ...publicContact,
       _verdict: verdict,
       _routing: assignee,
       _sla: slaMeta,
-      ...(Object.keys(customFields).length ? { _customFields: customFields } : {}),
+      ...(Object.keys(rawCustomFields).length ? { _customFields: rawCustomFields } : {}),
       ...(deduped ? { _deduped: true } : {}),
     });
   } catch (e) {
@@ -423,11 +492,14 @@ router.post("/leads", async (req, res) => {
         where: tenantWhere(req, { email: req.body.email }),
       });
       if (existing) {
-        const customFields = splitCustomLeadFields(req.body);
+        const { rawCustomFields, storageCustomFields } = splitCustomLeadFields(req.body);
+        if (Object.keys(storageCustomFields).length) {
+          await writeLeadCustomFieldValues(existing.id, req.tenantId, storageCustomFields);
+        }
         return res.status(200).json({
           ...existing,
           _deduped: true,
-          ...(Object.keys(customFields).length ? { _customFields: customFields } : {}),
+          ...(Object.keys(rawCustomFields).length ? { _customFields: rawCustomFields } : {}),
         });
       }
     }

--- a/backend/routes/gmail.js
+++ b/backend/routes/gmail.js
@@ -42,6 +42,9 @@ const {
   parseGmailMessage,
   extractEmailAddress,
 } = require("../lib/gmailMessage");
+const { requireTravelTenant } = require("../middleware/travelGuards");
+const { computeWindowOpenAt } = require("../lib/webCheckinWindow");
+const { GoogleGenerativeAI } = require("@google/generative-ai");
 
 // Memory-based upload — files stay as Buffers, never touch disk.
 // 25 MB per file (Gmail's attachment limit); 10 files max per send.
@@ -77,6 +80,16 @@ const SCOPES = [
 ];
 
 const PROVIDER = "google";
+
+// Gemini client for the Travel-vertical “email → web check-in” extraction.
+// Reuses the root .env loaded at the top of this file.
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "";
+let genAI = null;
+let geminiModel = null;
+if (GEMINI_API_KEY) {
+  genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+  geminiModel = genAI.getGenerativeModel({ model: process.env.GEMINI_MODEL || "gemini-2.5-flash" });
+}
 
 function buildOAuthClient() {
   return new google.auth.OAuth2(
@@ -295,7 +308,6 @@ router.get("/callback", async (req, res) => {
 // GET /status — is the current user's mailbox connected?
 router.get("/status", verifyToken, async (req, res) => {
   try {
-    const tenantId = req.user.tenantId;
     const integration = await prisma.gmailIntegration.findUnique({
       where: {
         tenantId_userId_provider: {
@@ -322,7 +334,6 @@ router.get("/status", verifyToken, async (req, res) => {
 // DELETE /disconnect — drop the integration row.
 router.delete("/disconnect", verifyToken, async (req, res) => {
   try {
-    const tenantId = req.user.tenantId;
     await prisma.gmailIntegration
       .delete({
         where: {
@@ -413,6 +424,256 @@ router.get("/messages", verifyToken, async (req, res) => {
       .json({ error: "Couldn't load your Gmail messages right now." });
   }
 });
+
+function safeJsonParse(str) {
+  if (!str || typeof str !== "string") return null;
+  const cleaned = str.replace(/^```json\s*|\s*```$/gi, "").trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+}
+
+function parseIsoOrNull(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+// POST /api/gmail/messages/:messageId/webcheckin
+//   Travel-vertical only. Reads the connected Gmail account, fetches the
+//   message + attachments, sends them to Gemini, and creates a WebCheckin row.
+//   MUST mount before `/messages/:messageId` so Express doesn't treat
+//   "webcheckin" as a message id.
+router.post(
+  "/messages/:messageId/webcheckin",
+  verifyToken,
+  requireTravelTenant,
+  async (req, res) => {
+    try {
+      if (!geminiModel) {
+        return res.status(400).json({
+          error: "Gemini is not configured on the server. Add GEMINI_API_KEY.",
+          code: "GEMINI_NOT_CONFIGURED",
+        });
+      }
+
+      const userId = req.user.userId;
+      const tenantId = req.user.tenantId;
+      const { messageId } = req.params;
+
+      const { client } = await getAuthorizedClientForUser(userId, tenantId);
+      const gmail = google.gmail({ version: "v1", auth: client });
+
+      // 1. Fetch the full message.
+      const full = await gmail.users.messages.get({
+        userId: "me",
+        id: messageId,
+        format: "full",
+      });
+      const parsed = parseGmailMessage(full.data);
+      if (!parsed) {
+        return res.status(404).json({ error: "Message not found", code: "MESSAGE_NOT_FOUND" });
+      }
+
+      // 2. Download every attachment into memory.
+      const attachmentBuffers = [];
+      if (Array.isArray(parsed.attachments)) {
+        for (const att of parsed.attachments) {
+          try {
+            const { data } = await gmail.users.messages.attachments.get({
+              userId: "me",
+              messageId,
+              id: att.attachmentId,
+            });
+            const buf = data && data.data
+              ? Buffer.from(data.data, "base64url")
+              : Buffer.alloc(0);
+            attachmentBuffers.push({ ...att, data: buf });
+          } catch (attErr) {
+            console.error(`[gmail/webcheckin] failed to download attachment ${att.attachmentId}:`, attErr.message);
+            // Continue without this attachment — don't fail the whole flow.
+          }
+        }
+      }
+
+      // 3. Build the multimodal Gemini prompt.
+      const emailContext = `Email subject: ${parsed.subject || "(no subject)"}
+From: ${parsed.from || "(unknown)"}
+Date: ${parsed.date || "(unknown)"}
+
+Body:
+${parsed.text || parsed.html || parsed.snippet || "(no body text)"}`;
+
+      const promptText = `You are an expert travel-document parser. Analyse the following airline email and any attached files (PDFs or images of tickets/boarding passes) and extract structured flight check-in details.
+
+${emailContext}
+
+Return ONLY a single JSON object with this exact shape (no markdown, no explanation):
+{
+  "isFlightTicket": true|false,
+  "confidence": 0.0-1.0,
+  "passengerName": "full name of the passenger",
+  "passengerEmail": "email if visible, else null",
+  "passengerPhone": "phone if visible, else null",
+  "pnr": "booking reference / PNR / confirmation code",
+  "airlineCode": "3-letter or 2-letter IATA airline code (e.g. EK, 6E, AI). Uppercase.",
+  "flightNumber": "flight number including airline prefix, e.g. EK-571 or 6E-1234",
+  "departureAt": "ISO-8601 datetime string in UTC if timezone is given, else local",
+  "seatPref": "seat preference if mentioned, else null",
+  "mealPref": "meal preference if mentioned, else null",
+  "notes": "any other useful check-in info"
+}
+
+Rules:
+- If the email is clearly NOT a flight ticket/booking, set isFlightTicket=false and confidence=0.
+- departureAt MUST be a valid ISO-8601 string (e.g. 2026-08-15T10:30:00Z or 2026-08-15T10:30:00+05:30). If only a date is given, use 00:00:00.
+- airlineCode should be just the carrier code (e.g. "EK"), not the full name.
+- flightNumber should include the airline prefix (e.g. "EK-571").
+- If multiple passengers are listed, use the first named adult passenger for passengerName.`;
+
+      const parts = [{ text: promptText }];
+      for (const att of attachmentBuffers) {
+        const mime = att.mimeType || "application/octet-stream";
+        if (mime.startsWith("image/") || mime === "application/pdf") {
+          parts.push({
+            inlineData: {
+              mimeType: mime,
+              data: att.data.toString("base64"),
+            },
+          });
+        }
+      }
+
+      let geminiResult;
+      try {
+        geminiResult = await geminiModel.generateContent({ contents: [{ role: "user", parts }] });
+      } catch (genErr) {
+        console.error("[gmail/webcheckin] Gemini error:", genErr.message || genErr);
+        return res.status(502).json({
+          error: "Failed to analyse the email with Gemini. Please try again.",
+          code: "GEMINI_ERROR",
+        });
+      }
+
+      const rawText = geminiResult?.response?.text?.() || "";
+      const extracted = safeJsonParse(rawText);
+      if (!extracted || typeof extracted !== "object") {
+        return res.status(502).json({
+          error: "Gemini returned an unparseable response.",
+          code: "GEMINI_MALFORMED",
+        });
+      }
+
+      if (extracted.isFlightTicket === false) {
+        return res.status(400).json({
+          error: "This email does not appear to be a flight ticket or booking.",
+          code: "NOT_FLIGHT_TICKET",
+          extracted,
+        });
+      }
+
+      const confidence = Number.isFinite(extracted.confidence) ? extracted.confidence : 0;
+      if (confidence < 0.5) {
+        return res.status(400).json({
+          error: "Could not confidently extract flight details from this email.",
+          code: "LOW_CONFIDENCE",
+          extracted,
+        });
+      }
+
+      const departureAt = parseIsoOrNull(extracted.departureAt);
+      if (!departureAt) {
+        return res.status(400).json({
+          error: "Could not determine the flight departure datetime.",
+          code: "MISSING_DEPARTURE",
+          extracted,
+        });
+      }
+
+      const airlineCode = String(extracted.airlineCode || "").toUpperCase().trim();
+      const flightNumber = String(extracted.flightNumber || "").trim();
+      const pnr = String(extracted.pnr || "").trim();
+      const passengerName = String(extracted.passengerName || "").trim();
+
+      if (!airlineCode || !flightNumber || !pnr || !passengerName) {
+        return res.status(400).json({
+          error: "Missing required flight details (airline, flight number, PNR, or passenger name).",
+          code: "INCOMPLETE_EXTRACTION",
+          extracted,
+        });
+      }
+
+      // 4. Resolve or auto-create the passenger Contact.
+      let contact = null;
+      if (extracted.passengerEmail) {
+        const email = String(extracted.passengerEmail).toLowerCase().trim();
+        contact = await prisma.contact.findFirst({
+          where: { tenantId, email },
+          select: { id: true },
+        });
+      }
+      if (!contact && passengerName) {
+        contact = await prisma.contact.findFirst({
+          where: { tenantId, name: passengerName },
+          select: { id: true },
+        });
+      }
+      if (!contact) {
+        contact = await prisma.contact.create({
+          data: {
+            tenantId,
+            name: passengerName || "Passenger",
+            email: extracted.passengerEmail || null,
+            phone: extracted.passengerPhone || null,
+            status: "Customer",
+            source: "email-webcheckin",
+          },
+        });
+      }
+
+      // 5. Create the WebCheckin row.
+      const windowOpenAt = computeWindowOpenAt(departureAt, airlineCode);
+      const webcheckin = await prisma.webCheckin.create({
+        data: {
+          tenantId,
+          contactId: contact.id,
+          itineraryId: null,
+          pnr,
+          airlineCode,
+          flightNumber,
+          departureAt,
+          windowOpenAt,
+          passengerName,
+          seatPref: extracted.seatPref || null,
+          mealPref: extracted.mealPref || null,
+          status: "pending",
+        },
+      });
+
+      return res.status(201).json({
+        success: true,
+        webcheckin,
+        contactId: contact.id,
+        extracted,
+      });
+    } catch (err) {
+      if (isReauthError(err)) {
+        return res.status(401).json({
+          error: "Your Gmail connection has expired. Please reconnect.",
+          code: "RECONNECT_REQUIRED",
+        });
+      }
+      if (isGmailNotEnabledError(err)) {
+        return res.status(400).json({ error: GMAIL_NOT_ENABLED_MSG, code: "GMAIL_NOT_ENABLED" });
+      }
+      if (err.status) return res.status(err.status).json({ error: err.message, code: err.code });
+      console.error("[gmail/webcheckin] error:", err);
+      return res.status(500).json({ error: "Could not create web check-in from this email." });
+    }
+  },
+);
 
 // GET /messages/:messageId — one full message, parsed.
 //

--- a/backend/routes/portal.js
+++ b/backend/routes/portal.js
@@ -471,10 +471,10 @@ router.get("/travel/itineraries", verifyPortalToken, requireTravelPortalTenant, 
         items: { orderBy: { position: "asc" } },
       },
     });
-    // Attach a web-check-in "due" flag per trip: any active WebCheckin row
-    // (pending/reminded) whose flight departs within the next 36h. Drives the
-    // portal's "Have you checked in? Yes/No" banner (2026-06-16). The Yes
-    // action flips those rows to "done" → flag clears + reminders stop.
+    // Attach a web-check-in "due" flag per trip: any pending WebCheckin row
+    // whose flight departs within the next 36h. Drives the portal's
+    // "Have you checked in? Yes/No" banner (2026-06-16). The Yes action flips
+    // those rows to "done" → flag clears + reminders stop.
     const ids = itineraries.map((i) => i.id);
     let dueByItin = {};
     if (ids.length) {
@@ -484,7 +484,7 @@ router.get("/travel/itineraries", verifyPortalToken, requireTravelPortalTenant, 
         where: {
           tenantId: req.portal.tenantId,
           itineraryId: { in: ids },
-          status: { in: ["pending", "reminded"] },
+          status: "pending",
           departureAt: { gte: now, lte: horizon },
         },
         select: { itineraryId: true },
@@ -833,11 +833,10 @@ router.post("/travel/itineraries/:id/preferred-dates", verifyPortalToken, requir
 // POST /api/portal/travel/itineraries/:id/webcheckin-confirm
 //
 // The customer's "Yes, I've checked in" action for a flight trip (2026-06-16).
-// Flips every still-active WebCheckin row for this trip → status "done" — the
-// SAME rows the existing webCheckinScheduler + the email engine read, so this
-// one confirm stops BOTH (no more reminder emails, no agent-fallback
-// escalation). Ownership verified by loadPortalOwnedItinerary. Idempotent: if
-// no active rows remain it's a no-op success (updated: 0).
+// Flips every still-pending WebCheckin row for this trip → status "done" —
+// the SAME rows the email engine reads, so this one confirm stops reminders.
+// Ownership verified by loadPortalOwnedItinerary. Idempotent: if no pending
+// rows remain it's a no-op success (updated: 0).
 router.post("/travel/itineraries/:id/webcheckin-confirm", verifyPortalToken, requireTravelPortalTenant, async (req, res) => {
   try {
     const itin = await loadPortalOwnedItinerary(req, res);
@@ -846,7 +845,7 @@ router.post("/travel/itineraries/:id/webcheckin-confirm", verifyPortalToken, req
       where: {
         itineraryId: itin.id,
         tenantId: req.portal.tenantId,
-        status: { in: ["pending", "reminded"] },
+        status: "pending",
       },
       data: { status: "done" },
     });

--- a/backend/routes/travel_webcheckin.js
+++ b/backend/routes/travel_webcheckin.js
@@ -55,14 +55,7 @@ const { resolveForSubBrand } = require("../lib/subBrandConfig");
 // const watiClient = require("../services/watiClient"); // legacy Wati REST (disabled)
 const watiClient = require("../services/whatsappWebClient"); // connected WhatsApp Web (drop-in)
 
-const VALID_STATUSES = Object.freeze([
-  "pending",
-  "reminded",
-  "in-progress",
-  "done",
-  "fallback-agent",
-  "failed",
-]);
+const VALID_STATUSES = Object.freeze(["pending", "done"]);
 
 // ─── Multer config: boarding-pass upload ─────────────────────────────
 //
@@ -153,7 +146,7 @@ router.get("/webcheckins", verifyToken, requireTravelTenant, async (req, res) =>
 });
 
 // GET /api/travel/webcheckins/upcoming — windowOpenAt within next 48h,
-// status in (pending, reminded). MUST mount before /:id.
+// status = pending. MUST mount before /:id.
 router.get("/webcheckins/upcoming", verifyToken, requireTravelTenant, async (req, res) => {
   try {
     const now = new Date();
@@ -161,7 +154,7 @@ router.get("/webcheckins/upcoming", verifyToken, requireTravelTenant, async (req
     const rows = await prisma.webCheckin.findMany({
       where: {
         tenantId: req.travelTenant.id,
-        status: { in: ["pending", "reminded"] },
+        status: "pending",
         windowOpenAt: { gte: now, lte: horizon },
       },
       orderBy: { windowOpenAt: "asc" },
@@ -1200,10 +1193,8 @@ router.post(
 );
 
 // PATCH /api/travel/webcheckins/:id — amend assignedAgentId, seatPref,
-// mealPref, status, attemptsJson, boardingPassUrl. The scheduler cron
-// owns 'pending → reminded → fallback-agent' transitions; this endpoint
-// exists for the operator to explicitly mark 'done' / 'failed' or
-// reassign to an agent.
+// mealPref, status, attemptsJson, boardingPassUrl. Status is binary:
+// pending → done (done when boarding pass uploaded or customer confirmed).
 router.patch(
   "/webcheckins/:id",
   verifyToken,
@@ -1408,47 +1399,20 @@ router.post(
   },
 );
 
-// POST /api/travel/webcheckins/:id/automation/retry — manually re-arm the
-// automation engine for a row (PRD FR-12). Resets status to 'reminded' and
-// clears attemptsJson so the engine treats it as a fresh attempt on its next
-// tick. Use case: airline portal was down at the original window and has since
-// recovered. ADMIN+MANAGER gated (web_checkins.update).
+// POST /api/travel/webcheckins/:id/automation/retry — DISABLED.
+// Automation is off for this vertical; all check-ins are handled manually
+// via the Web Check-ins queue. Kept as a 409 so any stale client call fails
+// clearly instead of 404-ing.
 router.post(
   "/webcheckins/:id/automation/retry",
   verifyToken,
   requirePermission("web_checkins", "update"),
   requireTravelTenant,
-  async (req, res) => {
-    try {
-      const id = parseInt(req.params.id, 10);
-      if (!Number.isFinite(id)) {
-        return res.status(400).json({ error: "id must be a number", code: "INVALID_ID" });
-      }
-      const existing = await prisma.webCheckin.findFirst({
-        where: { id, tenantId: req.travelTenant.id },
-      });
-      if (!existing) return res.status(404).json({ error: "Web check-in not found", code: "NOT_FOUND" });
-      if (existing.status === "done") {
-        return res.status(409).json({
-          error: "Check-in already completed — nothing to retry",
-          code: "ALREADY_DONE",
-        });
-      }
-      if (existing.automationSkipped) {
-        return res.status(409).json({
-          error: "Automation is skipped for this row — clear automationSkipped first",
-          code: "AUTOMATION_SKIPPED",
-        });
-      }
-      const updated = await prisma.webCheckin.update({
-        where: { id },
-        data: { status: "reminded", attemptsJson: null },
-      });
-      res.json({ ok: true, webcheckin: updated });
-    } catch (e) {
-      console.error("[travel-webcheckin] automation retry error:", e.message);
-      res.status(500).json({ error: "Failed to re-arm automation" });
-    }
+  async (_req, res) => {
+    return res.status(409).json({
+      error: "Check-in automation is disabled — handle this check-in manually.",
+      code: "AUTOMATION_DISABLED",
+    });
   },
 );
 

--- a/backend/scripts/seed-webcheckin-demo.js
+++ b/backend/scripts/seed-webcheckin-demo.js
@@ -1,18 +1,14 @@
 #!/usr/bin/env node
 /**
- * Demo seed for the web check-in AUTOMATION feature
- * (PRD_AIRLINE_WEBCHECKIN_AUTOMATION). Creates, for tenant 1:
+ * Demo seed for the Web Check-ins queue (manual-only model).
+ * Creates, for tenant 1:
  *   - a demo contact
- *   - a PAID, non-Visa-Sure (tmc) itinerary  ← the engine's gate
- *   - 3 WebCheckin rows in status 'reminded' whose PNR prefix drives the
- *     deterministic stub adapter (services/airlineAdapters/_stub.js):
- *         OK6E...     (6E / IndiGo)   -> success      -> status 'done'
- *         CAPTCHAEK.. (EK / Emirates) -> captcha      -> 'fallback-agent'
- *         FAILAI...   (AI / Air India)-> transient    -> retries -> 'fallback-agent'
+ *   - a PAID, non-Visa-Sure (tmc) itinerary
+ *   - 3 WebCheckin rows in status 'pending' with departureAt within the next
+ *     24 hours so the scheduler cron will notify operators on its next tick.
  *
  * Usage (from backend/):
  *   node scripts/seed-webcheckin-demo.js
- *   WEBCHECKIN_AUTOMATION_STUB=1 node -e "require('./cron/webCheckinAutomation').runWebCheckinAutomationTick().then(s=>console.log(s))"
  *
  * Idempotent-ish: re-running creates a fresh itinerary + rows each time (so you
  * can re-demo). Delete demo rows in Prisma Studio when done. Tenant 1 must exist
@@ -43,14 +39,14 @@ async function main() {
       contactId: contact.id,
       destination: "Dubai",
       subBrand: "tmc",
-      status: "fully_paid", // PAID gate the engine requires
+      status: "fully_paid",
     },
   });
 
   const flights = [
-    { pnr: "OK6E01", airlineCode: "6E", flightNumber: "6E-201", note: "-> success" },
-    { pnr: "CAPTCHAEK1", airlineCode: "EK", flightNumber: "EK-512", note: "-> captcha/fallback" },
-    { pnr: "FAILAI1", airlineCode: "AI", flightNumber: "AI-840", note: "-> retry/fallback" },
+    { pnr: "DEMO6E01", airlineCode: "6E", flightNumber: "6E-201" },
+    { pnr: "DEMOEK01", airlineCode: "EK", flightNumber: "EK-512" },
+    { pnr: "DEMOAI01", airlineCode: "AI", flightNumber: "AI-840" },
   ];
 
   const made = [];
@@ -64,21 +60,19 @@ async function main() {
         airlineCode: f.airlineCode,
         flightNumber: f.flightNumber,
         passengerName: "Web Check-in Demo Passenger",
-        departureAt: new Date(now + 30 * HOUR), // future flight
-        windowOpenAt: new Date(now - 2 * HOUR), // window already open
-        status: "reminded", // ready for the engine to pick up
-        automationSkipped: false,
+        departureAt: new Date(now + 12 * HOUR), // within 24h → scheduler will notify
+        windowOpenAt: new Date(now - 2 * HOUR),
+        status: "pending",
       },
     });
     made.push({ id: row.id, ...f });
   }
 
-  console.log("Seeded demo web check-in automation data:");
+  console.log("Seeded demo web check-in queue data:");
   console.log("  contact   id =", contact.id);
   console.log("  itinerary id =", itinerary.id, "(status fully_paid, subBrand tmc)");
-  for (const m of made) console.log(`  webcheckin id = ${m.id}  ${m.airlineCode} ${m.pnr}  ${m.note}`);
-  console.log("\nNext: run the engine tick with the stub adapter:");
-  console.log("  WEBCHECKIN_AUTOMATION_STUB=1 node -e \"require('./cron/webCheckinAutomation').runWebCheckinAutomationTick().then(s=>console.log(s))\"");
+  for (const m of made) console.log(`  webcheckin id = ${m.id}  ${m.airlineCode} ${m.pnr}`);
+  console.log("\nNext: wait for the scheduler cron (every 15 min) or open /travel/web-checkins.");
 }
 
 main()

--- a/backend/server.js
+++ b/backend/server.js
@@ -2304,10 +2304,9 @@ if (process.env.DISABLE_CRONS === "1") {
   console.log("✓ Cron engine: visaRiskFlagEngine (every 6 hours)");
 
   // Initialize Travel CRM web check-in scheduler (every 15 min).
-  // PRD §4.6 + §6.3 row 1 — flips WebCheckin status pending → reminded
-  // when windowOpenAt arrives, then reminded → fallback-agent if stalled
-  // 30m+. Browser-automation half (P1B) deferred — this scheduler only
-  // handles the tracking + reminder side.
+  // Notifies the assigned agent (or all admins/managers if unassigned) when a
+  // pending WebCheckin has departureAt within the next 24 hours. Status model
+  // is binary pending/done; no automation, no fallback-agent transitions.
   const { initWebCheckinSchedulerCron } = require("./cron/webCheckinScheduler");
   initWebCheckinSchedulerCron();
 

--- a/backend/test/cron/leadScoringEngine.test.js
+++ b/backend/test/cron/leadScoringEngine.test.js
@@ -139,6 +139,7 @@ const { mockGenerateContent } = vi.hoisted(() => {
 import {
   computeScore,
   tickLeadScoringEngine,
+  scoreContactsByIds,
 } from '../../cron/leadScoringEngine.js';
 
 beforeAll(() => {
@@ -851,6 +852,69 @@ describe('tickLeadScoringEngine — orchestration', () => {
     const dbErr = new Error('DB unreachable');
     prisma.contact.findMany.mockRejectedValueOnce(dbErr);
     await expect(tickLeadScoringEngine(null)).rejects.toThrow('DB unreachable');
+  });
+});
+
+// ─── scoreContactsByIds — on-demand sequential scoring ────────────────────
+
+describe('scoreContactsByIds — on-demand sequential scoring', () => {
+  test('happy path: scores provided contacts sequentially and returns counts', async () => {
+    prisma.contact.findMany.mockResolvedValue([
+      contactWith({ id: 11, status: 'Customer' }),
+      contactWith({ id: 22, status: 'Lead' }),
+    ]);
+
+    const result = await scoreContactsByIds(1, [11, 22], null);
+
+    expect(result).toEqual({ scored: 2, errors: 0 });
+    expect(prisma.contact.findMany).toHaveBeenCalledTimes(1);
+    const findArg = prisma.contact.findMany.mock.calls[0][0];
+    expect(findArg.where.tenantId).toBe(1);
+    expect(findArg.where.id.in).toEqual([11, 22]);
+    expect(prisma.contact.update).toHaveBeenCalledTimes(2);
+    for (const call of prisma.contact.update.mock.calls) {
+      const arg = call[0];
+      expect(arg.data).toHaveProperty('aiScore');
+      expect(arg.data).toHaveProperty('aiScoreLastComputedAt');
+    }
+  });
+
+  test('deduplicates and caps contactIds at 100', async () => {
+    prisma.contact.findMany.mockResolvedValue([]);
+    const ids = Array.from({ length: 150 }, (_, i) => i + 1);
+    await scoreContactsByIds(1, ids, null);
+    const findArg = prisma.contact.findMany.mock.calls[0][0];
+    expect(findArg.where.id.in.length).toBe(100);
+  });
+
+  test('emits lead_scores_updated when io is supplied', async () => {
+    prisma.contact.findMany.mockResolvedValue([contactWith({ id: 7 })]);
+    const io = { emit: vi.fn() };
+    await scoreContactsByIds(1, [7], io);
+    expect(io.emit).toHaveBeenCalledTimes(1);
+    const [event, payload] = io.emit.mock.calls[0];
+    expect(event).toBe('lead_scores_updated');
+    expect(payload.count).toBe(1);
+  });
+
+  test('tolerates single-contact update failures and counts them as errors', async () => {
+    prisma.contact.findMany.mockResolvedValue([
+      contactWith({ id: 31 }),
+      contactWith({ id: 32 }),
+    ]);
+    prisma.contact.update
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('deadlock'));
+
+    const result = await scoreContactsByIds(1, [31, 32], null);
+
+    expect(result).toEqual({ scored: 1, errors: 1 });
+  });
+
+  test('empty or invalid input returns zero counts without touching DB', async () => {
+    expect(await scoreContactsByIds(1, [], null)).toEqual({ scored: 0, errors: 0 });
+    expect(await scoreContactsByIds(null, [1], null)).toEqual({ scored: 0, errors: 0 });
+    expect(prisma.contact.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/test/cron/webCheckinEngine.test.js
+++ b/backend/test/cron/webCheckinEngine.test.js
@@ -43,7 +43,7 @@ describe("webCheckinEngine — scope query", () => {
     prisma.webCheckin.findMany.mockResolvedValue([]);
     await runWebCheckinTick(NOW);
     const where = prisma.webCheckin.findMany.mock.calls[0][0].where;
-    expect(where.status).toEqual({ in: ["pending", "reminded"] });
+    expect(where.status).toEqual("pending");
     expect(where.itineraryId).toEqual({ not: null });
     expect(where.departureAt).toHaveProperty("gte");
     expect(where.departureAt).toHaveProperty("lte");

--- a/backend/test/cron/webCheckinScheduler.test.js
+++ b/backend/test/cron/webCheckinScheduler.test.js
@@ -1,23 +1,17 @@
 /**
  * Unit tests for backend/cron/webCheckinScheduler.js — Travel CRM
- * web check-in lifecycle scheduler. Mirrors the tripPaymentReminders
- * mocking pattern.
+ * web check-in scheduler (manual-only model).
  *
  * Branches covered:
  *   runWebCheckinSchedulerForTenant:
- *     - query shape: tenant + status ∈ {pending, reminded} + windowOpenAt
- *       within look-ahead bound
- *     - empty result → fast-path {reminded:0, fallback:0}
- *     - pending with windowOpenAt in past → reminded transition +
- *       notification (type='info')
- *     - pending with windowOpenAt still in future → no transition
- *     - reminded but updatedAt > 30m ago → fallback-agent transition +
- *       warning notification
- *     - reminded but recently updated → no fallback
- *     - dedup: existing reminded-info notification → still flip status,
- *       skip notification create
- *     - dedup: existing fallback warning → no second fallback
- *     - race-tolerance: update throws → cron continues, next row processes
+ *     - query shape: tenant + status = pending + departureAt within next 24h
+ *     - empty result → fast-path {notifiedUsers: 0}
+ *     - pending with departureAt > 24h away → no notification
+ *     - pending with departureAt within 24h + assignedAgentId → notify agent
+ *     - pending with departureAt within 24h + no agent → notify all ADMIN/MANAGER
+ *     - dedup: existing notification within 24h → skip
+ *     - done rows are ignored
+ *     - race-tolerance: notification create throws → cron continues
  */
 
 import { describe, test, expect, vi, beforeAll, beforeEach } from 'vitest';
@@ -29,363 +23,195 @@ import {
 } from '../../cron/webCheckinScheduler.js';
 
 beforeAll(() => {
-  prisma.webCheckin = { findMany: vi.fn(), update: vi.fn() };
+  prisma.webCheckin = { findMany: vi.fn() };
+  prisma.user = { findUnique: vi.fn(), findMany: vi.fn() };
   prisma.notification = { findFirst: vi.fn(), create: vi.fn() };
-  // subBrandConfig resolver pull — Q9 cut-over plumbing reads tenant
-  // .subBrandConfigJson once per pass + itinerary.findMany to map the
-  // checkin → parent itinerary's subBrand for the per-checkin wabaId log.
-  prisma.tenant = { findUnique: vi.fn(), findMany: vi.fn() };
-  prisma.itinerary = { findMany: vi.fn() };
+  prisma.notificationPreference = { findUnique: vi.fn() };
+  prisma.tenant = { findMany: vi.fn() };
 });
 
 beforeEach(() => {
   prisma.webCheckin.findMany.mockReset();
-  prisma.webCheckin.update.mockReset();
+  prisma.user.findUnique.mockReset();
+  prisma.user.findMany.mockReset();
   prisma.notification.findFirst.mockReset();
   prisma.notification.create.mockReset();
-  prisma.tenant.findUnique.mockReset();
+  prisma.notificationPreference.findUnique.mockReset();
   prisma.tenant.findMany.mockReset();
-  prisma.itinerary.findMany.mockReset();
 
   prisma.webCheckin.findMany.mockResolvedValue([]);
-  prisma.webCheckin.update.mockResolvedValue({ id: 1 });
+  prisma.user.findMany.mockResolvedValue([]);
+  prisma.user.findUnique.mockResolvedValue(null);
   prisma.notification.findFirst.mockResolvedValue(null);
-  prisma.notification.create.mockResolvedValue({ id: 1 });
-  prisma.tenant.findUnique.mockResolvedValue({ subBrandConfigJson: null });
+  prisma.notification.create.mockImplementation(({ data }) => Promise.resolve({ id: 1, ...data }));
+  prisma.notificationPreference.findUnique.mockResolvedValue(null);
   prisma.tenant.findMany.mockResolvedValue([]);
-  prisma.itinerary.findMany.mockResolvedValue([]);
 });
 
 describe('cron/webCheckinScheduler — runWebCheckinSchedulerForTenant', () => {
-  test('query shape: tenant + status enum + windowOpenAt lookahead', async () => {
+  test('query shape: tenant + status pending + departureAt within 24h', async () => {
     await runWebCheckinSchedulerForTenant(42);
     expect(prisma.webCheckin.findMany).toHaveBeenCalledTimes(1);
     const arg = prisma.webCheckin.findMany.mock.calls[0][0];
     expect(arg.where.tenantId).toBe(42);
-    expect(arg.where.status).toEqual({ in: ['pending', 'reminded'] });
-    expect(arg.where.windowOpenAt).toHaveProperty('lte');
-    expect(arg.where.windowOpenAt.lte).toBeInstanceOf(Date);
-    // Lookahead should be ~now + 7d
-    const expected = Date.now() + 7 * 86400_000;
-    expect(arg.where.windowOpenAt.lte.getTime()).toBeGreaterThanOrEqual(expected - 1000);
-    expect(arg.where.windowOpenAt.lte.getTime()).toBeLessThanOrEqual(expected + 1000);
+    expect(arg.where.status).toBe('pending');
+    expect(arg.where.departureAt).toHaveProperty('gte');
+    expect(arg.where.departureAt).toHaveProperty('lte');
+    const span = arg.where.departureAt.lte.getTime() - arg.where.departureAt.gte.getTime();
+    expect(span).toBeGreaterThanOrEqual(24 * 3600_000 - 1000);
+    expect(span).toBeLessThanOrEqual(24 * 3600_000 + 1000);
   });
 
-  test('empty rows → fast-path {reminded:0, fallback:0}, no update/notification calls', async () => {
+  test('empty rows → fast-path {notifiedUsers:0}, no notification calls', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([]);
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 0, fallback: 0 });
-    expect(prisma.webCheckin.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ notifiedUsers: 0 });
     expect(prisma.notification.create).not.toHaveBeenCalled();
   });
 
-  test('pending with windowOpenAt 5min ago → flips to reminded + info notification', async () => {
-    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+  test('pending departure > 24h away → no notification', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       {
         id: 100, pnr: 'ABC123', airlineCode: '6E', flightNumber: '203',
-        passengerName: 'Alice', windowOpenAt: fiveMinAgo, status: 'pending',
-        updatedAt: fiveMinAgo,
+        passengerName: 'Alice', departureAt: new Date(Date.now() + 48 * 3600_000),
+        assignedAgentId: null,
       },
     ]);
-
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 1, fallback: 0 });
-    expect(prisma.webCheckin.update).toHaveBeenCalledWith({
-      where: { id: 100 },
-      data: { status: 'reminded' },
-    });
-    const noteArg = prisma.notification.create.mock.calls[0][0];
-    expect(noteArg.data.entityType).toBe('WebCheckin');
-    expect(noteArg.data.entityId).toBe(100);
-    expect(noteArg.data.type).toBe('info');
+    expect(result).toEqual({ notifiedUsers: 0 });
+    expect(prisma.notification.create).not.toHaveBeenCalled();
   });
 
-  test('pending with windowOpenAt in future → no transition', async () => {
-    const twoHoursAhead = new Date(Date.now() + 2 * 3600 * 1000);
+  test('pending within 24h + assignedAgentId → notify that agent only', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       {
         id: 100, pnr: 'ABC123', airlineCode: '6E', flightNumber: '203',
-        passengerName: 'Alice', windowOpenAt: twoHoursAhead, status: 'pending',
-        updatedAt: twoHoursAhead,
+        passengerName: 'Alice', departureAt: new Date(Date.now() + 6 * 3600_000),
+        assignedAgentId: 7,
       },
     ]);
+    prisma.user.findUnique.mockResolvedValue({ id: 7, tenantId: 1 });
 
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 0, fallback: 0 });
-    expect(prisma.webCheckin.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ notifiedUsers: 1 });
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: 7 }, select: { id: true, tenantId: true } });
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+    const note = prisma.notification.create.mock.calls[0][0].data;
+    expect(note.userId).toBe(7);
+    expect(note.entityType).toBe('WebCheckin');
+    expect(note.entityId).toBe(100);
+    expect(note.type).toBe('warning');
+    expect(note.priority).toBe('high');
   });
 
-  test('reminded stalled 45min ago → fallback-agent + warning notification', async () => {
-    const stalledAt = new Date(Date.now() - 45 * 60 * 1000);
+  test('pending within 24h + no assigned agent → notify all ADMIN/MANAGER', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       {
         id: 200, pnr: 'XYZ999', airlineCode: 'AI', flightNumber: '101',
-        passengerName: 'Bob', windowOpenAt: stalledAt, status: 'reminded',
-        updatedAt: stalledAt,
+        passengerName: 'Bob', departureAt: new Date(Date.now() + 4 * 3600_000),
+        assignedAgentId: null,
       },
+    ]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: 1 },
+      { id: 2 },
     ]);
 
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 0, fallback: 1 });
-    expect(prisma.webCheckin.update).toHaveBeenCalledWith({
-      where: { id: 200 },
-      data: { status: 'fallback-agent' },
-    });
-    const noteArg = prisma.notification.create.mock.calls[0][0];
-    expect(noteArg.data.type).toBe('warning');
-    expect(noteArg.data.priority).toBe('high');
+    expect(result).toEqual({ notifiedUsers: 2 });
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ tenantId: 1, role: { in: ['ADMIN', 'MANAGER'] } }),
+      }),
+    );
+    const userIds = prisma.notification.create.mock.calls.map((c) => c[0].data.userId).sort();
+    expect(userIds).toEqual([1, 2]);
   });
 
-  test('reminded recently (5 min ago) → no fallback (within stall window)', async () => {
-    const recentAt = new Date(Date.now() - 5 * 60 * 1000);
+  test('dedup: existing notification within 24h → skip', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       {
-        id: 200, pnr: 'XYZ999', airlineCode: 'AI', flightNumber: '101',
-        passengerName: 'Bob', windowOpenAt: recentAt, status: 'reminded',
-        updatedAt: recentAt,
+        id: 300, pnr: 'DEDUP', airlineCode: '6E', flightNumber: '100',
+        passengerName: 'Charlie', departureAt: new Date(Date.now() + 2 * 3600_000),
+        assignedAgentId: 7,
       },
     ]);
-
-    const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 0, fallback: 0 });
-    expect(prisma.webCheckin.update).not.toHaveBeenCalled();
-  });
-
-  test('dedup on fallback: existing warning notification → no double-fallback', async () => {
-    const stalledAt = new Date(Date.now() - 45 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 200, pnr: 'XYZ999', airlineCode: 'AI', flightNumber: '101',
-        passengerName: 'Bob', windowOpenAt: stalledAt, status: 'reminded',
-        updatedAt: stalledAt,
-      },
-    ]);
-    prisma.notification.findFirst.mockResolvedValue({ id: 99 });
-
-    const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 0, fallback: 0 });
-    expect(prisma.webCheckin.update).not.toHaveBeenCalled();
-  });
-
-  test('race-tolerance: webCheckin.update throws → next row still processes', async () => {
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      { id: 100, pnr: 'A', airlineCode: '6E', flightNumber: '1', passengerName: 'A', windowOpenAt: past, status: 'pending', updatedAt: past },
-      { id: 101, pnr: 'B', airlineCode: '6E', flightNumber: '2', passengerName: 'B', windowOpenAt: past, status: 'pending', updatedAt: past },
-    ]);
-    prisma.webCheckin.update
-      .mockRejectedValueOnce(new Error('race'))
-      .mockResolvedValueOnce({ id: 101 });
-
-    const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result.reminded).toBe(1);
-  });
-
-  test('NaN windowOpenAt → row skipped (Number.isNaN guard) — no transition, no notification', async () => {
-    // SUT line 94 guards against Date constructor returning NaN. Send a
-    // garbage timestamp; cron must skip + continue to next row, not crash.
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 300, pnr: 'NAN1', airlineCode: '6E', flightNumber: '999',
-        passengerName: 'GarbageDate', windowOpenAt: 'not-a-date',
-        status: 'pending', updatedAt: past,
-      },
-      // valid sibling row must still fire — proves the NaN guard `continue`s
-      // rather than short-circuiting the whole loop.
-      {
-        id: 301, pnr: 'OK1', airlineCode: '6E', flightNumber: '1',
-        passengerName: 'Valid', windowOpenAt: past, status: 'pending',
-        updatedAt: past,
-      },
-    ]);
-
-    const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 1, fallback: 0 });
-    // only row 301 was updated; row 300 (NaN) skipped
-    expect(prisma.webCheckin.update).toHaveBeenCalledTimes(1);
-    expect(prisma.webCheckin.update).toHaveBeenCalledWith({
-      where: { id: 301 },
-      data: { status: 'reminded' },
-    });
-  });
-
-  test('dedup on reminded: existing info notification → still flips status, skips notification.create', async () => {
-    // SUT lines 98-122: when a prior notification for this checkin already
-    // exists, the status update still happens (idempotent flip) but the
-    // notification.create is skipped (no double-fire).
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 400, pnr: 'DEDUP', airlineCode: '6E', flightNumber: '100',
-        passengerName: 'Charlie', windowOpenAt: past, status: 'pending',
-        updatedAt: past,
-      },
-    ]);
+    prisma.user.findUnique.mockResolvedValue({ id: 7, tenantId: 1 });
     prisma.notification.findFirst.mockResolvedValue({ id: 9999 });
 
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 1, fallback: 0 });
-    // status was still flipped
-    expect(prisma.webCheckin.update).toHaveBeenCalledWith({
-      where: { id: 400 },
-      data: { status: 'reminded' },
-    });
-    // but no second notification created
+    expect(result).toEqual({ notifiedUsers: 0 });
     expect(prisma.notification.create).not.toHaveBeenCalled();
   });
 
-  test('mixed batch: pending + stalled reminded → both transitions in single pass', async () => {
-    // Realistic Phase-1 tick: one freshly-opened checkin (pending → reminded)
-    // and one stalled checkin (reminded → fallback-agent). Both should fire
-    // independently in the same pass; result aggregates both counters.
-    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
-    const fortyFiveMinAgo = new Date(Date.now() - 45 * 60 * 1000);
+  test('done rows are ignored', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       {
-        id: 500, pnr: 'PEND', airlineCode: '6E', flightNumber: '200',
-        passengerName: 'Pending Pat', windowOpenAt: fiveMinAgo, status: 'pending',
-        updatedAt: fiveMinAgo,
-      },
-      {
-        id: 501, pnr: 'STAL', airlineCode: 'AI', flightNumber: '301',
-        passengerName: 'Stalled Sam', windowOpenAt: fortyFiveMinAgo,
-        status: 'reminded', updatedAt: fortyFiveMinAgo,
+        id: 400, pnr: 'DONE1', airlineCode: '6E', flightNumber: '1',
+        passengerName: 'Done Passenger', departureAt: new Date(Date.now() + 2 * 3600_000),
+        assignedAgentId: null,
       },
     ]);
+    // The cron query filters status='pending', so if findMany returns a row it
+    // would normally notify. To prove done rows are ignored we rely on the
+    // where clause; the real DB will not return them.
+    const result = await runWebCheckinSchedulerForTenant(1);
+    expect(result.notifiedUsers).toBeGreaterThanOrEqual(0);
+    expect(prisma.webCheckin.findMany.mock.calls[0][0].where.status).toBe('pending');
+  });
+
+  test('race-tolerance: notification create throws → next row still processes', async () => {
+    prisma.webCheckin.findMany.mockResolvedValue([
+      { id: 500, pnr: 'A', airlineCode: '6E', flightNumber: '1', passengerName: 'A', departureAt: new Date(Date.now() + 2 * 3600_000), assignedAgentId: null },
+      { id: 501, pnr: 'B', airlineCode: '6E', flightNumber: '2', passengerName: 'B', departureAt: new Date(Date.now() + 3 * 3600_000), assignedAgentId: null },
+    ]);
+    prisma.user.findMany.mockResolvedValue([{ id: 9 }]);
+    prisma.notification.create
+      .mockRejectedValueOnce(new Error('race'))
+      .mockImplementation(({ data }) => Promise.resolve({ id: 2, ...data }));
 
     const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 1, fallback: 1 });
-    expect(prisma.webCheckin.update).toHaveBeenCalledTimes(2);
-    // Both notifications fired — one info, one warning
-    expect(prisma.notification.create).toHaveBeenCalledTimes(2);
-    const types = prisma.notification.create.mock.calls.map((c) => c[0].data.type);
-    expect(types.sort()).toEqual(['info', 'warning']);
-  });
-
-  test('itinerary subBrand lookup: rows with itineraryId trigger itinerary.findMany pre-fetch (no N+1)', async () => {
-    // SUT lines 79-87: when checkin rows reference itineraryIds, the cron
-    // pre-fetches the itinerary→subBrand map in ONE batch query (not N+1).
-    // Distinct itineraryIds across multiple rows → one findMany call.
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 600, pnr: 'A', airlineCode: '6E', flightNumber: '1', passengerName: 'A',
-        windowOpenAt: past, status: 'pending', updatedAt: past, itineraryId: 11,
-      },
-      {
-        id: 601, pnr: 'B', airlineCode: '6E', flightNumber: '2', passengerName: 'B',
-        windowOpenAt: past, status: 'pending', updatedAt: past, itineraryId: 22,
-      },
-      // duplicate itineraryId — should be deduped by the Set
-      {
-        id: 602, pnr: 'C', airlineCode: '6E', flightNumber: '3', passengerName: 'C',
-        windowOpenAt: past, status: 'pending', updatedAt: past, itineraryId: 11,
-      },
-    ]);
-    prisma.itinerary.findMany.mockResolvedValue([
-      { id: 11, subBrand: 'tmc' },
-      { id: 22, subBrand: 'rfu' },
-    ]);
-
-    await runWebCheckinSchedulerForTenant(7);
-
-    // exactly ONE batch query for itineraries
-    expect(prisma.itinerary.findMany).toHaveBeenCalledTimes(1);
-    const itinArg = prisma.itinerary.findMany.mock.calls[0][0];
-    // deduped: 2 distinct IDs (11, 22), not 3
-    expect(itinArg.where.id.in.sort()).toEqual([11, 22]);
-    // scoped to tenant
-    expect(itinArg.where.tenantId).toBe(7);
-  });
-
-  test('no itineraryId on any row → itinerary.findMany skipped entirely', async () => {
-    // SUT line 81 `if (itinIds.length > 0)` guard: when no checkin row has
-    // an itineraryId, the cron must NOT issue an empty `WHERE id IN ()` query.
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 700, pnr: 'NOITIN', airlineCode: '6E', flightNumber: '1',
-        passengerName: 'Orphan', windowOpenAt: past, status: 'pending',
-        updatedAt: past, itineraryId: null,
-      },
-    ]);
-
-    const result = await runWebCheckinSchedulerForTenant(1);
-    expect(result).toEqual({ reminded: 1, fallback: 0 });
-    expect(prisma.itinerary.findMany).not.toHaveBeenCalled();
-  });
-
-  test('fallback dedup: notification.findFirst not called when status is "pending" (only "reminded" path checks fallback dedup)', async () => {
-    // SUT branches: for `status='pending'`, the dedup query looks for a
-    // type='info' notification. For `status='reminded'`, it looks for
-    // type='warning'. Make sure the right type is queried per branch.
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    prisma.webCheckin.findMany.mockResolvedValue([
-      {
-        id: 800, pnr: 'TYPE1', airlineCode: '6E', flightNumber: '1', passengerName: 'Pat',
-        windowOpenAt: past, status: 'pending', updatedAt: past,
-      },
-    ]);
-
-    await runWebCheckinSchedulerForTenant(1);
-
-    expect(prisma.notification.findFirst).toHaveBeenCalledTimes(1);
-    const queryArg = prisma.notification.findFirst.mock.calls[0][0];
-    expect(queryArg.where.type).toBe('info');
-    expect(queryArg.where.entityType).toBe('WebCheckin');
-    expect(queryArg.where.entityId).toBe(800);
+    expect(result).toEqual({ notifiedUsers: 1 });
   });
 });
 
 describe('cron/webCheckinScheduler — runWebCheckinSchedulerForAllTravelTenants', () => {
   test('empty travel-tenant list → fast-path zero totals', async () => {
     prisma.tenant.findMany.mockResolvedValue([]);
-
     const result = await runWebCheckinSchedulerForAllTravelTenants();
-    expect(result).toEqual({ reminded: 0, fallback: 0 });
-    // no per-tenant work should fire
+    expect(result).toEqual({ notifiedUsers: 0 });
     expect(prisma.webCheckin.findMany).not.toHaveBeenCalled();
   });
 
-  test('multi-tenant: aggregates reminded + fallback counters across tenants', async () => {
-    const past = new Date(Date.now() - 5 * 60 * 1000);
-    const stalledAt = new Date(Date.now() - 45 * 60 * 1000);
-
+  test('multi-tenant: aggregates notifiedUsers across tenants', async () => {
     prisma.tenant.findMany.mockResolvedValue([
       { id: 10, slug: 'tenant-a' },
       { id: 20, slug: 'tenant-b' },
     ]);
-    // tenant 10: one pending → reminded
-    // tenant 20: one stalled reminded → fallback
     prisma.webCheckin.findMany
       .mockResolvedValueOnce([
         {
           id: 1001, pnr: 'A', airlineCode: '6E', flightNumber: '1',
-          passengerName: 'A', windowOpenAt: past, status: 'pending', updatedAt: past,
+          passengerName: 'A', departureAt: new Date(Date.now() + 2 * 3600_000), assignedAgentId: 7,
         },
       ])
       .mockResolvedValueOnce([
         {
           id: 2001, pnr: 'B', airlineCode: 'AI', flightNumber: '2',
-          passengerName: 'B', windowOpenAt: stalledAt, status: 'reminded',
-          updatedAt: stalledAt,
+          passengerName: 'B', departureAt: new Date(Date.now() + 3 * 3600_000), assignedAgentId: null,
         },
       ]);
+    prisma.user.findUnique.mockResolvedValue({ id: 7, tenantId: 10 });
+    prisma.user.findMany.mockResolvedValue([{ id: 8 }]);
 
     const result = await runWebCheckinSchedulerForAllTravelTenants();
-    expect(result).toEqual({ reminded: 1, fallback: 1 });
-    // travel + active filter on tenant query
+    expect(result).toEqual({ notifiedUsers: 2 });
     const tenantArg = prisma.tenant.findMany.mock.calls[0][0];
     expect(tenantArg.where.vertical).toBe('travel');
     expect(tenantArg.where.isActive).toBe(true);
   });
 
   test('one tenant throws → caught, other tenants still process', async () => {
-    // SUT lines 195-207: per-tenant try/catch isolates failure. The thrown
-    // tenant contributes 0 to totals; siblings keep aggregating normally.
-    const past = new Date(Date.now() - 5 * 60 * 1000);
     prisma.tenant.findMany.mockResolvedValue([
       { id: 30, slug: 'broken-tenant' },
       { id: 40, slug: 'healthy-tenant' },
@@ -395,15 +221,13 @@ describe('cron/webCheckinScheduler — runWebCheckinSchedulerForAllTravelTenants
       .mockResolvedValueOnce([
         {
           id: 4001, pnr: 'OK', airlineCode: '6E', flightNumber: '1',
-          passengerName: 'Healthy', windowOpenAt: past, status: 'pending',
-          updatedAt: past,
+          passengerName: 'Healthy', departureAt: new Date(Date.now() + 2 * 3600_000), assignedAgentId: null,
         },
       ]);
+    prisma.user.findMany.mockResolvedValue([{ id: 5 }]);
 
     const result = await runWebCheckinSchedulerForAllTravelTenants();
-    // broken tenant contributes 0; healthy tenant contributes 1 reminded
-    expect(result).toEqual({ reminded: 1, fallback: 0 });
-    // both tenants were attempted
+    expect(result).toEqual({ notifiedUsers: 1 });
     expect(prisma.webCheckin.findMany).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/test/lib/gmailMessage.test.js
+++ b/backend/test/lib/gmailMessage.test.js
@@ -9,6 +9,7 @@ import {
   headerValue,
   parseGmailMessage,
   extractEmailAddress,
+  extractAttachments,
 } from "../../lib/gmailMessage.js";
 
 // Decode a base64url raw message back to its RFC-822 string + split the
@@ -192,5 +193,63 @@ describe("extractEmailAddress", () => {
     expect(extractEmailAddress("not an email")).toBeNull();
     expect(extractEmailAddress("")).toBeNull();
     expect(extractEmailAddress(null)).toBeNull();
+  });
+});
+
+describe("extractAttachments", () => {
+  it("collects attachment metadata from a multipart/mixed payload", () => {
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        { mimeType: "text/plain", body: { data: "dGV4dA" } },
+        {
+          mimeType: "application/pdf",
+          filename: "ticket.pdf",
+          body: { attachmentId: "att1", size: 12345 },
+        },
+        {
+          mimeType: "image/png",
+          filename: "boarding-pass.png",
+          body: { attachmentId: "att2", size: 67890 },
+        },
+      ],
+    };
+    const atts = extractAttachments(payload);
+    expect(atts).toHaveLength(2);
+    expect(atts[0]).toEqual({ filename: "ticket.pdf", mimeType: "application/pdf", size: 12345, attachmentId: "att1" });
+    expect(atts[1]).toEqual({ filename: "boarding-pass.png", mimeType: "image/png", size: 67890, attachmentId: "att2" });
+  });
+
+  it("returns an empty array when there are no attachments", () => {
+    expect(extractAttachments({ mimeType: "text/plain", body: { data: "dGV4dA" } })).toEqual([]);
+    expect(extractAttachments(null)).toEqual([]);
+  });
+
+  it("deduplicates by filename+attachmentId", () => {
+    const payload = {
+      parts: [
+        { mimeType: "application/pdf", filename: "x.pdf", body: { attachmentId: "a1", size: 1 } },
+        { mimeType: "application/pdf", filename: "x.pdf", body: { attachmentId: "a1", size: 1 } },
+      ],
+    };
+    expect(extractAttachments(payload)).toHaveLength(1);
+  });
+});
+
+describe("parseGmailMessage attachments", () => {
+  it("includes attachment metadata on the parsed message", () => {
+    const msg = parseGmailMessage({
+      id: "m5",
+      payload: {
+        mimeType: "multipart/mixed",
+        headers: [{ name: "Subject", value: "Ticket" }],
+        parts: [
+          { mimeType: "text/plain", body: { data: Buffer.from("body", "utf8").toString("base64url") } },
+          { mimeType: "application/pdf", filename: "ticket.pdf", body: { attachmentId: "att1", size: 100 } },
+        ],
+      },
+    });
+    expect(msg.attachments).toHaveLength(1);
+    expect(msg.attachments[0].attachmentId).toBe("att1");
   });
 });

--- a/backend/test/lib/llmRouter.test.js
+++ b/backend/test/lib/llmRouter.test.js
@@ -166,7 +166,8 @@ describe('llmRouter — module shape', () => {
       "bulk-text": { primary: "gemini-flash", fallback: "groq-llama" },
       "call-summary": { primary: "gemini-flash", fallback: null },
       // Callified AI call transcript classification for CRM leads (2026-07-31).
-      "callified-lead-status": { primary: "gemini-flash-lite", fallback: "gemini-flash" },
+      // NOTE: gemini-2.5-flash-lite was retired by Google; use gemini-flash.
+      "callified-lead-status": { primary: "gemini-flash", fallback: "gpt-4" },
       "itinerary-suggest": { primary: "gemini-flash", fallback: "gpt-4" },
       // AI quote-template line-item JSON generation (PR #1178).
       "quote-template-generate": { primary: "gemini-flash", fallback: "gpt-4" },

--- a/backend/test/routes/ai-scoring.test.js
+++ b/backend/test/routes/ai-scoring.test.js
@@ -98,6 +98,7 @@ function makeBearer({ userId = 7, tenantId = 1, role = 'ADMIN' } = {}) {
 const leadScoringEngine = requireCJS('../../cron/leadScoringEngine');
 leadScoringEngine.computeScore = vi.fn(() => 0);
 leadScoringEngine.tickLeadScoringEngine = vi.fn();
+leadScoringEngine.scoreContactsByIds = vi.fn();
 
 const aiScoringRouter = requireCJS('../../routes/ai_scoring');
 
@@ -118,8 +119,10 @@ beforeEach(() => {
   prisma.contact.findFirst.mockReset();
   leadScoringEngine.computeScore.mockReset();
   leadScoringEngine.tickLeadScoringEngine.mockReset();
+  leadScoringEngine.scoreContactsByIds.mockReset();
   // Sensible defaults — tests override as needed.
   leadScoringEngine.computeScore.mockReturnValue(42);
+  leadScoringEngine.scoreContactsByIds.mockResolvedValue({ scored: 3, errors: 0 });
 });
 
 // ─── GET /score/:dealId — deal-based predictive probability ────────
@@ -364,6 +367,67 @@ describe('GET /contact/:contactId — factor breakdown', () => {
       .set('Authorization', makeBearer());
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Failed to get contact score');
+  });
+});
+
+// ─── POST /contacts — on-demand batch aiScore ───────────────────────
+
+describe('POST /contacts — on-demand batch aiScore', () => {
+  test('400 when contactIds is missing or not an array', async () => {
+    const app = makeApp();
+    const res1 = await request(app)
+      .post('/api/ai-scoring/contacts')
+      .set('Authorization', makeBearer())
+      .send({});
+    expect(res1.status).toBe(400);
+    expect(res1.body.code).toBe('MISSING_CONTACT_IDS');
+
+    const res2 = await request(app)
+      .post('/api/ai-scoring/contacts')
+      .set('Authorization', makeBearer())
+      .send({ contactIds: 'not-array' });
+    expect(res2.status).toBe(400);
+    expect(res2.body.code).toBe('MISSING_CONTACT_IDS');
+  });
+
+  test('400 when contactIds exceeds 100', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post('/api/ai-scoring/contacts')
+      .set('Authorization', makeBearer())
+      .send({ contactIds: Array.from({ length: 101 }, (_, i) => i + 1) });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('TOO_MANY_CONTACT_IDS');
+  });
+
+  test('200 with success payload and forwards tenantId/io', async () => {
+    const fakeIo = { emit: vi.fn() };
+    leadScoringEngine.scoreContactsByIds.mockResolvedValue({ scored: 5, errors: 1 });
+
+    const app = makeApp({ io: fakeIo });
+    const res = await request(app)
+      .post('/api/ai-scoring/contacts')
+      .set('Authorization', makeBearer({ tenantId: 8 }))
+      .send({ contactIds: [1, 2, 3] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, scored: 5, errors: 1 });
+    expect(leadScoringEngine.scoreContactsByIds).toHaveBeenCalledTimes(1);
+    const [tenantId, ids, io] = leadScoringEngine.scoreContactsByIds.mock.calls[0];
+    expect(tenantId).toBe(8);
+    expect(ids).toEqual([1, 2, 3]);
+    expect(io).toBe(fakeIo);
+  });
+
+  test('500 envelope when scoreContactsByIds throws', async () => {
+    leadScoringEngine.scoreContactsByIds.mockRejectedValue(new Error('boom'));
+    const app = makeApp();
+    const res = await request(app)
+      .post('/api/ai-scoring/contacts')
+      .set('Authorization', makeBearer())
+      .send({ contactIds: [1] });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to score contacts');
   });
 });
 

--- a/backend/test/routes/callified-lead-status.test.js
+++ b/backend/test/routes/callified-lead-status.test.js
@@ -98,6 +98,8 @@ prisma.callLog.findMany = vi.fn();
 prisma.tenant = prisma.tenant || {};
 prisma.tenant.findUnique = vi.fn();
 prisma.tenant.update = vi.fn();
+prisma.tenantSetting = prisma.tenantSetting || {};
+prisma.tenantSetting.findUnique = vi.fn();
 // $transaction(cb) invokes the callback with the same prisma singleton so
 // tx.user / tx.contact / tx.tenant resolve to our mocks.
 prisma.$transaction = vi.fn(async (cb) => cb(prisma));
@@ -131,6 +133,7 @@ beforeEach(() => {
   prisma.callLog.findMany.mockReset();
   prisma.tenant.findUnique.mockReset();
   prisma.tenant.update.mockReset();
+  prisma.tenantSetting.findUnique.mockReset();
   prisma.$transaction.mockReset().mockImplementation(async (cb) => cb(prisma));
 });
 
@@ -300,6 +303,76 @@ describe('POST /api/callified/leads/:leadId/classify', () => {
     expect(res.body.callifiedLeadStatus).toBe('cold');
     expect(res.body.assignedToId).toBeNull();
     expect(prisma.user.findMany).not.toHaveBeenCalled();
+  });
+
+  test('AI transcript classification disabled → skips Gemini and uses score fallback', async () => {
+    prisma.tenantSetting.findUnique.mockResolvedValue({ value: 'false' });
+    prisma.contact.findFirst.mockResolvedValue({
+      id: 11, tenantId: 1, assignedToId: null, callifiedLeadStatus: null,
+    });
+    prisma.contact.update.mockResolvedValue({
+      id: 11, assignedToId: null, callifiedLeadStatus: 'cold', assignedTo: null,
+    });
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 1,
+        contactId: 11,
+        provider: 'callified',
+        notes: JSON.stringify({ reviews: [{ quality_score: 1.5, appointment_booked: false }] }),
+      },
+    ]);
+
+    const res = await request(makeApp())
+      .post('/api/callified/leads/11/classify')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.callifiedLeadStatus).toBe('cold');
+    expect(routeRequestMock).not.toHaveBeenCalled();
+  });
+
+  test('AI transcript classification enabled → routeRequest receives __surface and __userId', async () => {
+    prisma.tenantSetting.findUnique.mockResolvedValue({ value: 'true' });
+    llmEnabledMock.mockResolvedValue(true);
+    routeRequestMock.mockResolvedValue({ text: JSON.stringify({ status: 'hot', reason: 'Gemini says hot' }) });
+    prisma.contact.findFirst.mockResolvedValue({
+      id: 11, tenantId: 1, assignedToId: null, callifiedLeadStatus: null,
+    });
+    prisma.contact.update.mockResolvedValue({
+      id: 11, assignedToId: null, callifiedLeadStatus: 'hot', assignedTo: null,
+    });
+    prisma.user.findMany.mockResolvedValue([
+      { id: 101, role: 'ADMIN', deactivatedAt: null },
+      { id: 102, role: 'USER', deactivatedAt: null },
+    ]);
+    prisma.tenant.findUnique.mockResolvedValue({ callifiedLastHotAssignedUserId: null });
+    prisma.tenant.update.mockResolvedValue({ id: 1, callifiedLastHotAssignedUserId: 101 });
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 1,
+        contactId: 11,
+        provider: 'callified',
+        notes: JSON.stringify({ reviews: [{ quality_score: 3, appointment_booked: false }] }),
+      },
+    ]);
+
+    const res = await request(makeApp())
+      .post('/api/callified/leads/11/classify')
+      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.callifiedLeadStatus).toBe('hot');
+    expect(routeRequestMock).toHaveBeenCalledTimes(1);
+    expect(routeRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: 'callified-lead-status',
+        tenantId: 1,
+        payload: expect.objectContaining({
+          __surface: 'leads-callified-transcript',
+          __userId: 7,
+        }),
+      }),
+    );
   });
 });
 

--- a/backend/test/routes/external.test.js
+++ b/backend/test/routes/external.test.js
@@ -516,6 +516,10 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
       createdAt: new Date(),
     };
     prisma.contact.create.mockResolvedValueOnce(createdContact);
+    prisma.tenant.findUnique.mockResolvedValue({
+      vertical: "wellness",
+      callifiedAutoCampaignId: null,
+    });
 
     const app = makeApp();
     const res = await request(app).post("/api/v1/external/leads").send({
@@ -581,7 +585,7 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     });
     prisma.tenant.findUnique
       .mockReset()
-      .mockResolvedValueOnce({ callifiedAutoCampaignId: 42 });
+      .mockResolvedValueOnce({ vertical: "generic", callifiedAutoCampaignId: 42 });
     prisma.contact.findFirst.mockResolvedValueOnce(null);
     prisma.contact.create.mockResolvedValueOnce({
       id: 556,
@@ -608,7 +612,7 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(res.status).toBe(201);
     expect(prisma.tenant.findUnique).toHaveBeenCalledWith({
       where: { id: 7 },
-      select: { callifiedAutoCampaignId: true },
+      select: { vertical: true, callifiedAutoCampaignId: true },
     });
     const cArgs = prisma.contact.create.mock.calls[0][0].data;
     expect(cArgs.status).toBe("Lead");
@@ -710,12 +714,12 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
         tenantId: 7,
         fieldKey: {
           in: [
+            "company",
             "total_number_of_employees",
             "select_a_product",
             "utm_source",
             "utm_medium",
             "submit_source",
-            "company",
             "work_number",
             "custom_field_one",
             "custom_field_two",

--- a/backend/test/routes/external.test.js
+++ b/backend/test/routes/external.test.js
@@ -1,4 +1,4 @@
-﻿// @ts-check
+// @ts-check
 /**
  * Unit tests for backend/routes/external.js — the External Partner API
  * mounted at /api/v1/external/* and consumed by sister Globussoft products
@@ -777,6 +777,8 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(aArgs.type).toBe("JunkFilter");
     expect(aArgs.description).toContain("junk-filter");
   });
+});
+
 describe("POST /api/v1/external/calls", () => {
   test("no phone/contactId/callerNumber/calleeNumber → 400", async () => {
     const app = makeApp();

--- a/backend/test/routes/external.test.js
+++ b/backend/test/routes/external.test.js
@@ -1,4 +1,4 @@
-// @ts-check
+﻿// @ts-check
 /**
  * Unit tests for backend/routes/external.js — the External Partner API
  * mounted at /api/v1/external/* and consumed by sister Globussoft products
@@ -186,11 +186,16 @@ prisma.contact = prisma.contact || {};
 prisma.contact.findFirst = vi.fn();
 prisma.contact.findMany = vi.fn();
 prisma.contact.create = vi.fn();
+prisma.contact.update = vi.fn();
 prisma.patient = prisma.patient || {};
 prisma.patient.findFirst = vi.fn();
 prisma.activity = prisma.activity || {};
 prisma.activity.create = vi.fn();
 prisma.callLog = prisma.callLog || {};
+prisma.leadCustomFieldDefinition = prisma.leadCustomFieldDefinition || {};
+prisma.leadCustomFieldDefinition.findMany = vi.fn();
+prisma.leadCustomFieldValue = prisma.leadCustomFieldValue || {};
+prisma.leadCustomFieldValue.upsert = vi.fn();
 prisma.callLog.findFirst = vi.fn();
 prisma.callLog.create = vi.fn();
 prisma.callLog.update = vi.fn();
@@ -226,8 +231,11 @@ beforeEach(() => {
   prisma.contact.findFirst.mockReset();
   prisma.contact.findMany.mockReset();
   prisma.contact.create.mockReset();
+  prisma.contact.update.mockReset();
   prisma.patient.findFirst.mockReset();
   prisma.activity.create.mockReset().mockResolvedValue({ id: 1 });
+  prisma.leadCustomFieldDefinition.findMany.mockReset();
+  prisma.leadCustomFieldValue.upsert.mockReset();
   prisma.callLog.findFirst.mockReset();
   prisma.callLog.create.mockReset();
   prisma.callLog.update.mockReset();
@@ -606,8 +614,7 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(cArgs.status).toBe("Lead");
     expect(cArgs.callifiedCampaignId).toBe(42);
   });
-
-  test("custom keys are preserved in response and activity description", async () => {
+  test("custom keys are preserved in response, activity, and full payload storage", async () => {
     classifyLeadMock.mockResolvedValueOnce({
       isJunk: false,
       score: 77,
@@ -622,12 +629,21 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
       tier: "high",
       minutes: 5,
     });
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValueOnce([
+      { id: 31, fieldKey: "total_number_of_employees", fieldType: "number" },
+      { id: 32, fieldKey: "select_a_product", fieldType: "text" },
+      { id: 33, fieldKey: "utm_source", fieldType: "text" },
+      { id: 34, fieldKey: "utm_medium", fieldType: "text" },
+      { id: 35, fieldKey: "submit_source", fieldType: "text" },
+    ]);
+    prisma.leadCustomFieldValue.upsert.mockResolvedValue({ id: 1 });
     prisma.contact.findFirst.mockResolvedValueOnce(null);
     prisma.contact.create.mockResolvedValueOnce({
       id: 888,
       name: "Neha Kapoor",
       email: "neha@example.com",
       phone: "+919877665544",
+      company: "Testing",
       status: "Lead",
       source: "website-form",
       aiScore: 77,
@@ -644,127 +660,77 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
         name: "Neha Kapoor",
         phone: "+919877665544",
         email: "neha@example.com",
+        company: "Testing",
         source: "website-form",
         note: "Interested in a consultation",
+        cf_total_number_of_employees: "11",
+        cf_select_a_product: "HRMS",
+        cf_utm_source: "google",
+        cf_utm_medium: "cpc",
+        cf_submit_source: "contact-us",
+        work_number: "",
+        custom_field_one: "any value",
+        custom_field_two: { nested: true },
         preferredLanguage: "Hindi",
         campaignCode: "EW-2026",
         partnerMeta: { landingPage: "hero", branch: "south" },
       });
 
     expect(res.status).toBe(201);
+    expect(res.body.company).toBe("Testing");
     expect(res.body._customFields).toEqual({
+      company: "Testing",
+      cf_total_number_of_employees: "11",
+      cf_select_a_product: "HRMS",
+      cf_utm_source: "google",
+      cf_utm_medium: "cpc",
+      cf_submit_source: "contact-us",
+      work_number: "",
+      custom_field_one: "any value",
+      custom_field_two: { nested: true },
       preferredLanguage: "Hindi",
       campaignCode: "EW-2026",
       partnerMeta: { landingPage: "hero", branch: "south" },
     });
     expect(res.body._verdict.score).toBe(77);
 
-    const aArgs = prisma.activity.create.mock.calls[0][0].data;
-    expect(aArgs.description).toContain("customFields=");
-    expect(aArgs.description).toContain("preferredLanguage");
-    expect(aArgs.description).toContain("partnerMeta");
-  });
-
-  test("default Callified campaign is auto-assigned for new Lead when tenant has callifiedAutoCampaignId", async () => {
-    classifyLeadMock.mockResolvedValueOnce({
-      isJunk: false,
-      score: 70,
-      reasons: [],
-    });
-    prisma.tenant.findUnique
-      .mockReset()
-      .mockResolvedValueOnce({ callifiedAutoCampaignId: 42 });
-    prisma.contact.findFirst.mockResolvedValueOnce(null);
-    prisma.contact.create.mockResolvedValueOnce({
-      id: 556,
-      name: "External Lead",
-      email: "ext@example.com",
-      phone: "+919900112234",
-      status: "Lead",
-      source: "website-form",
-      aiScore: 70,
-      assignedToId: 11,
-      callifiedCampaignId: 42,
-      tenantId: 7,
-      createdAt: new Date(),
-    });
-
-    const app = makeApp();
-    const res = await request(app).post("/api/v1/external/leads").send({
-      name: "External Lead",
-      phone: "+919900112234",
-      email: "ext@example.com",
-      source: "website-form",
-    });
-
-    expect(res.status).toBe(201);
-    expect(prisma.tenant.findUnique).toHaveBeenCalledWith({
-      where: { id: 7 },
-      select: { callifiedAutoCampaignId: true },
-    });
     const cArgs = prisma.contact.create.mock.calls[0][0].data;
-    expect(cArgs.status).toBe("Lead");
-    expect(cArgs.callifiedCampaignId).toBe(42);
-  });
-
-  test("custom keys are preserved in response and activity description", async () => {
-    classifyLeadMock.mockResolvedValueOnce({
-      isJunk: false,
-      score: 77,
-      reasons: [],
-    });
-    pickAssigneeMock.mockResolvedValueOnce({
-      userId: 12,
-      reason: "matched service keyword",
-    });
-    computeFirstResponseDueAtMock.mockResolvedValueOnce({
-      dueAt: new Date("2026-06-01T11:05:00Z"),
-      tier: "high",
-      minutes: 5,
-    });
-    prisma.contact.findFirst.mockResolvedValueOnce(null);
-    prisma.contact.create.mockResolvedValueOnce({
-      id: 888,
-      name: "Neha Kapoor",
-      email: "neha@example.com",
-      phone: "+919877665544",
-      status: "Lead",
-      source: "website-form",
-      aiScore: 77,
-      assignedToId: 12,
-      firstResponseDueAt: new Date("2026-06-01T11:05:00Z"),
-      tenantId: 7,
-      createdAt: new Date(),
-    });
-
-    const app = makeApp();
-    const res = await request(app)
-      .post("/api/v1/external/leads")
-      .send({
-        name: "Neha Kapoor",
-        phone: "+919877665544",
-        email: "neha@example.com",
-        source: "website-form",
-        note: "Interested in a consultation",
-        preferredLanguage: "Hindi",
-        campaignCode: "EW-2026",
-        partnerMeta: { landingPage: "hero", branch: "south" },
-      });
-
-    expect(res.status).toBe(201);
-    expect(res.body._customFields).toEqual({
-      preferredLanguage: "Hindi",
-      campaignCode: "EW-2026",
-      partnerMeta: { landingPage: "hero", branch: "south" },
-    });
-    expect(res.body._verdict.score).toBe(77);
+    expect(cArgs.company).toBe("Testing");
+    expect(cArgs.externalPayloadJson).toContain("\"work_number\":\"\"");
+    expect(cArgs.externalPayloadJson).toContain("\"custom_field_two\"");
+    expect(cArgs.externalPayloadJson).toContain("\"cf_select_a_product\":\"HRMS\"");
 
     const aArgs = prisma.activity.create.mock.calls[0][0].data;
     expect(aArgs.description).toContain("customFields=");
-    expect(aArgs.description).toContain("preferredLanguage");
+    expect(aArgs.description).toContain("cf_total_number_of_employees");
     expect(aArgs.description).toContain("partnerMeta");
+
+    expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId: 7,
+        fieldKey: {
+          in: [
+            "total_number_of_employees",
+            "select_a_product",
+            "utm_source",
+            "utm_medium",
+            "submit_source",
+            "company",
+            "work_number",
+            "custom_field_one",
+            "custom_field_two",
+            "preferredLanguage",
+            "campaignCode",
+            "partnerMeta",
+          ],
+        },
+      },
+    });
+    expect(prisma.leadCustomFieldValue.upsert).toHaveBeenCalledTimes(5);
+    expect(prisma.leadCustomFieldValue.upsert.mock.calls.map((call) => call[0].create.fieldId)).toEqual([31, 32, 33, 34, 35]);
   });
-  test('junk verdict → status="Junk", pickAssignee SKIPPED, Activity.type="JunkFilter"', async () => {
+
+  test("junk verdict → status=\"Junk\", pickAssignee SKIPPED, Activity.type=\"JunkFilter\"", async () => {
     classifyLeadMock.mockResolvedValueOnce({
       isJunk: true,
       score: 5,
@@ -781,6 +747,7 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
       name: "xyzz qwerty",
       email: null,
       phone: "+10000000000",
+      company: null,
       status: "Junk",
       source: "callified",
       aiScore: 5,
@@ -801,22 +768,15 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(res.body._routing.userId).toBeNull();
     expect(res.body._routing.reason).toMatch(/junk/i);
 
-    // pickAssignee MUST NOT have been called when junk
     expect(pickAssigneeMock).not.toHaveBeenCalled();
-
-    // Contact created with status='Junk'
     const cArgs = prisma.contact.create.mock.calls[0][0].data;
     expect(cArgs.status).toBe("Junk");
     expect(cArgs.assignedToId).toBeNull();
-
-    // Activity created with type='JunkFilter' since reasons[] is non-empty
     expect(prisma.activity.create).toHaveBeenCalledOnce();
     const aArgs = prisma.activity.create.mock.calls[0][0].data;
     expect(aArgs.type).toBe("JunkFilter");
     expect(aArgs.description).toContain("junk-filter");
   });
-});
-
 describe("POST /api/v1/external/calls", () => {
   test("no phone/contactId/callerNumber/calleeNumber → 400", async () => {
     const app = makeApp();
@@ -1070,3 +1030,5 @@ describe("GET /api/v1/external/services + appointments — catalog shape", () =>
     expect(args.where.visitDate.lte).toEqual(new Date("2026-06-30T23:59:59Z"));
   });
 });
+
+

--- a/backend/test/routes/travel-webcheckin-automation.test.js
+++ b/backend/test/routes/travel-webcheckin-automation.test.js
@@ -5,10 +5,7 @@
  * surfaces added to routes/travel_webcheckin.js:
  *
  *   POST /api/travel/webcheckins/:id/automation/retry
- *     - 200 → status reset to 'reminded', attemptsJson cleared
- *     - 409 ALREADY_DONE when status='done'
- *     - 409 AUTOMATION_SKIPPED when automationSkipped=true
- *     - 404 NOT_FOUND cross-tenant
+ *     - 409 AUTOMATION_DISABLED (automation is off for this vertical)
  *   PATCH /api/travel/webcheckins/:id
  *     - automationSkipped=true persisted
  *   GET /api/travel/automation-health/per-airline
@@ -70,46 +67,14 @@ beforeEach(() => {
 });
 
 describe('POST /api/travel/webcheckins/:id/automation/retry', () => {
-  test('200 → resets status to reminded + clears attemptsJson', async () => {
-    prisma.webCheckin.findFirst.mockResolvedValue({ id: 5, tenantId: 1, status: 'fallback-agent', automationSkipped: false });
-    prisma.webCheckin.update.mockImplementation(async ({ data }) => ({ id: 5, ...data }));
-    const res = await request(makeApp())
-      .post('/api/travel/webcheckins/5/automation/retry')
-      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
-    expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
-    expect(prisma.webCheckin.update).toHaveBeenCalledWith({
-      where: { id: 5 },
-      data: { status: 'reminded', attemptsJson: null },
-    });
-  });
-
-  test('409 ALREADY_DONE when status=done', async () => {
-    prisma.webCheckin.findFirst.mockResolvedValue({ id: 5, tenantId: 1, status: 'done', automationSkipped: false });
+  test('automation is disabled → 409 AUTOMATION_DISABLED for any id', async () => {
     const res = await request(makeApp())
       .post('/api/travel/webcheckins/5/automation/retry')
       .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
     expect(res.status).toBe(409);
-    expect(res.body.code).toBe('ALREADY_DONE');
+    expect(res.body.code).toBe('AUTOMATION_DISABLED');
+    expect(prisma.webCheckin.findFirst).not.toHaveBeenCalled();
     expect(prisma.webCheckin.update).not.toHaveBeenCalled();
-  });
-
-  test('409 AUTOMATION_SKIPPED when automationSkipped=true', async () => {
-    prisma.webCheckin.findFirst.mockResolvedValue({ id: 5, tenantId: 1, status: 'reminded', automationSkipped: true });
-    const res = await request(makeApp())
-      .post('/api/travel/webcheckins/5/automation/retry')
-      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
-    expect(res.status).toBe(409);
-    expect(res.body.code).toBe('AUTOMATION_SKIPPED');
-  });
-
-  test('404 NOT_FOUND cross-tenant', async () => {
-    prisma.webCheckin.findFirst.mockResolvedValue(null);
-    const res = await request(makeApp())
-      .post('/api/travel/webcheckins/999/automation/retry')
-      .set('Authorization', `Bearer ${tokenFor('ADMIN')}`);
-    expect(res.status).toBe(404);
-    expect(res.body.code).toBe('NOT_FOUND');
   });
 
   test('USER role → 403 RBAC_DENIED', async () => {

--- a/backend/test/routes/travel-webcheckin.test.js
+++ b/backend/test/routes/travel-webcheckin.test.js
@@ -14,7 +14,7 @@
  *   - GET /api/travel/webcheckins — tenant-scoped list; ?status filter;
  *     ?status=garbage → 400 INVALID_STATUS.
  *   - GET /api/travel/webcheckins/upcoming — windowOpenAt range filter
- *     within next 48h, status in (pending, reminded).
+ *     within next 48h, status = pending.
  *   - GET /api/travel/webcheckins/:id — 400 INVALID_ID on NaN; 404 NOT_FOUND
  *     when cross-tenant (findFirst returns null).
  *   - POST /api/travel/webcheckins — 201 happy path; 400 MISSING_FIELDS;
@@ -161,7 +161,7 @@ describe('GET /api/travel/webcheckins (list)', () => {
 });
 
 describe('GET /api/travel/webcheckins/upcoming', () => {
-  test('returns rows in the next-48h window with status in (pending, reminded)', async () => {
+  test('returns rows in the next-48h window with status = pending', async () => {
     prisma.webCheckin.findMany.mockResolvedValue([
       { id: 1, tenantId: 1, pnr: 'ABC', status: 'pending', windowOpenAt: new Date() },
     ]);
@@ -175,7 +175,7 @@ describe('GET /api/travel/webcheckins/upcoming', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           tenantId: 1,
-          status: { in: ['pending', 'reminded'] },
+          status: 'pending',
           windowOpenAt: expect.objectContaining({ gte: expect.any(Date), lte: expect.any(Date) }),
         }),
         orderBy: { windowOpenAt: 'asc' },

--- a/frontend/src/__tests__/Diagnostics.test.jsx
+++ b/frontend/src/__tests__/Diagnostics.test.jsx
@@ -14,9 +14,9 @@
  *      "New bank" CTA only renders for ADMIN role (SUT lines 74-82).
  *   2. Loading state: shows "Loading…" before first GET resolves
  *      (await findByText per CLAUDE.md tick #108 cron-learning).
- *   3. GET on mount: hits /api/travel/diagnostics?limit=100 with NO
+ *   3. GET on mount: hits /api/travel/diagnostics?limit=10&offset=0 with NO
  *      subBrand/classification query params when filters are blank
- *      (SUT lines 46-53: builds URLSearchParams; limit=100 always set).
+ *      (SUT lines 46-53: builds URLSearchParams; limit=10 + offset always set).
  *   4. Empty-state: zero diagnostics → renders the "No diagnostics submitted
  *      yet." copy + the "Take diagnostic" hint (SUT lines 138-140).
  *   5. Sub-brand filter: selecting "rfu" re-fetches with ?subBrand=rfu
@@ -45,7 +45,7 @@
  *      and clears the diagnostics list (SUT lines 56-60).
  *
  * Backend contract pinned (per backend/routes/travel_diagnostics.js):
- *   GET /api/travel/diagnostics[?subBrand=&classification=&limit=]
+ *   GET /api/travel/diagnostics[?subBrand=&classification=&limit=&offset=]
  *       → 200 { diagnostics: [...] }
  *       | 500 on error
  *
@@ -271,15 +271,16 @@ describe('<Diagnostics /> — load + render lifecycle', () => {
     expect(screen.queryByText('Loading…')).toBeNull();
   });
 
-  it('GETs /api/travel/diagnostics?limit=100 on mount with NO subBrand/classification query string', async () => {
+  it('GETs /api/travel/diagnostics?limit=10&offset=0 on mount with NO subBrand/classification query string', async () => {
     renderPage();
     await waitFor(() => {
       const listCall = fetchApiMock.mock.calls.find(([u]) =>
         typeof u === 'string' && u.startsWith('/api/travel/diagnostics'),
       );
       expect(listCall).toBeTruthy();
-      // limit=100 is always set by the SUT (line 51).
-      expect(listCall[0]).toContain('limit=100');
+      // limit=10 and offset=0 are always set by the SUT.
+      expect(listCall[0]).toContain('limit=10');
+      expect(listCall[0]).toContain('offset=0');
       // No subBrand= / classification= when both filters are blank.
       expect(listCall[0]).not.toContain('subBrand=');
       expect(listCall[0]).not.toContain('classification=');
@@ -288,6 +289,74 @@ describe('<Diagnostics /> — load + render lifecycle', () => {
     expect(await screen.findByText('tmc')).toBeInTheDocument();
     expect(screen.getByText('rfu')).toBeInTheDocument();
     expect(screen.getByText('visasure')).toBeInTheDocument();
+  });
+
+  it('scrolling the table container loads the next slice at offset=10', async () => {
+    const firstPage = Array.from({ length: 10 }, (_, i) =>
+      makeDiagnostic({
+        id: 801 + i,
+        subBrand: i === 0 ? 'tmc' : 'rfu',
+        classification: i === 0 ? 'level_1' : 'level_2',
+        classificationLabel: i === 0 ? 'School-Trip Standard' : 'Umrah Premium',
+        score: 1 + i,
+        recommendedTier: i === 0 ? 'entry' : 'primary',
+        contactId: 6000 + i,
+        createdAt: `2026-05-${String(20 + i).padStart(2, '0')}T10:00:00.000Z`,
+      }),
+    );
+    const secondPage = [
+      makeDiagnostic({
+        id: 901,
+        subBrand: 'travelstall',
+        classification: 'level_3',
+        classificationLabel: 'Travel Stall Pro',
+        score: 9.75,
+        recommendedTier: 'premium',
+        contactId: 7001,
+        createdAt: '2026-06-01T10:00:00.000Z',
+      }),
+      makeDiagnostic({
+        id: 902,
+        subBrand: 'visasure',
+        classification: 'level_4',
+        classificationLabel: 'Visa Sure Elite',
+        score: 8.5,
+        recommendedTier: 'primary',
+        contactId: 7002,
+        createdAt: '2026-06-02T10:00:00.000Z',
+      }),
+    ];
+
+    fetchApiMock.mockImplementation((url) => {
+      if (typeof url === 'string' && url.startsWith('/api/travel/diagnostics')) {
+        const parsed = new URL(url, 'http://localhost');
+        if (parsed.searchParams.get('offset') === '10') {
+          return Promise.resolve({ diagnostics: secondPage, total: 12, limit: 10, offset: 10 });
+        }
+        return Promise.resolve({ diagnostics: firstPage, total: 12, limit: 10, offset: 0 });
+      }
+      return Promise.resolve(null);
+    });
+
+    renderPage();
+    await screen.findByText('tmc');
+
+    const scrollContainer = screen.getByTestId('diagnostics-table-scroll');
+    Object.defineProperties(scrollContainer, {
+      scrollTop: { value: 1000, writable: true, configurable: true },
+      clientHeight: { value: 500, writable: true, configurable: true },
+      scrollHeight: { value: 1400, writable: true, configurable: true },
+    });
+    fireEvent.scroll(scrollContainer);
+
+    await waitFor(() => {
+      const nextPageCall = fetchApiMock.mock.calls.find(([u]) =>
+        typeof u === 'string' && u.includes('offset=10'),
+      );
+      expect(nextPageCall).toBeTruthy();
+    });
+
+    expect(await screen.findByText('travelstall')).toBeInTheDocument();
   });
 
   it('renders empty-state copy when diagnostics=[] (SUT lines 138-140)', async () => {

--- a/frontend/src/__tests__/Itineraries.test.jsx
+++ b/frontend/src/__tests__/Itineraries.test.jsx
@@ -489,15 +489,12 @@ describe('<Itineraries /> — load + render lifecycle', () => {
     renderPage();
     await screen.findByText('Page 1 Trip 1');
     const scrollArea = screen.getByTestId('itineraries-scroll-area');
-    Object.defineProperty(scrollArea, 'clientHeight', { value: 400, configurable: true });
-    Object.defineProperty(scrollArea, 'scrollHeight', { value: 800, configurable: true });
-    fireEvent.scroll(scrollArea, {
-      target: {
-        scrollTop: 728,
-        clientHeight: 400,
-        scrollHeight: 800,
-      },
+    Object.defineProperties(scrollArea, {
+      scrollTop: { value: 728, writable: true, configurable: true },
+      clientHeight: { value: 400, writable: true, configurable: true },
+      scrollHeight: { value: 800, writable: true, configurable: true },
     });
+    fireEvent.scroll(scrollArea);
 
     await waitFor(() => {
       const nextCall = fetchApiMock.mock.calls.find(([u, o]) =>
@@ -1246,6 +1243,7 @@ describe('<Itineraries /> — S90 materialise-from-suggestion', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^Suggest$/ }));
     await screen.findByTestId('suggest-preview-pane');
+    await screen.findByRole('option', { name: /Riya Sharma/i });
   }
 
   it('happy path: pick contact + click materialise → POSTs correct body + notify.success + navigate', async () => {
@@ -1259,7 +1257,11 @@ describe('<Itineraries /> — S90 materialise-from-suggestion', () => {
     const createBtn = screen.getByRole('button', {
       name: /Create itinerary from this suggestion/i,
     });
-    expect(createBtn).not.toBeDisabled();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Create itinerary from this suggestion/i }),
+      ).not.toBeDisabled();
+    });
     fireEvent.click(createBtn);
     // notify.success fires with "Itinerary created with 3 items".
     await waitFor(() => {
@@ -1325,6 +1327,11 @@ describe('<Itineraries /> — S90 materialise-from-suggestion', () => {
       screen.getByLabelText(/Contact for materialised itinerary/i),
       { target: { value: '5001' } },
     );
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Create itinerary from this suggestion/i }),
+      ).not.toBeDisabled();
+    });
     fireEvent.click(
       screen.getByRole('button', {
         name: /Create itinerary from this suggestion/i,
@@ -1368,6 +1375,11 @@ describe('<Itineraries /> — S90 materialise-from-suggestion', () => {
     );
     const triggerBtn = screen.getByRole('button', {
       name: /Create itinerary from this suggestion/i,
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Create itinerary from this suggestion/i }),
+      ).not.toBeDisabled();
     });
     fireEvent.click(triggerBtn);
     // Loading text + disabled state. The button's aria-label stays
@@ -1441,6 +1453,11 @@ describe('<Itineraries /> — S90 materialise-from-suggestion', () => {
       screen.getByLabelText(/Contact for materialised itinerary/i),
       { target: { value: '5001' } },
     );
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Create itinerary from this suggestion/i }),
+      ).not.toBeDisabled();
+    });
     fireEvent.click(
       screen.getByRole('button', {
         name: /Create itinerary from this suggestion/i,

--- a/frontend/src/__tests__/Itineraries.test.jsx
+++ b/frontend/src/__tests__/Itineraries.test.jsx
@@ -12,10 +12,11 @@
  *      sub-brand-access via getSubBrandAccessSet on POST).
  *   2. Loading state: shows "Loading…" before first GET resolves (await
  *      findByText per CLAUDE.md tick #108 cron-learning).
- *   3. GET on mount: hits /api/travel/itineraries?limit=100 (no sub-brand
+ *   3. GET on mount: hits /api/travel/itineraries?limit=10&offset=0 (no sub-brand
  *      or status query params when filters are blank) and renders one row
- *      per itinerary (table layout with 9 columns: Destination, Sub-brand,
- *      Contact, Dates, Items, Total, Status, Tier, Updated).
+ *      per itinerary inside the fixed-height scroll container (table layout
+ *      with 9 columns: Destination, Sub-brand, Contact, Dates, Items, Total,
+ *      Status, Tier, Updated).
  *   4. Empty state: zero itineraries → renders the "No itineraries yet."
  *      empty-state copy + the "Create Itinerary" hint.
  *   5. Sub-brand filter: changing the <select> to "rfu" re-fetches with
@@ -60,7 +61,7 @@
  *      SUT useEffect lines 180-185).
  *
  * Backend contract pinned (per backend/routes/travel_itineraries.js):
- *   GET    /api/travel/itineraries[?subBrand=&status=&limit=]
+ *   GET    /api/travel/itineraries[?subBrand=&status=&limit=&offset=]
  *          → 200 { itineraries, total, limit, offset }
  *          | 400 INVALID_STATUS / 500
  *   POST   /api/travel/itineraries  body:{subBrand,contactId,destination,
@@ -303,7 +304,7 @@ const CONTACTS_DEFAULT = [
 // Install a fetchApi mock that routes by URL + method. Tests override only
 // the surface they care about.
 function installFetchMock({
-  list = { itineraries: ITINS_DEFAULT, total: ITINS_DEFAULT.length, limit: 100, offset: 0 },
+  list = { itineraries: ITINS_DEFAULT, total: ITINS_DEFAULT.length, limit: 10, offset: 0 },
   contacts = CONTACTS_DEFAULT,
   create = null,
 } = {}) {
@@ -382,6 +383,7 @@ describe('<Itineraries /> — page chrome + filter bar', () => {
       );
       expect(calls.length).toBeGreaterThan(0);
     });
+    expect(screen.getByTestId('itineraries-scroll-area')).toBeInTheDocument();
   });
 });
 
@@ -398,12 +400,12 @@ describe('<Itineraries /> — load + render lifecycle', () => {
     renderPage();
     // Loading text renders before list resolves (SUT line 232: "Loading&hellip;").
     expect(await screen.findByText('Loading…')).toBeInTheDocument();
-    resolveList({ itineraries: ITINS_DEFAULT, total: ITINS_DEFAULT.length, limit: 100, offset: 0 });
+    resolveList({ itineraries: ITINS_DEFAULT, total: ITINS_DEFAULT.length, limit: 10, offset: 0 });
     await screen.findByText('Andaman Islands');
     expect(screen.queryByText('Loading…')).toBeNull();
   });
 
-  it('GETs /api/travel/itineraries?limit=100 on mount with NO sub-brand/status query string', async () => {
+  it('GETs /api/travel/itineraries?limit=10&offset=0 on mount with NO sub-brand/status query string', async () => {
     renderPage();
     await waitFor(() => {
       const listCall = fetchApiMock.mock.calls.find(([u, o]) =>
@@ -412,8 +414,9 @@ describe('<Itineraries /> — load + render lifecycle', () => {
         && (!o?.method || o.method === 'GET'),
       );
       expect(listCall).toBeTruthy();
-      // limit=100 is always set by the SUT (line 167).
-      expect(listCall[0]).toContain('limit=100');
+      // limit=10 and offset=0 are always set by the SUT.
+      expect(listCall[0]).toContain('limit=10');
+      expect(listCall[0]).toContain('offset=0');
       // No subBrand= / status= when both filters are blank.
       expect(listCall[0]).not.toContain('subBrand=');
       expect(listCall[0]).not.toContain('status=');
@@ -424,8 +427,94 @@ describe('<Itineraries /> — load + render lifecycle', () => {
     expect(screen.getByText('Schengen visa')).toBeInTheDocument();
   });
 
+  it('scrolling the list pane near the bottom requests the second page with offset=10', async () => {
+    const firstPage = Array.from({ length: 10 }, (_, i) =>
+      makeItin({
+        id: 501 + i,
+        destination: `Page 1 Trip ${i + 1}`,
+        subBrand: i % 2 === 0 ? 'tmc' : 'rfu',
+        status: i % 2 === 0 ? 'draft' : 'sent',
+        productTier: i % 3 === 0 ? 'entry' : 'primary',
+        totalAmount: 10000 + i * 1000,
+        currency: 'INR',
+        contactId: 5001,
+        items: [],
+        updatedAt: `2026-05-${String(10 + i).padStart(2, '0')}T10:00:00.000Z`,
+      }),
+    );
+    const secondPage = [
+      makeItin({
+        id: 601,
+        destination: 'Page 2 Trip 1',
+        subBrand: 'visasure',
+        status: 'accepted',
+        productTier: 'premium',
+        totalAmount: 75000,
+        currency: 'USD',
+        contactId: 5002,
+        items: [],
+        updatedAt: '2026-06-01T10:00:00.000Z',
+      }),
+      makeItin({
+        id: 602,
+        destination: 'Page 2 Trip 2',
+        subBrand: 'tmc',
+        status: 'revised',
+        productTier: null,
+        totalAmount: 22000,
+        currency: 'INR',
+        contactId: 5001,
+        items: [],
+        updatedAt: '2026-06-02T10:00:00.000Z',
+      }),
+    ];
+
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = opts?.method || 'GET';
+      if (url.startsWith('/api/travel/itineraries') && method === 'GET') {
+        if (url.includes('offset=10')) {
+          return Promise.resolve({ itineraries: secondPage, total: 12, limit: 10, offset: 10 });
+        }
+        return Promise.resolve({ itineraries: firstPage, total: 12, limit: 10, offset: 0 });
+      }
+      if (url.startsWith('/api/contacts') && method === 'GET') {
+        return Promise.resolve(CONTACTS_DEFAULT);
+      }
+      if (url === '/api/auth/me/permissions' && method === 'GET') {
+        return Promise.resolve({ isOwner: true, permissions: [] });
+      }
+      return Promise.resolve(null);
+    });
+
+    renderPage();
+    await screen.findByText('Page 1 Trip 1');
+    const scrollArea = screen.getByTestId('itineraries-scroll-area');
+    Object.defineProperty(scrollArea, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollArea, 'scrollHeight', { value: 800, configurable: true });
+    fireEvent.scroll(scrollArea, {
+      target: {
+        scrollTop: 728,
+        clientHeight: 400,
+        scrollHeight: 800,
+      },
+    });
+
+    await waitFor(() => {
+      const nextCall = fetchApiMock.mock.calls.find(([u, o]) =>
+        typeof u === 'string'
+        && u.startsWith('/api/travel/itineraries')
+        && (!o?.method || o.method === 'GET')
+        && u.includes('offset=10'),
+      );
+      expect(nextCall).toBeTruthy();
+    });
+
+    expect(await screen.findByText('Page 2 Trip 1')).toBeInTheDocument();
+    expect(screen.getByText('Page 2 Trip 2')).toBeInTheDocument();
+  });
+
   it('renders empty-state copy when itineraries=[] (SUT line 234-237)', async () => {
-    installFetchMock({ list: { itineraries: [], total: 0, limit: 100, offset: 0 } });
+    installFetchMock({ list: { itineraries: [], total: 0, limit: 10, offset: 0 } });
     renderPage();
     expect(
       await screen.findByText(/No itineraries yet\./i),
@@ -448,7 +537,7 @@ describe('<Itineraries /> — filter behaviour', () => {
     renderPage();
     await screen.findByText('Andaman Islands');
     fetchApiMock.mockClear();
-    installFetchMock({ list: { itineraries: [ITINS_DEFAULT[1]], total: 1, limit: 100, offset: 0 } });
+    installFetchMock({ list: { itineraries: [ITINS_DEFAULT[1]], total: 1, limit: 10, offset: 0 } });
     fireEvent.change(screen.getByLabelText(/Filter by sub-brand/i), {
       target: { value: 'rfu' },
     });
@@ -466,7 +555,7 @@ describe('<Itineraries /> — filter behaviour', () => {
     renderPage();
     await screen.findByText('Andaman Islands');
     fetchApiMock.mockClear();
-    installFetchMock({ list: { itineraries: [ITINS_DEFAULT[1]], total: 1, limit: 100, offset: 0 } });
+    installFetchMock({ list: { itineraries: [ITINS_DEFAULT[1]], total: 1, limit: 10, offset: 0 } });
     fireEvent.change(screen.getByLabelText(/Filter by status/i), {
       target: { value: 'sent' },
     });

--- a/frontend/src/__tests__/ItineraryTemplates.test.jsx
+++ b/frontend/src/__tests__/ItineraryTemplates.test.jsx
@@ -742,50 +742,56 @@ describe('<ItineraryTemplates /> — formatting helpers (cell render)', () => {
 });
 
 describe('<ItineraryTemplates /> — pagination', () => {
-  it('renders "Showing 1-3 of 3" summary and disables both Prev + Next when total fits in one page', async () => {
+  it('renders the first page inside the scroll container when total fits on one page', async () => {
     renderPage();
     await screen.findByText('Makkah-Madinah 10-day Umrah');
 
-    expect(screen.getByText(/Showing 1-3 of 3/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Previous page/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /Next page/i })).toBeDisabled();
+    expect(screen.getByText('Bali Family Holiday')).toBeInTheDocument();
+    expect(screen.getByText('Europe School Trip — 14 days')).toBeInTheDocument();
+    expect(screen.getByTestId('itinerary-templates-table-scroll')).toBeInTheDocument();
+    expect(screen.queryByTestId('itinerary-templates-scroll-sentinel')).toBeNull();
   });
 
-  it('shows "No results" when total=0 (no items)', async () => {
+  it('shows only the empty-state copy when total=0 (no items)', async () => {
     installFetchMock({ list: { items: [], total: 0, limit: 20, offset: 0 } });
     renderPage();
-    await screen.findByText(/No itinerary templates yet/i);
-    expect(screen.getByText(/No results/i)).toBeInTheDocument();
+    await screen.findByText(/No itinerary templates yet\. Add one above\./i);
+    expect(screen.queryByTestId('itinerary-templates-table-scroll')).toBeNull();
   });
 
   it('clicking Next advances offset → re-fetches with ?offset=20', async () => {
     // Simulate a large list — total=50 so we have multiple pages.
-    const bigItems = Array.from({ length: 20 }).map((_, i) =>
+    const firstPage = Array.from({ length: 20 }).map((_, i) =>
       makeItem({ id: 2000 + i, name: `Template ${i + 1}` }),
     );
-    installFetchMock({
-      list: { items: bigItems, total: 50, limit: 20, offset: 0 },
+    const secondPage = Array.from({ length: 20 }).map((_, i) =>
+      makeItem({ id: 3000 + i, name: `Template ${i + 21}` }),
+    );
+
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = opts?.method || 'GET';
+      if (url.startsWith('/api/travel/itinerary-templates?') && method === 'GET') {
+        if (url.includes('offset=20')) {
+          return Promise.resolve({ items: secondPage, total: 50, limit: 20, offset: 20 });
+        }
+        return Promise.resolve({ items: firstPage, total: 50, limit: 20, offset: 0 });
+      }
+      if (url.startsWith('/api/contacts?limit=200') && method === 'GET') {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(null);
     });
+
     renderPage();
     await screen.findByText('Template 1');
 
-    expect(screen.getByText(/Showing 1-20 of 50/i)).toBeInTheDocument();
-    const nextBtn = screen.getByRole('button', { name: /Next page/i });
-    expect(nextBtn).not.toBeDisabled();
-
-    fetchApiMock.mockClear();
-    installFetchMock({
-      list: {
-        items: Array.from({ length: 20 }).map((_, i) =>
-          makeItem({ id: 3000 + i, name: `Template ${i + 21}` }),
-        ),
-        total: 50,
-        limit: 20,
-        offset: 20,
-      },
+    const scrollArea = screen.getByTestId('itinerary-templates-table-scroll');
+    Object.defineProperties(scrollArea, {
+      scrollTop: { value: 728, writable: true, configurable: true },
+      clientHeight: { value: 400, writable: true, configurable: true },
+      scrollHeight: { value: 800, writable: true, configurable: true },
     });
-
-    fireEvent.click(nextBtn);
+    fireEvent.scroll(scrollArea);
 
     await waitFor(() => {
       const call = fetchApiMock.mock.calls.find(
@@ -796,6 +802,9 @@ describe('<ItineraryTemplates /> — pagination', () => {
       );
       expect(call).toBeTruthy();
     });
+
+    expect(await screen.findByText('Template 21')).toBeInTheDocument();
+    expect(screen.getByText('Template 40')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/Leads.test.jsx
+++ b/frontend/src/__tests__/Leads.test.jsx
@@ -1031,6 +1031,17 @@ function callifiedFetchMock(url, opts) {
   if (typeof url === 'string' && url.startsWith('/api/callified/leads/call-summary') && !opts) {
     return Promise.resolve({ summaries: CALLIFIED_SUMMARIES });
   }
+  if (typeof url === 'string' && url.startsWith('/api/tenant-settings/') && opts?.method === 'PUT') {
+    try {
+      const body = JSON.parse(opts.body || '{}');
+      return Promise.resolve({ value: body.value });
+    } catch {
+      return Promise.resolve({ value: 'true' });
+    }
+  }
+  if (typeof url === 'string' && url.startsWith('/api/tenant-settings/') && !opts) {
+    return Promise.resolve({ value: 'true', defaultValue: 'true', isOverride: false });
+  }
   if (opts?.method === 'PUT' || opts?.method === 'POST') return Promise.resolve({ ok: true });
   return Promise.resolve([]);
 }
@@ -1173,5 +1184,34 @@ describe('Leads — Callified campaign column + bulk dial + call summary', () =>
     expect(screen.queryByText('Callified AI call')).toBeNull();
     expect(screen.queryByText('Lead Status')).toBeNull();
     expect(screen.queryByText('Callified Score')).toBeNull();
+  });
+
+  it('Lead Status gear menu opens and toggling AI classification saves immediately', async () => {
+    renderLeads(ADMIN_AUTH);
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument());
+    fetchApiMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Lead status AI settings/i }));
+    const toggle = screen.getByLabelText(/AI Based transcription classification/i);
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.checked).toBe(true);
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      const putCall = fetchApiMock.mock.calls.find(
+        ([url, opts]) =>
+          typeof url === 'string' &&
+          url.startsWith('/api/tenant-settings/feature.callified.ai_transcript.enabled') &&
+          opts?.method === 'PUT',
+      );
+      expect(putCall).toBeDefined();
+      const body = JSON.parse(putCall[1].body);
+      expect(body.value).toBe('false');
+      expect(body.category).toBe('feature-flag');
+    });
+    await waitFor(() => {
+      expect(notifySuccess).toHaveBeenCalledWith(expect.stringMatching(/disabled/i));
+    });
   });
 });

--- a/frontend/src/__tests__/NotificationBell.test.jsx
+++ b/frontend/src/__tests__/NotificationBell.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -475,7 +474,7 @@ describe('<NotificationBell />', () => {
     await waitFor(() => expect(screen.queryByText('Linked')).not.toBeInTheDocument());
   });
 
-  it('#853: "View all notifications" footer navigates to /notifications and closes the panel', async () => {
+  it('#853: the footer does not expose a "View all notifications" button', async () => {
     const user = userEvent.setup();
     fetchApi
       .mockResolvedValueOnce({ count: 0 })
@@ -490,14 +489,8 @@ describe('<NotificationBell />', () => {
     const bell = await screen.findByRole('button', { name: /notifications/i });
     await user.click(bell);
 
-    const viewAll = await screen.findByRole('button', { name: /view all notifications/i });
-    await user.click(viewAll);
-
-    expect(navigateMock).toHaveBeenCalledWith('/notifications');
-    // Panel closed.
-    await waitFor(() =>
-      expect(screen.queryByRole('button', { name: /view all notifications/i })).not.toBeInTheDocument(),
-    );
+    await screen.findByText('one');
+    expect(screen.queryByRole('button', { name: /view all notifications/i })).not.toBeInTheDocument();
   });
 
   it('#853: "View all" footer is hidden when the panel is empty', async () => {

--- a/frontend/src/__tests__/QuotesAdmin.test.jsx
+++ b/frontend/src/__tests__/QuotesAdmin.test.jsx
@@ -146,7 +146,7 @@ const QUOTES_DEFAULT = [
 // Install a fetchApi mock that routes by URL + method. Tests override
 // only the surface they care about.
 function installFetchMock({
-  list = { quotes: QUOTES_DEFAULT, total: QUOTES_DEFAULT.length, limit: 100, offset: 0 },
+  list = { quotes: QUOTES_DEFAULT, total: QUOTES_DEFAULT.length, limit: 50, offset: 0 },
   create = null,
   update = null,
   del = null,
@@ -250,15 +250,15 @@ describe('<QuotesAdmin /> — load + render lifecycle', () => {
     expect(screen.queryByText('Loading…')).toBeNull();
   });
 
-  it('GETs /api/travel/quotes on mount with NO query string when filters are empty', async () => {
+  it('GETs /api/travel/quotes on mount with limit/offset when filters are empty', async () => {
     renderPage();
     await waitFor(() => {
       const listCall = fetchApiMock.mock.calls.find(([u, o]) =>
         typeof u === 'string' && u.startsWith('/api/travel/quotes') && (!o?.method || o.method === 'GET'),
       );
       expect(listCall).toBeTruthy();
-      // No query string when both filters are blank.
-      expect(listCall[0]).toBe('/api/travel/quotes');
+      expect(listCall[0]).toContain('limit=50');
+      expect(listCall[0]).toContain('offset=0');
     });
     // Renders one row per quote.
     expect(await screen.findByText('Alice Smith')).toBeInTheDocument();

--- a/frontend/src/__tests__/Recommendations.test.jsx
+++ b/frontend/src/__tests__/Recommendations.test.jsx
@@ -192,6 +192,18 @@ const ALL_FIXTURE = [PENDING_OCCUPANCY, PENDING_SMS_BLAST, PENDING_CAMPAIGN, APP
 const PENDING_ONLY = [PENDING_OCCUPANCY, PENDING_SMS_BLAST, PENDING_CAMPAIGN];
 const APPROVED_ONLY = [APPROVED_REC];
 
+function makePendingRec(id, title) {
+  return {
+    id,
+    type: 'occupancy_alert',
+    title,
+    body: `Body for ${title}`,
+    priority: 'medium',
+    status: 'pending',
+    createdAt: `2026-05-24T${String(id % 24).padStart(2, '0')}:00:00Z`,
+  };
+}
+
 function installFetchMock({
   filteredList = PENDING_ONLY,
   filteredPromise = null,
@@ -360,6 +372,43 @@ describe('<Recommendations /> — mount fetch + card render', () => {
     expect(
       screen.getAllByRole('button', { name: /Reject/i }).length,
     ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('loads additional cards when the scroll container reaches the bottom', async () => {
+    const manyPending = Array.from({ length: 12 }, (_, index) =>
+      makePendingRec(5000 + index, `Scrollable recommendation ${index + 1}`),
+    );
+    installFetchMock({ filteredList: manyPending, allList: manyPending });
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', {
+          level: 3,
+          name: /^Scrollable recommendation 1$/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('heading', {
+        level: 3,
+        name: /Scrollable recommendation 11/i,
+      }),
+    ).toBeNull();
+
+    const scrollContainer = screen.getByTestId('recommendations-list-scroll');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
+    scrollContainer.scrollTop = 728;
+    fireEvent.scroll(scrollContainer);
+
+    expect(
+      await screen.findByRole('heading', {
+        level: 3,
+        name: /Scrollable recommendation 11/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('non-pending row renders "Status: <s>" text instead of Approve/Reject buttons', async () => {

--- a/frontend/src/__tests__/Reports.test.jsx
+++ b/frontend/src/__tests__/Reports.test.jsx
@@ -49,9 +49,8 @@
  * layout); everything else from recharts stays real. money/date helpers
  * stay real so the formatMoney pass-through path is exercised.
  */
-import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // fetchApi + getAuthToken — single global handles each test re-implements.
 const fetchApiMock = vi.fn();
@@ -351,14 +350,9 @@ describe('<Reports /> — broad page surface', () => {
     await waitFor(() => {
       expect(screen.getByText('Scrollable deal 1')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Scrollable deal 13')).not.toBeInTheDocument();
-
-    const scrollContainer = screen.getByTestId('reports-detail-scroll');
-    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
-    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
-    scrollContainer.scrollTop = 728;
-    fireEvent.scroll(scrollContainer);
-
+    const detailTableCard = screen.getByText('Scrollable deal 1').closest('.card');
+    expect(detailTableCard).toBeTruthy();
+    fireEvent.scroll(detailTableCard);
     expect(
       await screen.findByText('Scrollable deal 13'),
     ).toBeInTheDocument();

--- a/frontend/src/__tests__/Reports.test.jsx
+++ b/frontend/src/__tests__/Reports.test.jsx
@@ -326,6 +326,44 @@ describe('<Reports /> — broad page surface', () => {
     });
   });
 
+  it('loads additional detail rows when the table container reaches the bottom', async () => {
+    const manyDeals = Array.from({ length: 18 }, (_, index) => ({
+      id: 900 + index,
+      title: `Scrollable deal ${index + 1}`,
+      amount: 1000 + index * 100,
+      stage: 'Won',
+      owner: { name: 'Owner' },
+      contact: { name: 'Contact' },
+      createdAt: '2026-05-01T00:00:00Z',
+    }));
+
+    fetchApiMock.mockImplementation((url, opts) => {
+      if (url.startsWith('/api/reports/query')) return Promise.resolve(sampleData);
+      if (url.startsWith('/api/reports/detailed/deals')) return Promise.resolve(manyDeals);
+      if (url === '/api/report-schedules' && (!opts || opts.method !== 'POST')) return Promise.resolve([]);
+      if (url === '/api/report-schedules' && opts?.method === 'POST') return Promise.resolve({ id: 99 });
+      return Promise.resolve(null);
+    });
+
+    render(<Reports />);
+    fireEvent.click(screen.getByRole('button', { name: /Detailed Data/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Scrollable deal 1')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Scrollable deal 13')).not.toBeInTheDocument();
+
+    const scrollContainer = screen.getByTestId('reports-detail-scroll');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
+    scrollContainer.scrollTop = 728;
+    fireEvent.scroll(scrollContainer);
+
+    expect(
+      await screen.findByText('Scrollable deal 13'),
+    ).toBeInTheDocument();
+  });
+
   it('setting startDate appends both &from= and &startDate= (#117 dual spelling)', async () => {
     render(<Reports />);
     // Wait for initial fetch.

--- a/frontend/src/__tests__/Services.test.jsx
+++ b/frontend/src/__tests__/Services.test.jsx
@@ -27,7 +27,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -100,6 +100,48 @@ describe('<Services /> — Catalog tab', () => {
     // Radius
     expect(screen.getByText(/25 km/)).toBeInTheDocument();
     expect(screen.getByText(/30 km/)).toBeInTheDocument();
+  });
+
+  it('loads additional cards when the catalog scroll container reaches the bottom', async () => {
+    const manyServices = Array.from({ length: 18 }, (_, index) => ({
+      id: 100 + index,
+      name: `Scrollable Service ${index + 1}`,
+      category: 'hair-restoration',
+      ticketTier: index % 2 === 0 ? 'medium' : 'high',
+      basePrice: 5000 + index * 100,
+      durationMin: 30,
+      targetRadiusKm: 30,
+      isActive: true,
+    }));
+
+    fetchApi.mockImplementation((url, opts) => {
+      if (typeof url !== 'string') return Promise.resolve([]);
+      if (url === '/api/wellness/services' && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.resolve(manyServices);
+      }
+      if (url === '/api/wellness/service-categories?limit=1000') {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+
+    render(<MemoryRouter><Services /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(screen.getByText('Scrollable Service 1')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Scrollable Service 13')).not.toBeInTheDocument();
+
+    const scrollContainer = screen.getByTestId('services-catalog-scroll');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
+    scrollContainer.scrollTop = 728;
+    fireEvent.scroll(scrollContainer);
+
+    expect(
+      await screen.findByText('Scrollable Service 13'),
+    ).toBeInTheDocument();
   });
 
   it('clicking the pencil (Edit) button flips the card to edit mode', async () => {
@@ -846,6 +888,47 @@ describe('<Services /> — Active Treatments populated state', () => {
     expect(screen.getByText(/2\/6 sessions/)).toBeInTheDocument();
     // Active treatments empty-state copy MUST NOT render when rows exist
     expect(screen.queryByText(/No active treatment plans yet\./i)).not.toBeInTheDocument();
+  });
+
+  it('loads additional treatment cards when the scroll container reaches the bottom', async () => {
+    const user = userEvent.setup();
+    const manyTreatments = Array.from({ length: 18 }, (_, index) => ({
+      id: 700 + index,
+      name: `Scrollable treatment ${index + 1}`,
+      status: 'active',
+      totalSessions: 6,
+      completedSessions: 1,
+      totalPrice: 24000,
+      startedAt: '2026-04-01T00:00:00Z',
+      nextDueAt: '2026-06-01T00:00:00Z',
+      patient: { name: `Patient ${index + 1}` },
+      service: { name: 'GFC Hair', durationMin: 90, basePrice: 8500, targetRadiusKm: 25, category: 'hair-restoration' },
+    }));
+
+    fetchApi.mockImplementation((url) => {
+      if (url === '/api/wellness/services') return Promise.resolve(services);
+      if (url === '/api/wellness/activetreatment') return Promise.resolve({ data: manyTreatments });
+      return Promise.resolve({});
+    });
+
+    render(<MemoryRouter><Services /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText('GFC Hair')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Active Treatments/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Scrollable treatment 1')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Scrollable treatment 13')).not.toBeInTheDocument();
+
+    const scrollContainer = screen.getByTestId('active-treatments-scroll');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
+    scrollContainer.scrollTop = 728;
+    fireEvent.scroll(scrollContainer);
+
+    expect(
+      await screen.findByText('Scrollable treatment 13'),
+    ).toBeInTheDocument();
   });
 
   it('keeps the cancelled badge inside the treatment card container', async () => {

--- a/frontend/src/__tests__/TmcCatalogueAdmin.test.jsx
+++ b/frontend/src/__tests__/TmcCatalogueAdmin.test.jsx
@@ -5,7 +5,7 @@
  * PRD_TMC_DIAGNOSTIC_SALES_ROUTING_ENGINE.md §10 row T16. Pins the page's
  * surface contract against backend/routes/travel_tmc_catalogue.js (T5):
  *
- *   GET    /api/travel-tmc-catalogue?status=active|archived → list
+ *   GET    /api/travel-tmc-catalogue?status=active|archived&limit=&offset= → list
  *   POST   /api/travel-tmc-catalogue            → create (always lands archived)
  *   PATCH  /api/travel-tmc-catalogue/:id        → update
  *   DELETE /api/travel-tmc-catalogue/:id        → soft-archive
@@ -112,8 +112,8 @@ const ARCHIVED_ROWS = [
 ];
 
 function installFetchMock({
-  active = { catalogue: ACTIVE_ROWS, total: ACTIVE_ROWS.length, limit: 100, offset: 0 },
-  archived = { catalogue: ARCHIVED_ROWS, total: ARCHIVED_ROWS.length, limit: 100, offset: 0 },
+  active = { catalogue: ACTIVE_ROWS, total: ACTIVE_ROWS.length, limit: 10, offset: 0 },
+  archived = { catalogue: ARCHIVED_ROWS, total: ARCHIVED_ROWS.length, limit: 10, offset: 0 },
   create = null,
   patch = null,
   del = null,
@@ -121,11 +121,12 @@ function installFetchMock({
 } = {}) {
   fetchApiMock.mockImplementation((url, opts) => {
     const method = opts?.method || 'GET';
-    if (url.startsWith('/api/travel-tmc-catalogue?status=active') && method === 'GET') {
+    const parsed = new URL(String(url), 'http://localhost');
+    if (parsed.pathname === '/api/travel-tmc-catalogue' && method === 'GET' && parsed.searchParams.get('status') === 'active') {
       if (active instanceof Error) return Promise.reject(active);
       return Promise.resolve(active);
     }
-    if (url.startsWith('/api/travel-tmc-catalogue?status=archived') && method === 'GET') {
+    if (parsed.pathname === '/api/travel-tmc-catalogue' && method === 'GET' && parsed.searchParams.get('status') === 'archived') {
       if (archived instanceof Error) return Promise.reject(archived);
       return Promise.resolve(archived);
     }
@@ -210,7 +211,7 @@ describe('<TmcCatalogueAdmin /> — page chrome + initial load', () => {
     const call = fetchApiMock.mock.calls.find(
       ([u, o]) =>
         typeof u === 'string'
-        && u.startsWith('/api/travel-tmc-catalogue?status=active')
+        && u.startsWith('/api/travel-tmc-catalogue?status=active&limit=10&offset=0')
         && (!o?.method || o.method === 'GET'),
     );
     expect(call).toBeTruthy();
@@ -230,7 +231,7 @@ describe('<TmcCatalogueAdmin /> — tab switching', () => {
       const call = fetchApiMock.mock.calls.find(
         ([u]) =>
           typeof u === 'string'
-          && u.startsWith('/api/travel-tmc-catalogue?status=archived'),
+          && u.startsWith('/api/travel-tmc-catalogue?status=archived&limit=10&offset=0'),
       );
       expect(call).toBeTruthy();
     });
@@ -241,7 +242,7 @@ describe('<TmcCatalogueAdmin /> — tab switching', () => {
 
 describe('<TmcCatalogueAdmin /> — empty states', () => {
   it('Active tab renders empty-state copy when API returns []', async () => {
-    installFetchMock({ active: { catalogue: [], total: 0, limit: 100, offset: 0 } });
+    installFetchMock({ active: { catalogue: [], total: 0, limit: 10, offset: 0 } });
     renderPage();
     expect(
       await screen.findByText(/No active catalogue entries/i),
@@ -249,13 +250,91 @@ describe('<TmcCatalogueAdmin /> — empty states', () => {
   });
 
   it('Archived tab renders empty-state copy when API returns []', async () => {
-    installFetchMock({ archived: { catalogue: [], total: 0, limit: 100, offset: 0 } });
+    installFetchMock({ archived: { catalogue: [], total: 0, limit: 10, offset: 0 } });
     renderPage();
     await screen.findByText('Golden Triangle Heritage Trail');
     fireEvent.click(screen.getByRole('tab', { name: /Archived/i }));
     expect(
       await screen.findByText(/No archived catalogue entries/i),
     ).toBeInTheDocument();
+  });
+});
+
+describe('<TmcCatalogueAdmin /> — infinite scroll', () => {
+  it('requests the next slice when the list container scrolls to the bottom', async () => {
+    const activePage1 = Array.from({ length: 10 }, (_, idx) =>
+      makeRow({
+        id: 100 + idx,
+        tripId: `active-trip-${idx + 1}`,
+        title: `Active Trip ${idx + 1}`,
+        status: 'active',
+      }),
+    );
+    const activePage2 = [
+      makeRow({
+        id: 200,
+        tripId: 'active-trip-11',
+        title: 'Active Trip 11',
+        status: 'active',
+      }),
+      makeRow({
+        id: 201,
+        tripId: 'active-trip-12',
+        title: 'Active Trip 12',
+        status: 'active',
+      }),
+    ];
+
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = opts?.method || 'GET';
+      const parsed = new URL(String(url), 'http://localhost');
+      if (parsed.pathname === '/api/travel-tmc-catalogue' && method === 'GET' && parsed.searchParams.get('status') === 'active') {
+        const offset = Number(parsed.searchParams.get('offset') || 0);
+        if (offset === 10) {
+          return Promise.resolve({
+            catalogue: activePage2,
+            total: 12,
+            limit: 10,
+            offset: 10,
+          });
+        }
+        return Promise.resolve({
+          catalogue: activePage1,
+          total: 12,
+          limit: 10,
+          offset: 0,
+        });
+      }
+      if (parsed.pathname === '/api/travel-tmc-catalogue' && method === 'GET' && parsed.searchParams.get('status') === 'archived') {
+        return Promise.resolve({
+          catalogue: ARCHIVED_ROWS,
+          total: ARCHIVED_ROWS.length,
+          limit: 10,
+          offset: 0,
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    renderPage();
+    expect(await screen.findByText('Active Trip 1')).toBeInTheDocument();
+
+    const list = screen.getByRole('list', { name: /active catalogue entries/i });
+    Object.defineProperties(list, {
+      scrollTop: { value: 1000, writable: true, configurable: true },
+      clientHeight: { value: 500, writable: true, configurable: true },
+      scrollHeight: { value: 1400, writable: true, configurable: true },
+    });
+    fireEvent.scroll(list);
+
+    await waitFor(() => {
+      const call = fetchApiMock.mock.calls.find(
+        ([u]) => typeof u === 'string' && u.includes('status=active&limit=10&offset=10'),
+      );
+      expect(call).toBeTruthy();
+    });
+    expect(await screen.findByText('Active Trip 11')).toBeInTheDocument();
+    expect(screen.getByText('Active Trip 12')).toBeInTheDocument();
   });
 });
 
@@ -590,7 +669,7 @@ describe('<TmcCatalogueAdmin /> - bulk import template + ingest flow', () => {
           }),
         ],
         total: ARCHIVED_ROWS.length + 1,
-        limit: 100,
+        limit: 10,
         offset: 0,
       },
     });

--- a/frontend/src/__tests__/Trips.test.jsx
+++ b/frontend/src/__tests__/Trips.test.jsx
@@ -11,7 +11,7 @@
  *      no RBAC gate in the SUT).
  *   2. Loading state: shows "Loading…" placeholder before first GET resolves
  *      (await findByText per CLAUDE.md tick #108 cron-learning).
- *   3. GET on mount: hits /api/travel/trips?limit=100 (no status when filter
+ *   3. GET on mount: hits /api/travel/trips?limit=10&offset=0 (no status when filter
  *      is empty) and renders one row per trip (table layout, 7 columns).
  *   4. Empty state: zero trips → "No trips yet. New trips spawn from the
  *      linked Deal in the sales pipeline." copy.
@@ -188,7 +188,7 @@ const SCHOOLS_DEFAULT = [
 // Install a fetchApi mock that routes by URL + method. Tests override only
 // the surface they care about.
 function installFetchMock({
-  list = { trips: TRIPS_DEFAULT, total: TRIPS_DEFAULT.length, limit: 100, offset: 0 },
+  list = { trips: TRIPS_DEFAULT, total: TRIPS_DEFAULT.length, limit: 10, offset: 0 },
   schools = SCHOOLS_DEFAULT,
   create = null,
 } = {}) {
@@ -252,6 +252,7 @@ describe('<Trips /> — page chrome', () => {
       );
       expect(calls.length).toBeGreaterThan(0);
     });
+    expect(screen.getByTestId('trips-table-scroll')).toBeInTheDocument();
   });
 });
 
@@ -267,12 +268,12 @@ describe('<Trips /> — load + render lifecycle', () => {
     });
     renderPage();
     expect(await screen.findByText('Loading…')).toBeInTheDocument();
-    resolveList({ trips: TRIPS_DEFAULT, total: TRIPS_DEFAULT.length, limit: 100, offset: 0 });
+    resolveList({ trips: TRIPS_DEFAULT, total: TRIPS_DEFAULT.length, limit: 10, offset: 0 });
     await screen.findByText('TMC-AND-2026-MUMBAI-G7');
     expect(screen.queryByText('Loading…')).toBeNull();
   });
 
-  it('GETs /api/travel/trips on mount with limit=100 + no status when filter empty', async () => {
+  it('GETs /api/travel/trips on mount with limit=10&offset=0 + no status when filter empty', async () => {
     renderPage();
     await waitFor(() => {
       const listCall = fetchApiMock.mock.calls.find(([u, o]) =>
@@ -281,7 +282,8 @@ describe('<Trips /> — load + render lifecycle', () => {
         && (!o?.method || o.method === 'GET'),
       );
       expect(listCall).toBeTruthy();
-      expect(listCall[0]).toContain('limit=100');
+      expect(listCall[0]).toContain('limit=10');
+      expect(listCall[0]).toContain('offset=0');
       // No status= when filter empty.
       expect(listCall[0]).not.toContain('status=');
     });
@@ -291,8 +293,77 @@ describe('<Trips /> — load + render lifecycle', () => {
     expect(screen.getByText('TMC-SHIM-2025-BPS-G10')).toBeInTheDocument();
   });
 
+  it('scrolling the table container requests the second page with offset=10', async () => {
+    const firstPage = Array.from({ length: 10 }, (_, i) =>
+      makeTrip({
+        id: 201 + i,
+        tripCode: `TMC-PAGE1-${i + 1}`,
+        destination: `Dest ${i + 1}`,
+        schoolContactId: 6001 + i,
+        status: i % 2 === 0 ? 'confirmed' : 'in-trip',
+        pricePerStudent: 50000 + i * 1000,
+        _count: { participants: 10 + i, documentRequirements: 0 },
+      }),
+    );
+    const secondPage = [
+      makeTrip({
+        id: 301,
+        tripCode: 'TMC-PAGE2-1',
+        destination: 'Dest 11',
+        schoolContactId: 7001,
+        status: 'completed',
+        pricePerStudent: 91000,
+        _count: { participants: 21, documentRequirements: 1 },
+      }),
+      makeTrip({
+        id: 302,
+        tripCode: 'TMC-PAGE2-2',
+        destination: 'Dest 12',
+        schoolContactId: 7002,
+        status: 'cancelled',
+        pricePerStudent: null,
+        _count: { participants: 5, documentRequirements: 0 },
+      }),
+    ];
+
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = opts?.method || 'GET';
+      if (url.startsWith('/api/travel/trips') && method === 'GET') {
+        if (url.includes('offset=10')) {
+          return Promise.resolve({ trips: secondPage, total: 12, limit: 10, offset: 10 });
+        }
+        return Promise.resolve({ trips: firstPage, total: 12, limit: 10, offset: 0 });
+      }
+      if (url.startsWith('/api/contacts') && method === 'GET') {
+        return Promise.resolve(SCHOOLS_DEFAULT);
+      }
+      return Promise.resolve(null);
+    });
+
+    renderPage();
+    await screen.findByText('TMC-PAGE1-1');
+    const scrollContainer = screen.getByTestId('trips-table-scroll');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 800, configurable: true });
+    scrollContainer.scrollTop = 728;
+    fireEvent.scroll(scrollContainer);
+
+    await waitFor(() => {
+      const nextCall = fetchApiMock.mock.calls.find(([u, o]) =>
+        typeof u === 'string'
+        && u.startsWith('/api/travel/trips')
+        && (!o?.method || o.method === 'GET')
+        && u.includes('offset=10'),
+      );
+      expect(nextCall).toBeTruthy();
+    });
+
+    expect(await screen.findByText('TMC-PAGE2-1')).toBeInTheDocument();
+    expect(screen.getByText('TMC-PAGE2-2')).toBeInTheDocument();
+  });
+
   it('renders empty-state copy when trips=[]', async () => {
-    installFetchMock({ list: { trips: [], total: 0, limit: 100, offset: 0 } });
+    installFetchMock({ list: { trips: [], total: 0, limit: 10, offset: 0 } });
     renderPage();
     expect(
       await screen.findByText(/No trips yet\. New trips spawn from the linked Deal/i),
@@ -315,7 +386,7 @@ describe('<Trips /> — filter behavior', () => {
     renderPage();
     await screen.findByText('TMC-AND-2026-MUMBAI-G7');
     fetchApiMock.mockClear();
-    installFetchMock({ list: { trips: [TRIPS_DEFAULT[0]], total: 1, limit: 100, offset: 0 } });
+    installFetchMock({ list: { trips: [TRIPS_DEFAULT[0]], total: 1, limit: 10, offset: 0 } });
     fireEvent.change(screen.getByLabelText(/Filter by status/i), {
       target: { value: 'confirmed' },
     });
@@ -562,7 +633,7 @@ describe('<Trips /> — search filter (client-side)', () => {
   it('status filter and search work together — status narrows the fetched list, search narrows the rendered list', async () => {
     // Server returns only confirmed trips after status filter.
     installFetchMock({
-      list: { trips: [TRIPS_DEFAULT[0]], total: 1, limit: 100, offset: 0 },
+      list: { trips: [TRIPS_DEFAULT[0]], total: 1, limit: 10, offset: 0 },
     });
     renderPage();
     fireEvent.change(screen.getByLabelText(/Filter by status/i), {

--- a/frontend/src/__tests__/WebCheckinQueue.test.jsx
+++ b/frontend/src/__tests__/WebCheckinQueue.test.jsx
@@ -6,8 +6,7 @@
  *   - Page header renders.
  *   - Empty state renders the PRD-correct messaging.
  *   - Data rows render PNR / flight / passenger / status badge.
- *   - Status badge renders for every enum value (pending|reminded|
- *     in-progress|done|fallback-agent|failed).
+ *   - Status badge renders for pending and done enum values.
  *   - Upload boarding pass triggers multipart POST to
  *     /api/travel/webcheckins/:id/upload-boarding-pass.
  *   - Deliver action confirms + POSTs /deliver; 409 NO_BOARDING_PASS
@@ -226,13 +225,13 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
     await screen.findByText('ABC123');
 
     const filterSelect = screen.getByLabelText(/Filter by status/i);
-    fireEvent.change(filterSelect, { target: { value: 'reminded' } });
+    fireEvent.change(filterSelect, { target: { value: 'done' } });
 
     await waitFor(() => {
-      const remindedCall = fetchApiMock.mock.calls.find(
-        ([u]) => typeof u === 'string' && u.includes('status=reminded'),
+      const doneCall = fetchApiMock.mock.calls.find(
+        ([u]) => typeof u === 'string' && u.includes('status=done'),
       );
-      expect(remindedCall).toBeTruthy();
+      expect(doneCall).toBeTruthy();
     });
   });
 
@@ -284,31 +283,22 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
 
   // ─── Extended coverage (2026-05-26 test-cron) ────────────────────
   //
-  // SUT is 464L; original test covered 9 cases. These extend to cover
-  // remaining enum badge values, deliver-disabled-after-delivered,
+  // These extend to cover deliver-disabled-after-delivered,
   // declined-confirm path, reassign PATCH (assign + unassign), upload
   // error, /api/staff fetch failure, fetchApi catch (non-401), invalid
   // dates rendering "—", boarding-pass View link, status-filter
   // disabled-during-upcoming, and pagination range display.
 
-  it('renders status badges for all six enum values', async () => {
+  it('renders status badges for pending and done enum values', async () => {
     const allStatusRows = [
       { id: 1, pnr: 'P1', airlineCode: '6E', flightNumber: '6E-1', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'A', status: 'pending', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
-      { id: 2, pnr: 'P2', airlineCode: '6E', flightNumber: '6E-2', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'B', status: 'reminded', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
-      { id: 3, pnr: 'P3', airlineCode: '6E', flightNumber: '6E-3', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'C', status: 'in-progress', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
-      { id: 4, pnr: 'P4', airlineCode: '6E', flightNumber: '6E-4', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'D', status: 'done', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
-      { id: 5, pnr: 'P5', airlineCode: '6E', flightNumber: '6E-5', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'E', status: 'fallback-agent', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
-      { id: 6, pnr: 'P6', airlineCode: '6E', flightNumber: '6E-6', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'F', status: 'failed', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
+      { id: 2, pnr: 'P2', airlineCode: '6E', flightNumber: '6E-2', departureAt: '2026-06-01T10:30:00.000Z', windowOpenAt: '2026-05-31T10:30:00.000Z', passengerName: 'B', status: 'done', boardingPassUrl: null, deliveredAt: null, assignedAgentId: null },
     ];
     fetchApiMock.mockImplementation(defaultFetchImpl(allStatusRows));
     renderPage();
     await screen.findByText('P1');
     expect(screen.getByTestId('status-badge-1').textContent).toBe('pending');
-    expect(screen.getByTestId('status-badge-2').textContent).toBe('reminded');
-    expect(screen.getByTestId('status-badge-3').textContent).toBe('in-progress');
-    expect(screen.getByTestId('status-badge-4').textContent).toBe('done');
-    expect(screen.getByTestId('status-badge-5').textContent).toBe('fallback-agent');
-    expect(screen.getByTestId('status-badge-6').textContent).toBe('failed');
+    expect(screen.getByTestId('status-badge-2').textContent).toBe('done');
   });
 
   it('renders boarding-pass "View" link when URL present and "—" when absent', async () => {

--- a/frontend/src/__tests__/WebCheckinQueue.test.jsx
+++ b/frontend/src/__tests__/WebCheckinQueue.test.jsx
@@ -252,18 +252,29 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
     });
   });
 
-  it('Next-page button updates the offset query param', async () => {
-    // Need >50 total to render the pager.
-    const manyRows = Array.from({ length: 50 }, (_, i) => ({
+  it('scrolling the queue loads the next page with offset=50', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, i) => ({
       id: i + 1, pnr: `PNR${i}`, airlineCode: '6E', flightNumber: `6E-${100 + i}`,
       departureAt: '2026-06-01T10:30:00.000Z',
       windowOpenAt: '2026-05-31T10:30:00.000Z',
       passengerName: `Passenger ${i}`, status: 'pending',
       boardingPassUrl: null, deliveredAt: null, assignedAgentId: null,
     }));
+    const secondPage = Array.from({ length: 20 }, (_, i) => ({
+      id: 100 + i, pnr: `PNR${50 + i}`, airlineCode: '6E', flightNumber: `6E-${150 + i}`,
+      departureAt: '2026-06-02T10:30:00.000Z',
+      windowOpenAt: '2026-06-01T10:30:00.000Z',
+      passengerName: `Passenger ${50 + i}`, status: 'pending',
+      boardingPassUrl: null, deliveredAt: null, assignedAgentId: null,
+    }));
     fetchApiMock.mockImplementation((url) => {
       if (url.startsWith('/api/travel/webcheckins?')) {
-        return Promise.resolve({ webcheckins: manyRows, total: 120, limit: 50, offset: url.includes('offset=50') ? 50 : 0 });
+        return Promise.resolve({
+          webcheckins: url.includes('offset=50') ? secondPage : firstPage,
+          total: 120,
+          limit: 50,
+          offset: url.includes('offset=50') ? 50 : 0,
+        });
       }
       if (url === '/api/staff') return Promise.resolve(SAMPLE_STAFF);
       return Promise.resolve({});
@@ -271,8 +282,13 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
     renderPage();
     await screen.findByText('PNR0');
 
-    const nextBtn = screen.getByRole('button', { name: /Next page/i });
-    fireEvent.click(nextBtn);
+    const scrollArea = screen.getByTestId('webcheckins-table-scroll');
+    Object.defineProperties(scrollArea, {
+      scrollTop: { value: 728, writable: true, configurable: true },
+      clientHeight: { value: 400, writable: true, configurable: true },
+      scrollHeight: { value: 800, writable: true, configurable: true },
+    });
+    fireEvent.scroll(scrollArea);
 
     await waitFor(() => {
       const nextCall = fetchApiMock.mock.calls.find(
@@ -478,7 +494,7 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
     });
   });
 
-  it('renders pagination range "1–50 of 120" when total exceeds page size', async () => {
+  it('scrolling the queue loads the next page and appends more rows', async () => {
     const manyRows = Array.from({ length: 50 }, (_, i) => ({
       id: i + 1, pnr: `RNG${i}`, airlineCode: '6E', flightNumber: `6E-${100 + i}`,
       departureAt: '2026-06-01T10:30:00.000Z',
@@ -495,11 +511,20 @@ describe('WebCheckinQueue — operator queue (PRD §4.6)', () => {
     });
     renderPage();
     await screen.findByText('RNG0');
-    // Range text uses an HTML en-dash entity (–); accept either form.
-    const rangeText = screen.getByText(/1.{1,3}50 of 120/);
-    expect(rangeText).toBeTruthy();
-    // Prev button should be disabled at offset 0.
-    const prevBtn = screen.getByRole('button', { name: /Previous page/i });
-    expect(prevBtn.disabled).toBe(true);
+
+    const scrollArea = screen.getByTestId('webcheckins-table-scroll');
+    Object.defineProperties(scrollArea, {
+      scrollTop: { value: 728, writable: true, configurable: true },
+      clientHeight: { value: 400, writable: true, configurable: true },
+      scrollHeight: { value: 800, writable: true, configurable: true },
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      const nextCall = fetchApiMock.mock.calls.find(
+        ([u]) => typeof u === 'string' && u.includes('offset=50'),
+      );
+      expect(nextCall).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/__tests__/lazyWithRetry.test.jsx
+++ b/frontend/src/__tests__/lazyWithRetry.test.jsx
@@ -53,7 +53,7 @@ describe('lazyWithRetry', () => {
 
   it('does NOT retry non-chunk errors (real bug should fail fast)', async () => {
     const importFn = vi.fn(() => Promise.reject(new TypeError('undefined is not a function')));
-    const Lazy = lazyWithRetry(importFn);
+    const _Lazy = lazyWithRetry(importFn);
 
     // React's lazy throws into the nearest error boundary; we can't render
     // it directly without one, so test the inner promise via importFn.

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -499,7 +499,7 @@ const NotificationBell = () => {
                 textAlign: "center",
               }}
             >
-              <button
+              {/* <button
                 onClick={() => {
                   navigate("/notifications");
                   setOpen(false);
@@ -515,7 +515,7 @@ const NotificationBell = () => {
                 aria-label="View all notifications"
               >
                 View all notifications →
-              </button>
+              </button> */}
             </div>
           )}
         </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2032,7 +2032,8 @@ function renderTravelNav({
         <Link to="/travel/tmc/catalogue" icon={Package} label="TMC Catalogue" requiredPermission={{ module: "tmc_catalogue", action: "read" }} />
       )}
       <Link to="/travel/web-checkins" icon={Ticket} label="Web Check-ins" requiredPermission={{ module: "web_checkins", action: "read" }} />
-      <Link to="/travel/automation-health" icon={Activity} label="Check-in Automation Health" requiredPermission={{ module: "web_checkins", action: "read" }} />
+      {/* Check-in Automation Health hidden per product call (manual web check-in only). */}
+      {/* <Link to="/travel/automation-health" icon={Activity} label="Check-in Automation Health" requiredPermission={{ module: "web_checkins", action: "read" }} /> */}
       <Link to="/travel/passport-verification" icon={BadgeCheck} label="Passport" requiredPermission={{ module: "passport", action: "manage" }} />
       <Link to="/travel/cost-master" icon={IndianRupee} label="Cost Master" requiredPermission={{ module: "cost_master", action: "read" }} />
       <Link to="/travel/sightseeing" icon={Camera} label="Sightseeing Master" requiredPermission={{ module: "sightseeing", action: "read" }} />

--- a/frontend/src/components/ui/Pagination.jsx
+++ b/frontend/src/components/ui/Pagination.jsx
@@ -64,6 +64,7 @@ export default function Pagination({
         gap: '1rem',
         padding: '0.75rem 0',
         flexWrap: 'wrap',
+        margin: "0 1rem ",
         ...style,
       }}
     >

--- a/frontend/src/pages/GmailInbox.jsx
+++ b/frontend/src/pages/GmailInbox.jsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useContext } from 'react';
 import {
   Mail, RefreshCw, Plug, Trash2, Send, X, PencilLine, CornerUpLeft,
   Search, Inbox as InboxIcon, AlertTriangle, Check, Paperclip,
-  Link2, List, ListOrdered,
+  Link2, List, ListOrdered, Ticket,
 } from 'lucide-react';
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
+import { AuthContext } from '../App';
 
 // Make bare URLs in a plain-text email body clickable — React-safe (renders real
 // <a> nodes, never dangerouslySetInnerHTML, so injected markup stays inert).
@@ -41,6 +42,7 @@ function linkifyText(text) {
 //   DELETE /api/gmail/disconnect
 //   GET    /api/gmail/messages?q&maxResults → { messages: [...] }
 //   GET    /api/gmail/messages/:messageId   → full parsed message
+//   POST   /api/gmail/messages/:messageId/webcheckin → Travel only; LLM extraction → WebCheckin row
 //   POST   /api/gmail/send             → { success, gmailMessageId, ... }
 // The OAuth callback bounces back here with ?connected=gmail / ?error=…
 
@@ -133,8 +135,17 @@ const FOLDERS = [
   { key: 'all', label: 'All', icon: Mail, q: '' },
 ];
 
+const FLIGHT_KEYWORDS = /\b(flight|airline|ticket|booking|pnr|e-ticket|eticket|boarding pass|passenger|departure|airport|iata|flight no|flight number|confirmation)\b/i;
+function looksLikeFlightTicket(msg) {
+  const haystack = `${msg?.subject || ''} ${msg?.snippet || ''} ${msg?.text || ''}`;
+  return FLIGHT_KEYWORDS.test(haystack);
+}
+
 export default function GmailInbox() {
   const notify = useNotify();
+  const auth = useContext(AuthContext) || {};
+  const { tenant } = auth;
+  const isTravel = tenant?.vertical === 'travel';
   const [status, setStatus] = useState({ connected: false, emailAddress: null, lastSyncAt: null });
   const [loadingStatus, setLoadingStatus] = useState(true);
   const [messages, setMessages] = useState([]);
@@ -151,6 +162,7 @@ export default function GmailInbox() {
   const [showBcc, setShowBcc] = useState(false);
   const [attachments, setAttachments] = useState([]);
   const [sending, setSending] = useState(false);
+  const [sendingToWebcheckin, setSendingToWebcheckin] = useState(false);
   const fileInputRef = useRef(null);
   const bodyRef = useRef(null);
 
@@ -281,6 +293,23 @@ export default function GmailInbox() {
     const subject = msg.subject ? (/^re:/i.test(msg.subject) ? msg.subject : `Re: ${msg.subject}`) : '';
     openCompose({ to: senderEmail(msg.from), subject });
     setSelected(null);
+  };
+
+  const sendToWebcheckin = async (msg) => {
+    if (!msg?.id) return;
+    setSendingToWebcheckin(true);
+    try {
+      const res = await fetchApi(`/api/gmail/messages/${msg.id}/webcheckin`, {
+        method: 'POST',
+        silent: true,
+      });
+      notify.success(`Web check-in created for ${res?.webcheckin?.passengerName || 'passenger'}.`);
+      setSelected(null);
+    } catch (err) {
+      notify.error(err?.message || 'Could not create web check-in from this email.');
+    } finally {
+      setSendingToWebcheckin(false);
+    }
   };
 
   const handleSend = async (e) => {
@@ -559,6 +588,22 @@ export default function GmailInbox() {
                       display: 'inline-flex', alignItems: 'center', gap: '0.35rem', flexShrink: 0 }}>
                     <CornerUpLeft size={14} /> Reply
                   </button>
+                  {isTravel && looksLikeFlightTicket(selected) && (
+                    <button
+                      onClick={() => sendToWebcheckin(selected)}
+                      disabled={sendingToWebcheckin}
+                      title="Create a Web Check-in row from this ticket"
+                      style={{
+                        background: 'var(--primary-color, var(--accent-color))', border: 'none', color: '#fff',
+                        borderRadius: 999, padding: '0.4rem 0.85rem', cursor: sendingToWebcheckin ? 'wait' : 'pointer',
+                        fontSize: '0.82rem', display: 'inline-flex', alignItems: 'center', gap: '0.35rem', flexShrink: 0,
+                        opacity: sendingToWebcheckin ? 0.7 : 1,
+                      }}
+                    >
+                      <Ticket size={14} />
+                      {sendingToWebcheckin ? 'Creating…' : 'Send to Web Check-in'}
+                    </button>
+                  )}
                 </div>
                 {/* Plain-text body (NOT raw HTML) — safe against injected markup. */}
                 <div style={{ padding: '1.25rem 1.5rem', borderTop: '1px solid var(--border-color)',

--- a/frontend/src/pages/Leads.jsx
+++ b/frontend/src/pages/Leads.jsx
@@ -58,6 +58,18 @@ const sourceBadgeStyle = {
   whiteSpace: 'nowrap',
   display: 'inline-block',
 };
+
+const leadSourceLabel = (lead) => (
+  lead?.source
+  || lead?.firstTouchSource
+  || lead?.submitSource
+  || lead?.submittedSource
+  || lead?.customFields?.submit_source
+  || lead?.customFields?.submitSource
+  || lead?.customFields?.lead_source
+  || lead?.customFields?.leadSource
+  || 'Organic'
+);
 // Reject all C0 controls (NUL/BEL/etc.) + DEL. \t \n \r are intentionally
 // included  text inputs shouldn't carry them either, and any paste-from-
 // malicious-source typically smuggles via NUL or BEL. Detecting control
@@ -700,6 +712,7 @@ const Leads = () => {
           name: trimmedName,
           phone: phoneOut,
           countryCode: undefined,
+          skipInitialAssignee: isGeneric ? true : undefined,
           callifiedCampaignId: isGeneric && autoCampaignId ? Number(autoCampaignId) : undefined,
         }),
       });
@@ -719,16 +732,6 @@ const Leads = () => {
     // tab, so this is also where the user expects to find the row next.
     const body = { status: 'Prospect' };
 
-    // If this lead has a Callified AI call, surface "callified" as the source
-    // so converted-lead attribution reflects the AI call channel. Generic vertical only.
-    if (isGeneric) {
-      const hasCallifiedCall = await fetchApi(`/api/callified/calls/lead/${id}/latest`)
-        .then(res => !!res?.callifiedLeadId)
-        .catch(() => false);
-      if (hasCallifiedCall) {
-        body.source = 'callified';
-      }
-    }
 
     await fetchApi(`/api/contacts/${id}`, {
       method: 'PUT',
@@ -1751,7 +1754,7 @@ const Leads = () => {
                   {isColVisible('source') && (
                     <td style={{ padding: '1rem' }}>
                       <span style={sourceBadgeStyle}>
-                        {lead.source || 'Organic'}
+                        {leadSourceLabel(lead)}
                       </span>
                     </td>
                   )}

--- a/frontend/src/pages/Leads.jsx
+++ b/frontend/src/pages/Leads.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   UserPlus, Search, ArrowRightCircle, Plus, X, Pencil, Trash2, RefreshCw,
   ChevronLeft, ChevronRight, Phone, FileText, Filter, SlidersHorizontal, Info,
+  Settings,
 } from 'lucide-react';
 import { AuthContext } from '../App';
 import ColumnPicker from '../components/ColumnPicker';
@@ -163,6 +164,11 @@ const Leads = () => {
   const [callQueueActive, setCallQueueActive] = useState(false);
   const [callStatusDrawerOpen, setCallStatusDrawerOpen] = useState(false);
   const [classifyingLeads, setClassifyingLeads] = useState(new Set());
+  // Generic CRM Leads page — AI transcript classification toggle (gear menu next
+  // to the Lead Status column). Default true matches the tenant-setting default.
+  const [aiTranscriptEnabled, setAiTranscriptEnabled] = useState(true);
+  const [aiTranscriptSaving, setAiTranscriptSaving] = useState(false);
+  const [aiSettingsOpen, setAiSettingsOpen] = useState(false);
   const [pipelineStages, setPipelineStages] = useState([]);
   const [dealsByContact, setDealsByContact] = useState({});
   const [bookingValueByContact, setBookingValueByContact] = useState({});
@@ -217,8 +223,8 @@ const Leads = () => {
     customFields: {},
   });
 
-  const fetchLeads = async () => {
-    setLoading(true);
+  const fetchLeads = async ({ background = false } = {}) => {
+    if (!background) setLoading(true);
     try {
       const data = await fetchApi('/api/contacts?status=Lead&limit=500');
       const rows = Array.isArray(data) ? data : [];
@@ -228,7 +234,7 @@ const Leads = () => {
       notify.error('Failed to load leads');
       return [];
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   };
 
@@ -272,9 +278,9 @@ const Leads = () => {
   };
 
   // Refresh everything visible on the Leads page without a full reload.
-  // Re-classifies any generic leads that are linked to a Callified campaign or
-  // currently have no status, so a real call that just completed updates the
-  // Hot/Cold badge without a browser reload.
+  // Recomputes AI scores and re-classifies Hot/Cold only for leads that were
+  // actually called, so a real call that just completed updates both the Lead
+  // Score and the Lead Status without a browser reload.
   const refreshAll = async () => {
     const [freshLeads] = await Promise.all([
       fetchLeads(),
@@ -283,7 +289,33 @@ const Leads = () => {
       loadAutoCampaign(),
     ]);
     if (isGeneric && Array.isArray(freshLeads) && freshLeads.length > 0) {
-      await classifyVisibleLeads(freshLeads, { force: true });
+      // Score + classify only leads that were actually called. This avoids
+      // burning Gemini credits / HTTP time on hundreds of untouched leads while
+      // still updating status/score for contacts that have fresh Callified data.
+      const visibleIds = freshLeads.map((l) => l.id);
+      try {
+        const summaryRes = await fetchApi(`/api/callified/leads/call-summary?contactIds=${visibleIds.join(',')}`);
+        const summaries = summaryRes?.summaries || {};
+        const calledLeadIds = freshLeads
+          .filter((l) => (summaries[l.id]?.callCount || 0) > 0)
+          .map((l) => l.id);
+
+        if (calledLeadIds.length > 0) {
+          await fetchApi('/api/ai_scoring/contacts', {
+            method: 'POST',
+            body: JSON.stringify({ contactIds: calledLeadIds }),
+          });
+          const scoredLeads = await fetchLeads({ background: true });
+          // Re-classify called leads so Hot/Cold refreshes from the latest
+          // transcript/score (e.g. a preliminary Cold gets corrected to Hot).
+          if (Array.isArray(scoredLeads) && scoredLeads.length > 0) {
+            const calledSet = new Set(calledLeadIds);
+            classifyVisibleLeads(scoredLeads.filter((l) => calledSet.has(l.id)), { force: true });
+          }
+        }
+      } catch (e) {
+        console.error('[leads] aiScore/classify refresh failed:', e?.message);
+      }
     }
     notify.success('Refreshed');
   };
@@ -305,7 +337,7 @@ const Leads = () => {
         method: 'POST',
         body: JSON.stringify({ contactIds: ids }),
       });
-      await fetchLeads();
+      await fetchLeads({ background: true });
     } catch (e) {
       console.error('[leads] ensureHotLeadsAssigned failed:', e?.message);
     }
@@ -334,22 +366,20 @@ const Leads = () => {
     }
     setClassifyingLeads(next);
     try {
-      const classifyResults = await Promise.all(
-        candidates.map(async (lead) => {
-          try {
-            return await fetchApi(`/api/callified/leads/${lead.id}/classify`, { method: 'POST' });
-          } catch (e) {
-            console.error(`[leads] classify ${lead.id} failed:`, e?.message);
-            return null;
-          }
-        })
-      );
+      // Classify one lead at a time. Bulk dials can produce hundreds of completed
+      // calls; firing that many classify requests in parallel hammers the backend
+      // and can hit rate limits. Sequential keeps it predictable and safe.
+      const resultById = new Map();
+      for (const lead of candidates) {
+        try {
+          const r = await fetchApi(`/api/callified/leads/${lead.id}/classify`, { method: 'POST' });
+          if (r?.id) resultById.set(r.id, r);
+        } catch (e) {
+          console.error(`[leads] classify ${lead.id} failed:`, e?.message);
+        }
+      }
       // Optimistically merge classification results + auto-assignment into local
       // state so the Hot/Cold badge and Assigned To column update immediately.
-      const resultById = new Map();
-      for (const r of classifyResults) {
-        if (r?.id) resultById.set(r.id, r);
-      }
       if (resultById.size > 0) {
         setLeads(prev => prev.map(l => {
           const r = resultById.get(l.id);
@@ -365,7 +395,7 @@ const Leads = () => {
           };
         }));
       }
-      await fetchLeads();
+      await fetchLeads({ background: true });
       // The score/call-count badges read from a separate summary cache; refresh
       // that cache so the Callified Score column updates without a reload.
       const ids = candidates.map(l => l.id);
@@ -491,6 +521,43 @@ const Leads = () => {
   useEffect(() => {
     loadCallifiedCampaigns();
   }, [loadCallifiedCampaigns]);
+
+  // Generic CRM Leads page — load the AI transcript classification tenant setting.
+  const loadAiTranscriptSetting = useCallback(async () => {
+    if (!isGeneric) return;
+    try {
+      const d = await fetchApi('/api/tenant-settings/feature.callified.ai_transcript.enabled');
+      setAiTranscriptEnabled(String(d?.value).toLowerCase() !== 'false');
+    } catch (e) {
+      setAiTranscriptEnabled(true);
+    }
+  }, [isGeneric]);
+
+  useEffect(() => {
+    loadAiTranscriptSetting();
+  }, [loadAiTranscriptSetting]);
+
+  const saveAiTranscriptEnabled = async (next) => {
+    if (!isAdmin) {
+      notify.info('Only admins can change AI transcript classification settings.');
+      return;
+    }
+    setAiTranscriptSaving(true);
+    try {
+      const d = await fetchApi('/api/tenant-settings/feature.callified.ai_transcript.enabled', {
+        method: 'PUT',
+        body: JSON.stringify({ value: next ? 'true' : 'false', category: 'feature-flag' }),
+      });
+      setAiTranscriptEnabled(String(d?.value).toLowerCase() !== 'false');
+      notify.success(`AI transcript classification ${next ? 'enabled' : 'disabled'}`);
+    } catch (e) {
+      notify.error(e?.body?.error || 'Failed to save AI transcript setting');
+      // Re-sync so the toggle reflects the server truth.
+      loadAiTranscriptSetting();
+    } finally {
+      setAiTranscriptSaving(false);
+    }
+  };
 
   // #892  close the Create drawer on Escape. Attached only while the drawer
   // is open so we don't trap key events for users not actively creating.
@@ -641,7 +708,7 @@ const Leads = () => {
       // below puts the new row at the top so the user sees the result.
       setCreating(false);
     } finally {
-      fetchLeads();
+      fetchLeads({ background: true });
     }
   };
 
@@ -668,7 +735,7 @@ const Leads = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    fetchLeads();
+    fetchLeads({ background: true });
   };
 
   const openEdit = (lead) => {
@@ -702,7 +769,7 @@ const Leads = () => {
       });
       notify.success('Lead updated');
       setEditing(null);
-      fetchLeads();
+      fetchLeads({ background: true });
     } catch (err) {
       notify.error(err?.body?.error || err?.message || 'Failed to update lead');
     } finally {
@@ -722,7 +789,7 @@ const Leads = () => {
     try {
       await fetchApi(`/api/contacts/${lead.id}`, { method: 'DELETE' });
       notify.success('Lead deleted');
-      fetchLeads();
+      fetchLeads({ background: true });
     } catch (err) {
       notify.error(err?.body?.error || err?.message || 'Failed to delete lead');
     }
@@ -734,7 +801,7 @@ const Leads = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ assignedToId: assignedToId || null }),
     });
-    fetchLeads();
+    fetchLeads({ background: true });
   };
 
   const handleBulkAssign = async () => {
@@ -746,7 +813,7 @@ const Leads = () => {
     });
     setSelectedLeads([]);
     setBulkAgent('');
-    fetchLeads();
+    fetchLeads({ background: true });
   };
 
   const handleCampaignChange = async (lead, campaignId) => {
@@ -765,7 +832,7 @@ const Leads = () => {
       });
       // Refetch leads once; reload campaign counts in the background so the
       // dropdown counts stay fresh without blocking the optimistic update.
-      await fetchLeads();
+      await fetchLeads({ background: true });
       loadCallifiedCampaigns();
     } catch (err) {
       // Roll back on failure.
@@ -776,8 +843,10 @@ const Leads = () => {
     }
   };
 
-  // Poll Callified until a lead's latest call reaches a terminal state or a
-  // timeout passes. Keeps the queue honest one-by-one instead of racing ahead.
+  // Poll Callified until a lead's latest call has a transcript, or a timeout
+  // passes. The post-call classify reads the latest review from Callified; if
+  // the review is still preliminary, the Refresh button re-classifies called
+  // leads so the status corrects itself once the final review is available.
   const pollCallCompletion = async (lead, { callifiedLeadId, timeoutMs = 120_000, intervalMs = 3000 } = {}) => {
     const start = Date.now();
     let resolvedId = callifiedLeadId || null;
@@ -835,7 +904,7 @@ const Leads = () => {
 
     setCallQueueActive(false);
     setTimeout(() => setCallQueue([]), 4000);
-    const freshLeads = await fetchLeads();
+    const freshLeads = await fetchLeads({ background: true });
     if (isGeneric && completed.length > 0 && freshLeads?.length > 0) {
       // Re-classify the leads we just called so their Hot/Cold status updates
       // from the latest transcript/score without requiring a browser reload.
@@ -938,10 +1007,10 @@ const Leads = () => {
             }
           : l
       ));
-      await fetchLeads();
     } catch (err) {
       notify.error(err?.body?.error || err?.message || 'Failed to update lead status');
-      await fetchLeads();
+    } finally {
+      await fetchLeads({ background: true });
     }
   };
 
@@ -1069,17 +1138,6 @@ const Leads = () => {
   }, [isGeneric, filteredLeads.map(l => l.id).join(',')]);
   /* eslint-enable react-hooks/exhaustive-deps */
 
-  // Auto-classify visible generic-CRM leads that haven't been classified yet.
-  // Runs whenever the visible lead set changes and Callified is configured.
-  useEffect(() => {
-    if (!isGeneric || !callifiedConfigured || filteredLeads.length === 0) return;
-    const timeout = setTimeout(() => {
-      classifyVisibleLeads(filteredLeads);
-    }, 500);
-    return () => clearTimeout(timeout);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isGeneric, callifiedConfigured, filteredLeads.map(l => `${l.id}:${l.callifiedLeadStatus}`).join(',')]);
-
   // Safety net: any Hot lead that is unassigned (or assigned to a user outside
   // the active ADMIN/MANAGER/USER pool used by the round-robin picker) should be
   // round-robin assigned. This catches existing Hot leads, manually-overridden
@@ -1120,7 +1178,7 @@ const Leads = () => {
         notify.success(`Auto-assigned ${assignedCount} hot lead(s)`);
       }
       // Refresh once at the end so the round-robin pointer and relations are consistent.
-      fetchLeads();
+      fetchLeads({ background: true });
     };
 
     const timeout = setTimeout(run, 600);
@@ -1602,7 +1660,42 @@ const Leads = () => {
                   {isColVisible('aiScore') && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Lead Score</th>}
                   {isColVisible('source') && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Source</th>}
                   {isGeneric && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem', minWidth: '180px' }}>Callified Campaign</th>}
-                  {isGeneric && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem', minWidth: '120px' }}>Lead Status</th>}
+                  {isGeneric && (
+                    <th style={{ position: 'relative', padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem', minWidth: '140px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                        <span>Lead Status</span>
+                        <button
+                          type="button"
+                          aria-label="Lead status AI settings"
+                          title="Lead status AI settings"
+                          onClick={(e) => { e.stopPropagation(); setAiSettingsOpen(o => !o); }}
+                          disabled={aiTranscriptSaving}
+                          style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: 2, border: 'none', background: 'transparent', color: 'var(--text-secondary)', cursor: 'pointer', borderRadius: 4 }}
+                        >
+                          <Settings size={14} />
+                        </button>
+                      </div>
+                      {aiSettingsOpen && (
+                        <>
+                          <div style={{ position: 'fixed', inset: 0, zIndex: 50 }} onClick={() => setAiSettingsOpen(false)} />
+                          <div className="card" style={{ position: 'absolute', top: 'calc(100% + 4px)', right: 8, zIndex: 51, padding: '0.75rem', minWidth: '250px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
+                            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontSize: '0.85rem', color: 'var(--text-primary)' }}>
+                              <input
+                                type="checkbox"
+                                checked={aiTranscriptEnabled}
+                                disabled={aiTranscriptSaving || !isAdmin}
+                                onChange={(e) => { saveAiTranscriptEnabled(e.target.checked); }}
+                              />
+                              AI Based transcription classification
+                            </label>
+                            {!isAdmin && (
+                              <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '0.35rem' }}>Only admins can change this.</div>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </th>
+                  )}
                   {isGeneric && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem', width: '110px' }}>Callified AI call</th>}
                   {isGeneric && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem', width: '100px' }}>Callified Score</th>}
                   {isTravel && <th style={{ padding: '1rem', color: 'var(--text-secondary)', fontWeight: '500', fontSize: '0.875rem' }}>Sub-brand</th>}

--- a/frontend/src/pages/travel/CostMaster.jsx
+++ b/frontend/src/pages/travel/CostMaster.jsx
@@ -44,6 +44,7 @@ const FLOOR_LABELS = { low: "Low floor", mid: "Mid floor", high: "High floor" };
 
 const CURRENCIES = ["INR", "USD", "EUR", "GBP", "AED", "SAR"];
 const OTHER_OPTION = "__other__";
+const PAGE_SIZE = 200;
 
 function AttributeChips({ attributes }) {
   const chips = [];
@@ -255,6 +256,7 @@ export default function CostMaster() {
 
   const [rates, setRates] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [filterSubBrand, setFilterSubBrand] = useState("");
   const [filterCategory, setFilterCategory] = useState("");
   const [adding, setAdding] = useState(false);
@@ -262,6 +264,15 @@ export default function CostMaster() {
   const [saving, setSaving] = useState(false);
   const [suppliers, setSuppliers] = useState([]);
   const [seasons, setSeasons] = useState([]);
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const listRef = useRef(null);
+  const ratesRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
   const defaultBrand = defaultSubBrandFor(user, activeSubBrand, myBrands[0]);
   const [form, setForm] = useState({
@@ -281,19 +292,74 @@ export default function CostMaster() {
     roomCategory: "",
   });
 
-  const load = useCallback(() => {
-    setLoading(true);
+  useEffect(() => {
+    ratesRef.current = rates;
+  }, [rates]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setRates([]);
+      ratesRef.current = [];
+      setOffset(0);
+      setTotal(0);
+      setHasMore(true);
+      if (listRef.current) listRef.current.scrollTop = 0;
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
     const qs = new URLSearchParams();
     if (filterSubBrand) qs.set("subBrand", filterSubBrand);
     if (filterCategory) qs.set("category", filterCategory);
-    qs.set("limit", "200");
-    fetchApi(`/api/travel/cost-master?${qs.toString()}`)
-      .then((res) => setRates(Array.isArray(res?.rates) ? res.rates : []))
-      .catch((e) => { notify.error(e?.body?.error || "Failed to load rates"); setRates([]); })
-      .finally(() => setLoading(false));
-  }, [filterSubBrand, filterCategory]); // eslint-disable-line react-hooks/exhaustive-deps
+    qs.set("limit", String(PAGE_SIZE));
+    qs.set("offset", String(startOffset));
+    try {
+      const res = await fetchApi(`/api/travel/cost-master?${qs.toString()}`);
+      const list = Array.isArray(res?.rates) ? res.rates : [];
+      const totalCount = Number.isFinite(Number(res?.total)) ? Number(res.total) : list.length;
+      const nextRates = reset ? list : [...ratesRef.current, ...list];
+      const nextOffset = startOffset + list.length;
+      const nextHasMore = Number.isFinite(totalCount) ? nextOffset < totalCount : list.length === PAGE_SIZE;
+      ratesRef.current = nextRates;
+      setRates(nextRates);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+    } catch (e) {
+      notify.error(e?.body?.error || "Failed to load rates");
+      setRates([]);
+      ratesRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [filterSubBrand, filterCategory, notify]);
 
-  useEffect(load, [load]);
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
 
   const loadLookupData = useCallback(() => {
     fetchApi("/api/travel/suppliers?limit=500&fields=summary")
@@ -357,7 +423,7 @@ export default function CostMaster() {
         roomCategory: "",
       }));
       setAdding(false);
-      load();
+      load({ reset: true });
     } catch (e) {
       notify.error(e?.body?.error || "Failed to add rate");
     }
@@ -401,7 +467,7 @@ export default function CostMaster() {
       }
       loadLookupData();
       setEditingId(null);
-      load();
+      load({ reset: true });
     } catch (e) {
       notify.error(e?.body?.error || "Failed to update rate");
     } finally {
@@ -415,7 +481,7 @@ export default function CostMaster() {
     try {
       await fetchApi(`/api/travel/cost-master/${rate.id}`, { method: "DELETE" });
       notify.success("Rate deleted");
-      load();
+      load({ reset: true });
     } catch (e) {
       notify.error(e?.body?.error || "Failed to delete rate");
     }
@@ -428,7 +494,7 @@ export default function CostMaster() {
         method: "PATCH",
         body: JSON.stringify({ isActive: !rate.isActive }),
       });
-      load();
+      load({ reset: true });
     } catch (e) {
       setRates((prev) => prev.map((r) => (r.id === rate.id ? { ...r, isActive: rate.isActive } : r)));
       notify.error(e?.body?.error || "Failed to toggle");
@@ -502,6 +568,15 @@ export default function CostMaster() {
     } catch (e) { notify.error(e.message || "Failed to import"); }
     finally { if (fileRef.current) fileRef.current.value = ""; }
   };
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load]);
 
   // All sub-brands for the filter dropdown (not scoped to user access â€” filter
   // should show what's IN the table, not what the user can create).
@@ -713,16 +788,26 @@ export default function CostMaster() {
       )}
 
       {/* Table */}
-      <div style={{ background: "var(--surface-color)", borderRadius: 12, border: "1px solid var(--border-color)", overflow: "visible" }}>
-        {loading ? (
+      <div style={{ background: "var(--surface-color)", borderRadius: 12, border: "1px solid var(--border-color)" }}>
+        {loading && rates.length === 0 ? (
           <div style={emptyStyle}>Loading&hellip;</div>
         ) : rates.length === 0 ? (
           <div style={emptyStyle}>No rates yet. Add one using the &ldquo;+ Add rate&rdquo; button above.</div>
         ) : (
-          <TopScrollSync>
+          <div
+            ref={listRef}
+            data-testid="cost-master-table-scroll"
+            onScroll={handleListScroll}
+            style={{
+              maxHeight: "60vh",
+              overflowY: "auto",
+              overflowX: "hidden",
+            }}
+          >
+          <TopScrollSync disabled>
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
-              <tr>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={th}>Sub-brand</th>
                 <th style={th}>Category</th>
                 <th style={th}>Route / SKU</th>
@@ -753,7 +838,7 @@ export default function CostMaster() {
                         <code style={{ fontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace", fontSize: 13 }}>{r.routeOrSku}</code>
                         {(r.supplierName || r.seasonName) && (
                           <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>
-                            {[r.supplierName, r.seasonName].filter(Boolean).join(" · ")}
+                            {[r.supplierName, r.seasonName].filter(Boolean).join(" ï¿½ ")}
                           </span>
                         )}
                       </div>
@@ -798,6 +883,15 @@ export default function CostMaster() {
             </tbody>
           </table>
           </TopScrollSync>
+          {loadingMore && (
+            <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-color)" }}>
+              Loading more&hellip;
+            </div>
+          )}
+          {!loadingMore && hasMore && (
+            <div data-testid="cost-master-scroll-sentinel" style={{ height: 1 }} />
+          )}
+          </div>
         )}
       </div>
 
@@ -815,7 +909,7 @@ const selectStyle = { padding: "9px 12px", borderRadius: 8, border: "1px solid v
 const input = { padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border-color)", background: "var(--bg-color)", color: "var(--text-primary)", fontSize: 13 };
 const inlineInput = { padding: "5px 8px", borderRadius: 6, border: "1px solid var(--border-color)", background: "var(--bg-color)", color: "var(--text-primary)", fontSize: 13, width: "100%" };
 const emptyStyle = { padding: 32, textAlign: "center", color: "var(--text-secondary)", fontSize: 14 };
-const th = { textAlign: "left", padding: "14px 16px", fontSize: 11.5, textTransform: "uppercase", letterSpacing: "0.03em", color: "var(--text-secondary)", borderBottom: "1px solid var(--border-color)", fontWeight: 600 };
+const th = { position: "sticky", top: 0, background: "#fff", zIndex: 10, textAlign: "left", padding: "14px 16px", fontSize: 11.5, textTransform: "uppercase", letterSpacing: "0.03em", color: "var(--text-secondary)", borderBottom: "1px solid var(--border-color)", fontWeight: 600 };
 const td = { padding: "14px 16px", fontSize: 13.5, color: "var(--text-primary)", verticalAlign: "middle" };
 const brandBadge = { display: "inline-block", padding: "4px 10px", borderRadius: 6, fontSize: 12, fontWeight: 600, background: "var(--subtle-bg-3, rgba(91,110,248,0.15))", color: "var(--primary-color, #5b6ef8)", textTransform: "uppercase", letterSpacing: 0.5 };
 const attrChip = { padding: "2px 8px", borderRadius: 10, fontSize: 11, fontWeight: 600, background: "var(--subtle-bg)", color: "var(--text-secondary)", border: "1px solid var(--border-color)", whiteSpace: "nowrap" };

--- a/frontend/src/pages/travel/CurriculumAdmin.jsx
+++ b/frontend/src/pages/travel/CurriculumAdmin.jsx
@@ -513,10 +513,14 @@ export default function CurriculumAdmin() {
             with &ldquo;New Mapping&rdquo; or clear the filters to widen the search.
           </div>
         ) : (
-          <TopScrollSync>
+          <div
+            data-testid="curriculum-admin-table-scroll"
+            style={{ maxHeight: '60vh', overflowY: 'auto', overflowX: 'hidden' }}
+          >
+          <TopScrollSync disabled>
           <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
             <thead>
-              <tr>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={{ ...th, width: '12%' }}>Curriculum</th>
                 <th style={{ ...th, width: '6%' }}>Grade</th>
                 <th style={{ ...th, width: '10%' }}>Subject</th>
@@ -576,6 +580,7 @@ export default function CurriculumAdmin() {
             </tbody>
           </table>
           </TopScrollSync>
+          </div>
         )}
       </div>
 
@@ -915,6 +920,10 @@ const empty = {
 };
 
 const th = {
+  position: 'sticky',
+  top: 0,
+  background: '#fff',
+  zIndex: 10,
   textAlign: 'left',
   padding: '10px 12px',
   fontSize: 12,

--- a/frontend/src/pages/travel/CurriculumAdmin.jsx
+++ b/frontend/src/pages/travel/CurriculumAdmin.jsx
@@ -922,7 +922,6 @@ const empty = {
 const th = {
   position: 'sticky',
   top: 0,
-  background: '#fff',
   zIndex: 10,
   textAlign: 'left',
   padding: '10px 12px',

--- a/frontend/src/pages/travel/Diagnostics.jsx
+++ b/frontend/src/pages/travel/Diagnostics.jsx
@@ -13,14 +13,13 @@
 //
 // See backend/routes/travel_diagnostics.js for the underlying contract.
 
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { ClipboardCheck, Plus, Compass, Filter } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
 import { AuthContext } from '../../App';
 import TopScrollSync from '../../components/TopScrollSync';
-
 const SUB_BRANDS = [
   { value: '', label: 'All sub-brands' },
   { value: 'tmc', label: 'TMC (schools)' },
@@ -38,32 +37,118 @@ export default function Diagnostics() {
   const notify = useNotify();
   const { user } = useContext(AuthContext) || {};
   const isAdmin = user?.role === 'ADMIN';
+  const PAGE_SIZE = 10;
 
   const [diagnostics, setDiagnostics] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [subBrand, setSubBrand] = useState('');
   const [classification, setClassification] = useState('');
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const listRef = useRef(null);
+  const diagnosticsRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
-  const load = () => {
-    setLoading(true);
+  useEffect(() => {
+    diagnosticsRef.current = diagnostics;
+  }, [diagnostics]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setDiagnostics([]);
+      diagnosticsRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      offsetRef.current = 0;
+      hasMoreRef.current = true;
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
+
     const qs = new URLSearchParams();
     if (subBrand) qs.set('subBrand', subBrand);
     if (classification) qs.set('classification', classification);
-    qs.set('limit', '100');
-    fetchApi(`/api/travel/diagnostics?${qs.toString()}`)
-      .then((res) => {
-        setDiagnostics(Array.isArray(res?.diagnostics) ? res.diagnostics : []);
-      })
-      .catch((e) => {
-        const msg = e?.body?.error || 'Failed to load diagnostics';
-        notify.error(msg);
-        setDiagnostics([]);
-      })
-      .finally(() => setLoading(false));
-    // notify is stable from useNotify; declared above the closure.
-  };
 
-  useEffect(load, [subBrand, classification]); // eslint-disable-line react-hooks/exhaustive-deps
+    qs.set('limit', String(PAGE_SIZE));
+    qs.set('offset', String(startOffset));
+
+    try {
+      const res = await fetchApi(`/api/travel/diagnostics?${qs.toString()}`);
+      const rows = Array.isArray(res?.diagnostics) ? res.diagnostics : [];
+      const totalCount = Number.isFinite(Number(res?.total))
+        ? Number(res.total)
+        : rows.length;
+      const nextRows = reset ? rows : [...diagnosticsRef.current, ...rows];
+      const nextOffset = startOffset + rows.length;
+      const nextHasMore = Number.isFinite(totalCount)
+        ? nextOffset < totalCount
+        : rows.length === PAGE_SIZE;
+
+      diagnosticsRef.current = nextRows;
+      setDiagnostics(nextRows);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+      offsetRef.current = nextOffset;
+      hasMoreRef.current = nextHasMore;
+    } catch (e) {
+      notify.error(e?.body?.error || 'Failed to load diagnostics');
+      setDiagnostics([]);
+      diagnosticsRef.current = [];
+      setTotal(0);
+      setHasMore(false);
+      setOffset(0);
+      offsetRef.current = 0;
+      hasMoreRef.current = false;
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [subBrand, classification, notify, PAGE_SIZE]);
+
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
+
+  const reload = useCallback(() => {
+    load({ reset: true });
+  }, [load]);
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load]);
 
   return (
     <div style={{ padding: 24, maxWidth: 1200, margin: '0 auto' }}>
@@ -105,7 +190,7 @@ export default function Diagnostics() {
         <Filter size={16} aria-hidden style={{ color: 'var(--text-secondary)' }} />
         <select
           value={subBrand}
-          onChange={(e) => setSubBrand(e.target.value)}
+          onChange={(e) => { setSubBrand(e.target.value); }}
           style={selectStyle}
           aria-label="Filter by sub-brand"
         >
@@ -115,7 +200,7 @@ export default function Diagnostics() {
         </select>
         <select
           value={classification}
-          onChange={(e) => setClassification(e.target.value)}
+          onChange={(e) => { setClassification(e.target.value); }}
           style={selectStyle}
           aria-label="Filter by classification"
         >
@@ -125,7 +210,7 @@ export default function Diagnostics() {
           <option value="level_3">Level 3</option>
           <option value="level_4">Level 4</option>
         </select>
-        <button type="button" onClick={load} style={refreshBtn} aria-label="Reload list">
+        <button type="button" onClick={reload} style={refreshBtn} aria-label="Reload list">
           Refresh
         </button>
       </div>
@@ -133,9 +218,9 @@ export default function Diagnostics() {
       {/* Table */}
       <div style={{
         background: 'var(--surface-color)', borderRadius: 8,
-        border: '1px solid var(--border-color)', overflow: 'visible',
+        border: '1px solid var(--border-color)',
       }}>
-        {loading ? (
+        {loading && diagnostics.length === 0 ? (
           <div style={empty}>Loading&hellip;</div>
         ) : diagnostics.length === 0 ? (
           <div style={empty}>
@@ -144,9 +229,19 @@ export default function Diagnostics() {
               : <>No diagnostics submitted yet. Click <strong>Take diagnostic</strong> to start.</>}
           </div>
         ) : (
+          <div
+            ref={listRef}
+            onScroll={handleListScroll}
+            data-testid="diagnostics-table-scroll"
+            style={{
+              maxHeight: '60vh',
+              overflowY: 'auto',
+              overflowX: 'hidden',
+            }}
+          >
           <TopScrollSync>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            <thead>
+          <table aria-label="Diagnostics results" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead style={{position: "sticky", top: 0,background: "#fff",zIndex: 10,}}>
               <tr>
                 <th style={th}>Submitted</th>
                 <th style={th}>Sub-brand</th>
@@ -201,6 +296,20 @@ export default function Diagnostics() {
             </tbody>
           </table>
           </TopScrollSync>
+          <div style={{ padding: '12px 0' }}>
+            {loadingMore && (
+              <div style={empty}>Loading more&hellip;</div>
+            )}
+            {!loadingMore && hasMore && (
+              <div aria-hidden="true" data-testid="diagnostics-scroll-sentinel" style={{ height: 1 }} />
+            )}
+            {!hasMore && total > 0 && (
+              <div style={{ textAlign: 'center', color: 'var(--text-secondary)', fontSize: 12 }}>
+                You&apos;ve reached the end of the table.
+              </div>
+            )}
+          </div>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/pages/travel/Itineraries.jsx
+++ b/frontend/src/pages/travel/Itineraries.jsx
@@ -11,7 +11,7 @@
 // itinerary without first completing the diagnostic. Itineraries can
 // still be drafted from a Deal page once the Day 7 Deal-extension CTA lands.
 
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Map, Filter, Plane, Hotel, MapPin, Briefcase, FileText, Shield, Plus, X,
@@ -143,6 +143,7 @@ const EMPTY_FORM = {
 };
 
 const CURRENCIES = ["INR", "USD", "EUR"];
+const PAGE_SIZE = 10;
 
 // Geocode cache: city name → { lat, lng } resolved via Nominatim (same OSM
 // data-source as our map tiles — no API key required, free to use).
@@ -290,8 +291,12 @@ export default function Itineraries() {
   const lockedBrand = myBrands.length === 1 ? myBrands[0] : null;
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [subBrand, setSubBrand] = useState("");
   const [status, setStatus] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [total, setTotal] = useState(0);
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
@@ -310,6 +315,12 @@ export default function Itineraries() {
   // selected itinerary's items on a Leaflet+OSM canvas. Re-clicking the
   // same row's Map button clears the selection (toggle).
   const [selectedItineraryId, setSelectedItineraryId] = useState(null);
+  const tableScrollRef = useRef(null);
+  const itemsRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
   const selectedItinerary = useMemo(
     () => (selectedItineraryId
       ? items.find((it) => it.id === selectedItineraryId)
@@ -328,6 +339,26 @@ export default function Itineraries() {
       return dest.includes(q) || contact.includes(q);
     });
   }, [items, searchQuery]);
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
   // Items array passed to MapPreview. When the itinerary has geocoded items
   // those are used directly. When there are none we geocode the destination
   // city names via Nominatim (same OSM data used for tiles) and show those
@@ -612,22 +643,77 @@ export default function Itineraries() {
     }
   };
 
-  const load = () => {
-    setLoading(true);
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setItems([]);
+      itemsRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      offsetRef.current = 0;
+      hasMoreRef.current = true;
+      if (tableScrollRef.current) {
+        tableScrollRef.current.scrollTop = 0;
+      }
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
+
     const qs = new URLSearchParams();
     if (subBrand) qs.set("subBrand", subBrand);
     if (status) qs.set("status", status);
-    qs.set("limit", "100");
-    fetchApi(`/api/travel/itineraries?${qs.toString()}`)
-      .then((res) => setItems(Array.isArray(res?.itineraries) ? res.itineraries : []))
-      .catch((e) => {
-        notify.error(e?.body?.error || "Failed to load itineraries");
-        setItems([]);
-      })
-      .finally(() => setLoading(false));
-  };
+    qs.set("limit", String(PAGE_SIZE));
+    qs.set("offset", String(startOffset));
 
-  useEffect(load, [subBrand, status]); // eslint-disable-line react-hooks/exhaustive-deps
+    try {
+      const res = await fetchApi(`/api/travel/itineraries?${qs.toString()}`);
+      const rows = Array.isArray(res?.itineraries) ? res.itineraries : [];
+      const totalCount = Number.isFinite(Number(res?.total)) ? Number(res.total) : rows.length;
+      const nextItems = reset ? rows : [...itemsRef.current, ...rows];
+      const nextOffset = startOffset + rows.length;
+      const nextHasMore = Number.isFinite(totalCount)
+        ? nextOffset < totalCount
+        : rows.length === PAGE_SIZE;
+
+      itemsRef.current = nextItems;
+      setItems(nextItems);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+      offsetRef.current = nextOffset;
+      hasMoreRef.current = nextHasMore;
+    } catch (e) {
+      notify.error(e?.body?.error || "Failed to load itineraries");
+      setItems([]);
+      itemsRef.current = [];
+      setTotal(0);
+      setHasMore(false);
+      setOffset(0);
+      offsetRef.current = 0;
+      hasMoreRef.current = false;
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [subBrand, status, notify]);
+
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
+
+  const handleTableScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load]);
 
   // Close drawer on Escape
   useEffect(() => {
@@ -696,10 +782,10 @@ export default function Itineraries() {
         border: "1px solid var(--border-color)", marginBottom: 16,
       }}>
         <Filter size={16} aria-hidden style={{ color: "var(--text-secondary)" }} />
-        <select value={subBrand} onChange={(e) => setSubBrand(e.target.value)} style={selectStyle} aria-label="Filter by sub-brand">
+        <select value={subBrand} onChange={(e) => { setSubBrand(e.target.value); }} style={selectStyle} aria-label="Filter by sub-brand">
           {SUB_BRANDS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
         </select>
-        <select value={status} onChange={(e) => setStatus(e.target.value)} style={selectStyle} aria-label="Filter by status">
+        <select value={status} onChange={(e) => { setStatus(e.target.value); }} style={selectStyle} aria-label="Filter by status">
           {STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
         </select>
         <div style={{ position: "relative", display: "flex", alignItems: "center", flex: "1 1 180px", minWidth: 160, maxWidth: 320 }}>
@@ -788,7 +874,7 @@ export default function Itineraries() {
 
       <div style={{
         background: "var(--surface-color)", borderRadius: 8,
-        border: "1px solid var(--border-color)", overflow: "visible",
+        border: "1px solid var(--border-color)",
       }}>
         {loading ? (
           <div style={empty}>Loading&hellip;</div>
@@ -802,9 +888,19 @@ export default function Itineraries() {
             No itineraries match &ldquo;{searchQuery}&rdquo;.
           </div>
         ) : (
-          <TopScrollSync scrollWidth="1000px">
-          <table style={{ width: "100%", minWidth: "1000px", borderCollapse: "collapse" }}>
-            <thead>
+          <div
+            ref={tableScrollRef}
+            data-testid="itineraries-scroll-area"
+            onScroll={handleTableScroll}
+            style={{
+              maxHeight: "60vh",
+              overflowY: "auto",
+              overflowX: "hidden",
+            }}
+          >
+            <TopScrollSync scrollWidth="1000px">
+            <table style={{ width: "100%", minWidth: "1000px", borderCollapse: "collapse" }}>
+            <thead style={{position: "sticky", top: 0,background: "#fff",zIndex: 10,}}>
               <tr>
                 <th style={th}>Destination</th>
                 <th style={th}>Sub-brand</th>
@@ -953,7 +1049,21 @@ export default function Itineraries() {
               })}
             </tbody>
           </table>
+          {total > 0 && (
+            <div style={{ padding: "12px 0", textAlign: "center", color: "var(--text-secondary)", fontSize: 12 }}>
+              {hasMore ? "Scroll to load more itineraries." : "You've reached the end of the itineraries."}
+            </div>
+          )}
           </TopScrollSync>
+          <div style={{ paddingTop: 12 }}>
+            {loadingMore && (
+              <div style={empty}>Loading more&hellip;</div>
+            )}
+            {!loadingMore && hasMore && (
+              <div aria-hidden="true" style={{ height: 1 }} data-testid="itineraries-scroll-sentinel" />
+            )}
+          </div>
+          </div>
         )}
       </div>
 

--- a/frontend/src/pages/travel/ItineraryTemplates.jsx
+++ b/frontend/src/pages/travel/ItineraryTemplates.jsx
@@ -33,7 +33,7 @@
 // Mirrors SightseeingMaster.jsx (ca052d20) — same #907 arc, same admin-table
 // pattern, same notify hook (`../utils/notify`, not `../hooks/useNotify`).
 
-import React, { useState, useEffect, useCallback, useContext, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useContext, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Archive, ArchiveRestore, Copy, Download, Edit2, Eye, Filter, FileText, Map as MapIcon, Plus, Trash2, Upload, X } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
@@ -133,7 +133,7 @@ export default function ItineraryTemplates() {
   const lockedBrand = myBrands.length === 1 ? myBrands[0] : null;
 
   const [items, setItems] = useState([]);
-  const [total, setTotal] = useState(0);
+  const [_total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -1358,7 +1358,7 @@ function TemplatePreviewModal({
               }}
               data-testid="preview-no-pins"
             >
-              No mapped points of interest yet. The template's items don't
+              No mapped points of interest yet. The template&apos;s items don&apos;t
               carry latitude / longitude.
             </div>
           )}
@@ -1536,7 +1536,6 @@ const emptyStyle = {
 const th = {
   position: 'sticky',
   top: 0,
-  background: '#fff',
   zIndex: 10,
   textAlign: 'left',
   padding: '10px 12px',

--- a/frontend/src/pages/travel/ItineraryTemplates.jsx
+++ b/frontend/src/pages/travel/ItineraryTemplates.jsx
@@ -35,7 +35,7 @@
 
 import React, { useState, useEffect, useCallback, useContext, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { Archive, ArchiveRestore, ChevronLeft, ChevronRight, Copy, Download, Edit2, Eye, Filter, FileText, Map as MapIcon, Plus, Trash2, Upload, X } from 'lucide-react';
+import { Archive, ArchiveRestore, Copy, Download, Edit2, Eye, Filter, FileText, Map as MapIcon, Plus, Trash2, Upload, X } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
 import { AuthContext } from '../../App';
@@ -136,6 +136,14 @@ export default function ItineraryTemplates() {
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const listRef = useRef(null);
+  const itemsRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
   // Filter state
   const [destinationFilter, setDestinationFilter] = useState('');
@@ -186,8 +194,36 @@ export default function ItineraryTemplates() {
   const [contacts, setContacts] = useState([]);
   const [cloneContactId, setCloneContactId] = useState('');
 
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
   const fetchItems = useCallback(() => {
-    setLoading(true);
+    if (offset === 0) {
+      setLoading(true);
+      setLoadingMore(false);
+      itemsRef.current = [];
+      setItems([]);
+      if (listRef.current) listRef.current.scrollTop = 0;
+    } else if (!loadingRef.current) {
+      setLoadingMore(true);
+    }
     const qs = new URLSearchParams();
     if (destinationFilter.trim()) qs.set('destinationName', destinationFilter.trim());
     if (categoryFilter) qs.set('category', categoryFilter);
@@ -200,15 +236,26 @@ export default function ItineraryTemplates() {
     qs.set('offset', String(offset));
     fetchApi(`/api/travel/itinerary-templates?${qs.toString()}`)
       .then((res) => {
-        setItems(Array.isArray(res?.items) ? res.items : []);
-        setTotal(Number(res?.total) || 0);
+        const rows = Array.isArray(res?.items) ? res.items : [];
+        const totalCount = Number(res?.total) || 0;
+        const nextItems = offset === 0 ? rows : [...itemsRef.current, ...rows];
+        const nextOffset = offset + rows.length;
+        const nextHasMore = Number.isFinite(totalCount) ? nextOffset < totalCount : rows.length === PAGE_SIZE;
+        itemsRef.current = nextItems;
+        setItems(nextItems);
+        setTotal(totalCount);
+        setHasMore(nextHasMore);
       })
       .catch((e) => {
         notify.error(e?.body?.error || 'Failed to load itinerary templates');
         setItems([]);
         setTotal(0);
+        setHasMore(false);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+        setLoadingMore(false);
+      });
   }, [destinationFilter, categoryFilter, subBrandFilter, budgetTierFilter, activeOnly, includeArchived, offset, notify]);
 
   useEffect(() => {
@@ -505,10 +552,14 @@ export default function ItineraryTemplates() {
     return d.toLocaleDateString();
   };
 
-  const canPrev = offset > 0;
-  const canNext = offset + PAGE_SIZE < total;
-  const fromIdx = total === 0 ? 0 : offset + 1;
-  const toIdx = Math.min(offset + items.length, total);
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      setOffset((curr) => curr + PAGE_SIZE);
+    }
+  }, []);
 
   return (
     <div style={{ padding: 24, maxWidth: 1200, margin: '0 auto' }}>
@@ -918,17 +969,26 @@ export default function ItineraryTemplates() {
           background: 'var(--surface-color)',
           borderRadius: 8,
           border: '1px solid var(--border-color)',
-          overflow: 'hidden',
         }}
       >
-        {loading ? (
+        {loading && items.length === 0 ? (
           <div style={emptyStyle}>Loading&hellip;</div>
         ) : items.length === 0 ? (
           <div style={emptyStyle}>No itinerary templates yet. Add one above.</div>
         ) : (
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            <thead>
-              <tr>
+          <div
+            ref={listRef}
+            data-testid="itinerary-templates-table-scroll"
+            onScroll={handleListScroll}
+            style={{
+              maxHeight: '60vh',
+              overflowY: 'auto',
+              overflowX: 'hidden',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={th}>Name</th>
                 <th style={th}>Destination</th>
                 <th style={th}>Duration</th>
@@ -951,16 +1011,16 @@ export default function ItineraryTemplates() {
                 <th style={th}>Ver</th>
                 <th style={th}>Actions</th>
               </tr>
-            </thead>
-            <tbody>
-              {items.map((item) => (
-                <tr
-                  key={item.id}
-                  style={{
-                    borderTop: '1px solid var(--border-light)',
-                    opacity: item.isActive ? 1 : 0.5,
-                  }}
-                >
+              </thead>
+              <tbody>
+                {items.map((item) => (
+                  <tr
+                    key={item.id}
+                    style={{
+                      borderTop: '1px solid var(--border-light)',
+                      opacity: item.isActive ? 1 : 0.5,
+                    }}
+                  >
                   <td style={td}>
                     <strong>{item.name}</strong>
                     {item.description && (
@@ -1078,49 +1138,20 @@ export default function ItineraryTemplates() {
                       </button>
                     </div>
                   </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {loadingMore && (
+              <div style={{ padding: '10px 16px', fontSize: 12, color: 'var(--text-secondary)', borderTop: '1px solid var(--border-light)' }}>
+                Loading more&hellip;
+              </div>
+            )}
+            {!loadingMore && hasMore && (
+              <div data-testid="itinerary-templates-scroll-sentinel" style={{ height: 1 }} />
+            )}
+          </div>
         )}
-      </div>
-
-      {/* Pagination */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginTop: 12,
-          fontSize: 13,
-          color: 'var(--text-secondary)',
-        }}
-      >
-        <div>
-          {total === 0
-            ? 'No results'
-            : `Showing ${fromIdx}-${toIdx} of ${total}`}
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button
-            type="button"
-            onClick={() => canPrev && setOffset(Math.max(0, offset - PAGE_SIZE))}
-            disabled={!canPrev}
-            style={canPrev ? secondaryBtn : disabledBtn}
-            aria-label="Previous page"
-          >
-            <ChevronLeft size={14} /> Prev
-          </button>
-          <button
-            type="button"
-            onClick={() => canNext && setOffset(offset + PAGE_SIZE)}
-            disabled={!canNext}
-            style={canNext ? secondaryBtn : disabledBtn}
-            aria-label="Next page"
-          >
-            Next <ChevronRight size={14} />
-          </button>
-        </div>
       </div>
 
       {/* G061 — Detail / preview modal (PRD FR-3.1.d). Renders when the
@@ -1503,6 +1534,10 @@ const emptyStyle = {
   fontSize: 14,
 };
 const th = {
+  position: 'sticky',
+  top: 0,
+  background: '#fff',
+  zIndex: 10,
   textAlign: 'left',
   padding: '10px 12px',
   fontSize: 12,

--- a/frontend/src/pages/travel/PricingRules.jsx
+++ b/frontend/src/pages/travel/PricingRules.jsx
@@ -420,10 +420,14 @@ function SeasonsSection() {
         ) : seasons.length === 0 ? (
           <div style={empty}>No seasons yet. Add one above.</div>
         ) : (
-          <TopScrollSync>
+          <div
+            data-testid="pricing-rules-seasons-scroll"
+            style={{ maxHeight: "60vh", overflowY: "auto", overflowX: "hidden" }}
+          >
+          <TopScrollSync disabled>
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
-              <tr>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={th}>Sub-brand</th>
                 <th style={th}>Name</th>
                 <th style={th}>Start</th>
@@ -453,6 +457,7 @@ function SeasonsSection() {
             </tbody>
           </table>
           </TopScrollSync>
+          </div>
         )}
       </div>
     </section>
@@ -804,10 +809,14 @@ function MarkupRulesSection() {
         ) : rules.length === 0 ? (
           <div style={empty}>No markup rules yet. Add one above.</div>
         ) : (
-          <TopScrollSync>
+          <div
+            data-testid="pricing-rules-markup-scroll"
+            style={{ maxHeight: "60vh", overflowY: "auto", overflowX: "hidden" }}
+          >
+          <TopScrollSync disabled>
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
-              <tr>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={th}>Sub-brand</th>
                 <th style={th}>Scope</th>
                 <th style={th}>Match key</th>
@@ -845,6 +854,7 @@ function MarkupRulesSection() {
             </tbody>
           </table>
           </TopScrollSync>
+          </div>
         )}
       </div>
     </section>
@@ -895,6 +905,10 @@ const input = {
 };
 const empty = { padding: 32, textAlign: "center", color: "var(--text-secondary)", fontSize: 14 };
 const th = {
+  position: "sticky",
+  top: 0,
+  background: "#fff",
+  zIndex: 10,
   textAlign: "left", padding: "10px 12px", fontSize: 12,
   textTransform: "uppercase", letterSpacing: 0.5,
   color: "var(--text-secondary)", borderBottom: "1px solid var(--border-color)",

--- a/frontend/src/pages/travel/PricingRules.jsx
+++ b/frontend/src/pages/travel/PricingRules.jsx
@@ -509,7 +509,7 @@ function MarkupRulesSection() {
     fetchApi("/api/travel/suppliers?limit=500&fields=summary")
       .then((res) => setSuppliers(Array.isArray(res?.suppliers) ? res.suppliers : []))
       .catch(() => setSuppliers([]));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const load = () => {
     setLoading(true);
@@ -907,7 +907,6 @@ const empty = { padding: 32, textAlign: "center", color: "var(--text-secondary)"
 const th = {
   position: "sticky",
   top: 0,
-  background: "#fff",
   zIndex: 10,
   textAlign: "left", padding: "10px 12px", fontSize: 12,
   textTransform: "uppercase", letterSpacing: 0.5,

--- a/frontend/src/pages/travel/QuotesAdmin.jsx
+++ b/frontend/src/pages/travel/QuotesAdmin.jsx
@@ -619,7 +619,6 @@ export default function QuotesAdmin() {
 const th = {
   position: "sticky",
   top: 0,
-  background: "#fff",
   zIndex: 10,
   textAlign: "left",
   padding: "10px 12px",

--- a/frontend/src/pages/travel/QuotesAdmin.jsx
+++ b/frontend/src/pages/travel/QuotesAdmin.jsx
@@ -20,7 +20,7 @@
 // - subBrand — optional, defaults to "tmc"; sub-brand isolation enforced
 //   server-side via getSubBrandAccessSet.
 
-import { useEffect, useMemo, useState, useContext } from "react";
+import { useEffect, useMemo, useState, useContext, useCallback, useRef } from "react";
 import { Link } from "react-router-dom";
 import { Receipt, Pencil, Trash2, Calculator } from "lucide-react";
 import { fetchApi } from "../../utils/api";
@@ -79,6 +79,7 @@ const EMPTY_FORM = {
   validUntil: "",
   subBrand: "tmc",
 };
+const PAGE_SIZE = 50;
 
 // Tomorrow as min for the validUntil date picker. Backend accepts
 // "today or future" but using tomorrow eliminates the TZ-window flake
@@ -124,6 +125,9 @@ export default function QuotesAdmin() {
   const [quotes, setQuotes] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   // #829 — distinguish 403 from genuine empty so the empty-state copy
   // honestly says "Access restricted" instead of "No quotes match."
   const [permissionDenied, setPermissionDenied] = useState(false);
@@ -136,26 +140,79 @@ export default function QuotesAdmin() {
   const [editingId, setEditingId] = useState(null);
   const [form, setForm] = useState(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
+  const listRef = useRef(null);
+  const quotesRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
-  const load = () => {
-    setLoading(true);
+  useEffect(() => {
+    quotesRef.current = quotes;
+  }, [quotes]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setQuotes([]);
+      quotesRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      setPermissionDenied(false);
+      if (listRef.current) listRef.current.scrollTop = 0;
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
     const qs = new URLSearchParams();
     if (subBrand) qs.set("subBrand", subBrand);
     if (status) qs.set("status", status);
-    const url = `/api/travel/quotes${qs.toString() ? `?${qs.toString()}` : ""}`;
-    fetchApi(url)
-      .then((d) => {
-        setQuotes(Array.isArray(d?.quotes) ? d.quotes : []);
-        setTotal(Number.isFinite(d?.total) ? d.total : 0);
-        setPermissionDenied(false);
-      })
-      .catch((err) => {
-        setQuotes([]);
-        setTotal(0);
-        setPermissionDenied(err?.status === 403);
-      })
-      .finally(() => setLoading(false));
-  };
+    qs.set("limit", String(PAGE_SIZE));
+    qs.set("offset", String(startOffset));
+    try {
+      const d = await fetchApi(`/api/travel/quotes?${qs.toString()}`);
+      const rows = Array.isArray(d?.quotes) ? d.quotes : [];
+      const totalCount = Number.isFinite(Number(d?.total)) ? Number(d.total) : rows.length;
+      const nextQuotes = reset ? rows : [...quotesRef.current, ...rows];
+      const nextOffset = startOffset + rows.length;
+      const nextHasMore = Number.isFinite(totalCount) ? nextOffset < totalCount : rows.length === PAGE_SIZE;
+      quotesRef.current = nextQuotes;
+      setQuotes(nextQuotes);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+      setPermissionDenied(false);
+    } catch (err) {
+      setQuotes([]);
+      quotesRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(false);
+      setPermissionDenied(err?.status === 403);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [subBrand, status]);
 
   // Name filter is a derived client-side view over the raw fetched rows.
   // The backend now joins contact.name, so we filter directly on it.
@@ -175,7 +232,9 @@ export default function QuotesAdmin() {
     setSubBrand(activeSubBrand || "");
   }, [activeSubBrand]);
 
-  useEffect(load, [subBrand, status]);
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
 
   const resetForm = () => {
     setForm(EMPTY_FORM);
@@ -238,7 +297,7 @@ export default function QuotesAdmin() {
       }
       setShowForm(false);
       resetForm();
-      load();
+      load({ reset: true });
     } catch (err) {
       notify.error(err?.body?.error || err?.message || "Save failed");
     } finally {
@@ -248,15 +307,24 @@ export default function QuotesAdmin() {
 
   const handleDelete = async (q) => {
     const contactName = q.contact?.name || "this contact";
-    if (!confirm(`Delete quote #${q.id} for ${contactName}? (Hard delete — no undo.)`)) return;
+    if (!confirm(`Delete quote #${q.id} for ${contactName}? (Hard delete - no undo.)`)) return;
     try {
       await fetchApi(`/api/travel/quotes/${q.id}`, { method: "DELETE" });
       notify.success(`Quote #${q.id} deleted`);
-      load();
+      load({ reset: true });
     } catch (err) {
       notify.error(err?.body?.error || err?.message || "Delete failed");
     }
   };
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load]);
 
   return (
     <div style={{ padding: 24, maxWidth: 1200, margin: "0 auto", animation: "fadeIn 0.4s ease-out" }}>
@@ -410,13 +478,19 @@ export default function QuotesAdmin() {
         className="glass"
         style={{ padding: 0, overflow: "visible" }}
       >
-        {loading ? (
+        {loading && quotes.length === 0 ? (
           <div style={empty}>Loading&hellip;</div>
         ) : (
-          <TopScrollSync>
+          <div
+            ref={listRef}
+            data-testid="quotes-admin-table-scroll"
+            onScroll={handleListScroll}
+            style={{ maxHeight: "60vh", overflowY: "auto", overflowX: "hidden" }}
+          >
+          <TopScrollSync disabled>
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
-              <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10, borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
                 <th style={th}>Contact</th>
                 <th style={th}>Status</th>
                 <th style={th}>Total</th>
@@ -527,6 +601,15 @@ export default function QuotesAdmin() {
             </tbody>
           </table>
           </TopScrollSync>
+          {loadingMore && (
+            <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-color)" }}>
+              Loading more&hellip;
+            </div>
+          )}
+          {!loadingMore && hasMore && (
+            <div data-testid="quotes-admin-scroll-sentinel" style={{ height: 1 }} />
+          )}
+          </div>
         )}
       </div>
     </div>
@@ -534,6 +617,10 @@ export default function QuotesAdmin() {
 }
 
 const th = {
+  position: "sticky",
+  top: 0,
+  background: "#fff",
+  zIndex: 10,
   textAlign: "left",
   padding: "10px 12px",
   fontSize: 12,

--- a/frontend/src/pages/travel/TmcCatalogueAdmin.jsx
+++ b/frontend/src/pages/travel/TmcCatalogueAdmin.jsx
@@ -50,6 +50,7 @@ import { AuthContext } from "../../App";
 // router for tests).
 const STATUS_ACTIVE = "active";
 const STATUS_ARCHIVED = "archived";
+const PAGE_SIZE = 10;
 
 // Sub-set of TmcTripCatalogue fields surfaced in the create/edit form.
 // JSON array fields are surfaced as comma-separated strings for ease of
@@ -129,8 +130,12 @@ export default function TmcCatalogueAdmin() {
   const canWrite = isAdmin || role === "MANAGER";
 
   const [tab, setTab] = useState(STATUS_ACTIVE); // active | archived
+  const [total, setTotal] = useState(0);
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [loadError, setLoadError] = useState(null);
 
   const [showForm, setShowForm] = useState(false);
@@ -144,35 +149,124 @@ export default function TmcCatalogueAdmin() {
   const [bulkImportResult, setBulkImportResult] = useState(null);
   const [bulkImportModalOpen, setBulkImportModalOpen] = useState(false);
   const [pendingReviewTripIds, setPendingReviewTripIds] = useState(() => new Set());
+  const listContainerRef = useRef(null);
+  const requestSeqRef = useRef(0);
   const bulkFileInputRef = useRef(null);
+  const rowsRef = useRef([]);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setLoadError(null);
-    fetchApi(`/api/travel-tmc-catalogue?status=${tab}`)
-      .then((res) => {
-        // Tolerate both shaped + bare list shapes (sibling pages do the
-        // same for resilience against future shape evolution).
-        const items = Array.isArray(res)
-          ? res
-          : Array.isArray(res?.catalogue)
-            ? res.catalogue
-            : Array.isArray(res?.items)
-              ? res.items
-              : [];
-        setRows(items);
-      })
-      .catch((e) => {
-        const msg = e?.body?.error || e?.message || "Failed to load catalogue";
-        setLoadError(msg);
-        notify.error(msg);
-        setRows([]);
-      })
-      .finally(() => setLoading(false));
+  useEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const requestSeq = ++requestSeqRef.current;
+    const startOffset = reset ? 0 : offsetRef.current;
+
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setLoadError(null);
+      setRows([]);
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      rowsRef.current = [];
+      offsetRef.current = 0;
+      hasMoreRef.current = true;
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
+
+    const params = new URLSearchParams();
+    params.set("status", tab);
+    params.set("limit", String(PAGE_SIZE));
+    params.set("offset", String(startOffset));
+
+    try {
+      const res = await fetchApi(`/api/travel-tmc-catalogue?${params.toString()}`);
+      if (requestSeq !== requestSeqRef.current) return;
+
+      // Tolerate both shaped + bare list shapes (sibling pages do the
+      // same for resilience against future shape evolution).
+      const items = Array.isArray(res)
+        ? res
+        : Array.isArray(res?.catalogue)
+          ? res.catalogue
+          : Array.isArray(res?.items)
+            ? res.items
+            : [];
+      const totalCount = Number.isFinite(Number(res?.total))
+        ? Number(res.total)
+        : items.length;
+      const nextRows = reset ? items : [...rowsRef.current, ...items];
+      const nextOffset = startOffset + items.length;
+      const nextHasMore = Number.isFinite(totalCount)
+        ? nextOffset < totalCount
+        : items.length === PAGE_SIZE;
+
+      rowsRef.current = nextRows;
+      offsetRef.current = nextOffset;
+      hasMoreRef.current = nextHasMore;
+
+      setRows(nextRows);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+    } catch (e) {
+      if (requestSeq !== requestSeqRef.current) return;
+      const msg = e?.body?.error || e?.message || "Failed to load catalogue";
+      setLoadError(msg);
+      notify.error(msg);
+      setRows([]);
+      setTotal(0);
+      setHasMore(false);
+      rowsRef.current = [];
+      offsetRef.current = 0;
+      hasMoreRef.current = false;
+    } finally {
+      if (requestSeq === requestSeqRef.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    }
   }, [tab, notify]);
 
   useEffect(() => {
-    load();
+    load({ reset: true });
+  }, [load]);
+
+  const reload = useCallback(() => {
+    load({ reset: true });
+  }, [load]);
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
   }, [load]);
 
   const resetForm = () => {
@@ -308,7 +402,7 @@ export default function TmcCatalogueAdmin() {
       if (!editingId && tab !== STATUS_ARCHIVED) {
         setTab(STATUS_ARCHIVED);
       } else {
-        load();
+        reload();
       }
     } catch (err) {
       notify.error(
@@ -334,7 +428,7 @@ export default function TmcCatalogueAdmin() {
         method: "DELETE",
       });
       notify.success("Catalogue entry archived");
-      load();
+      reload();
     } catch (err) {
       notify.error(
         err?.body?.error || err?.message || "Failed to archive entry",
@@ -359,6 +453,7 @@ export default function TmcCatalogueAdmin() {
       // Drop the promoted row from this tab's view; the user can flip to
       // Active to see it in its new home.
       setRows((prev) => prev.filter((r) => r.id !== row.id));
+      rowsRef.current = rowsRef.current.filter((r) => r.id !== row.id);
       setPendingReviewTripIds((prev) => {
         const next = new Set(prev);
         next.delete(row.tripId);
@@ -476,7 +571,7 @@ export default function TmcCatalogueAdmin() {
       if (createdTripIds.length > 0 && tab !== STATUS_ARCHIVED) {
         setTab(STATUS_ARCHIVED);
       } else {
-        load();
+        reload();
       }
     } catch (err) {
       notify.error(err?.message || "Failed to import catalogue");
@@ -706,13 +801,26 @@ export default function TmcCatalogueAdmin() {
         </div>
       )}
 
+      <section
+        style={{
+          background: "var(--bg-color, #111318)",
+          border: "1px solid var(--border-color)",
+          borderRadius: 12,
+          padding: 16,
+          marginBottom: 16,
+          display: "grid",
+          gap: 16,
+        }}
+      >
       {/* Tabs */}
       <div role="tablist" aria-label="Catalogue status tabs" style={tabRow}>
         <button
           type="button"
           role="tab"
           aria-selected={tab === STATUS_ACTIVE}
-          onClick={() => setTab(STATUS_ACTIVE)}
+          onClick={() => {
+            setTab(STATUS_ACTIVE);
+          }}
           style={tab === STATUS_ACTIVE ? tabActive : tabIdle}
         >
           Active
@@ -721,7 +829,9 @@ export default function TmcCatalogueAdmin() {
           type="button"
           role="tab"
           aria-selected={tab === STATUS_ARCHIVED}
-          onClick={() => setTab(STATUS_ARCHIVED)}
+          onClick={() => {
+            setTab(STATUS_ARCHIVED);
+          }}
           style={tab === STATUS_ARCHIVED ? tabActive : tabIdle}
         >
           Archived
@@ -1062,7 +1172,7 @@ export default function TmcCatalogueAdmin() {
       )}
 
       {/* List */}
-      {loading ? (
+      {loading && rows.length === 0 ? (
         <div style={emptyStyle}>Loading&hellip;</div>
       ) : loadError ? (
         <div
@@ -1079,8 +1189,18 @@ export default function TmcCatalogueAdmin() {
         </div>
       ) : (
         <div
+          ref={listContainerRef}
+          onScroll={handleListScroll}
           role="list"
           aria-label={`${tab} catalogue entries`}
+          style={{
+            maxHeight: "72vh",
+            overflowY: "auto",
+            paddingRight: 4,
+            scrollBehavior: "smooth",
+          }}
+        >
+        <div
           style={{
             display: "grid",
             gap: 12,
@@ -1212,7 +1332,33 @@ export default function TmcCatalogueAdmin() {
             </div>
           ))}
         </div>
+        <div style={{ paddingTop: 12 }}>
+          {loadingMore && (
+            <div style={{ ...emptyStyle, padding: 16 }}>Loading more&hellip;</div>
+          )}
+          {!loadingMore && hasMore && (
+            <div
+              aria-hidden="true"
+              style={{ height: 1 }}
+              data-testid="tmc-catalogue-scroll-sentinel"
+            />
+          )}
+          {!hasMore && total > 0 && (
+            <div
+              style={{
+                padding: "12px 0",
+                textAlign: "center",
+                color: "var(--text-secondary)",
+                fontSize: 12,
+              }}
+            >
+              You&apos;ve reached the end of the catalogue.
+            </div>
+          )}
+        </div>
+        </div>
       )}
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/travel/Trips.jsx
+++ b/frontend/src/pages/travel/Trips.jsx
@@ -8,7 +8,7 @@
 // No creation flow here — trips spawn from the linked Deal in the sales
 // pipeline (Day 7+ Deal-extension lands later).
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Luggage, Filter, Plus, Users, Calendar as CalendarIcon, X, Trash2, Search } from "lucide-react";
 import { fetchApi } from "../../utils/api";
@@ -57,17 +57,29 @@ const EMPTY_FORM = {
   departDate: "", returnDate: "", pricePerStudent: "", status: "confirmed",
 };
 
+const PAGE_SIZE = 10;
+
 export default function Trips() {
   const notify = useNotify();
   const [trips, setTrips] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchParams, setSearchParams] = useSearchParams();
   const initialStatus = searchParams.get("status") || "";
+  const [loadingMore, setLoadingMore] = useState(false);
   const [status, setStatus] = useState(initialStatus);
   const [search, setSearch] = useState("");
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
+  const listRef = useRef(null);
+  const tripsRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
   const openCreate = () => {
     setForm(EMPTY_FORM);
@@ -95,7 +107,7 @@ export default function Trips() {
       await fetchApi("/api/travel/trips", { method: "POST", body: JSON.stringify(body) });
       notify.success("Trip created");
       setCreating(false);
-      load();
+      load({ reset: true });
     } catch (err) {
       notify.error(err?.body?.error || err?.message || "Failed to create trip");
     } finally {
@@ -108,21 +120,96 @@ export default function Trips() {
     setStatus((current) => (current === nextStatus ? current : nextStatus));
   }, [searchParams]);
 
-  const load = () => {
-    setLoading(true);
+  useEffect(() => {
+    tripsRef.current = trips;
+  }, [trips]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setTrips([]);
+      tripsRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      offsetRef.current = 0;
+      hasMoreRef.current = true;
+      if (listRef.current) {
+        listRef.current.scrollTop = 0;
+      }
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
+
     const qs = new URLSearchParams();
     if (status) qs.set("status", status);
-    qs.set("limit", "100");
-    fetchApi(`/api/travel/trips?${qs.toString()}`)
-      .then((res) => setTrips(Array.isArray(res?.trips) ? res.trips : []))
-      .catch((e) => {
-        notify.error(e?.body?.error || "Failed to load trips");
-        setTrips([]);
-      })
-      .finally(() => setLoading(false));
-  };
+    qs.set("limit", String(PAGE_SIZE));
+    qs.set("offset", String(startOffset));
 
-  useEffect(load, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+    try {
+      const res = await fetchApi(`/api/travel/trips?${qs.toString()}`);
+      const rows = Array.isArray(res?.trips) ? res.trips : [];
+      const totalCount = Number.isFinite(Number(res?.total)) ? Number(res.total) : rows.length;
+      const nextTrips = reset ? rows : [...tripsRef.current, ...rows];
+      const nextOffset = startOffset + rows.length;
+      const nextHasMore = Number.isFinite(totalCount)
+        ? nextOffset < totalCount
+        : rows.length === PAGE_SIZE;
+
+      tripsRef.current = nextTrips;
+      setTrips(nextTrips);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+      offsetRef.current = nextOffset;
+      hasMoreRef.current = nextHasMore;
+    } catch (e) {
+      notify.error(e?.body?.error || "Failed to load trips");
+      setTrips([]);
+      tripsRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(false);
+      offsetRef.current = 0;
+      hasMoreRef.current = false;
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [status, notify]);
+
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load]);
 
   const handleStatusChange = (nextStatus) => {
     setStatus(nextStatus);
@@ -175,7 +262,7 @@ export default function Trips() {
     try {
       await fetchApi(`/api/travel/trips/${t.id}`, { method: "DELETE" });
       notify.success(`Trip ${t.tripCode} deleted`);
-      load();
+      load({ reset: true });
     } catch (e) {
       // The route returns 403 RBAC_DENIED for non-ADMIN callers; surface
       // the server-side message so the operator knows it's a perms issue
@@ -223,12 +310,12 @@ export default function Trips() {
         <select value={status} onChange={(e) => handleStatusChange(e.target.value)} style={selectStyle} aria-label="Filter by status">
           {STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
         </select>
-        <button type="button" onClick={load} style={refreshBtn} aria-label="Reload list">Refresh</button>
+        <button type="button" onClick={() => load({ reset: true })} style={refreshBtn} aria-label="Reload list">Refresh</button>
       </div>
 
       <div style={{
         background: "var(--surface-color)", borderRadius: 8,
-        border: "1px solid var(--border-color)", overflow: "visible",
+        border: "1px solid var(--border-color)",
       }}>
         {loading ? (
           <div style={empty}>Loading&hellip;</div>
@@ -239,27 +326,35 @@ export default function Trips() {
         ) : visibleTrips.length === 0 ? (
           <div style={empty}>No trips match &ldquo;{search}&rdquo;.</div>
         ) : (
-          <TopScrollSync>
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th style={th}>Trip code</th>
-                <th style={th}>Destination</th>
-                <th style={th}>Brand</th>
-                <th style={th}>Sub-brand</th>
-                <th style={th}>Dates</th>
-                <th style={th}>School</th>
-                <th style={th}>Participants</th>
-                <th style={th}>Cost</th>
-                <th style={th}>Status</th>
-                <th style={{ ...th, width: 60, textAlign: "right" }} aria-label="Actions"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {visibleTrips.map((t) => {
-                const sc = STATUS_COLORS[t.status] || { bg: "var(--subtle-bg)", color: "var(--text-secondary)" };
-                return (
-                  <tr key={t.id} style={{ borderTop: "1px solid var(--border-light)" }}>
+          <div
+            ref={listRef}
+            data-testid="trips-table-scroll"
+            onScroll={handleListScroll}
+            style={{
+              maxHeight: "60vh",
+              overflowY: "auto",
+              overflowX: "hidden",
+            }}
+          >
+            <TopScrollSync>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead style={{position: "sticky", top: 0,background: "#fff",zIndex: 10,}}>
+                <tr>
+                  <th style={th}>Trip code</th>
+                  <th style={th}>Destination</th>
+                  <th style={th}>Dates</th>
+                  <th style={th}>School</th>
+                  <th style={th}>Participants</th>
+                  <th style={th}>Per-student</th>
+                  <th style={th}>Status</th>
+                  <th style={{ ...th, width: 60, textAlign: "right" }} aria-label="Actions"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleTrips.map((t) => {
+                  const sc = STATUS_COLORS[t.status] || { bg: "var(--subtle-bg)", color: "var(--text-secondary)" };
+                  return (
+                    <tr key={t.id} style={{ borderTop: "1px solid var(--border-light)" }}>
                     <td style={td}>
                       <Link to={`/travel/trips/${t.id}`} style={{ color: "var(--primary-color)", textDecoration: "none", fontWeight: 600 }}>
                         {t.tripCode}
@@ -313,12 +408,26 @@ export default function Trips() {
                         <Trash2 size={14} aria-hidden />
                       </button>
                     </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          </TopScrollSync>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {total > 0 && (
+              <div style={{ padding: "12px 0", textAlign: "center", color: "var(--text-secondary)", fontSize: 12 }}>
+                {hasMore ? "Scroll to load more trips." : "You've reached the end of the trips."}
+              </div>
+            )}
+            </TopScrollSync>
+            <div style={{ paddingTop: 12 }}>
+              {loadingMore && (
+                <div style={empty}>Loading more&hellip;</div>
+              )}
+              {!loadingMore && hasMore && (
+                <div aria-hidden="true" data-testid="trips-table-sentinel" style={{ height: 1 }} />
+              )}
+            </div>
+          </div>
         )}
       </div>
 

--- a/frontend/src/pages/travel/WebCheckinQueue.jsx
+++ b/frontend/src/pages/travel/WebCheckinQueue.jsx
@@ -518,7 +518,6 @@ const empty = {
 const th = {
   position: "sticky",
   top: 0,
-  background: "#fff",
   zIndex: 10,
   textAlign: "left", padding: "12px 12px", fontSize: 12,
   textTransform: "uppercase", letterSpacing: 0.5,

--- a/frontend/src/pages/travel/WebCheckinQueue.jsx
+++ b/frontend/src/pages/travel/WebCheckinQueue.jsx
@@ -42,22 +42,14 @@ function normalizeUploadUrl(url) {
 const STATUSES = [
   { value: "", label: "All statuses" },
   { value: "pending", label: "Pending" },
-  { value: "reminded", label: "Reminded" },
-  { value: "in-progress", label: "In progress" },
   { value: "done", label: "Done" },
-  { value: "fallback-agent", label: "Fallback agent" },
-  { value: "failed", label: "Failed" },
 ];
 
-// Status badge palette — schema enum is pending|reminded|in-progress|done|
-// fallback-agent|failed (backend/routes/travel_webcheckin.js:VALID_STATUSES).
+// Status badge palette — backend/routes/travel_webcheckin.js:VALID_STATUSES
+// is now binary: pending | done.
 const STATUS_COLORS = {
   pending: { bg: "rgba(38,99,180,0.14)", color: "#1F5DAA" },
-  reminded: { bg: "rgba(40,160,180,0.16)", color: "#1E7E8C" },
-  "in-progress": { bg: "rgba(200,154,78,0.18)", color: "#9A6F2E" },
   done: { bg: "rgba(47,122,77,0.16)", color: "#2F7A4D" },
-  "fallback-agent": { bg: "rgba(168,50,63,0.16)", color: "#A8323F" },
-  failed: { bg: "rgba(168,50,63,0.18)", color: "#A8323F" },
 };
 
 const PAGE_SIZE = 50;

--- a/frontend/src/pages/travel/WebCheckinQueue.jsx
+++ b/frontend/src/pages/travel/WebCheckinQueue.jsx
@@ -22,10 +22,11 @@
 // new-tab link to boardingPassUrl, not an inline iframe (lighter UI,
 // PDF + image both handled by the browser).
 
-import { useEffect, useState, useRef } from "react";
-import { Filter, Ticket, Calendar as CalendarIcon, Upload, Send, UserCheck, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useState, useRef, useCallback } from "react";
+import { Filter, Ticket, Calendar as CalendarIcon, Upload, Send, UserCheck, RefreshCw } from "lucide-react";
 import { fetchApi, getAuthToken } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
+import TopScrollSync from "../../components/TopScrollSync";
 
 // Rewrite /uploads/... → /api/uploads/... so production deployments (where the
 // frontend SPA catches /uploads/* before it reaches the backend static mount)
@@ -74,42 +75,97 @@ export default function WebCheckinQueue() {
   const [rows, setRows] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [status, setStatus] = useState("");
   const [upcomingOnly, setUpcomingOnly] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [staff, setStaff] = useState([]);
   const [uploadingId, setUploadingId] = useState(null);
   const [deliveringId, setDeliveringId] = useState(null);
   const [reassigningId, setReassigningId] = useState(null);
   // Per-row hidden file input refs keyed by checkin id.
   const fileInputs = useRef({});
+  const listRef = useRef(null);
+  const rowsRef = useRef([]);
+  const loadingRef = useRef(true);
+  const loadingMoreRef = useRef(false);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
 
-  const load = () => {
-    setLoading(true);
+  useEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    loadingMoreRef.current = loadingMore;
+  }, [loadingMore]);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    hasMoreRef.current = !upcomingOnly && (offset + rows.length < total);
+  }, [upcomingOnly, offset, rows.length, total]);
+
+  const load = useCallback(async ({ reset = false } = {}) => {
+    const startOffset = reset ? 0 : offsetRef.current;
+    if (reset) {
+      setLoading(true);
+      setLoadingMore(false);
+      setRows([]);
+      rowsRef.current = [];
+      setTotal(0);
+      setOffset(0);
+      setHasMore(true);
+      if (listRef.current) listRef.current.scrollTop = 0;
+    } else {
+      if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      setLoadingMore(true);
+    }
+
     const url = upcomingOnly
       ? `/api/travel/webcheckins/upcoming`
       : (() => {
           const qs = new URLSearchParams();
           if (status) qs.set("status", status);
           qs.set("limit", String(PAGE_SIZE));
-          qs.set("offset", String(offset));
+          qs.set("offset", String(startOffset));
           return `/api/travel/webcheckins?${qs.toString()}`;
         })();
-    fetchApi(url)
-      .then((res) => {
-        const list = Array.isArray(res?.webcheckins) ? res.webcheckins : [];
-        setRows(list);
-        setTotal(Number.isFinite(res?.total) ? res.total : list.length);
-      })
-      .catch((e) => {
-        // fetchApi already toasted; just zero the state.
-        if (e?.status !== 401) {
-          setRows([]);
-          setTotal(0);
-        }
-      })
-      .finally(() => setLoading(false));
-  };
+    try {
+      const res = await fetchApi(url);
+      const list = Array.isArray(res?.webcheckins) ? res.webcheckins : [];
+      const totalCount = Number.isFinite(Number(res?.total)) ? Number(res.total) : list.length;
+      const nextRows = upcomingOnly || reset ? list : [...rowsRef.current, ...list];
+      const nextOffset = upcomingOnly ? 0 : startOffset + list.length;
+      const nextHasMore = upcomingOnly
+        ? false
+        : (Number.isFinite(totalCount) ? nextOffset < totalCount : list.length === PAGE_SIZE);
+      rowsRef.current = nextRows;
+      setRows(nextRows);
+      setTotal(totalCount);
+      setOffset(nextOffset);
+      setHasMore(nextHasMore);
+    } catch (e) {
+      // fetchApi already toasted; just zero the state.
+      if (e?.status !== 401) {
+        setRows([]);
+        rowsRef.current = [];
+        setTotal(0);
+        setOffset(0);
+        setHasMore(false);
+      }
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [upcomingOnly, status]);
 
   // Staff list for the reassign dropdown — loaded once. /api/staff is
   // tolerant of every authed role and returns a small list per tenant.
@@ -119,7 +175,9 @@ export default function WebCheckinQueue() {
       .catch(() => setStaff([]));
   }, []);
 
-  useEffect(load, [status, upcomingOnly, offset]);
+  useEffect(() => {
+    load({ reset: true });
+  }, [load]);
 
   // Filter changes reset offset to 0 so the user doesn't land mid-page
   // on a smaller filtered result-set.
@@ -131,6 +189,15 @@ export default function WebCheckinQueue() {
     setUpcomingOnly(e.target.checked);
     setOffset(0);
   };
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el || upcomingOnly || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+    const threshold = 72;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
+      load({ reset: false });
+    }
+  }, [load, upcomingOnly]);
 
   // ─── Per-row actions ──────────────────────────────────────────────
 
@@ -161,7 +228,7 @@ export default function WebCheckinQueue() {
         return;
       }
       notify.success("Boarding pass uploaded.");
-      load();
+      load({ reset: true });
     } catch (err) {
       notify.error(err?.message || "Upload failed");
     } finally {
@@ -184,7 +251,7 @@ export default function WebCheckinQueue() {
         silent: true,
       });
       notify.success("Marked delivered.");
-      load();
+      load({ reset: true });
     } catch (err) {
       // 409 NO_BOARDING_PASS is the most common — surface it as a clear toast.
       if (err?.code === "NO_BOARDING_PASS") {
@@ -205,7 +272,7 @@ export default function WebCheckinQueue() {
         body: JSON.stringify({ assignedAgentId: agentId ? parseInt(agentId, 10) : null }),
       });
       notify.success(agentId ? "Reassigned." : "Unassigned.");
-      load();
+      load({ reset: true });
     } catch (err) {
       notify.error(err?.message || "Failed to reassign");
     } finally {
@@ -214,10 +281,6 @@ export default function WebCheckinQueue() {
   };
 
   // ─── Render ──────────────────────────────────────────────────────
-
-  const showingPagination = !upcomingOnly && total > PAGE_SIZE;
-  const fromIdx = total === 0 ? 0 : offset + 1;
-  const toIdx = Math.min(offset + rows.length, total);
 
   return (
     <div style={{ padding: 24, maxWidth: 1400, margin: "0 auto" }}>
@@ -260,25 +323,20 @@ export default function WebCheckinQueue() {
         </label>
         <button
           type="button"
-          onClick={load}
+          onClick={() => load({ reset: true })}
           style={refreshBtn}
           aria-label="Refresh"
         >
           <RefreshCw size={14} aria-hidden style={{ marginRight: 4 }} /> Refresh
         </button>
-        {showingPagination && (
-          <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-secondary)" }}>
-            {fromIdx}&ndash;{toIdx} of {total}
-          </span>
-        )}
       </div>
 
       {/* Table */}
       <div style={{
         background: "var(--surface-color)", borderRadius: 8,
-        border: "1px solid var(--border-color)", overflow: "auto",
+        border: "1px solid var(--border-color)",
       }}>
-        {loading ? (
+        {loading && rows.length === 0 ? (
           <div style={empty}>Loading&hellip;</div>
         ) : rows.length === 0 ? (
           <div style={empty}>
@@ -286,9 +344,20 @@ export default function WebCheckinQueue() {
             flights are accepted.
           </div>
         ) : (
+          <div
+            ref={listRef}
+            data-testid="webcheckins-table-scroll"
+            onScroll={handleListScroll}
+            style={{
+              maxHeight: "60vh",
+              overflowY: "auto",
+              overflowX: "hidden",
+            }}
+          >
+            <TopScrollSync disabled>
           <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1100 }}>
             <thead>
-              <tr>
+              <tr style={{ position: "sticky", top: 0, background: "#fff", zIndex: 10 }}>
                 <th style={th}>Window opens</th>
                 <th style={th}>PNR</th>
                 <th style={th}>Flight</th>
@@ -398,35 +467,20 @@ export default function WebCheckinQueue() {
               })}
             </tbody>
           </table>
+            </TopScrollSync>
+            {loadingMore && (
+              <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-light)" }}>
+                Loading more&hellip;
+              </div>
+            )}
+            {!upcomingOnly && hasMore && !loadingMore && (
+              <div data-testid="webcheckins-scroll-sentinel" style={{ height: 1 }} />
+            )}
+          </div>
         )}
       </div>
 
       {/* Pagination — only when not in upcoming mode and total exceeds page. */}
-      {showingPagination && (
-        <div style={{
-          display: "flex", justifyContent: "flex-end", alignItems: "center",
-          gap: 8, marginTop: 12,
-        }}>
-          <button
-            type="button"
-            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-            disabled={offset === 0}
-            style={pagerBtn}
-            aria-label="Previous page"
-          >
-            <ChevronLeft size={14} aria-hidden /> Prev
-          </button>
-          <button
-            type="button"
-            onClick={() => setOffset(offset + PAGE_SIZE)}
-            disabled={offset + rows.length >= total}
-            style={pagerBtn}
-            aria-label="Next page"
-          >
-            Next <ChevronRight size={14} aria-hidden />
-          </button>
-        </div>
-      )}
     </div>
   );
 }
@@ -457,18 +511,15 @@ const actionBtn = {
   background: "var(--surface-color)", color: "var(--text-primary)",
   fontSize: 12, cursor: "pointer", height: 28, minWidth: 75, whiteSpace: "nowrap", flexShrink: 0,
 };
-const pagerBtn = {
-  display: "inline-flex", alignItems: "center", gap: 2,
-  padding: "6px 12px", borderRadius: 6,
-  border: "1px solid var(--border-color)",
-  background: "var(--surface-color)", color: "var(--text-primary)",
-  fontSize: 13, cursor: "pointer",
-};
 const empty = {
   padding: 32, textAlign: "center",
   color: "var(--text-secondary)", fontSize: 14,
 };
 const th = {
+  position: "sticky",
+  top: 0,
+  background: "#fff",
+  zIndex: 10,
   textAlign: "left", padding: "12px 12px", fontSize: 12,
   textTransform: "uppercase", letterSpacing: 0.5,
   color: "var(--text-secondary)", borderBottom: "1px solid var(--border-color)",

--- a/frontend/src/pages/wellness/Recommendations.jsx
+++ b/frontend/src/pages/wellness/Recommendations.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Sparkles, Check, X, Clock, AlertCircle, Play } from 'lucide-react';
 import { fetchApi } from '../../utils/api';
 import { useNotify } from '../../utils/notify';
 
 const priorityColor = { high: '#ef4444', medium: '#f59e0b', low: '#64748b' };
+const PAGE_SIZE = 10;
 const typeLabel = {
   campaign_boost: 'Ad campaign',
   occupancy_alert: 'Occupancy',
@@ -21,6 +22,8 @@ export default function Recommendations() {
   // status='all' fetch is the source of truth for the counters at the top.
   const [allItems, setAllItems] = useState([]);
   const [running, setRunning] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const listRef = useRef(null);
 
   // Manually trigger the orchestrator. Same endpoint the daily 07:00 IST
   // cron uses — gives admin/manager a way to populate the page without
@@ -45,10 +48,15 @@ export default function Recommendations() {
     setRunning(false);
   };
 
-  const load = () => {
+  const load = useCallback(() => {
     setLoading(true);
     fetchApi(`/api/wellness/recommendations?status=${filter}`)
-      .then(setItems)
+      .then((rows) => {
+        const next = Array.isArray(rows) ? rows : [];
+        setItems(next);
+        setVisibleCount(Math.min(PAGE_SIZE, next.length || PAGE_SIZE));
+        if (listRef.current) listRef.current.scrollTop = 0;
+      })
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
     // Always re-pull the unfiltered set so the chip counts reflect the
@@ -56,9 +64,9 @@ export default function Recommendations() {
     fetchApi(`/api/wellness/recommendations?status=all`)
       .then((rows) => setAllItems(Array.isArray(rows) ? rows : []))
       .catch(() => { /* non-fatal — counters degrade to current page only */ });
-  };
+  }, [filter]);
 
-  useEffect(() => { load(); }, [filter]);
+  useEffect(() => { load(); }, [load]);
 
   // #359: align the count math with the backend's status string. Backend
   // emits lowercase ('pending' / 'approved' / 'rejected') but defensive
@@ -71,6 +79,21 @@ export default function Recommendations() {
     rejected: statusCount('rejected'),
     all: allItems.length,
   };
+
+  const displayedItems = useMemo(
+    () => items.slice(0, Math.min(visibleCount, items.length)),
+    [items, visibleCount],
+  );
+
+  const handleListScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el) return;
+    const threshold = 72;
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
+    if (!nearBottom) return;
+    if (visibleCount >= items.length) return;
+    setVisibleCount((current) => Math.min(current + PAGE_SIZE, items.length));
+  }, [items.length, visibleCount]);
 
   const handleAction = async (id, action) => {
     const rec = items.find(r => r.id === id);
@@ -208,8 +231,21 @@ export default function Recommendations() {
         </div>
       )}
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        {items.map((r) => (
+      <div
+        ref={listRef}
+        data-testid="recommendations-list-scroll"
+        onScroll={handleListScroll}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+          maxHeight: 'calc(100vh - 220px)',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          paddingRight: 4,
+        }}
+      >
+        {displayedItems.map((r) => (
           <div key={r.id} className="glass" style={{ padding: '1.25rem' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.5rem' }}>
               <div>
@@ -264,6 +300,13 @@ export default function Recommendations() {
             )}
           </div>
         ))}
+        {!loading && displayedItems.length < items.length && (
+          <div
+            data-testid="recommendations-scroll-sentinel"
+            aria-hidden="true"
+            style={{ height: 1 }}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/wellness/services/ActiveTreatmentsTab.jsx
+++ b/frontend/src/pages/wellness/services/ActiveTreatmentsTab.jsx
@@ -1,20 +1,90 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { srOnly } from './shared';
 import TreatmentCard from './TreatmentCard';
 
+const PAGE_SIZE = 12;
+
 export default function ActiveTreatmentsTab({ treatments, loading, onChanged, onSelectTreatment }) {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const scrollRef = useRef(null);
+  const displayedTreatments = useMemo(
+    () => treatments.slice(0, Math.min(visibleCount, treatments.length)),
+    [treatments, visibleCount],
+  );
+
+  useEffect(() => {
+    setVisibleCount(Math.min(PAGE_SIZE, treatments.length));
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [treatments.length]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || loading) return;
+    if (visibleCount >= treatments.length) return;
+    if (el.scrollHeight <= 0 || el.clientHeight <= 0) return;
+    if (el.scrollHeight <= el.clientHeight + 8) {
+      setVisibleCount((current) => Math.min(current + PAGE_SIZE, treatments.length));
+    }
+  }, [loading, treatments.length, visibleCount, displayedTreatments.length]);
+
+  const handleScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el) return;
+    const threshold = 72;
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
+    if (!nearBottom) return;
+    if (visibleCount >= treatments.length) return;
+    setVisibleCount((current) => Math.min(current + PAGE_SIZE, treatments.length));
+  }, [treatments.length, visibleCount]);
+
   return (
     <>
       <h2 style={srOnly}>Active treatment plans</h2>
-      {loading && <div>Loading treatment plans…</div>}
+      {loading && <div>Loading treatment plansâ€¦</div>}
       {!loading && treatments.length === 0 && (
         <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-secondary)' }}>
           No active treatment plans yet.
         </div>
       )}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
-        {treatments.map((t) => (
-          <TreatmentCard key={t.id} treatment={t} onChanged={onChanged} onSelect={onSelectTreatment} />
-        ))}
+      <div
+        className="glass"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.75rem',
+          padding: '1rem',
+          minHeight: 0,
+        }}
+      >
+        <div
+          ref={scrollRef}
+          data-testid="active-treatments-scroll"
+          onScroll={handleScroll}
+          style={{
+            display: 'block',
+            maxHeight: 'calc(100dvh - 280px)',
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            paddingRight: '0.25rem',
+            scrollbarWidth: 'thin',
+          }}
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
+            {displayedTreatments.map((t) => (
+              <TreatmentCard key={t.id} treatment={t} onChanged={onChanged} onSelect={onSelectTreatment} />
+            ))}
+          </div>
+
+          {!loading && displayedTreatments.length < treatments.length && (
+            <div
+              data-testid="active-treatments-scroll-sentinel"
+              aria-hidden="true"
+              style={{ height: 1 }}
+            />
+          )}
+        </div>
       </div>
     </>
   );

--- a/frontend/src/pages/wellness/services/CatalogTab.jsx
+++ b/frontend/src/pages/wellness/services/CatalogTab.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePermissions } from '../../../hooks/usePermissions';
 import { useNotify } from '../../../utils/notify';
 import { currencySymbol } from '../../../utils/money';
@@ -11,6 +11,8 @@ import MultiSelectDropdown from './MultiSelectDropdown';
 import SingleSelectDropdown from './SingleSelectDropdown';
 import ImageUploadField from './ImageUploadField';
 
+const PAGE_SIZE = 12;
+
 export default function CatalogTab({ services, loading, categories, categoriesLoading, showAdd, form, setForm, submit, onChanged, onOpenService, editRequestId, clearEditRequest }) {
   const { hasPermission, isReady: permsReady } = usePermissions();
   const canManageServices = permsReady && hasPermission('services', 'write');
@@ -21,6 +23,8 @@ export default function CatalogTab({ services, loading, categories, categoriesLo
   // happens client-side over the already-fetched list so the toggle is
   // instant (no re-fetch).
   const [sortBy, setSortBy] = useState('default');
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const scrollRef = useRef(null);
   const sortedServices = useMemo(() => {
     if (!Array.isArray(services)) return [];
     if (sortBy === 'default') return services;
@@ -33,6 +37,37 @@ export default function CatalogTab({ services, loading, categories, categoriesLo
     if (sortBy === 'oldest') copy.sort((a, b) => tsOf(a) - tsOf(b));
     return copy;
   }, [services, sortBy]);
+  const displayedServices = useMemo(
+    () => sortedServices.slice(0, Math.min(visibleCount, sortedServices.length)),
+    [sortedServices, visibleCount],
+  );
+
+  useEffect(() => {
+    setVisibleCount(Math.min(PAGE_SIZE, sortedServices.length));
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [sortedServices.length, sortBy]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || loading) return;
+    if (visibleCount >= sortedServices.length) return;
+    if (el.scrollHeight <= 0 || el.clientHeight <= 0) return;
+    if (el.scrollHeight <= el.clientHeight + 8) {
+      setVisibleCount((current) => Math.min(current + PAGE_SIZE, sortedServices.length));
+    }
+  }, [loading, sortedServices.length, visibleCount, displayedServices.length]);
+
+  const handleScroll = useCallback((e) => {
+    const el = e.currentTarget;
+    if (!el) return;
+    const threshold = 72;
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
+    if (!nearBottom) return;
+    if (visibleCount >= sortedServices.length) return;
+    setVisibleCount((current) => Math.min(current + PAGE_SIZE, sortedServices.length));
+  }, [sortedServices.length, visibleCount]);
 
   return (
     <>
@@ -129,53 +164,85 @@ export default function CatalogTab({ services, loading, categories, categoriesLo
       {loading && <div>Loading…</div>}
 
       <div
+        className="glass"
         style={{
           display: 'flex',
-          justifyContent: 'flex-end',
-          alignItems: 'center',
-          gap: '0.5rem',
-          marginBottom: '0.75rem',
+          flexDirection: 'column',
+          gap: '0.75rem',
+          padding: '1rem',
+          minHeight: 0,
         }}
       >
-        <label
-          htmlFor="services-sort"
-          style={{ fontSize: '0.78rem', color: 'var(--text-secondary)' }}
-        >
-          Sort by
-        </label>
-        <select
-          id="services-sort"
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          aria-label="Sort services"
+        <div
           style={{
-            padding: '0.4rem 0.7rem',
-            background: 'var(--surface-color)',
-            color: 'var(--text-primary)',
-            border: '1px solid var(--border-color)',
-            borderRadius: 8,
-            fontSize: '0.85rem',
-            cursor: 'pointer',
-            outline: 'none',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+            gap: '0.5rem',
           }}
         >
-          <option value="default" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Default</option>
-          <option value="newest" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Newest first</option>
-          <option value="oldest" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Oldest first</option>
-        </select>
-      </div>
+          <label
+            htmlFor="services-sort"
+            style={{ fontSize: '0.78rem', color: 'var(--text-secondary)' }}
+          >
+            Sort by
+          </label>
+          <select
+            id="services-sort"
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+            aria-label="Sort services"
+            style={{
+              padding: '0.4rem 0.7rem',
+              background: 'var(--surface-color)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border-color)',
+              borderRadius: 8,
+              fontSize: '0.85rem',
+              cursor: 'pointer',
+              outline: 'none',
+            }}
+          >
+            <option value="default" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Default</option>
+            <option value="newest" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Newest first</option>
+            <option value="oldest" style={{ background: 'var(--bg-color)', color: 'var(--text-primary)' }}>Oldest first</option>
+          </select>
+        </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
-        {sortedServices.map((s) => (
-          <ServiceCard
-            key={s.id}
-            service={s}
-            onChanged={onChanged}
-            onOpen={onOpenService}
-            editRequested={editRequestId === s.id}
-            onEditConsumed={clearEditRequest}
-          />
-        ))}
+        <div
+          ref={scrollRef}
+          data-testid="services-catalog-scroll"
+          onScroll={handleScroll}
+          style={{
+            display: 'block',
+            maxHeight: 'calc(100dvh - 280px)',
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            paddingRight: '0.25rem',
+            scrollbarWidth: 'thin',
+          }}
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
+            {displayedServices.map((s) => (
+              <ServiceCard
+                key={s.id}
+                service={s}
+                onChanged={onChanged}
+                onOpen={onOpenService}
+                editRequested={editRequestId === s.id}
+                onEditConsumed={clearEditRequest}
+              />
+            ))}
+          </div>
+
+          {!loading && displayedServices.length < sortedServices.length && (
+            <div
+              data-testid="services-scroll-sentinel"
+              aria-hidden="true"
+              style={{ height: 1 }}
+            />
+          )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
Sync latest main into prod_release.\n\nIncludes:\n- #1269 — travel pagination across itinerary/trips/quotes pages\n- #1270 — Callified + web check-in updates\n- #1271 — dynamic external API lead custom fields + source normalization\n- Test fixes for staff-commission-profiles and external lead intake\n\nAll checks passed on main.