### PR TITLE
fix(frontend/itineraries): prevent scroll pagination race on frontend_unit_tests

### DIFF
--- a/frontend/src/pages/travel/Itineraries.jsx
+++ b/frontend/src/pages/travel/Itineraries.jsx
@@ -666,6 +666,8 @@ export default function Itineraries() {
     const startOffset = reset ? 0 : offsetRef.current;
 
     if (reset) {
+      loadingRef.current = true;
+      loadingMoreRef.current = false;
       setLoading(true);
       setLoadingMore(false);
       setItems([]);
@@ -681,6 +683,7 @@ export default function Itineraries() {
       }
     } else {
       if (loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
+      loadingMoreRef.current = true;
       setLoadingMore(true);
     }
     const qs = new URLSearchParams();
@@ -718,6 +721,8 @@ export default function Itineraries() {
         hasMoreRef.current = false;
       }
     } finally {
+      loadingRef.current = false;
+      loadingMoreRef.current = false;
       setLoading(false);
       setLoadingMore(false);
     }


### PR DESCRIPTION
Synchronously updates loadingRef/loadingMoreRef inside the Itineraries load() function so the infinite-scroll guard is consistent with the actual in-flight state, eliminating a timing flake that caused the scroll-pagination test to fail in CI frontend_unit_tests.