### PR TITLE
fix(deploy): repair api_tests gate regressions

### DIFF
--- a/backend/routes/landing_pages.js
+++ b/backend/routes/landing_pages.js
@@ -3074,7 +3074,7 @@ router.put("/:id", verifyToken, async (req, res) => {
 
                   });
 
-                  const formattedAmount = `?${inst.amount.toLocaleString('en-IN')}`;
+                  const formattedAmount = `₹${inst.amount.toLocaleString('en-IN')}`;
 
                   return {
 
@@ -3426,7 +3426,7 @@ router.post("/:id/sync-investment", verifyToken, async (req, res) => {
 
       });
 
-      const formattedAmount = `?${inst.amount.toLocaleString('en-IN')}`;
+      const formattedAmount = `₹${inst.amount.toLocaleString('en-IN')}`;
 
       return {
 

--- a/e2e/tests/landing-pages-investment-sync-api.spec.js
+++ b/e2e/tests/landing-pages-investment-sync-api.spec.js
@@ -35,6 +35,12 @@ async function assertOk(response, label) {
   }
 }
 
+function uniqueTripCode(base) {
+  // Defensive suffix so retries / stale demo data do not collide on the
+  // tripCode unique constraint (see previous api_tests failures).
+  return `${base}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`;
+}
+
 async function createTrip(request, tripCode, destination, pricePerStudent, dayOffsets = [30, 40]) {
   const tripRes = await request.post(`${API_BASE}/travel/trips`, {
     headers: adminHeaders,
@@ -98,7 +104,7 @@ test.describe('landing-pages-investment-sync-api', () => {
   });
 
   test('POST /landing-pages/:id — auto-fill investment when linking to trip with payment plan', async ({ request }) => {
-    const trip = await createTrip(request, 'tmc-test-sync-001', 'Jaipur', 95000);
+    const trip = await createTrip(request, uniqueTripCode('tmc-test-sync-001'), 'Jaipur', 95000);
     await createPaymentPlan(request, trip.id, [
       { dueDate: '2026-04-20', amount: 25000, reminderDays: 7 },
       { dueDate: '2026-05-15', amount: 35000, reminderDays: 7 },
@@ -142,7 +148,7 @@ test.describe('landing-pages-investment-sync-api', () => {
   });
 
   test('POST /landing-pages/:id/sync-investment — regenerate installments from trip', async ({ request }) => {
-    const trip = await createTrip(request, 'tmc-test-sync-002', 'Andaman', 120000, [50, 60]);
+    const trip = await createTrip(request, uniqueTripCode('tmc-test-sync-002'), 'Andaman', 120000, [50, 60]);
     await createPaymentPlan(request, trip.id, [
       { dueDate: '2026-05-01', amount: 40000, reminderDays: 7 },
       { dueDate: '2026-06-01', amount: 40000, reminderDays: 7 },

--- a/e2e/tests/reports-api.spec.js
+++ b/e2e/tests/reports-api.spec.js
@@ -582,7 +582,7 @@ test.describe('Wellness Reports API — regression-coverage-backlog #12', () => 
     test('P&L bucketed visits + unbucketed equal canonical (#281 row-sum invariant)', async ({ request }) => {
       const from = daysAgo(60);
       const to = daysAgo(0);
-      const res = await wAuthGet(request, `/api/wellness/reports/pnl-by-service?from=${from}&to=${to}`);
+      const res = await wAuthGet(request, `/api/wellness/reports/pnl-by-service?from=${from}&to=${to}&limit=100`);
       expect(res.status()).toBe(200);
       const body = await res.json();
       // Header card invariant: bucketed (totals.visits) + unbucketed = canonical.

--- a/e2e/tests/wellness-read-audit-api.spec.js
+++ b/e2e/tests/wellness-read-audit-api.spec.js
@@ -98,14 +98,14 @@ async function put(request, token, path, body) {
 // Find the most-recent audit row for (entity, action) in the requester's
 // tenant whose createdAt >= afterMs. Returns null if not found within
 // the first /api/audit page (cap=100 per routes/audit.js).
-async function findAuditRow(request, token, entity, action, afterMs) {
+async function findAuditRow(request, token, entity, action, afterMs, userId) {
   const r = await get(request, token, `/api/audit?entity=${encodeURIComponent(entity)}&action=${encodeURIComponent(action)}`);
   if (!r.ok()) return null;
   const rows = await r.json();
   const list = Array.isArray(rows) ? rows : (rows.audit || rows.data || []);
   const candidates = list.filter((row) => {
     const created = row.createdAt ? new Date(row.createdAt).getTime() : 0;
-    return created >= afterMs;
+    return created >= afterMs && (!userId || Number(row.userId) === Number(userId));
   });
   // Newest first (server returns desc) — pick the first match.
   return candidates[0] || null;
@@ -198,7 +198,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
     // INSERT commit on a busy demo).
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'Visit', 'VISIT_LIST_READ', before);
+      row = await findAuditRow(request, token, 'Visit', 'VISIT_LIST_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -221,7 +221,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'Visit', 'VISIT_CONSUMPTIONS_READ', before);
+      row = await findAuditRow(request, token, 'Visit', 'VISIT_CONSUMPTIONS_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -242,7 +242,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'Prescription', 'PRESCRIPTION_LIST_READ', before);
+      row = await findAuditRow(request, token, 'Prescription', 'PRESCRIPTION_LIST_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -260,7 +260,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'ConsentForm', 'CONSENT_LIST_READ', before);
+      row = await findAuditRow(request, token, 'ConsentForm', 'CONSENT_LIST_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -278,7 +278,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'TreatmentPlan', 'TREATMENT_PLAN_LIST_READ', before);
+      row = await findAuditRow(request, token, 'TreatmentPlan', 'TREATMENT_PLAN_LIST_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -297,7 +297,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'TreatmentPlan', 'TREATMENT_PLAN_READ', before);
+      row = await findAuditRow(request, token, 'TreatmentPlan', 'TREATMENT_PLAN_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
 
@@ -322,7 +322,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
 
     let row = null;
     for (let i = 0; i < 5 && !row; i++) {
-      row = await findAuditRow(request, token, 'Visit', 'VISIT_LIST_READ', before);
+      row = await findAuditRow(request, token, 'Visit', 'VISIT_LIST_READ', before, userId);
       if (!row) await new Promise((res) => setTimeout(res, 200));
     }
     expect(row, 'staff VISIT_LIST_READ row found').toBeTruthy();

--- a/e2e/tests/wellness-reports-api.spec.js
+++ b/e2e/tests/wellness-reports-api.spec.js
@@ -498,7 +498,7 @@ test.describe('Wellness Reports API — attribution JSON shape', () => {
   let payload;
 
   test.beforeAll(async ({ request }) => {
-    const res = await authGet(request, '/api/wellness/reports/attribution', 'admin');
+    const res = await authGet(request, '/api/wellness/reports/attribution?limit=100', 'admin');
     expect(res.status()).toBe(200);
     payload = await res.json();
   });
@@ -808,7 +808,7 @@ test.describe('Wellness Reports API — PDF exports (#227)', () => {
 
 test.describe('#565 (HI-16) — canonical revenue reconciliation across surfaces', () => {
   test('P&L by-service totalRevenue == sum(rows.revenue) (internal sanity, #281)', async ({ request }) => {
-    const r = await authGet(request, '/api/wellness/reports/pnl-by-service', 'admin');
+    const r = await authGet(request, '/api/wellness/reports/pnl-by-service?limit=100', 'admin');
     expect(r.ok()).toBeTruthy();
     const body = await r.json();
     expect(typeof body.totalRevenue).toBe('number');


### PR DESCRIPTION
Fixes the remaining deterministic failures in the api_tests gate after the unit_tests auth regression was resolved in #1285.

Changes:
- Restore corrupted ₹ symbol in landing-page investment installment rendering (was showing '?').
- Use unique tripCode per attempt in landing-page sync tests to avoid DUPLICATE_TRIP_CODE collisions.
- Add  to report row-sum invariant checks so paginated responses include all buckets.
- Filter wellness-read-audit lookup by the requesting userId to avoid picking up audit rows from parallel specs.

Validation: these are targeted fixes for the 5 failing + 1 flaky test identified in deploy run 31083798882.