### PR TITLE
fix(e2e): destructure userId in actorType audit spec

### DIFF
--- a/e2e/tests/wellness-read-audit-api.spec.js
+++ b/e2e/tests/wellness-read-audit-api.spec.js
@@ -311,7 +311,7 @@ test.describe('Wellness PHI-read audit contract — T2.2', () => {
   });
 
   test('staff actorType is implicit user (no _actorType / _patientActorId in details)', async ({ request }) => {
-    const { token } = await getWellnessAdmin(request);
+    const { token, userId } = await getWellnessAdmin(request);
     // Sanity check that the patient-portal indicator stays absent on staff
     // path. PATIENT_DETAIL_READ from /portal/me has _actorType:'patient',
     // _patientActorId:<id> in details; staff reads must NOT carry those


### PR DESCRIPTION
Follow-up to #1286. The  test only destructured  from , but  now expects a  parameter. This caused  and failed the api_tests gate in deploy run 31085500221.