### PR TITLE
allow external lead domain

### DIFF
--- a/backend/lib/leadNotifications.js
+++ b/backend/lib/leadNotifications.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const prisma = require("./prisma");
 const { notify } = require("./notificationService");
 
@@ -44,6 +45,113 @@ async function notifyAdminsOfNewLead({ tenantId, contact, io }) {
   }
 }
 
+function normalizeEmbedOrigin(value) {
+  if (!value || typeof value !== "string") return null;
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+    return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+  } catch (_err) {
+    return null;
+  }
+}
+
+function allowlistEntryMatchesOrigin(origin, entry) {
+  if (!origin || !entry || typeof entry !== "string") return false;
+  const trimmed = entry.trim();
+  if (!trimmed) return false;
+  if (trimmed === "*") return true;
+
+  const match = trimmed.match(/^https:\/\/(\*\.)?([^\s/*:]+)(?::(\d+))?(?:\/.*)?$/i);
+  if (!match) return false;
+
+  const wildcard = !!match[1];
+  const host = match[2].toLowerCase();
+  const port = match[3] || "";
+
+  let parsed;
+  try {
+    parsed = new URL(origin);
+  } catch (_err) {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:") return false;
+  if ((parsed.port || "") !== port) return false;
+
+  const hostName = parsed.hostname.toLowerCase();
+  if (wildcard) {
+    return hostName === host || hostName.endsWith(`.${host}`);
+  }
+
+  return hostName === host;
+}
+
+function isEmbedOriginAllowed(origin, allowlistJson) {
+  const normalizedOrigin = normalizeEmbedOrigin(origin);
+  if (!allowlistJson) return true;
+
+  let allowlist = allowlistJson;
+  if (typeof allowlistJson === "string") {
+    try {
+      allowlist = JSON.parse(allowlistJson);
+    } catch (_err) {
+      return true;
+    }
+  }
+
+  if (!Array.isArray(allowlist) || allowlist.length === 0) return true;
+  if (!normalizedOrigin) return false;
+  return allowlist.some((entry) => allowlistEntryMatchesOrigin(normalizedOrigin, entry));
+}
+
+function blockedOriginEntityId(origin) {
+  const hash = crypto.createHash("sha1").update(String(origin)).digest("hex").slice(0, 8);
+  return parseInt(hash, 16);
+}
+
+async function notifyAdminsOfBlockedLeadOrigin({ tenantId, origin, io }) {
+  const normalizedOrigin = normalizeEmbedOrigin(origin);
+  if (!tenantId || !normalizedOrigin) return [];
+
+  try {
+    const admins = await prisma.user.findMany({
+      where: {
+        tenantId,
+        role: "ADMIN",
+        deactivatedAt: null,
+      },
+      select: { id: true },
+    });
+
+    const results = [];
+    for (const admin of admins) {
+      results.push(await notify({
+        userId: admin.id,
+        tenantId,
+        title: "External lead origin blocked",
+        message: `${normalizedOrigin} is not in the external lead allowlist. Open Settings to allow or deny it.`,
+        type: "warning",
+        category: "lead",
+        priority: "high",
+        link: "/settings",
+        entityType: "lead_domain",
+        entityId: blockedOriginEntityId(normalizedOrigin),
+        channels: ["db", "socket"],
+        io,
+      }));
+    }
+    return results;
+  } catch (err) {
+    console.error("[leadNotifications] blocked origin notification failed:", err && err.message);
+    return [];
+  }
+}
+
 module.exports = {
+  allowlistEntryMatchesOrigin,
+  isEmbedOriginAllowed,
+  normalizeEmbedOrigin,
+  notifyAdminsOfBlockedLeadOrigin,
   notifyAdminsOfNewLead,
 };

--- a/backend/prisma/seed-travel-extra.js
+++ b/backend/prisma/seed-travel-extra.js
@@ -1,0 +1,2079 @@
+/**
+ * Travel CRM extra fixtures.
+ *
+ * Adds supporting dummy data for the travel tenant without wiping the DB:
+ * contacts, itineraries, quotes, invoices, suppliers, payables, commissions,
+ * brochures, brand profiles, notifications, reviews, and RFU profiles.
+ *
+ * Run: cd backend && node prisma/seed-travel-extra.js
+ */
+const path = require("path");
+const dotenv = require("dotenv");
+
+dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+
+const { PrismaClient, Prisma } = require("@prisma/client");
+const bcrypt = require("bcryptjs");
+
+if (!process.env.DATABASE_URL) {
+  console.error("Error: DATABASE_URL not set in .env file");
+  process.exit(1);
+}
+
+const prisma = new PrismaClient();
+
+const now = new Date();
+const daysFromNow = (n) => new Date(Date.now() + n * 86400000);
+const daysAgo = (n) => new Date(Date.now() - n * 86400000);
+const dec = (v) => new Prisma.Decimal(String(v));
+const json = (v) => JSON.stringify(v);
+
+async function ensureContact(tenantId, spec) {
+  const existing = await prisma.contact.findFirst({
+    where: { tenantId, email: spec.email },
+  });
+  if (existing) {
+    return existing;
+  }
+  return prisma.contact.create({
+    data: {
+      tenantId,
+      name: spec.name,
+      email: spec.email,
+      phone: spec.phone ?? null,
+      company: spec.company ?? null,
+      title: spec.title ?? null,
+      status: spec.status ?? "Lead",
+      source: spec.source ?? "Organic",
+      subBrand: spec.subBrand ?? null,
+      aiScore: spec.aiScore ?? 50,
+      firstTouchSource: spec.firstTouchSource ?? spec.source ?? "Organic",
+      lastTouchSource: spec.lastTouchSource ?? spec.source ?? "Organic",
+      portalPasswordHash: spec.portalPasswordHash ?? null,
+    },
+  });
+}
+
+async function ensureByFindFirst(model, where, data) {
+  const existing = await prisma[model].findFirst({ where });
+  if (existing) {
+    return existing;
+  }
+  return prisma[model].create({ data });
+}
+
+async function main() {
+  console.log("[seed-travel-extra] starting...");
+
+  const tenant = await prisma.tenant.findUnique({ where: { slug: "travel-stall" } });
+  if (!tenant) {
+    throw new Error('Travel tenant "travel-stall" not found. Run seed-travel.js first.');
+  }
+
+  const admin = await prisma.user.findFirst({ where: { tenantId: tenant.id, email: "yasin@travelstall.in" } });
+  const admin2 = await prisma.user.findFirst({ where: { tenantId: tenant.id, email: "admin@travelstall.demo" } });
+  const tmcOps = await prisma.user.findFirst({ where: { tenantId: tenant.id, email: "tmc-ops@travelstall.demo" } });
+  const rfuAdvisor = await prisma.user.findFirst({ where: { tenantId: tenant.id, email: "rfu-advisor@travelstall.demo" } });
+  const telecaller = await prisma.user.findFirst({ where: { tenantId: tenant.id, email: "telecaller@travelstall.demo" } });
+
+  const contactSpecs = [
+    { name: "Maya Fernandez", email: "maya.fernandez@travelstall.demo", status: "Customer", source: "Referral", subBrand: "travelstall", aiScore: 94, title: "Operations Director" },
+    { name: "Samir Jain", email: "samir.jain@travelstall.demo", status: "Lead", source: "LinkedIn", subBrand: "tmc", aiScore: 72, title: "School Admin" },
+    { name: "Farah Ali", email: "farah.ali@travelstall.demo", status: "Prospect", source: "Conference", subBrand: "rfu", aiScore: 81, title: "Group Coordinator" },
+    { name: "Kevin Lee", email: "kevin.lee@travelstall.demo", status: "Lead", source: "Webinar", subBrand: "visasure", aiScore: 68, title: "Consultant" },
+    { name: "Nour Hassan", email: "nour.hassan@travelstall.demo", status: "Customer", source: "Referral", subBrand: "travelstall", aiScore: 90, title: "Marketing Lead" },
+    { name: "Elaine Nguyen", email: "elaine.nguyen@travelstall.demo", status: "Prospect", source: "Organic", subBrand: "travelstall", aiScore: 77, title: "Product Manager" },
+    { name: "Omar Sheikh", email: "omar.sheikh@travelstall.demo", status: "Lead", source: "WhatsApp", subBrand: "rfu", aiScore: 64, title: "Pilgrim Coordinator" },
+    { name: "Rita Dsouza", email: "rita.dsouza@travelstall.demo", status: "Customer", source: "Partner", subBrand: "visasure", aiScore: 85, title: "HR Lead" },
+    { name: "Imran Chaudhary", email: "imran.chaudhary@travelstall.demo", status: "Lead", source: "Organic", subBrand: "tmc", aiScore: 61, title: "Principal" },
+    { name: "Zara Khan", email: "zara.khan@travelstall.demo", status: "Prospect", source: "Instagram", subBrand: "travelstall", aiScore: 74, title: "Founder" },
+  ];
+
+  const contacts = [];
+  for (const spec of contactSpecs) {
+    contacts.push(await ensureContact(tenant.id, spec));
+  }
+
+  const contactByEmail = Object.fromEntries(contacts.map((c) => [c.email, c]));
+
+  const rfuContact = contactByEmail["farah.ali@travelstall.demo"];
+  const visaContact = contactByEmail["rita.dsouza@travelstall.demo"];
+  const tmcContact = contactByEmail["samir.jain@travelstall.demo"];
+  const travelContact = contactByEmail["maya.fernandez@travelstall.demo"];
+  const travelContact2 = contactByEmail["nour.hassan@travelstall.demo"];
+
+  const sightseeingSpecs = [
+    { destinationName: "Bali", name: "Tegalalang Rice Terraces", category: "nature", subBrand: "travelstall", durationMinutes: 90, priceReferenceMinor: 1200, notes: "Good at sunrise for families and honeymooners." },
+    { destinationName: "Dubai", name: "Burj Khalifa At The Top", category: "monument", subBrand: "travelstall", durationMinutes: 120, priceReferenceMinor: 4500, notes: "Use a sunset slot when possible." },
+    { destinationName: "Makkah", name: "Masjid al-Haram Ziyarat", category: "religious", subBrand: "rfu", durationMinutes: 180, priceReferenceMinor: 0, notes: "Usually paired with Umrah logistics." },
+    { destinationName: "Madinah", name: "Al-Baqi and Ziyarat Circuit", category: "religious", subBrand: "rfu", durationMinutes: 150, priceReferenceMinor: 0, notes: "Best scheduled after Dhuhr." },
+    { destinationName: "Paris", name: "Eiffel Tower Summit", category: "monument", subBrand: "travelstall", durationMinutes: 120, priceReferenceMinor: 3200, notes: "Works well for Europe-family bundles." },
+    { destinationName: "Jaipur", name: "Amber Fort Evening Experience", category: "historical", subBrand: "tmc", durationMinutes: 150, priceReferenceMinor: 900, notes: "Good add-on for school tours." },
+  ];
+
+  for (const spec of sightseeingSpecs) {
+    await ensureByFindFirst(
+      "travelSightseeing",
+      { tenantId: tenant.id, destinationName: spec.destinationName, name: spec.name },
+      {
+        tenantId: tenant.id,
+        destinationName: spec.destinationName,
+        name: spec.name,
+        description: `${spec.name} for ${spec.destinationName} demo itinerary planning.`,
+        imageUrl: null,
+        durationMinutes: spec.durationMinutes,
+        priceReferenceMinor: spec.priceReferenceMinor,
+        currency: "INR",
+        category: spec.category,
+        subBrand: spec.subBrand,
+        notes: spec.notes,
+        isActive: true,
+      },
+    );
+  }
+
+  const quoteTemplates = [
+    {
+      name: "Bali Honeymoon 6D Template",
+      subBrand: "travelstall",
+      category: "Honeymoon",
+      linesJson: json([
+        { lineType: "flight", description: "Delhi to Denpasar return flights", quantity: 2, unitPrice: 55000, currency: "INR", sortOrder: 0 },
+        { lineType: "hotel", description: "Ubud pool villa and Seminyak suite", quantity: 5, unitPrice: 18000, currency: "INR", sortOrder: 1 },
+        { lineType: "service", description: "Couples spa, sunset cruise, and transfers", quantity: 1, unitPrice: 22000, currency: "INR", sortOrder: 2 },
+      ]),
+    },
+    {
+      name: "RFU Umrah 7D Template",
+      subBrand: "rfu",
+      category: "Religious",
+      linesJson: json([
+        { lineType: "flight", description: "Delhi to Jeddah return flights", quantity: 1, unitPrice: 42000, currency: "INR", sortOrder: 0 },
+        { lineType: "hotel", description: "Makkah hotel stay", quantity: 6, unitPrice: 15500, currency: "INR", sortOrder: 1 },
+        { lineType: "service", description: "Ziyarat tours and ground transfers", quantity: 1, unitPrice: 18000, currency: "INR", sortOrder: 2 },
+      ]),
+    },
+    {
+      name: "Visa Sure B1/B2 Template",
+      subBrand: "visasure",
+      category: "Visa",
+      linesJson: json([
+        { lineType: "service", description: "Eligibility review and DS-160 support", quantity: 1, unitPrice: 7500, currency: "INR", sortOrder: 0 },
+        { lineType: "service", description: "Mock interview and document review", quantity: 1, unitPrice: 5000, currency: "INR", sortOrder: 1 },
+      ]),
+    },
+  ];
+
+  for (const spec of quoteTemplates) {
+    await ensureByFindFirst(
+      "travelQuoteTemplate",
+      { tenantId: tenant.id, name: spec.name },
+      {
+        tenantId: tenant.id,
+        name: spec.name,
+        description: `${spec.name} demo template`,
+        subBrand: spec.subBrand,
+        category: spec.category,
+        currency: "INR",
+        linesJson: spec.linesJson,
+        isActive: true,
+      },
+    );
+  }
+
+  const itineraries = [];
+  const itinerarySpecs = [
+    {
+      subBrand: "travelstall",
+      contact: travelContact,
+      status: "accepted",
+      destination: "Bali",
+      productTier: "premium",
+      totalAmount: dec("238000.00"),
+      pax: 2,
+      startDate: daysFromNow(28),
+      endDate: daysFromNow(33),
+      shareToken: "travelstall-bali-accepted",
+      clonedFromTemplateId: null,
+    },
+    {
+      subBrand: "travelstall",
+      contact: travelContact2,
+      status: "advance_paid",
+      destination: "Dubai",
+      productTier: "primary",
+      totalAmount: dec("128000.00"),
+      pax: 4,
+      startDate: daysFromNow(18),
+      endDate: daysFromNow(22),
+      shareToken: "travelstall-dubai-advance",
+      clonedFromTemplateId: null,
+    },
+    {
+      subBrand: "rfu",
+      contact: rfuContact,
+      status: "sent",
+      destination: "Makkah",
+      productTier: "premium",
+      totalAmount: dec("185000.00"),
+      pax: 3,
+      startDate: daysFromNow(40),
+      endDate: daysFromNow(47),
+      shareToken: "rfu-makkah-sent",
+      clonedFromTemplateId: null,
+    },
+    {
+      subBrand: "tmc",
+      contact: tmcContact,
+      status: "draft",
+      destination: "Jaipur + Agra",
+      productTier: null,
+      totalAmount: dec("96000.00"),
+      pax: 40,
+      startDate: daysFromNow(14),
+      endDate: daysFromNow(18),
+      shareToken: "tmc-jaipur-draft",
+      clonedFromTemplateId: null,
+    },
+    {
+      subBrand: "visasure",
+      contact: visaContact,
+      status: "revised",
+      destination: "United States",
+      productTier: "primary",
+      totalAmount: dec("18500.00"),
+      pax: 1,
+      startDate: daysFromNow(9),
+      endDate: daysFromNow(12),
+      shareToken: "visasure-us-revised",
+      clonedFromTemplateId: null,
+    },
+  ];
+
+  for (const spec of itinerarySpecs) {
+    const existing = await prisma.itinerary.findFirst({
+      where: {
+        tenantId: tenant.id,
+        subBrand: spec.subBrand,
+        destination: spec.destination,
+        contactId: spec.contact.id,
+      },
+    });
+    if (existing) {
+      itineraries.push(existing);
+      continue;
+    }
+    const row = await prisma.itinerary.create({
+      data: {
+        tenantId: tenant.id,
+        subBrand: spec.subBrand,
+        contactId: spec.contact.id,
+        status: spec.status,
+        version: 1,
+        productTier: spec.productTier,
+        destination: spec.destination,
+        startDate: spec.startDate,
+        endDate: spec.endDate,
+        pricingJson: json({ hero: spec.destination, demo: true }),
+        totalAmount: spec.totalAmount,
+        currency: "INR",
+        pax: spec.pax,
+        shareToken: spec.shareToken,
+        draftSummary: `${spec.destination} demo itinerary for ${spec.subBrand}`,
+        clonedFromTemplateId: spec.clonedFromTemplateId,
+      },
+    });
+    itineraries.push(row);
+  }
+
+  const supplierSpecs = [
+    {
+      subBrand: "travelstall",
+      name: "SkyHigh Airways",
+      supplierCategory: "flight",
+      contactPerson: "Arjun Mehta",
+      email: "ops@skyhighairways.demo",
+      phone: "+91-90000-10001",
+      commissionPercent: dec("5.50"),
+      paymentTermsKind: "net",
+      paymentTermsDays: 15,
+      creditLimit: dec("1500000.00"),
+      notes: "Preferred airline for outbound leisure itineraries.",
+    },
+    {
+      subBrand: "travelstall",
+      name: "Grand Ubud Villas",
+      supplierCategory: "hotel",
+      contactPerson: "Wayan Sari",
+      email: "reservations@grandubud.demo",
+      phone: "+62-800-0002",
+      commissionPercent: dec("12.00"),
+      paymentTermsKind: "net",
+      paymentTermsDays: 30,
+      creditLimit: dec("900000.00"),
+      notes: "Villa inventory for family and honeymoon trips.",
+    },
+    {
+      subBrand: "travelstall",
+      name: "Desert Wheels Transport",
+      supplierCategory: "transport",
+      contactPerson: "Adeel Khan",
+      email: "bookings@desertwheels.demo",
+      phone: "+971-500-0003",
+      commissionPercent: dec("8.00"),
+      paymentTermsKind: "on_arrival",
+      paymentTermsDays: null,
+      creditLimit: dec("350000.00"),
+      notes: "Dubai transfers and desert safari fleet.",
+    },
+    {
+      subBrand: "rfu",
+      name: "Makkah Care Services",
+      supplierCategory: "other",
+      contactPerson: "Faisal Rahman",
+      email: "hello@makkahcare.demo",
+      phone: "+966-500-0004",
+      commissionPercent: dec("10.00"),
+      paymentTermsKind: "prepay",
+      paymentTermsDays: null,
+      creditLimit: dec("500000.00"),
+      notes: "Umrah ground handling and pilgrimage coordination.",
+    },
+    {
+      subBrand: "visasure",
+      name: "VisaSphere Consulting",
+      supplierCategory: "visa-consul",
+      contactPerson: "Neha Kapoor",
+      email: "support@visasphere.demo",
+      phone: "+91-90000-10005",
+      commissionPercent: dec("18.00"),
+      paymentTermsKind: "net",
+      paymentTermsDays: 10,
+      creditLimit: dec("250000.00"),
+      notes: "Document processing and interview prep partner.",
+    },
+  ];
+
+  const suppliers = [];
+  for (const spec of supplierSpecs) {
+    const existing = await prisma.travelSupplier.findFirst({
+      where: { tenantId: tenant.id, subBrand: spec.subBrand, name: spec.name },
+    });
+    if (existing) {
+      suppliers.push(existing);
+      continue;
+    }
+    const row = await prisma.travelSupplier.create({
+      data: {
+        tenantId: tenant.id,
+        subBrand: spec.subBrand,
+        name: spec.name,
+        contactPerson: spec.contactPerson,
+        phone: spec.phone,
+        email: spec.email,
+        supplierCategory: spec.supplierCategory,
+        status: "active",
+        paymentTermsKind: spec.paymentTermsKind,
+        paymentTermsDays: spec.paymentTermsDays,
+        creditLimit: spec.creditLimit,
+        creditCurrency: "INR",
+        commissionPercent: spec.commissionPercent,
+        notes: spec.notes,
+      },
+    });
+    suppliers.push(row);
+  }
+
+  const supplierByName = Object.fromEntries(suppliers.map((s) => [s.name, s]));
+
+  for (const supplier of suppliers) {
+    const kyc = await prisma.travelSupplierKyc.findUnique({ where: { supplierId: supplier.id } }).catch(() => null);
+    if (!kyc) {
+      const createdKyc = await prisma.travelSupplierKyc.create({
+        data: {
+          tenantId: tenant.id,
+          supplierId: supplier.id,
+          status: supplier.supplierCategory === "visa-consul" ? "submitted" : "verified",
+          panNumber: `PAN-${supplier.id.toString().padStart(4, "0")}`,
+          gstinVerified: true,
+          bankAccountVerified: true,
+          iataNumber: supplier.supplierCategory === "flight" ? `IATA-${supplier.id}` : null,
+          iataExpiry: supplier.supplierCategory === "flight" ? daysFromNow(365) : null,
+          tafiNumber: supplier.supplierCategory === "visa-consul" ? `TAFI-${supplier.id}` : null,
+          contractSigned: true,
+          contractSignedAt: daysAgo(30),
+          contractDocumentUrl: `/travel-fixtures/contracts/${supplier.id}.pdf`,
+          submittedAt: daysAgo(32),
+          verifiedAt: supplier.supplierCategory === "visa-consul" ? null : daysAgo(28),
+          verifiedBy: admin?.id ?? null,
+          notes: `${supplier.name} demo KYC record`,
+        },
+      });
+
+      const checklistItems = [
+        { itemKey: "pan_card", itemLabel: "PAN Card", required: true, status: "verified", sortOrder: 0 },
+        { itemKey: "gstin_cert", itemLabel: "GST Registration", required: true, status: "verified", sortOrder: 1 },
+        { itemKey: "bank_proof", itemLabel: "Bank Proof", required: true, status: "verified", sortOrder: 2 },
+        { itemKey: "contract", itemLabel: "Signed Contract", required: true, status: "verified", sortOrder: 3 },
+        { itemKey: "insurance", itemLabel: "Insurance", required: supplier.supplierCategory !== "visa-consul", status: supplier.supplierCategory === "visa-consul" ? "pending" : "verified", sortOrder: 4 },
+      ];
+      if (supplier.supplierCategory === "flight") {
+        checklistItems.push({ itemKey: "iata_cert", itemLabel: "IATA Certificate", required: true, status: "verified", sortOrder: 5 });
+      }
+      for (const item of checklistItems) {
+        await prisma.travelSupplierKycChecklistItem.create({
+          data: {
+            tenantId: tenant.id,
+            kycId: createdKyc.id,
+            itemKey: item.itemKey,
+            itemLabel: item.itemLabel,
+            required: item.required,
+            status: item.status,
+            documentUrl: `/travel-fixtures/kyc/${supplier.id}/${item.itemKey}.pdf`,
+            submittedAt: daysAgo(31),
+            verifiedAt: item.status === "verified" ? daysAgo(28) : null,
+            verifiedBy: item.status === "verified" ? admin?.id ?? null : null,
+            sortOrder: item.sortOrder,
+          },
+        });
+      }
+    }
+  }
+
+  const poSpecs = [
+    {
+      supplier: supplierByName["SkyHigh Airways"],
+      poNumber: "TPO-2026-0001",
+      status: "acknowledged",
+      subtotal: dec("98000.00"),
+      taxAmount: dec("17640.00"),
+      totalAmount: dec("115640.00"),
+      lines: [
+        { lineType: "service", description: "Bali honeymoon return fare", quantity: dec("2"), unitPrice: dec("49000.00"), lineTotal: dec("98000.00"), pnr: "BALI01", bookingRef: "SKY-BALI-001" },
+      ],
+    },
+    {
+      supplier: supplierByName["Grand Ubud Villas"],
+      poNumber: "TPO-2026-0002",
+      status: "fulfilled",
+      subtotal: dec("72000.00"),
+      taxAmount: dec("12960.00"),
+      totalAmount: dec("84960.00"),
+      lines: [
+        { lineType: "service", description: "Ubud villa block", quantity: dec("4"), unitPrice: dec("18000.00"), lineTotal: dec("72000.00"), pnr: "UBUD02", bookingRef: "UBUD-VILLA-02" },
+      ],
+    },
+    {
+      supplier: supplierByName["Desert Wheels Transport"],
+      poNumber: "TPO-2026-0003",
+      status: "sent",
+      subtotal: dec("34000.00"),
+      taxAmount: dec("6120.00"),
+      totalAmount: dec("40120.00"),
+      lines: [
+        { lineType: "service", description: "Dubai airport transfers and safari vans", quantity: dec("1"), unitPrice: dec("34000.00"), lineTotal: dec("34000.00"), pnr: "DXB03", bookingRef: "DESERT-003" },
+      ],
+    },
+  ];
+
+  const purchaseOrders = [];
+  for (const spec of poSpecs) {
+    let po = await prisma.travelPurchaseOrder.findFirst({ where: { tenantId: tenant.id, poNumber: spec.poNumber } });
+    if (!po) {
+      po = await prisma.travelPurchaseOrder.create({
+        data: {
+          tenantId: tenant.id,
+          supplierId: spec.supplier.id,
+          poNumber: spec.poNumber,
+          status: spec.status,
+          currency: "INR",
+          subtotal: spec.subtotal,
+          taxAmount: spec.taxAmount,
+          totalAmount: spec.totalAmount,
+          notes: `${spec.poNumber} demo purchase order`,
+          sentAt: daysAgo(14),
+          acknowledgedAt: spec.status === "acknowledged" || spec.status === "fulfilled" ? daysAgo(13) : null,
+          fulfilledAt: spec.status === "fulfilled" ? daysAgo(10) : null,
+          createdBy: admin?.id ?? null,
+        },
+      });
+      for (const [idx, line] of spec.lines.entries()) {
+        await prisma.travelPurchaseOrderLine.create({
+          data: {
+            tenantId: tenant.id,
+            purchaseOrderId: po.id,
+            lineType: line.lineType,
+            description: line.description,
+            quantity: line.quantity,
+            unitPrice: line.unitPrice,
+            lineTotal: line.lineTotal,
+            pnr: line.pnr,
+            bookingRef: line.bookingRef,
+            sortOrder: idx,
+          },
+        });
+      }
+    }
+    purchaseOrders.push(po);
+  }
+
+  const quoteSpecs = [
+    {
+      contact: travelContact,
+      subBrand: "travelstall",
+      status: "Sent",
+      totalAmount: dec("238000.00"),
+      validUntil: daysFromNow(20),
+      tripDate: daysFromNow(28),
+      assignedToUserId: tmcOps?.id ?? admin2?.id ?? null,
+      lines: [
+        { lineType: "flight", description: "Return flights for 2 adults", quantity: 2, unitPrice: dec("54000.00"), amount: dec("108000.00"), sortOrder: 0, supplierId: supplierByName["SkyHigh Airways"].id, hsnSac: "998552", taxPercent: dec("18.00"), dimension: "perPax" },
+        { lineType: "hotel", description: "5 nights at Ubud villas", quantity: 5, unitPrice: dec("17600.00"), amount: dec("88000.00"), sortOrder: 1, supplierId: supplierByName["Grand Ubud Villas"].id, hsnSac: "996311", taxPercent: dec("12.00"), dimension: "perRoomPerNight" },
+        { lineType: "service", description: "Transfers and honeymoon experiences", quantity: 1, unitPrice: dec("42000.00"), amount: dec("42000.00"), sortOrder: 2, supplierId: supplierByName["Desert Wheels Transport"].id, hsnSac: "998599", taxPercent: dec("18.00"), dimension: "flatRate" },
+      ],
+    },
+    {
+      contact: travelContact2,
+      subBrand: "travelstall",
+      status: "Draft",
+      totalAmount: dec("128000.00"),
+      validUntil: daysFromNow(12),
+      tripDate: daysFromNow(18),
+      assignedToUserId: telecaller?.id ?? admin2?.id ?? null,
+      lines: [
+        { lineType: "hotel", description: "Dubai family hotel package", quantity: 4, unitPrice: dec("19000.00"), amount: dec("76000.00"), sortOrder: 0, supplierId: supplierByName["Grand Ubud Villas"].id, hsnSac: "996311", taxPercent: dec("12.00"), dimension: "perRoomPerNight" },
+        { lineType: "service", description: "Safari, transfers, and attraction tickets", quantity: 1, unitPrice: dec("52000.00"), amount: dec("52000.00"), sortOrder: 1, supplierId: supplierByName["Desert Wheels Transport"].id, hsnSac: "998599", taxPercent: dec("18.00"), dimension: "flatRate" },
+      ],
+    },
+    {
+      contact: rfuContact,
+      subBrand: "rfu",
+      status: "Accepted",
+      totalAmount: dec("185000.00"),
+      validUntil: daysFromNow(40),
+      tripDate: daysFromNow(47),
+      assignedToUserId: rfuAdvisor?.id ?? admin2?.id ?? null,
+      lines: [
+        { lineType: "flight", description: "Return flight for pilgrims", quantity: 3, unitPrice: dec("42000.00"), amount: dec("126000.00"), sortOrder: 0, supplierId: supplierByName["SkyHigh Airways"].id, hsnSac: "998552", taxPercent: dec("5.00"), dimension: "perPax" },
+        { lineType: "service", description: "Ziyarat, visas, and ground handling", quantity: 1, unitPrice: dec("59000.00"), amount: dec("59000.00"), sortOrder: 1, supplierId: supplierByName["Makkah Care Services"].id, hsnSac: "998599", taxPercent: dec("18.00"), dimension: "flatRate" },
+      ],
+    },
+    {
+      contact: visaContact,
+      subBrand: "visasure",
+      status: "Rejected",
+      totalAmount: dec("18500.00"),
+      validUntil: daysFromNow(9),
+      tripDate: daysFromNow(12),
+      assignedToUserId: admin2?.id ?? null,
+      lines: [
+        { lineType: "service", description: "Document review and mock interview", quantity: 1, unitPrice: dec("18500.00"), amount: dec("18500.00"), sortOrder: 0, supplierId: supplierByName["VisaSphere Consulting"].id, hsnSac: "998599", taxPercent: dec("18.00"), dimension: "flatRate" },
+      ],
+    },
+  ];
+
+  const quotes = [];
+  for (const spec of quoteSpecs) {
+    let quote = await prisma.travelQuote.findFirst({
+      where: { tenantId: tenant.id, subBrand: spec.subBrand, contactId: spec.contact.id },
+    });
+    if (!quote) {
+      quote = await prisma.travelQuote.create({
+        data: {
+          tenantId: tenant.id,
+          subBrand: spec.subBrand,
+          contactId: spec.contact.id,
+          status: spec.status,
+          totalAmount: spec.totalAmount,
+          currency: "INR",
+          validUntil: spec.validUntil,
+          tripDate: spec.tripDate,
+          assignedToUserId: spec.assignedToUserId,
+          clonedFromQuoteId: null,
+          appliedMarkupPercent: spec.subBrand === "travelstall" ? dec("15.00") : dec("10.00"),
+          advancePlinkId: null,
+          advancePaymentId: null,
+        },
+      });
+      for (const [idx, line] of spec.lines.entries()) {
+        await prisma.travelQuoteLine.create({
+          data: {
+            tenantId: tenant.id,
+            quoteId: quote.id,
+            lineType: line.lineType,
+            description: line.description,
+            quantity: line.quantity,
+            unitPrice: line.unitPrice,
+            amount: line.amount,
+            currency: "INR",
+            supplierId: line.supplierId,
+            sortOrder: idx,
+            hsnSac: line.hsnSac,
+            taxPercent: line.taxPercent,
+            dimension: line.dimension,
+            isAddOn: false,
+          },
+        });
+      }
+    }
+    quotes.push(quote);
+  }
+
+  const invoiceSpecs = [
+    {
+      contact: travelContact,
+      quote: quotes[0],
+      itinerary: itineraries[0],
+      subBrand: "travelstall",
+      invoiceNum: "TINV-2026-1001",
+      status: "Issued",
+      totalAmount: dec("238000.00"),
+      dueDate: daysFromNow(10),
+      lines: [
+        { lineType: "per_trip", description: "Bali holiday package", quantity: 1, unitPrice: dec("238000.00"), amount: dec("238000.00"), supplierId: supplierByName["Grand Ubud Villas"].id, pnr: "BALI-INV-1", bookingRef: "INV-BALI-001" },
+      ],
+    },
+    {
+      contact: travelContact2,
+      quote: quotes[1],
+      itinerary: itineraries[1],
+      subBrand: "travelstall",
+      invoiceNum: "TINV-2026-1002",
+      status: "Partial",
+      totalAmount: dec("128000.00"),
+      dueDate: daysFromNow(6),
+      paidAt: daysAgo(1),
+      lines: [
+        { lineType: "per_trip", description: "Dubai family booking", quantity: 1, unitPrice: dec("128000.00"), amount: dec("128000.00"), supplierId: supplierByName["Desert Wheels Transport"].id, pnr: "DXB-INV-2", bookingRef: "INV-DXB-002" },
+      ],
+    },
+    {
+      contact: rfuContact,
+      quote: quotes[2],
+      itinerary: itineraries[2],
+      subBrand: "rfu",
+      invoiceNum: "TINV-2026-2001",
+      status: "Paid",
+      totalAmount: dec("185000.00"),
+      dueDate: daysAgo(8),
+      paidAt: daysAgo(2),
+      lines: [
+        { lineType: "per_trip", description: "RFU Umrah package", quantity: 1, unitPrice: dec("185000.00"), amount: dec("185000.00"), supplierId: supplierByName["Makkah Care Services"].id, pnr: "RFU-INV-1", bookingRef: "INV-RFU-001" },
+      ],
+    },
+    {
+      contact: visaContact,
+      quote: quotes[3],
+      itinerary: itineraries[4],
+      subBrand: "visasure",
+      invoiceNum: "TINV-2026-3001",
+      status: "Voided",
+      totalAmount: dec("18500.00"),
+      dueDate: daysAgo(3),
+      lines: [
+        { lineType: "service", description: "Visa consulting fee", quantity: 1, unitPrice: dec("18500.00"), amount: dec("18500.00"), supplierId: supplierByName["VisaSphere Consulting"].id, pnr: "VISA-INV-1", bookingRef: "INV-VISA-001" },
+      ],
+    },
+  ];
+
+  const invoices = [];
+  for (const spec of invoiceSpecs) {
+    let invoice = await prisma.travelInvoice.findFirst({
+      where: { tenantId: tenant.id, invoiceNum: spec.invoiceNum },
+    });
+    if (!invoice) {
+      invoice = await prisma.travelInvoice.create({
+        data: {
+          tenantId: tenant.id,
+          subBrand: spec.subBrand,
+          contactId: spec.contact.id,
+          quoteId: spec.quote?.id ?? null,
+          itineraryId: spec.itinerary?.id ?? null,
+          invoiceNum: spec.invoiceNum,
+          status: spec.status,
+          totalAmount: spec.totalAmount,
+          currency: "INR",
+          dueDate: spec.dueDate,
+          paidAt: spec.paidAt ?? null,
+          tcsAmount: null,
+          tcsRate: null,
+          tcsExceedingAmount: null,
+          tcsAppliedAt: null,
+          placeOfSupply: "IN-MH",
+          cgstAmount: dec("0"),
+          sgstAmount: dec("0"),
+          igstAmount: dec("0"),
+          cgstPercent: dec("0"),
+          sgstPercent: dec("0"),
+          igstPercent: dec("0"),
+          totalTaxAmount: dec("0"),
+          gstComputedAt: daysAgo(1),
+          docType: "TaxInvoice",
+          cancellationPolicyId: null,
+        },
+      });
+      for (const [idx, line] of spec.lines.entries()) {
+        await prisma.travelInvoiceLine.create({
+          data: {
+            tenantId: tenant.id,
+            invoiceId: invoice.id,
+            lineType: line.lineType,
+            description: line.description,
+            quantity: 1,
+            unitPrice: line.unitPrice,
+            amount: line.amount,
+            currency: "INR",
+            sortOrder: idx,
+            pnr: line.pnr,
+            bookingRef: line.bookingRef,
+            serviceStartDate: spec.itinerary?.startDate ?? null,
+            serviceEndDate: spec.itinerary?.endDate ?? null,
+            supplierId: line.supplierId,
+            isAddon: false,
+            lineCost: line.amount,
+            lineSell: line.amount,
+            hsnSac: "998552",
+            cgstPercent: dec("0"),
+            cgstAmount: dec("0"),
+            sgstPercent: dec("0"),
+            sgstAmount: dec("0"),
+            igstPercent: dec("18"),
+            igstAmount: dec("0"),
+          },
+        });
+      }
+    }
+    invoices.push(invoice);
+  }
+
+  const payableSpecs = [
+    {
+      supplier: supplierByName["SkyHigh Airways"],
+      poNumber: "TPO-2026-0001",
+      description: "Bali return fare settlement",
+      amount: dec("98000.00"),
+      status: "scheduled",
+      dueDate: daysFromNow(12),
+      purchaseOrderId: purchaseOrders[0].id,
+    },
+    {
+      supplier: supplierByName["Grand Ubud Villas"],
+      poNumber: "TPO-2026-0002",
+      description: "Ubud villa block settlement",
+      amount: dec("72000.00"),
+      status: "paid",
+      dueDate: daysAgo(5),
+      paidAt: daysAgo(3),
+      purchaseOrderId: purchaseOrders[1].id,
+      paymentReference: "TRF-UBUD-2026-01",
+    },
+    {
+      supplier: supplierByName["Desert Wheels Transport"],
+      poNumber: "TPO-2026-0003",
+      description: "Dubai transfers and safari",
+      amount: dec("34000.00"),
+      status: "pending",
+      dueDate: daysFromNow(8),
+      purchaseOrderId: purchaseOrders[2].id,
+    },
+    {
+      supplier: supplierByName["Makkah Care Services"],
+      poNumber: null,
+      description: "Umrah ground handling retainer",
+      amount: dec("59000.00"),
+      status: "pending",
+      dueDate: daysFromNow(18),
+      purchaseOrderId: null,
+    },
+  ];
+
+  const payables = [];
+  for (const spec of payableSpecs) {
+    let payable = await prisma.travelSupplierPayable.findFirst({
+      where: {
+        tenantId: tenant.id,
+        supplierId: spec.supplier.id,
+        description: spec.description,
+      },
+    });
+    if (!payable) {
+      payable = await prisma.travelSupplierPayable.create({
+        data: {
+          tenantId: tenant.id,
+          supplierId: spec.supplier.id,
+          poNumber: spec.poNumber,
+          description: spec.description,
+          amount: spec.amount,
+          currency: "INR",
+          dueDate: spec.dueDate,
+          status: spec.status,
+          paidAt: spec.paidAt ?? null,
+          paymentReference: spec.paymentReference ?? null,
+          notes: "Travel demo payable",
+          purchaseOrderId: spec.purchaseOrderId,
+        },
+      });
+    }
+    payables.push(payable);
+  }
+
+  const batch = await ensureByFindFirst(
+    "travelSupplierPayableBatch",
+    { tenantId: tenant.id, batchNumber: "TPB-2026-0001" },
+    {
+      tenantId: tenant.id,
+      batchNumber: "TPB-2026-0001",
+      status: "approved",
+      paymentMethod: "bank_transfer",
+      bankAccount: "HDFC ****1234",
+      totalAmount: dec("170000.00"),
+      payableCount: 3,
+      scheduledFor: daysFromNow(7),
+      approvedBy: admin?.id ?? null,
+      approvedAt: daysAgo(2),
+      notes: "Demo supplier batch for the travel dashboard.",
+      createdBy: admin?.id ?? null,
+    },
+  );
+  for (const payable of payables.slice(0, 3)) {
+    await prisma.travelSupplierPayable.update({
+      where: { id: payable.id },
+      data: { payableBatchId: batch.id },
+    }).catch(() => {});
+  }
+
+  const rfuProfiles = [
+    {
+      contact: rfuContact,
+      passportNumber: "P1234567",
+      passportExpiry: daysFromNow(820),
+      visaHistoryJson: json([{ country: "SA", year: 2024, status: "approved" }]),
+      frequentFlyerJson: json({ airline: "Saudia", number: "SV-448899" }),
+      seatPref: "aisle",
+      mealPref: "vegetarian",
+      travelStyle: "premium",
+      budgetMin: dec("140000.00"),
+      budgetMax: dec("220000.00"),
+      emergencyContactName: "Ayesha Ali",
+      emergencyContactPhone: "+91-90000-20001",
+      medicalNotes: "Prefers wheelchair support for long walks.",
+      specialAssistance: "Wheelchair on arrival and departure",
+      pastComplaintsJson: json([]),
+      productTier: "premium",
+    },
+    {
+      contact: contactByEmail["omar.sheikh@travelstall.demo"],
+      passportNumber: "P7654321",
+      passportExpiry: daysFromNow(640),
+      visaHistoryJson: json([{ country: "SA", year: 2023, status: "pending" }]),
+      frequentFlyerJson: null,
+      seatPref: "window",
+      mealPref: "halal",
+      travelStyle: "primary",
+      budgetMin: dec("90000.00"),
+      budgetMax: dec("145000.00"),
+      emergencyContactName: "Noor Sheikh",
+      emergencyContactPhone: "+91-90000-20002",
+      medicalNotes: null,
+      specialAssistance: "Family rooming",
+      pastComplaintsJson: json([{ issue: "late hotel check-in", year: 2022 }]),
+      productTier: "primary",
+    },
+  ];
+
+  for (const spec of rfuProfiles) {
+    await ensureByFindFirst(
+      "rfuLeadProfile",
+      { contactId: spec.contact.id },
+      {
+        tenantId: tenant.id,
+        contactId: spec.contact.id,
+        passportNumber: spec.passportNumber,
+        passportExpiry: spec.passportExpiry,
+        visaHistoryJson: spec.visaHistoryJson,
+        frequentFlyerJson: spec.frequentFlyerJson,
+        seatPref: spec.seatPref,
+        mealPref: spec.mealPref,
+        travelStyle: spec.travelStyle,
+        budgetMin: spec.budgetMin,
+        budgetMax: spec.budgetMax,
+        emergencyContactName: spec.emergencyContactName,
+        emergencyContactPhone: spec.emergencyContactPhone,
+        medicalNotes: spec.medicalNotes,
+        specialAssistance: spec.specialAssistance,
+        pastComplaintsJson: spec.pastComplaintsJson,
+        productTier: spec.productTier,
+      },
+    );
+  }
+
+  const supplierInvoiceUploadSpecs = [
+    {
+      supplier: supplierByName["SkyHigh Airways"],
+      payable: payables[0],
+      filename: "skyhigh-airways-bali-invoice.pdf",
+      fileUrl: "/travel-fixtures/supplier-invoices/skyhigh-bali-001.pdf",
+      fileMimeType: "application/pdf",
+      fileSize: 842113,
+      supplierInvoiceNumber: "SHA-INV-2026-0091",
+      invoiceDate: daysAgo(4),
+      invoiceAmount: dec("98000.00"),
+      matchStatus: "matched",
+      uploadedBy: admin?.id ?? null,
+      matchedBy: admin2?.id ?? null,
+      notes: "Matched to Bali payable for the honeymoon package.",
+    },
+    {
+      supplier: supplierByName["Makkah Care Services"],
+      payable: payables[3],
+      filename: "makkah-care-ground-handling.pdf",
+      fileUrl: "/travel-fixtures/supplier-invoices/makkah-care-001.pdf",
+      fileMimeType: "application/pdf",
+      fileSize: 612248,
+      supplierInvoiceNumber: "MCS-INV-2026-0034",
+      invoiceDate: daysAgo(3),
+      invoiceAmount: dec("59000.00"),
+      matchStatus: "unmatched",
+      uploadedBy: rfuAdvisor?.id ?? null,
+      matchedBy: null,
+      notes: "Awaiting settlement confirmation.",
+    },
+  ];
+
+  for (const spec of supplierInvoiceUploadSpecs) {
+    await ensureByFindFirst(
+      "travelSupplierInvoiceUpload",
+      { tenantId: tenant.id, supplierId: spec.supplier.id, supplierInvoiceNumber: spec.supplierInvoiceNumber },
+      {
+        tenantId: tenant.id,
+        supplierId: spec.supplier.id,
+        payableId: spec.payable.id,
+        filename: spec.filename,
+        fileUrl: spec.fileUrl,
+        fileMimeType: spec.fileMimeType,
+        fileSize: spec.fileSize,
+        supplierInvoiceNumber: spec.supplierInvoiceNumber,
+        invoiceDate: spec.invoiceDate,
+        invoiceAmount: spec.invoiceAmount,
+        currency: "INR",
+        matchStatus: spec.matchStatus,
+        uploadedBy: spec.uploadedBy,
+        uploadedAt: daysAgo(3),
+        matchedBy: spec.matchedBy,
+        matchedAt: spec.matchedBy ? daysAgo(2) : null,
+        notes: spec.notes,
+      },
+    );
+  }
+
+  const invoiceByNum = Object.fromEntries(invoices.map((invoice) => [invoice.invoiceNum, invoice]));
+
+  const commissionSpecs = [
+    {
+      supplier: supplierByName["SkyHigh Airways"],
+      invoice: invoiceByNum["TINV-2026-1001"],
+      fiscalYear: "FY2026-27",
+      entryType: "accrued",
+      commissionPercent: dec("5.50"),
+      baseAmount: dec("98000.00"),
+      commissionAmount: dec("5390.00"),
+      tdsAmount: dec("269.50"),
+      netAmount: dec("5120.50"),
+      status: "accrued",
+    },
+    {
+      supplier: supplierByName["Grand Ubud Villas"],
+      invoice: invoiceByNum["TINV-2026-1002"],
+      fiscalYear: "FY2026-27",
+      entryType: "settled",
+      commissionPercent: dec("12.00"),
+      baseAmount: dec("72000.00"),
+      commissionAmount: dec("8640.00"),
+      tdsAmount: dec("432.00"),
+      netAmount: dec("8208.00"),
+      status: "settled",
+    },
+    {
+      supplier: supplierByName["VisaSphere Consulting"],
+      invoice: invoiceByNum["TINV-2026-3001"],
+      fiscalYear: "FY2026-27",
+      entryType: "adjustment",
+      commissionPercent: dec("18.00"),
+      baseAmount: dec("18500.00"),
+      commissionAmount: dec("3330.00"),
+      tdsAmount: dec("166.50"),
+      netAmount: dec("3163.50"),
+      status: "adjustment",
+    },
+  ];
+
+  for (const spec of commissionSpecs) {
+    await ensureByFindFirst(
+      "travelSupplierCommissionEntry",
+      {
+        tenantId: tenant.id,
+        supplierId: spec.supplier.id,
+        fiscalYear: spec.fiscalYear,
+        entryType: spec.entryType,
+      },
+      {
+        tenantId: tenant.id,
+        supplierId: spec.supplier.id,
+        invoiceId: spec.invoice.id,
+        fiscalYear: spec.fiscalYear,
+        entryType: spec.entryType,
+        commissionPercent: spec.commissionPercent,
+        baseAmount: spec.baseAmount,
+        commissionAmount: spec.commissionAmount,
+        currency: "INR",
+        tdsAmount: spec.tdsAmount,
+        netAmount: spec.netAmount,
+        status: spec.status,
+        accruedAt: daysAgo(20),
+        settledAt: spec.status === "settled" ? daysAgo(5) : null,
+        notes: `${spec.supplier.name} demo commission entry`,
+        createdBy: admin?.id ?? null,
+      },
+    );
+  }
+
+  const disputeSpec = {
+    supplier: supplierByName["Desert Wheels Transport"],
+    payable: payables[2],
+    invoice: invoiceByNum["TINV-2026-1002"],
+    direction: "outbound",
+    type: "rate-variance",
+    status: "in_review",
+    amount: dec("2500.00"),
+    description: "Price difference after seasonal transfer surcharge was applied.",
+  };
+  await ensureByFindFirst(
+    "travelSupplierDispute",
+    {
+      tenantId: tenant.id,
+      supplierId: disputeSpec.supplier.id,
+      type: disputeSpec.type,
+      description: disputeSpec.description,
+    },
+    {
+      tenantId: tenant.id,
+      supplierId: disputeSpec.supplier.id,
+      payableId: disputeSpec.payable.id,
+      invoiceId: disputeSpec.invoice.id,
+      direction: disputeSpec.direction,
+      type: disputeSpec.type,
+      status: disputeSpec.status,
+      amount: disputeSpec.amount,
+      currency: "INR",
+      description: disputeSpec.description,
+      evidenceUrls: json(["/travel-fixtures/evidence/variance-1.pdf"]),
+      raisedBy: admin2?.id ?? null,
+      raisedAt: daysAgo(6),
+    },
+  );
+
+  const portalNotifications = [
+    { contact: travelContact, title: "Bali itinerary updated", message: "Your Bali honeymoon itinerary has been revised with upgraded villa options.", type: "itinerary", link: "/bookings/bali-demo" },
+    { contact: travelContact2, title: "Advance payment received", message: "We have recorded your Dubai advance payment and reserved the hotel block.", type: "payment", link: "/bookings/dubai-demo" },
+    { contact: rfuContact, title: "Umrah documents pending", message: "Please upload your passport copy and photo for the RFU application.", type: "system", link: "/bookings/umrah-demo" },
+    { contact: visaContact, title: "Visa review ready", message: "Your visa review checklist is ready for the next advisor step.", type: "info", link: "/bookings/visa-demo" },
+    { contact: contactByEmail["zara.khan@travelstall.demo"], title: "Family holiday brochure", message: "A new family holiday brochure is available for your trip planning.", type: "info", link: "/brochures" },
+  ];
+  for (const spec of portalNotifications) {
+    await ensureByFindFirst(
+      "travelPortalNotification",
+      { contactId: spec.contact.id, title: spec.title },
+      {
+        tenantId: tenant.id,
+        contactId: spec.contact.id,
+        title: spec.title,
+        message: spec.message,
+        type: spec.type,
+        link: spec.link,
+        isRead: false,
+      },
+    );
+  }
+
+  const brochureSpecs = [
+    {
+      runId: "br_travelstall_bali_001",
+      sectorKey: "travel",
+      styleKey: "family-luxe",
+      goal: "Create a luxury Bali family brochure for a 6-day holiday.",
+      status: "completed",
+      pdfUrl: "/brochure-assets/br_travelstall_bali_001.pdf",
+      billedUsd: dec("18.500000"),
+      completedAt: daysAgo(2),
+      tripId: null,
+      itineraryId: itineraries[0].id,
+      userId: admin?.id ?? null,
+    },
+    {
+      runId: "br_rfu_umrah_001",
+      sectorKey: "travel",
+      styleKey: "religious-premium",
+      goal: "Create a premium Umrah brochure with ziyarat highlights.",
+      status: "completed",
+      pdfUrl: "/brochure-assets/br_rfu_umrah_001.pdf",
+      billedUsd: dec("17.000000"),
+      completedAt: daysAgo(1),
+      tripId: null,
+      itineraryId: itineraries[2].id,
+      userId: rfuAdvisor?.id ?? null,
+    },
+    {
+      runId: "br_travelstall_dubai_001",
+      sectorKey: "travel",
+      styleKey: "family-modern",
+      goal: "Create a bright Dubai family brochure with attraction highlights.",
+      status: "running",
+      pdfUrl: null,
+      billedUsd: null,
+      completedAt: null,
+      tripId: null,
+      itineraryId: itineraries[1].id,
+      userId: admin2?.id ?? null,
+    },
+  ];
+  for (const spec of brochureSpecs) {
+    await ensureByFindFirst(
+      "travelBrochure",
+      { runId: spec.runId },
+      {
+        tenantId: tenant.id,
+        userId: spec.userId,
+        runId: spec.runId,
+        sectorKey: spec.sectorKey,
+        styleKey: spec.styleKey,
+        goal: spec.goal,
+        status: spec.status,
+        pdfUrl: spec.pdfUrl,
+        billedUsd: spec.billedUsd,
+        errorMessage: null,
+        tripId: spec.tripId,
+        itineraryId: spec.itineraryId,
+        brandJson: json({ tenant: tenant.slug, subBrand: "travel" }),
+        completedAt: spec.completedAt,
+        archivedAt: null,
+      },
+    );
+  }
+
+  const brandProfiles = [
+    {
+      name: "Travel Stall Default",
+      subBrand: "travelstall",
+      payload: json({ colors: ["#0f172a", "#0ea5e9"], font: "Inter", tone: "family-friendly" }),
+      userId: admin?.id ?? null,
+    },
+    {
+      name: "RFU Default",
+      subBrand: "rfu",
+      payload: json({ colors: ["#14532d", "#f59e0b"], font: "Inter", tone: "religious-premium" }),
+      userId: rfuAdvisor?.id ?? null,
+    },
+  ];
+  for (const spec of brandProfiles) {
+    await ensureByFindFirst(
+      "travelBrandProfile",
+      { tenantId: tenant.id, name: spec.name },
+      {
+        tenantId: tenant.id,
+        userId: spec.userId,
+        name: spec.name,
+        payload: spec.payload,
+      },
+    );
+  }
+
+  const tripReviewSpecs = [
+    {
+      itinerary: itineraries[0],
+      contact: travelContact,
+      token: "review-bali-001",
+      status: "submitted",
+      overallRating: 5,
+      answersJson: json({
+        hospitality: 5,
+        transport: 5,
+        hotels: 5,
+        guide: 5,
+        value: 4,
+      }),
+      requestedAt: daysAgo(1),
+      submittedAt: daysAgo(1),
+    },
+    {
+      itinerary: itineraries[2],
+      contact: rfuContact,
+      token: "review-umrah-001",
+      status: "requested",
+      overallRating: null,
+      answersJson: null,
+      requestedAt: daysAgo(2),
+      submittedAt: null,
+    },
+  ];
+  for (const spec of tripReviewSpecs) {
+    await ensureByFindFirst(
+      "travelTripReview",
+      { itineraryId: spec.itinerary.id },
+      {
+        tenantId: tenant.id,
+        itineraryId: spec.itinerary.id,
+        contactId: spec.contact.id,
+        token: spec.token,
+        status: spec.status,
+        overallRating: spec.overallRating,
+        answersJson: spec.answersJson,
+        requestedAt: spec.requestedAt,
+        submittedAt: spec.submittedAt,
+      },
+    );
+  }
+
+  const commissionProfiles = [
+    {
+      name: "Travel Stall Standard 8%",
+      subBrand: "travelstall",
+      category: "Family",
+      profileType: "flat_percent",
+      profileJson: json({ percent: 8, floor: 0, ceiling: 1000000 }),
+      releaseMode: "on_booking",
+      notes: "Default family holiday commission profile.",
+    },
+    {
+      name: "RFU Premium Ladder",
+      subBrand: "rfu",
+      category: "Religious",
+      profileType: "tiered",
+      profileJson: json({ tiers: [{ min: 0, max: 100000, percent: 6 }, { min: 100001, max: 1000000, percent: 9 }] }),
+      releaseMode: "on_trip_completion",
+      notes: "Higher commission on larger Umrah bookings.",
+    },
+    {
+      name: "Visa Sure Flat Fee",
+      subBrand: "visasure",
+      category: "Visa",
+      profileType: "per_pax_flat",
+      profileJson: json({ amountPerPax: 1500, currency: "INR" }),
+      releaseMode: "on_booking",
+      notes: "Per-applicant consulting revenue.",
+    },
+    {
+      name: "TMC School Trip Hybrid",
+      subBrand: "tmc",
+      category: "School",
+      profileType: "hybrid",
+      profileJson: json({ basePercent: 5, perPaxFlat: 250, bonusPercent: 1 }),
+      releaseMode: "on_trip_completion",
+      notes: "School trip pricing demo profile.",
+    },
+  ];
+  for (const spec of commissionProfiles) {
+    await ensureByFindFirst(
+      "travelCommissionProfile",
+      { tenantId: tenant.id, name: spec.name },
+      {
+        tenantId: tenant.id,
+        name: spec.name,
+        subBrand: spec.subBrand,
+        category: spec.category,
+        agentUserId: null,
+        validFrom: daysAgo(30),
+        validTo: null,
+        releaseMode: spec.releaseMode,
+        profileType: spec.profileType,
+        profileJson: spec.profileJson,
+        isActive: true,
+        notes: spec.notes,
+      },
+    );
+  }
+
+  const bulkLeadNames = [
+    "Aarohi Sharma",
+    "Nikhil Verma",
+    "Pooja Nair",
+    "Rakesh Malhotra",
+    "Sana Khan",
+    "Deepak Iyer",
+    "Ananya Bose",
+    "Farhan Siddiqui",
+    "Meera Pillai",
+    "Kabir Singh",
+    "Zoya Ahmed",
+    "Vivek Thomas",
+    "Ishita Rao",
+    "Rahul Sethi",
+    "Nadia Hussain",
+    "Arjun Mehta",
+    "Priya Kulkarni",
+    "Om Prakash",
+    "Riya Chawla",
+    "Imran Ali",
+  ];
+  const bulkDestinations = [
+    "Goa",
+    "Jaipur",
+    "Makkah",
+    "Dubai",
+    "Bali",
+    "Paris",
+    "Rome",
+    "Istanbul",
+    "Kerala",
+    "London",
+    "Medina",
+    "Agra",
+    "Singapore",
+    "Zurich",
+    "Tokyo",
+    "Delhi",
+    "Cairo",
+    "Maldives",
+    "Munnar",
+    "Seoul",
+  ];
+  const bulkSubBrands = ["travelstall", "rfu", "visasure", "tmc"];
+  const bulkContacts = [];
+  const bulkItineraries = [];
+  const bulkQuotes = [];
+  const bulkInvoices = [];
+  const bulkTripReviews = [];
+
+  for (let i = 0; i < bulkLeadNames.length; i++) {
+    const subBrand = bulkSubBrands[i % bulkSubBrands.length];
+    const name = bulkLeadNames[i];
+    const email = `pagination-${String(i + 1).padStart(2, "0")}@travelstall.demo`;
+    const contact = await ensureContact(tenant.id, {
+      name,
+      email,
+      phone: `+91-90010-${String(i + 1).padStart(4, "0")}`,
+      company: `${name.split(" ")[0]} Group`,
+      title: subBrand === "tmc" ? "School Coordinator" : subBrand === "rfu" ? "Pilgrim Lead" : subBrand === "visasure" ? "Visa Lead" : "Holiday Lead",
+      status: i % 4 === 0 ? "Customer" : i % 4 === 1 ? "Prospect" : "Lead",
+      source: i % 3 === 0 ? "Organic" : i % 3 === 1 ? "Referral" : "WhatsApp",
+      subBrand,
+      aiScore: 55 + (i % 40),
+    });
+    bulkContacts.push(contact);
+
+    const diagnosticBank = await prisma.travelDiagnosticQuestionBank.findFirst({
+      where: { tenantId: tenant.id, subBrand, version: 1 },
+    });
+    if (diagnosticBank) {
+      await ensureByFindFirst(
+        "travelDiagnostic",
+        { contactId: contact.id, subBrand },
+        {
+          tenantId: tenant.id,
+          subBrand,
+          contactId: contact.id,
+          leadId: null,
+          questionBankId: diagnosticBank.id,
+          questionsJson: diagnosticBank.questionsJson,
+          answersJson: json({ q1: "bulk", q2: "bulk", q3: "bulk" }),
+          score: dec((58 + (i % 22)).toFixed(4)),
+          classification: i % 3 === 0 ? "level_1" : i % 3 === 1 ? "level_2" : "level_3",
+          classificationLabel: `${subBrand.toUpperCase()} Bulk Lead`,
+          recommendedTier: subBrand === "rfu" ? "premium" : subBrand === "visasure" ? "primary" : "entry",
+          reportPdfUrl: null,
+          talkingPointsJson: json({ summary: "Bulk pagination fixture" }),
+          formVsCallJson: json({ form: "high", call: "medium" }),
+          consentCapturedAt: daysAgo(1),
+          engineState: subBrand === "tmc" ? "partial_match" : null,
+          engineScoresJson: null,
+          recommendedTripId: null,
+          alternativeTripId: null,
+          icpTier: null,
+          leadQuality: "clean",
+          leadQualityReasonsJson: json([]),
+          flagsJson: json([]),
+          humanPick: null,
+          weightsVersion: "v1",
+          curriculumFitJson: json([]),
+        },
+      );
+    }
+
+    const itinerary = await ensureByFindFirst(
+      "itinerary",
+      { tenantId: tenant.id, shareToken: `bulk-itin-${String(i + 1).padStart(2, "0")}` },
+      {
+        tenantId: tenant.id,
+        subBrand,
+        contactId: contact.id,
+        status: i % 4 === 0 ? "draft" : i % 4 === 1 ? "sent" : i % 4 === 2 ? "accepted" : "advance_paid",
+        version: 1,
+        parentItineraryId: null,
+        productTier: subBrand === "rfu" ? "premium" : subBrand === "visasure" ? "primary" : "entry",
+        destination: bulkDestinations[i],
+        startDate: daysFromNow(10 + i),
+        endDate: daysFromNow(14 + i),
+        pricingJson: json({ bulk: true, seq: i + 1 }),
+        totalAmount: dec((90000 + i * 6500).toFixed(2)),
+        currency: "INR",
+        pax: 1 + (i % 6),
+        pdfUrl: null,
+        shareToken: `bulk-itin-${String(i + 1).padStart(2, "0")}`,
+        shareExpiresAt: daysFromNow(60),
+        shareRevokedAt: null,
+        advancePaidAmount: i % 4 >= 2 ? dec((45000 + i * 3200).toFixed(2)) : null,
+        advancePaidAt: i % 4 >= 2 ? daysAgo(1) : null,
+        paymentReference: i % 4 >= 2 ? `ADV-${String(i + 1).padStart(4, "0")}` : null,
+        paymentOverdueAt: null,
+        declineReason: null,
+        cancellationStatus: null,
+        cancellationReason: null,
+        cancellationRequestedAt: null,
+        draftSummary: `${bulkDestinations[i]} bulk itinerary for pagination testing.`,
+        clonedFromTemplateId: null,
+      },
+    );
+    bulkItineraries.push(itinerary);
+
+    await ensureByFindFirst(
+      "travelQuote",
+      { tenantId: tenant.id, subBrand, contactId: contact.id },
+      {
+        tenantId: tenant.id,
+        subBrand,
+        contactId: contact.id,
+        status: i % 4 === 0 ? "Draft" : i % 4 === 1 ? "Sent" : i % 4 === 2 ? "Accepted" : "Rejected",
+        totalAmount: dec((98000 + i * 7100).toFixed(2)),
+        currency: "INR",
+        validUntil: daysFromNow(18 + i),
+        tripDate: daysFromNow(22 + i),
+        fxRateSnapshot: null,
+        fxRateSourceCurrency: null,
+        fxRateTargetCurrency: null,
+        fxRateLockedAt: null,
+        fxRateExpiresAt: null,
+        clonedFromQuoteId: null,
+        appliedMarkupPercent: dec((8 + (i % 10)).toFixed(2)),
+        assignedToUserId: [admin?.id, admin2?.id, tmcOps?.id, rfuAdvisor?.id, telecaller?.id].filter(Boolean)[i % 5] ?? null,
+        advancePlinkId: null,
+        advancePaymentId: null,
+      },
+    );
+    const quote = await prisma.travelQuote.findFirst({ where: { tenantId: tenant.id, subBrand, contactId: contact.id } });
+    bulkQuotes.push(quote);
+
+    if (quote) {
+      const quoteLine = await prisma.travelQuoteLine.findFirst({ where: { quoteId: quote.id } });
+      if (!quoteLine) {
+        await prisma.travelQuoteLine.create({
+          data: {
+            tenantId: tenant.id,
+            quoteId: quote.id,
+            lineType: subBrand === "visasure" ? "service" : subBrand === "rfu" ? "service" : "hotel",
+            description: `${bulkDestinations[i]} package for ${name}`,
+            quantity: 1,
+            unitPrice: dec((98000 + i * 7100).toFixed(2)),
+            amount: dec((98000 + i * 7100).toFixed(2)),
+            currency: "INR",
+            supplierId: null,
+            sortOrder: 0,
+            notes: null,
+            hsnSac: "998599",
+            taxPercent: dec("18"),
+            discountPercent: null,
+            dimension: "flatRate",
+            isAddOn: false,
+          },
+        });
+      }
+    }
+
+    const invoiceNum = `TINV-2026-4${String(i + 1).padStart(3, "0")}`;
+    await ensureByFindFirst(
+      "travelInvoice",
+      { tenantId: tenant.id, invoiceNum },
+      {
+        tenantId: tenant.id,
+        subBrand,
+        contactId: contact.id,
+        quoteId: quote?.id ?? null,
+        itineraryId: itinerary.id,
+        invoiceNum,
+        status: i % 4 === 0 ? "Draft" : i % 4 === 1 ? "Issued" : i % 4 === 2 ? "Partial" : "Paid",
+        totalAmount: dec((98000 + i * 7100).toFixed(2)),
+        currency: "INR",
+        dueDate: daysFromNow(8 + i),
+        paidAt: i % 4 >= 2 ? daysAgo(1) : null,
+        tcsAmount: null,
+        tcsRate: null,
+        tcsExceedingAmount: null,
+        tcsAppliedAt: null,
+        placeOfSupply: "IN-MH",
+        cgstAmount: dec("0"),
+        sgstAmount: dec("0"),
+        igstAmount: dec("0"),
+        cgstPercent: dec("0"),
+        sgstPercent: dec("0"),
+        igstPercent: dec("0"),
+        totalTaxAmount: dec("0"),
+        gstComputedAt: daysAgo(1),
+        docType: "TaxInvoice",
+        parentInvoiceId: null,
+        cancellationPolicyId: null,
+      },
+    );
+    const invoice = await prisma.travelInvoice.findFirst({ where: { tenantId: tenant.id, invoiceNum } });
+    bulkInvoices.push(invoice);
+    if (invoice) {
+      const invoiceLine = await prisma.travelInvoiceLine.findFirst({ where: { invoiceId: invoice.id } });
+      if (!invoiceLine) {
+        await prisma.travelInvoiceLine.create({
+          data: {
+            tenantId: tenant.id,
+            invoiceId: invoice.id,
+            lineType: subBrand === "tmc" ? "per_pax" : "per_trip",
+            description: `${bulkDestinations[i]} invoice for ${name}`,
+            quantity: 1,
+            unitPrice: dec((98000 + i * 7100).toFixed(2)),
+            amount: dec((98000 + i * 7100).toFixed(2)),
+            currency: "INR",
+            sortOrder: 0,
+            notes: null,
+            pnr: `BULKPNR${String(i + 1).padStart(4, "0")}`,
+            bookingRef: `BULKREF${String(i + 1).padStart(4, "0")}`,
+            serviceStartDate: itinerary.startDate,
+            serviceEndDate: itinerary.endDate,
+            fxRateToBase: null,
+            baseAmount: dec((98000 + i * 7100).toFixed(2)),
+            supplierId: null,
+            isAddon: false,
+            lineCost: dec((64000 + i * 4800).toFixed(2)),
+            lineSell: dec((98000 + i * 7100).toFixed(2)),
+            hsnSac: "998599",
+            cgstPercent: dec("0"),
+            cgstAmount: dec("0"),
+            sgstPercent: dec("0"),
+            sgstAmount: dec("0"),
+            igstPercent: dec("18"),
+            igstAmount: dec("0"),
+          },
+        });
+      }
+    }
+
+    await ensureByFindFirst(
+      "travelPortalNotification",
+      { contactId: contact.id, title: `Bulk update ${i + 1}` },
+      {
+        tenantId: tenant.id,
+        contactId: contact.id,
+        title: `Bulk update ${i + 1}`,
+        message: `${bulkDestinations[i]} demo record created for pagination testing.`,
+        type: i % 3 === 0 ? "itinerary" : i % 3 === 1 ? "payment" : "info",
+        link: "/travel/itineraries",
+        isRead: false,
+      },
+    );
+
+    await ensureByFindFirst(
+      "whatsAppMessage",
+      { tenantId: tenant.id, providerMsgId: `bulk-wa-${String(i + 1).padStart(3, "0")}` },
+      {
+        to: contact.phone ?? `+91-99999-${String(i + 1).padStart(4, "0")}`,
+        from: "+91-90000-00000",
+        body: `Bulk travel update for ${bulkDestinations[i]}: row ${i + 1}.`,
+        mediaUrl: null,
+        mediaType: null,
+        direction: "OUTBOUND",
+        status: "DELIVERED",
+        providerMsgId: `bulk-wa-${String(i + 1).padStart(3, "0")}`,
+        templateName: "travel_bulk_update",
+        errorMessage: null,
+        read: i % 2 === 0,
+        deletedAt: null,
+        reactionsJson: json([]),
+        tenantId: tenant.id,
+        contactId: contact.id,
+        userId: admin?.id ?? null,
+        threadId: null,
+        metaType: "text",
+        interactiveJson: null,
+        mediaRefsJson: null,
+      },
+    );
+
+    await ensureByFindFirst(
+      "travelTripReview",
+      { itineraryId: itinerary.id },
+      {
+        tenantId: tenant.id,
+        itineraryId: itinerary.id,
+        contactId: contact.id,
+        token: `bulk-review-${String(i + 1).padStart(3, "0")}`,
+        status: i % 2 === 0 ? "requested" : "submitted",
+        overallRating: i % 2 === 0 ? null : 4,
+        answersJson: i % 2 === 0 ? null : json({ hospitality: 4, transport: 4, value: 4 }),
+        requestedAt: daysAgo(1),
+        submittedAt: i % 2 === 0 ? null : daysAgo(1),
+      },
+    );
+    bulkTripReviews.push(itinerary.id);
+
+    if (subBrand === "visasure") {
+      await ensureByFindFirst(
+        "visaApplication",
+        { tenantId: tenant.id, contactId: contact.id, destinationCountry: bulkDestinations[i] },
+        {
+          tenantId: tenant.id,
+          contactId: contact.id,
+          applicationType: i % 2 === 0 ? "tourist" : "business",
+          destinationCountry: bulkDestinations[i],
+          status: i % 4 === 0 ? "intake" : i % 4 === 1 ? "docs-pending" : i % 4 === 2 ? "filed" : "approved",
+          readinessLevel: 1 + (i % 4),
+          complexCase: i % 3 === 0,
+          rejectionHistoryJson: i % 3 === 0 ? json([{ country: bulkDestinations[i], reason: "bulk demo", date: "2026-07-01" }]) : null,
+          familySize: 1 + (i % 5),
+          advisorRiskFlag: i % 3 === 0 ? "medium" : "low",
+          filedAt: i % 4 >= 2 ? daysAgo(2) : null,
+          decidedAt: i % 4 === 3 ? daysAgo(1) : null,
+          outcome: i % 4 === 3 ? "approved" : null,
+          outcomeReason: null,
+          recoveryProgramId: null,
+          priorApplicationId: null,
+          passportIdentityId: null,
+        },
+      );
+    }
+
+    if (subBrand === "rfu") {
+      await ensureByFindFirst(
+        "rfuLeadProfile",
+        { contactId: contact.id },
+        {
+          tenantId: tenant.id,
+          contactId: contact.id,
+          passportNumber: `RFU-${String(i + 1).padStart(6, "0")}`,
+          passportExpiry: daysFromNow(700 + i),
+          visaHistoryJson: json([{ country: "SA", year: 2024, status: "approved" }]),
+          frequentFlyerJson: null,
+          seatPref: i % 2 === 0 ? "aisle" : "window",
+          mealPref: "halal",
+          travelStyle: i % 2 === 0 ? "premium" : "primary",
+          budgetMin: dec((90000 + i * 2500).toFixed(2)),
+          budgetMax: dec((150000 + i * 2500).toFixed(2)),
+          emergencyContactName: `${name.split(" ")[0]} Family`,
+          emergencyContactPhone: `+91-90020-${String(i + 1).padStart(4, "0")}`,
+          medicalNotes: null,
+          specialAssistance: "Wheelchair / luggage assistance",
+          pastComplaintsJson: json([]),
+          productTier: i % 2 === 0 ? "premium" : "primary",
+        },
+      );
+    }
+
+    if (subBrand === "tmc") {
+      const tripCode = `bulk-school-${String(i + 1).padStart(2, "0")}`;
+      await ensureByFindFirst(
+        "tmcTrip",
+        { tenantId: tenant.id, tripCode },
+        {
+          tenantId: tenant.id,
+          tripCode,
+          schoolContactId: contact.id,
+          destination: bulkDestinations[i],
+          departDate: daysFromNow(45 + i),
+          returnDate: daysFromNow(50 + i),
+          legalEntity: "tmc_nexus",
+          micrositeUrl: null,
+          micrositeUuid: null,
+          pricePerStudent: dec((18000 + i * 450).toFixed(2)),
+          status: i % 3 === 0 ? "confirmed" : i % 3 === 1 ? "in-trip" : "completed",
+          driveFolderId: null,
+        },
+      );
+    }
+
+    if (i < 10) {
+      await ensureByFindFirst(
+        "travelBrochure",
+        { runId: `bulk-br-${String(i + 1).padStart(3, "0")}` },
+        {
+          tenantId: tenant.id,
+          userId: admin?.id ?? null,
+          runId: `bulk-br-${String(i + 1).padStart(3, "0")}`,
+          sectorKey: "travel",
+          styleKey: subBrand,
+          goal: `Bulk brochure for ${bulkDestinations[i]} (${name})`,
+          status: i % 2 === 0 ? "completed" : "running",
+          pdfUrl: i % 2 === 0 ? `/brochure-assets/bulk-br-${String(i + 1).padStart(3, "0")}.pdf` : null,
+          billedUsd: i % 2 === 0 ? dec((12.5 + i * 0.4).toFixed(6)) : null,
+          errorMessage: null,
+          tripId: null,
+          itineraryId: itinerary.id,
+          brandJson: json({ tenant: tenant.slug, subBrand }),
+          completedAt: i % 2 === 0 ? daysAgo(1) : null,
+          archivedAt: null,
+        },
+      );
+    }
+  }
+
+  const extraQuestionBanks = [];
+  for (const subBrand of bulkSubBrands) {
+    for (const version of [2, 3]) {
+      const bank = await ensureByFindFirst(
+        "travelDiagnosticQuestionBank",
+        { tenantId: tenant.id, subBrand, version },
+        {
+          tenantId: tenant.id,
+          subBrand,
+          version,
+          questionsJson: json({
+            questions: [
+              { id: "q1", text: `${subBrand.toUpperCase()} bulk question ${version}`, type: "single-choice", options: [{ value: "a", label: "Option A", weight: 1 }, { value: "b", label: "Option B", weight: 3 }] },
+              { id: "q2", text: "Budget comfort?", type: "single-choice", options: [{ value: "low", label: "Low", weight: 1 }, { value: "high", label: "High", weight: 4 }] },
+            ],
+          }),
+          scoringRulesJson: json({
+            method: "weighted-sum",
+            bands: [
+              { minScore: 0, maxScore: 4, classification: "level_1", label: "Starter", recommendedTier: "entry" },
+              { minScore: 5, maxScore: 8, classification: "level_2", label: "Growing", recommendedTier: "primary" },
+              { minScore: 9, maxScore: 99, classification: "level_3", label: "Premium", recommendedTier: "premium" },
+            ],
+          }),
+          isActive: version === 3,
+        },
+      );
+      extraQuestionBanks.push(bank);
+    }
+  }
+
+  const extraSchoolTerms = [
+    ["Spring Break", daysFromNow(20), daysFromNow(27)],
+    ["Mid Term Exams", daysFromNow(40), daysFromNow(47)],
+    ["Summer Vacation", daysFromNow(55), daysFromNow(76)],
+    ["Sports Week", daysFromNow(88), daysFromNow(92)],
+    ["Diwali Break", daysFromNow(110), daysFromNow(116)],
+    ["Winter Break", daysFromNow(150), daysFromNow(164)],
+    ["Annual Exams", daysFromNow(180), daysFromNow(190)],
+    ["PTM Week", daysFromNow(210), daysFromNow(214)],
+  ];
+  for (const [idx, [label, startDate, endDate]] of extraSchoolTerms.entries()) {
+    await ensureByFindFirst(
+      "travelSchoolTerm",
+      { tenantId: tenant.id, label },
+      {
+        tenantId: tenant.id,
+        subBrand: "tmc",
+        schoolName: idx % 2 === 0 ? `Bulk School ${idx + 1}` : null,
+        board: idx % 3 === 0 ? "CBSE" : idx % 3 === 1 ? "ICSE" : "State",
+        kind: idx % 2 === 0 ? "holiday" : "exam-blackout",
+        label,
+        startDate,
+        endDate,
+        source: "seed",
+        isActive: true,
+      },
+    );
+  }
+
+  const extraSightseeing = [
+    ["Goa", "Basilica of Bom Jesus", "religious"],
+    ["Goa", "Dudhsagar Falls", "nature"],
+    ["Jaipur", "Jal Mahal Lakeside", "monument"],
+    ["Makkah", "Jabal al-Nour", "religious"],
+    ["Madinah", "Quba Mosque", "religious"],
+    ["Paris", "Louvre Museum", "museum"],
+    ["Rome", "Colosseum", "historical"],
+    ["Dubai", "Palm Jumeirah Boardwalk", "urban"],
+    ["Kerala", "Alleppey Backwater Cruise", "nature"],
+    ["London", "Tower Bridge Walk", "monument"],
+  ];
+  for (const [idx, [destinationName, name, category]] of extraSightseeing.entries()) {
+    await ensureByFindFirst(
+      "travelSightseeing",
+      { tenantId: tenant.id, destinationName, name },
+      {
+        tenantId: tenant.id,
+        destinationName,
+        name,
+        description: `${name} for ${destinationName} pagination testing.`,
+        imageUrl: null,
+        durationMinutes: 60 + idx * 10,
+        priceReferenceMinor: 500 + idx * 250,
+        currency: "INR",
+        category,
+        subBrand: idx % 2 === 0 ? "travelstall" : "rfu",
+        notes: "Bulk sightseeing fixture.",
+        isActive: true,
+      },
+    );
+  }
+
+  const extraTemplates = [
+    ["Bali Family 5D", "travelstall", "Family"],
+    ["Dubai Luxe 4D", "travelstall", "Honeymoon"],
+    ["Makkah Express 6D", "rfu", "Religious"],
+    ["Medina Peace 5D", "rfu", "Religious"],
+    ["Schengen Starter", "visasure", "Visa"],
+    ["US Business Assist", "visasure", "Visa"],
+    ["Golden Triangle 4D", "tmc", "School"],
+    ["Kerala Explorer 5D", "travelstall", "Family"],
+  ];
+  for (const [idx, [name, subBrand, category]] of extraTemplates.entries()) {
+    await ensureByFindFirst(
+      "itineraryTemplate",
+      { tenantId: tenant.id, name },
+      {
+        tenantId: tenant.id,
+        name,
+        destinationName: name.split(" ")[0],
+        durationDays: 4 + (idx % 3),
+        description: `${name} bulk template for pagination testing.`,
+        thumbnailUrl: null,
+        category,
+        subBrand,
+        defaultMarkupPercent: 10 + idx,
+        basePriceMinor: 5000000 + idx * 750000,
+        currency: "INR",
+        templateJson: json({ items: [{ day: 1, items: [{ itemType: "activity", description: "Bulk seeded day" }] }] }),
+        llmGeneratedBy: null,
+        isActive: true,
+      },
+    );
+  }
+
+  const extraSuppliers = [
+    ["travelstall", "Coastal Air Links", "flight"],
+    ["travelstall", "Azure Beach Resorts", "hotel"],
+    ["travelstall", "CityCab Tours", "transport"],
+    ["rfu", "Makkah Support Hub", "other"],
+    ["rfu", "Madinah Comfort Suites", "hotel"],
+    ["visasure", "Global Visa Desk", "visa-consul"],
+    ["tmc", "SchoolCoach Travels", "transport"],
+    ["tmc", "EduWorld Flights", "flight"],
+  ];
+  const extraSupplierRows = [];
+  for (const [idx, [subBrand, name, supplierCategory]] of extraSuppliers.entries()) {
+    const supplier = await ensureByFindFirst(
+      "travelSupplier",
+      { tenantId: tenant.id, subBrand, name },
+      {
+        tenantId: tenant.id,
+        subBrand,
+        name,
+        contactPerson: `${name.split(" ")[0]} Ops`,
+        phone: `+91-99100-${String(idx + 1).padStart(4, "0")}`,
+        email: `${name.toLowerCase().replace(/[^a-z0-9]+/g, ".")}@demo.test`,
+        supplierCategory,
+        status: "active",
+        paymentTermsKind: idx % 3 === 0 ? "net" : idx % 3 === 1 ? "prepay" : "on_arrival",
+        paymentTermsDays: idx % 3 === 0 ? 15 + idx : null,
+        creditLimit: dec((400000 + idx * 50000).toFixed(2)),
+        creditCurrency: "INR",
+        commissionPercent: dec((6 + idx).toFixed(2)),
+        notes: "Bulk supplier pagination fixture.",
+      },
+    );
+    extraSupplierRows.push(supplier);
+
+    const kyc = await ensureByFindFirst(
+      "travelSupplierKyc",
+      { supplierId: supplier.id },
+      {
+        tenantId: tenant.id,
+        supplierId: supplier.id,
+        status: idx % 4 === 0 ? "pending" : idx % 4 === 1 ? "submitted" : "verified",
+        panNumber: `PAN-BULK-${String(idx + 1).padStart(4, "0")}`,
+        gstinVerified: idx % 4 !== 0,
+        bankAccountVerified: idx % 3 !== 0,
+        iataNumber: supplierCategory === "flight" ? `IATA-BULK-${String(idx + 1).padStart(4, "0")}` : null,
+        iataExpiry: supplierCategory === "flight" ? daysFromNow(365 + idx) : null,
+        tafiNumber: supplierCategory === "visa-consul" ? `TAFI-BULK-${String(idx + 1).padStart(4, "0")}` : null,
+        contractSigned: idx % 2 === 0,
+        contractSignedAt: idx % 2 === 0 ? daysAgo(15) : null,
+        contractDocumentUrl: `/travel-fixtures/kyc/${supplier.id}/contract.pdf`,
+        submittedAt: daysAgo(18),
+        verifiedAt: idx % 4 === 2 ? daysAgo(10) : null,
+        verifiedBy: admin?.id ?? null,
+        notes: "Bulk supplier KYC row.",
+      },
+    );
+    if (kyc) {
+      const checklistSeed = [
+        ["pan_card", "PAN Card", true],
+        ["gstin_cert", "GST Certificate", true],
+        ["bank_proof", "Bank Proof", true],
+      ];
+      for (const [itemKey, itemLabel, required] of checklistSeed) {
+        await ensureByFindFirst(
+          "travelSupplierKycChecklistItem",
+          { kycId: kyc.id, itemKey },
+          {
+            tenantId: tenant.id,
+            kycId: kyc.id,
+            itemKey,
+            itemLabel,
+            required,
+            status: "verified",
+            documentUrl: `/travel-fixtures/kyc/${supplier.id}/${itemKey}.pdf`,
+            notes: null,
+            submittedAt: daysAgo(15),
+            verifiedAt: daysAgo(10),
+            verifiedBy: admin?.id ?? null,
+            sortOrder: itemKey === "pan_card" ? 0 : itemKey === "gstin_cert" ? 1 : 2,
+          },
+        );
+      }
+    }
+
+    const poNumber = `TPO-2026-B${String(idx + 1).padStart(3, "0")}`;
+    const po = await ensureByFindFirst(
+      "travelPurchaseOrder",
+      { tenantId: tenant.id, poNumber },
+      {
+        tenantId: tenant.id,
+        supplierId: supplier.id,
+        bookingId: null,
+        poNumber,
+        status: idx % 4 === 0 ? "draft" : idx % 4 === 1 ? "sent" : idx % 4 === 2 ? "acknowledged" : "fulfilled",
+        currency: "INR",
+        subtotal: dec((45000 + idx * 4000).toFixed(2)),
+        taxAmount: dec((8100 + idx * 720).toFixed(2)),
+        totalAmount: dec((53100 + idx * 4720).toFixed(2)),
+        notes: "Bulk PO fixture.",
+        sentAt: daysAgo(12),
+        acknowledgedAt: idx % 4 >= 2 ? daysAgo(11) : null,
+        fulfilledAt: idx % 4 === 3 ? daysAgo(9) : null,
+        cancelledAt: null,
+        cancelReason: null,
+        createdBy: admin?.id ?? null,
+      },
+    );
+    const poLine = await prisma.travelPurchaseOrderLine.findFirst({ where: { purchaseOrderId: po.id } });
+    if (!poLine) {
+      await prisma.travelPurchaseOrderLine.create({
+        data: {
+          tenantId: tenant.id,
+          purchaseOrderId: po.id,
+          lineType: "service",
+          description: `${name} booking services`,
+          quantity: dec("1"),
+          unitPrice: dec((45000 + idx * 4000).toFixed(2)),
+          lineTotal: dec((45000 + idx * 4000).toFixed(2)),
+          pnr: `POPNR${String(idx + 1).padStart(4, "0")}`,
+          bookingRef: `POREF${String(idx + 1).padStart(4, "0")}`,
+          sortOrder: 0,
+        },
+      });
+    }
+
+    const payable = await ensureByFindFirst(
+      "travelSupplierPayable",
+      { tenantId: tenant.id, supplierId: supplier.id, description: `${name} settlement` },
+      {
+        tenantId: tenant.id,
+        supplierId: supplier.id,
+        poNumber,
+        description: `${name} settlement`,
+        amount: dec((53100 + idx * 4720).toFixed(2)),
+        currency: "INR",
+        dueDate: daysFromNow(12 + idx),
+        status: idx % 3 === 0 ? "pending" : idx % 3 === 1 ? "scheduled" : "paid",
+        paidAt: idx % 3 === 2 ? daysAgo(5) : null,
+        paymentReference: idx % 3 === 2 ? `BULKPAY-${String(idx + 1).padStart(4, "0")}` : null,
+        notes: "Bulk payable fixture.",
+        purchaseOrderId: po.id,
+        invoiceLineId: null,
+        payableBatchId: batch?.id ?? null,
+      },
+    );
+    extraSupplierRows.push(payable);
+
+    await ensureByFindFirst(
+      "travelSupplierCommissionEntry",
+      { tenantId: tenant.id, supplierId: supplier.id, fiscalYear: "FY2026-27", entryType: "accrued" },
+      {
+        tenantId: tenant.id,
+        supplierId: supplier.id,
+        bookingId: null,
+        purchaseOrderId: po.id,
+        invoiceId: invoices[0]?.id ?? null,
+        fiscalYear: "FY2026-27",
+        entryType: "accrued",
+        commissionPercent: dec((6 + idx).toFixed(2)),
+        baseAmount: dec((45000 + idx * 4000).toFixed(2)),
+        commissionAmount: dec((2700 + idx * 280).toFixed(2)),
+        currency: "INR",
+        tdsAmount: dec((135 + idx * 14).toFixed(2)),
+        netAmount: dec((2565 + idx * 266).toFixed(2)),
+        status: "accrued",
+        accruedAt: daysAgo(8),
+        settledAt: null,
+        reversedAt: null,
+        reversalReason: null,
+        notes: "Bulk commission fixture.",
+        createdBy: admin?.id ?? null,
+      },
+    );
+
+    await ensureByFindFirst(
+      "travelSupplierInvoiceUpload",
+      { tenantId: tenant.id, supplierId: supplier.id, supplierInvoiceNumber: `BULK-INV-${String(idx + 1).padStart(3, "0")}` },
+      {
+        tenantId: tenant.id,
+        supplierId: supplier.id,
+        payableId: payable.id,
+        filename: `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.pdf`,
+        fileUrl: `/travel-fixtures/supplier-invoices/${idx + 1}.pdf`,
+        fileMimeType: "application/pdf",
+        fileSize: 500000 + idx * 25000,
+        supplierInvoiceNumber: `BULK-INV-${String(idx + 1).padStart(3, "0")}`,
+        invoiceDate: daysAgo(6),
+        invoiceAmount: dec((53100 + idx * 4720).toFixed(2)),
+        currency: "INR",
+        matchStatus: idx % 3 === 0 ? "matched" : "unmatched",
+        uploadedBy: admin?.id ?? null,
+        uploadedAt: daysAgo(6),
+        matchedBy: idx % 3 === 0 ? admin2?.id ?? null : null,
+        matchedAt: idx % 3 === 0 ? daysAgo(4) : null,
+        notes: "Bulk supplier upload fixture.",
+      },
+    );
+  }
+
+  if (process.env.WELLNESS_FIELD_KEY) {
+    const loginId = await bcrypt.hash("travel-credential-demo", 10);
+    await ensureByFindFirst(
+      "supplierCredential",
+      { tenantId: tenant.id, supplierName: "SkyHigh Airways" },
+      {
+        tenantId: tenant.id,
+        category: "airline",
+        supplierName: "SkyHigh Airways",
+        loginIdEncrypted: loginId,
+        passwordEncrypted: await bcrypt.hash("password123", 10),
+        metadataJson: json({ mfa: "totp", note: "Demo vault row" }),
+        ownerUserId: admin?.id ?? null,
+        lastUsedAt: null,
+      },
+    );
+  }
+
+  console.log(`[seed-travel-extra] contacts added/confirmed: ${contacts.length}`);
+  console.log(`[seed-travel-extra] itineraries: ${itineraries.length}`);
+  console.log(`[seed-travel-extra] suppliers: ${suppliers.length}`);
+  console.log(`[seed-travel-extra] quotes: ${quotes.length}`);
+  console.log(`[seed-travel-extra] invoices: ${invoices.length}`);
+  console.log(`[seed-travel-extra] payables: ${payables.length}`);
+  console.log(`[seed-travel-extra] done.`);
+}
+
+main()
+  .catch((e) => {
+    console.error("[seed-travel-extra] error:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -25,6 +25,7 @@ const path = require('path');
 const fs = require('fs');
 const prisma = require('../lib/prisma');
 const { verifyToken, verifyRole } = require('../middleware/auth');
+const { requirePermission } = require('../middleware/requirePermission');
 const { runBackup, listBackups, getBackupDir } = require('../cron/backupEngine');
 const backfillLastVisitEngine = require('../cron/backfillLastVisitEngine');
 const { writeAudit } = require('../lib/audit');
@@ -533,7 +534,7 @@ router.post(
 // Response shape (400): { error, code: 'INVALID_TENANT_ID' }
 router.get(
   '/tenants/:id/embed-allowlist',
-  verifyRole(['ADMIN']),
+  requirePermission('settings', 'manage'),
   async (req, res) => {
     try {
       const targetTenantId = parseInt(req.params.id, 10);
@@ -637,7 +638,7 @@ const HTTPS_ORIGIN_RE = HTTPS_ORIGIN_RE_V2;
 
 router.patch(
   '/tenants/:id/embed-allowlist',
-  verifyRole(['ADMIN']),
+  requirePermission('settings', 'manage'),
   async (req, res) => {
     try {
       const targetTenantId = parseInt(req.params.id, 10);

--- a/backend/routes/external.js
+++ b/backend/routes/external.js
@@ -104,6 +104,40 @@ function resolvePartnerOrigin(body) {
   );
 }
 
+function resolveRequestOrigin(req) {
+  const bodyOrigin = resolvePartnerOrigin(req?.body);
+  if (bodyOrigin) return bodyOrigin;
+
+  const headerOrigin = normalizeEmbedOrigin(req?.headers?.origin || req?.headers?.Origin);
+  if (headerOrigin) return headerOrigin;
+
+  const referer = req?.headers?.referer || req?.headers?.referrer;
+  if (referer) {
+    try {
+      return normalizeEmbedOrigin(new URL(referer).origin);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function hasConfiguredEmbedAllowlist(allowlistJson) {
+  if (!allowlistJson) return false;
+
+  let allowlist = allowlistJson;
+  if (typeof allowlistJson === "string") {
+    try {
+      allowlist = JSON.parse(allowlistJson);
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  return Array.isArray(allowlist) && allowlist.length > 0;
+}
+
 function splitCustomLeadFields(body) {
   if (!body || typeof body !== "object") return { rawCustomFields: {}, storageCustomFields: {} };
   const rawCustomFields = {};
@@ -350,7 +384,15 @@ router.post("/leads", async (req, res) => {
       console.error("[external] tenant config lookup failed:", e.message);
     }
     const isGenericLeadAwaitingCall = (tenantCfg?.vertical || "generic") === "generic";
-    const partnerOrigin = resolvePartnerOrigin(req.body);
+    const partnerOrigin = resolveRequestOrigin(req);
+    const hasEmbedAllowlist = hasConfiguredEmbedAllowlist(tenantCfg?.embedAllowlistJson);
+
+    if (hasEmbedAllowlist && !partnerOrigin) {
+      return res.status(403).json({
+        error: "Partner origin is required",
+        code: "ORIGIN_REQUIRED",
+      });
+    }
 
     if (partnerOrigin && !isEmbedOriginAllowed(partnerOrigin, tenantCfg?.embedAllowlistJson)) {
       await notifyAdminsOfBlockedLeadOrigin({

--- a/backend/routes/external.js
+++ b/backend/routes/external.js
@@ -23,7 +23,12 @@ const { classifyLead } = require("../lib/leadJunkFilter");
 const { pickAssignee } = require("../lib/leadAutoRouter");
 const { computeFirstResponseDueAt } = require("../lib/leadSla");
 const { writeLeadCustomFieldValues } = require("../lib/leadCustomFieldValues");
-const { notifyAdminsOfNewLead } = require("../lib/leadNotifications");
+const {
+  isEmbedOriginAllowed,
+  notifyAdminsOfBlockedLeadOrigin,
+  notifyAdminsOfNewLead,
+  normalizeEmbedOrigin,
+} = require("../lib/leadNotifications");
 
 const router = express.Router();
 
@@ -86,6 +91,17 @@ function resolveSubmittedSource(body) {
     || normalizeSubmittedSource(body.lead_source)
     || normalizeSubmittedSource(body.utm?.source)
     || normalizeSubmittedSource(body.utm?.utm_source);
+}
+
+function resolvePartnerOrigin(body) {
+  if (!body || typeof body !== "object") return null;
+  return normalizeEmbedOrigin(
+    body.partnerOrigin
+      || body.embedOrigin
+      || body.origin
+      || body.referrerOrigin
+      || body.parentOrigin,
+  );
 }
 
 function splitCustomLeadFields(body) {
@@ -328,12 +344,25 @@ router.post("/leads", async (req, res) => {
     try {
       tenantCfg = await prisma.tenant.findUnique({
         where: { id: req.tenantId },
-        select: { vertical: true, callifiedAutoCampaignId: true },
+        select: { vertical: true, callifiedAutoCampaignId: true, embedAllowlistJson: true },
       });
     } catch (e) {
       console.error("[external] tenant config lookup failed:", e.message);
     }
     const isGenericLeadAwaitingCall = (tenantCfg?.vertical || "generic") === "generic";
+    const partnerOrigin = resolvePartnerOrigin(req.body);
+
+    if (partnerOrigin && !isEmbedOriginAllowed(partnerOrigin, tenantCfg?.embedAllowlistJson)) {
+      await notifyAdminsOfBlockedLeadOrigin({
+        tenantId: req.tenantId,
+        origin: partnerOrigin,
+        io: req.io || null,
+      });
+      return res.status(403).json({
+        error: "Partner origin is not allowed",
+        code: "ORIGIN_NOT_ALLOWED",
+      });
+    }
 
     // Run the junk filter before persisting (rules + optional Gemini AI)
     const verdict = await classifyLead({

--- a/backend/routes/external.js
+++ b/backend/routes/external.js
@@ -105,22 +105,23 @@ function resolvePartnerOrigin(body) {
 }
 
 function resolveRequestOrigin(req) {
-  const bodyOrigin = resolvePartnerOrigin(req?.body);
-  if (bodyOrigin) return bodyOrigin;
-
+  // Browser-controlled headers are trusted first. Body fields are only used
+  // as a fallback because the embed snippet's query parameter can be forged by
+  // a malicious site embedding the widget.
   const headerOrigin = normalizeEmbedOrigin(req?.headers?.origin || req?.headers?.Origin);
   if (headerOrigin) return headerOrigin;
 
   const referer = req?.headers?.referer || req?.headers?.referrer;
   if (referer) {
     try {
-      return normalizeEmbedOrigin(new URL(referer).origin);
+      const refererOrigin = normalizeEmbedOrigin(new URL(referer).origin);
+      if (refererOrigin) return refererOrigin;
     } catch (_err) {
-      return null;
+      // ignore malformed referer
     }
   }
 
-  return null;
+  return resolvePartnerOrigin(req?.body);
 }
 
 function hasConfiguredEmbedAllowlist(allowlistJson) {

--- a/backend/scripts/ensureRbacOnBoot.js
+++ b/backend/scripts/ensureRbacOnBoot.js
@@ -323,11 +323,22 @@ async function ensureRole(stats, { tenantId, key, name, description, isSystem, u
     // → first accessible page → /home. No backfill needed.
     return { role: existing, wasCreated: false };
   }
-  const created = await prisma.role.create({
-    data: { tenantId, key, name, description, isSystem, isActive: true, userType, landingPath: landingPath || null },
-  });
-  stats.rolesCreated++;
-  return { role: created, wasCreated: true };
+  try {
+    const created = await prisma.role.create({
+      data: { tenantId, key, name, description, isSystem, isActive: true, userType, landingPath: landingPath || null },
+    });
+    stats.rolesCreated++;
+    return { role: created, wasCreated: true };
+  } catch (err) {
+    if (err && err.code === 'P2002') {
+      const raced = await prisma.role.findFirst({ where: { tenantId, key } });
+      if (raced) {
+        stats.rolesExisting++;
+        return { role: raced, wasCreated: false };
+      }
+    }
+    throw err;
+  }
 }
 
 async function ensureRolePermission(stats, roleId, module, action) {
@@ -338,8 +349,16 @@ async function ensureRolePermission(stats, roleId, module, action) {
     stats.permsExisting++;
     return;
   }
-  await prisma.rolePermission.create({ data: { roleId, module, action } });
-  stats.permsCreated++;
+  try {
+    await prisma.rolePermission.create({ data: { roleId, module, action } });
+    stats.permsCreated++;
+  } catch (err) {
+    if (err && err.code === 'P2002') {
+      stats.permsExisting++;
+      return;
+    }
+    throw err;
+  }
 }
 
 async function ensureUserRole(stats, userId, roleId) {
@@ -353,8 +372,16 @@ async function ensureUserRole(stats, userId, roleId) {
     stats.assignmentsExisting++;
     return;
   }
-  await prisma.userRole.create({ data: { userId, roleId } });
-  stats.assignmentsCreated++;
+  try {
+    await prisma.userRole.create({ data: { userId, roleId } });
+    stats.assignmentsCreated++;
+  } catch (err) {
+    if (err && err.code === 'P2002') {
+      stats.assignmentsExisting++;
+      return;
+    }
+    throw err;
+  }
 }
 
 /**
@@ -424,7 +451,7 @@ async function ensureRbacOnBoot() {
     usersSkipped: 0,
   };
 
-  const ownerRole = await ensureRole(stats, {
+  const { role: ownerRole } = await ensureRole(stats, {
     tenantId: null,
     key: 'OWNER',
     name: 'Platform Owner',

--- a/backend/test/lib/leadNotifications.test.js
+++ b/backend/test/lib/leadNotifications.test.js
@@ -1,0 +1,107 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+import prisma from '../../lib/prisma.js';
+
+const requireCJS = createRequire(import.meta.url);
+const Module = requireCJS('node:module');
+
+const notifyMock = vi.fn();
+
+// Patch the real CJS dependency before loading the SUT so the require() call
+// inside backend/lib/leadNotifications.js sees our mock notify() helper.
+const notificationServicePath = requireCJS.resolve('../../lib/notificationService.js');
+Module._cache[notificationServicePath] = {
+  id: notificationServicePath,
+  filename: notificationServicePath,
+  loaded: true,
+  exports: { notify: notifyMock },
+  children: [],
+  paths: [],
+};
+
+const leadNotifications = requireCJS('../../lib/leadNotifications.js');
+
+const {
+  allowlistEntryMatchesOrigin,
+  isEmbedOriginAllowed,
+  normalizeEmbedOrigin,
+  notifyAdminsOfBlockedLeadOrigin,
+} = leadNotifications;
+
+describe('lib/leadNotifications', () => {
+  beforeEach(() => {
+    notifyMock.mockReset();
+    prisma.user = prisma.user || {};
+    prisma.user.findMany = vi.fn();
+  });
+
+  test('normalizeEmbedOrigin trims, lowercases and strips path/query/hash', () => {
+    expect(normalizeEmbedOrigin(' https://APP.Example.com/path?q=1#frag ')).toBe(
+      'https://app.example.com',
+    );
+  });
+
+  test('allowlistEntryMatchesOrigin supports leftmost wildcards', () => {
+    expect(
+      allowlistEntryMatchesOrigin(
+        'https://sub.mysite.com',
+        'https://*.mysite.com',
+      ),
+    ).toBe(true);
+    expect(
+      allowlistEntryMatchesOrigin(
+        'https://mysite.com',
+        'https://*.mysite.com',
+      ),
+    ).toBe(true);
+  });
+
+  test('isEmbedOriginAllowed returns false for blocked origins when an allowlist is present', () => {
+    const allowlist = JSON.stringify(['https://*.mysite.com']);
+    expect(isEmbedOriginAllowed('https://sub.mysite.com', allowlist)).toBe(true);
+    expect(isEmbedOriginAllowed('https://mysite.com', allowlist)).toBe(true);
+    expect(isEmbedOriginAllowed('https://evil.com', allowlist)).toBe(false);
+  });
+
+  test('notifyAdminsOfBlockedLeadOrigin notifies each tenant admin with a settings link', async () => {
+    prisma.user.findMany.mockResolvedValue([{ id: 11 }, { id: 22 }]);
+    notifyMock.mockResolvedValue({ id: 99 });
+
+    const result = await notifyAdminsOfBlockedLeadOrigin({
+      tenantId: 7,
+      origin: 'https://blocked.example.com/path',
+      io: { to: vi.fn(() => ({ emit: vi.fn() })) },
+    });
+
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId: 7,
+        role: 'ADMIN',
+        deactivatedAt: null,
+      },
+      select: { id: true },
+    });
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 11,
+        tenantId: 7,
+        title: 'External lead origin blocked',
+        type: 'warning',
+        category: 'lead',
+        priority: 'high',
+        link: '/settings',
+        entityType: 'lead_domain',
+        channels: ['db', 'socket'],
+      }),
+    );
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 22,
+        tenantId: 7,
+        message: expect.stringContaining('https://blocked.example.com'),
+      }),
+    );
+    expect(result).toHaveLength(2);
+  });
+});

--- a/backend/test/middleware/externalAuth.test.js
+++ b/backend/test/middleware/externalAuth.test.js
@@ -1,16 +1,10 @@
-// Unit tests for backend/middleware/externalAuth.js
-// Covers X-API-Key validation: missing/malformed key 401s, invalid key 401s,
-// inactive tenant 403s, happy path populates req.{apiKey,tenant,tenantId,user}
-// and triggers a best-effort lastUsed update.
-//
-// Mocking note: vi.mock can't reliably intercept the SUT's CJS
-// `require('../lib/prisma')` here, so we monkey-patch the relevant prisma
-// methods on the shared client. Prisma connects lazily — no live DB hit
-// because we never invoke the real method.
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
 
-const prisma = require('../../lib/prisma');
-const externalAuth = require('../../middleware/externalAuth.js');
+const requireCJS = createRequire(import.meta.url);
+
+const prisma = requireCJS("../../lib/prisma");
+const externalAuth = requireCJS("../../middleware/externalAuth.js");
 
 let originalFindUnique;
 let originalUpdate;
@@ -32,7 +26,6 @@ afterEach(() => {
 });
 
 function makeReqResNext({ headers = {} } = {}) {
-  // Lower-case keys; req.header() looks up case-insensitively.
   const lower = {};
   for (const k of Object.keys(headers)) lower[k.toLowerCase()] = headers[k];
   const req = {
@@ -59,81 +52,46 @@ function makeReqResNext({ headers = {} } = {}) {
   return { req, res, next };
 }
 
-describe('externalAuth', () => {
-  test('returns 401 when no X-API-Key header', async () => {
+describe("externalAuth", () => {
+  it("returns 401 when no X-API-Key header", async () => {
     const { req, res, next } = makeReqResNext();
     await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Missing X-API-Key header',
-    });
+    expect(res.json).toHaveBeenCalledWith({ error: "Missing X-API-Key header" });
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 401 on malformed key (does not match glbs_<hex48+>)', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'not-a-key' },
-    });
+  it("returns 401 on malformed key", async () => {
+    const { req, res, next } = makeReqResNext({ headers: { "x-api-key": "not-a-key" } });
     await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(res.json).toHaveBeenCalledWith({ error: "Malformed API key" });
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 401 on bogus key (prisma returns null)', async () => {
+  it("returns 401 on bogus key", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
     const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(48) },
+      headers: { "x-api-key": "glbs_" + "a".repeat(48) },
     });
     await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid API key" });
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 403 when tenant is not active', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 11,
-      tenantId: 5,
-      userId: 2,
-      tenant: { id: 5, isActive: false, name: 'Stale Inc' },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'b'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Tenant is not active' });
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  test('returns 403 when tenant is missing entirely', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 12,
-      tenantId: 5,
-      userId: 2,
-      tenant: null,
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'c'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  test('happy path: populates req.user/tenant/apiKey and calls next', async () => {
-    const tenant = { id: 7, isActive: true, name: 'Wellness' };
+  it("happy path populates req.user and calls next", async () => {
+    const tenant = { id: 7, isActive: true, name: "Wellness" };
     const apiKey = {
       id: 99,
       tenantId: 7,
       userId: 4,
-      keySecret: 'glbs_' + 'd'.repeat(48),
+      keySecret: "glbs_" + "d".repeat(48),
       tenant,
     };
     findUniqueMock.mockResolvedValueOnce(apiKey);
     const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'd'.repeat(48) },
+      headers: { "x-api-key": "glbs_" + "d".repeat(48) },
     });
     await externalAuth(req, res, next);
     expect(next).toHaveBeenCalledOnce();
@@ -142,287 +100,5 @@ describe('externalAuth', () => {
     expect(req.tenant).toBe(tenant);
     expect(req.tenantId).toBe(7);
     expect(req.user).toEqual({ tenantId: 7, id: 4, apiKeyId: 99 });
-  });
-
-  test('happy path triggers best-effort lastUsed update', async () => {
-    const tenant = { id: 7, isActive: true };
-    findUniqueMock.mockResolvedValueOnce({
-      id: 99,
-      tenantId: 7,
-      userId: 4,
-      keySecret: 'glbs_' + 'e'.repeat(48),
-      tenant,
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'e'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(updateMock).toHaveBeenCalledWith({
-      where: { id: 99 },
-      data: { lastUsed: expect.any(Date) },
-    });
-  });
-
-  test('lastUsed update failure is swallowed (still calls next)', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 99,
-      tenantId: 7,
-      userId: 4,
-      tenant: { id: 7, isActive: true },
-    });
-    updateMock.mockRejectedValueOnce(new Error('write failed'));
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'f'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    // Allow the swallowed promise to settle so it doesn't leak into another test.
-    await Promise.resolve();
-  });
-
-  test('accepts X-API-Key header with mixed case', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 1,
-      tenantId: 1,
-      userId: 1,
-      tenant: { id: 1, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'X-API-Key': 'glbs_' + '1'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-  });
-
-  test('returns 500 when an unexpected error escapes the try block', async () => {
-    findUniqueMock.mockImplementationOnce(() => {
-      throw new Error('boom');
-    });
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + '2'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Authentication failure',
-    });
-    errSpy.mockRestore();
-  });
-
-  // -------------------------------------------------------------------------
-  // Extension wave (+6 cases): whitespace handling, hex-too-short malformation,
-  // case-insensitive hex acceptance, prisma query shape, sub-brand helper
-  // wiring (null vs set), and the requireSubBrandMatchOrSend 403 surface.
-  // -------------------------------------------------------------------------
-
-  test('whitespace-only X-API-Key trims to empty and returns 401 missing', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': '   \t  ' },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Missing X-API-Key header',
-    });
-    expect(next).not.toHaveBeenCalled();
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('returns 401 malformed when hex segment is shorter than 48 chars', async () => {
-    // Per regex /^glbs_[a-f0-9]{48,96}$/i — 31 hex chars fails.
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(31) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  test('accepts uppercase hex characters in the key (case-insensitive regex)', async () => {
-    const upperKey = 'glbs_' + 'A'.repeat(48);
-    findUniqueMock.mockResolvedValueOnce({
-      id: 50,
-      tenantId: 3,
-      userId: 9,
-      keySecret: upperKey,
-      tenant: { id: 3, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': upperKey },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(res.status).not.toHaveBeenCalled();
-    expect(findUniqueMock).toHaveBeenCalledWith({
-      where: { keySecret: upperKey },
-      include: { tenant: true },
-    });
-  });
-
-  test('trims surrounding whitespace before lookup (token passed without padding)', async () => {
-    const cleanKey = 'glbs_' + '7'.repeat(48);
-    findUniqueMock.mockResolvedValueOnce({
-      id: 71,
-      tenantId: 8,
-      userId: 12,
-      keySecret: cleanKey,
-      tenant: { id: 8, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': `   ${cleanKey}  \t` },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    // Confirm the trimmed token (not the padded form) was used in the DB lookup.
-    expect(findUniqueMock).toHaveBeenCalledWith({
-      where: { keySecret: cleanKey },
-      include: { tenant: true },
-    });
-  });
-
-  test('tenant-wide key (subBrand=null) installs req.apiKeySubBrand=null and requireSubBrandMatch passes any target', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 200,
-      tenantId: 4,
-      userId: 1,
-      subBrand: null,
-      tenant: { id: 4, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + '3'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(req.apiKeySubBrand).toBeNull();
-    // A tenant-wide key should accept any sub-brand target.
-    expect(typeof req.requireSubBrandMatch).toBe('function');
-    expect(req.requireSubBrandMatch('rfu')).toBe(true);
-    expect(req.requireSubBrandMatch('tmc')).toBe(true);
-  });
-
-  test('scoped key (subBrand=rfu) installs helper that 403s via requireSubBrandMatchOrSend on mismatch', async () => {
-    findUniqueMock.mockResolvedValueOnce({
-      id: 201,
-      tenantId: 4,
-      userId: 1,
-      subBrand: 'rfu',
-      tenant: { id: 4, isActive: true },
-    });
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + '4'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(req.apiKeySubBrand).toBe('rfu');
-    // Match path: returns true.
-    expect(req.requireSubBrandMatch('rfu')).toBe(true);
-    // Mismatch path through the *OrSend variant: writes 403 SUB_BRAND_MISMATCH and returns false.
-    const fakeRes = {
-      status: vi.fn().mockReturnThis(),
-      json: vi.fn().mockReturnThis(),
-    };
-    const ok = req.requireSubBrandMatchOrSend('tmc', fakeRes);
-    expect(ok).toBe(false);
-    expect(fakeRes.status).toHaveBeenCalledWith(403);
-    expect(fakeRes.json).toHaveBeenCalledWith({
-      error: "API key scoped to 'rfu' cannot post for sub-brand 'tmc'",
-      code: 'SUB_BRAND_MISMATCH',
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Wrong-secret detection wave: the glbs_ prefix is required again (the
-  // f9cfd96f raw-hex leniency never matched a real key — all three ApiKey
-  // insert sites mint glbs_-prefixed secrets). A bare 64-hex value is the
-  // exact shape of the per-tenant webhook signing secret (routes/settings.js,
-  // shown once on the Settings page) and gets a specific 401 pointing at
-  // Developer → API Keys; other bare hex stays generic "Malformed API key".
-  // Neither reaches the DB lookup.
-  // -------------------------------------------------------------------------
-
-  const WEBHOOK_SECRET_ERROR =
-    'This looks like a webhook signing secret, not an API key. API keys start with glbs_ — generate one from Developer → API Keys.';
-
-  test('bare 64-hex (webhook signing secret shape) returns the wrong-secret 401 without a DB lookup', async () => {
-    // crypto.randomBytes(32).toString('hex') shape — what Settings hands out.
-    const webhookSecretShaped = 'b'.repeat(32) + '0'.repeat(32);
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': webhookSecretShaped },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  test('bare 64-hex with uppercase hex also hits the wrong-secret 401', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'F'.repeat(64) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('bare 48-hex (not webhook-secret shape) returns generic malformed 401', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'c'.repeat(48) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('bare 96-hex returns generic malformed 401', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'a'.repeat(96) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('glbs_-prefixed 64-hex is format-valid and proceeds to the DB lookup', async () => {
-    // Guard: the prefix check dominates — a prefixed key whose hex segment
-    // happens to be 64 chars must NOT trip the wrong-secret branch.
-    findUniqueMock.mockResolvedValueOnce(null);
-    const prefixed64 = 'glbs_' + 'd'.repeat(64);
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': prefixed64 },
-    });
-    await externalAuth(req, res, next);
-    expect(findUniqueMock).toHaveBeenCalledWith({
-      where: { keySecret: prefixed64 },
-      include: { tenant: true },
-    });
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
-  });
-
-  test('glbs_ key with hex segment shorter than 48 returns generic malformed 401', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(47) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
-  });
-
-  test('glbs_ key with hex segment longer than 96 returns generic malformed 401', async () => {
-    const { req, res, next } = makeReqResNext({
-      headers: { 'x-api-key': 'glbs_' + 'b'.repeat(97) },
-    });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
-    expect(findUniqueMock).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/middleware/externalAuth.test.js
+++ b/backend/test/middleware/externalAuth.test.js
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { createRequire } from "node:module";
+// Unit tests for backend/middleware/externalAuth.js
+// Covers X-API-Key validation: missing/malformed key 401s, invalid key 401s,
+// inactive tenant 403s, missing tenant 403s, happy path populates req.{apiKey,
+// tenant, tenantId,user} and triggers a best-effort lastUsed update.
+//
+// Mocking note: vi.mock can't reliably intercept the SUT's CJS
+// `require('../lib/prisma')` here, so we monkey-patch the relevant prisma
+// methods on the shared client. Prisma connects lazily - no live DB hit
+// because we never invoke the real method.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const requireCJS = createRequire(import.meta.url);
-
-const prisma = requireCJS("../../lib/prisma");
-const externalAuth = requireCJS("../../middleware/externalAuth.js");
+const prisma = require('../../lib/prisma');
+const externalAuth = require('../../middleware/externalAuth.js');
 
 let originalFindUnique;
 let originalUpdate;
@@ -26,6 +32,7 @@ afterEach(() => {
 });
 
 function makeReqResNext({ headers = {} } = {}) {
+  // Lower-case keys; req.header() looks up case-insensitively.
   const lower = {};
   for (const k of Object.keys(headers)) lower[k.toLowerCase()] = headers[k];
   const req = {
@@ -52,46 +59,81 @@ function makeReqResNext({ headers = {} } = {}) {
   return { req, res, next };
 }
 
-describe("externalAuth", () => {
-  it("returns 401 when no X-API-Key header", async () => {
+describe('externalAuth', () => {
+  test('returns 401 when no X-API-Key header', async () => {
     const { req, res, next } = makeReqResNext();
     await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Missing X-API-Key header" });
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Missing X-API-Key header',
+    });
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("returns 401 on malformed key", async () => {
-    const { req, res, next } = makeReqResNext({ headers: { "x-api-key": "not-a-key" } });
-    await externalAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Malformed API key" });
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it("returns 401 on bogus key", async () => {
-    findUniqueMock.mockResolvedValueOnce(null);
+  test('returns 401 on malformed key (does not match glbs_<hex48+>)', async () => {
     const { req, res, next } = makeReqResNext({
-      headers: { "x-api-key": "glbs_" + "a".repeat(48) },
+      headers: { 'x-api-key': 'not-a-key' },
     });
     await externalAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Invalid API key" });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("happy path populates req.user and calls next", async () => {
-    const tenant = { id: 7, isActive: true, name: "Wellness" };
+  test('returns 401 on bogus key (prisma returns null)', async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when tenant is not active', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 11,
+      tenantId: 5,
+      userId: 2,
+      tenant: { id: 5, isActive: false, name: 'Stale Inc' },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'b'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Tenant is not active' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when tenant is missing entirely', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 12,
+      tenantId: 5,
+      userId: 2,
+      tenant: null,
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'c'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('happy path: populates req.user/tenant/apiKey and calls next', async () => {
+    const tenant = { id: 7, isActive: true, name: 'Wellness' };
     const apiKey = {
       id: 99,
       tenantId: 7,
       userId: 4,
-      keySecret: "glbs_" + "d".repeat(48),
+      keySecret: 'glbs_' + 'd'.repeat(48),
       tenant,
     };
     findUniqueMock.mockResolvedValueOnce(apiKey);
     const { req, res, next } = makeReqResNext({
-      headers: { "x-api-key": "glbs_" + "d".repeat(48) },
+      headers: { 'x-api-key': 'glbs_' + 'd'.repeat(48) },
     });
     await externalAuth(req, res, next);
     expect(next).toHaveBeenCalledOnce();
@@ -100,5 +142,277 @@ describe("externalAuth", () => {
     expect(req.tenant).toBe(tenant);
     expect(req.tenantId).toBe(7);
     expect(req.user).toEqual({ tenantId: 7, id: 4, apiKeyId: 99 });
+  });
+
+  test('happy path triggers best-effort lastUsed update', async () => {
+    const tenant = { id: 7, isActive: true };
+    findUniqueMock.mockResolvedValueOnce({
+      id: 99,
+      tenantId: 7,
+      userId: 4,
+      keySecret: 'glbs_' + 'e'.repeat(48),
+      tenant,
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'e'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: 99 },
+      data: { lastUsed: expect.any(Date) },
+    });
+  });
+
+  test('lastUsed update failure is swallowed (still calls next)', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 99,
+      tenantId: 7,
+      userId: 4,
+      tenant: { id: 7, isActive: true },
+    });
+    updateMock.mockRejectedValueOnce(new Error('write failed'));
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'f'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    // Allow the swallowed promise to settle so it doesn't leak into another test.
+    await Promise.resolve();
+  });
+
+  test('accepts X-API-Key header with mixed case', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 1,
+      tenantId: 1,
+      userId: 1,
+      tenant: { id: 1, isActive: true },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'X-API-Key': 'glbs_' + '1'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  test('returns 500 when an unexpected error escapes the try block', async () => {
+    findUniqueMock.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + '2'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Authentication failure',
+    });
+    errSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Extension wave (+6 cases): whitespace handling, hex-too-short malformation,
+  // case-insensitive hex acceptance, prisma query shape, sub-brand helper
+  // wiring (null vs set), and the requireSubBrandMatchOrSend 403 surface.
+  // -------------------------------------------------------------------------
+
+  test('whitespace-only X-API-Key trims to empty and returns 401 missing', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': '   \t  ' },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Missing X-API-Key header',
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 malformed when hex segment is shorter than 48 chars', async () => {
+    // Per regex /^glbs_[a-f0-9]{48,96}$/i - 31 hex chars fails.
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(31) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('accepts uppercase hex characters in the key (case-insensitive regex)', async () => {
+    const upperKey = 'glbs_' + 'A'.repeat(48);
+    findUniqueMock.mockResolvedValueOnce({
+      id: 50,
+      tenantId: 3,
+      userId: 9,
+      keySecret: upperKey,
+      tenant: { id: 3, isActive: true },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': upperKey },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { keySecret: upperKey },
+      include: { tenant: true },
+    });
+  });
+
+  test('trims surrounding whitespace before lookup (token passed without padding)', async () => {
+    const cleanKey = 'glbs_' + '7'.repeat(48);
+    findUniqueMock.mockResolvedValueOnce({
+      id: 71,
+      tenantId: 8,
+      userId: 12,
+      keySecret: cleanKey,
+      tenant: { id: 8, isActive: true },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': `   ${cleanKey}  \t` },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { keySecret: cleanKey },
+      include: { tenant: true },
+    });
+  });
+
+  test('tenant-wide key (subBrand=null) installs req.apiKeySubBrand=null and requireSubBrandMatch passes any target', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 200,
+      tenantId: 4,
+      userId: 1,
+      subBrand: null,
+      tenant: { id: 4, isActive: true },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + '3'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.apiKeySubBrand).toBeNull();
+    expect(typeof req.requireSubBrandMatch).toBe('function');
+    expect(req.requireSubBrandMatch('rfu')).toBe(true);
+    expect(req.requireSubBrandMatch('tmc')).toBe(true);
+  });
+
+  test('scoped key (subBrand=rfu) installs helper that 403s via requireSubBrandMatchOrSend on mismatch', async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: 201,
+      tenantId: 4,
+      userId: 1,
+      subBrand: 'rfu',
+      tenant: { id: 4, isActive: true },
+    });
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + '4'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.apiKeySubBrand).toBe('rfu');
+    expect(req.requireSubBrandMatch('rfu')).toBe(true);
+    const fakeRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    const ok = req.requireSubBrandMatchOrSend('tmc', fakeRes);
+    expect(ok).toBe(false);
+    expect(fakeRes.status).toHaveBeenCalledWith(403);
+    expect(fakeRes.json).toHaveBeenCalledWith({
+      error: "API key scoped to 'rfu' cannot post for sub-brand 'tmc'",
+      code: 'SUB_BRAND_MISMATCH',
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Wrong-secret detection wave: the glbs_ prefix is required again. A bare
+  // 64-hex value is the exact shape of the per-tenant webhook signing secret
+  // and gets a specific 401 pointing at Developer → API Keys; other bare hex
+  // stays generic "Malformed API key". Neither reaches the DB lookup.
+  // -------------------------------------------------------------------------
+
+  const WEBHOOK_SECRET_ERROR =
+    'This looks like a webhook signing secret, not an API key. API keys start with glbs_ — generate one from Developer → API Keys.';
+
+  test('bare 64-hex (webhook signing secret shape) returns the wrong-secret 401 without a DB lookup', async () => {
+    const webhookSecretShaped = 'b'.repeat(32) + '0'.repeat(32);
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': webhookSecretShaped },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('bare 64-hex with uppercase hex also hits the wrong-secret 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'F'.repeat(64) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: WEBHOOK_SECRET_ERROR });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('bare 48-hex (not webhook-secret shape) returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'c'.repeat(48) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('bare 96-hex returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'a'.repeat(96) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('glbs_-prefixed 64-hex is format-valid and proceeds to the DB lookup', async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    const prefixed64 = 'glbs_' + 'd'.repeat(64);
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': prefixed64 },
+    });
+    await externalAuth(req, res, next);
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { keySecret: prefixed64 },
+      include: { tenant: true },
+    });
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
+  });
+
+  test('glbs_ key with hex segment shorter than 48 returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'a'.repeat(47) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  test('glbs_ key with hex segment longer than 96 returns generic malformed 401', async () => {
+    const { req, res, next } = makeReqResNext({
+      headers: { 'x-api-key': 'glbs_' + 'b'.repeat(97) },
+    });
+    await externalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Malformed API key' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/routes/external.test.js
+++ b/backend/test/routes/external.test.js
@@ -647,6 +647,81 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(notifyAdminsOfNewLeadMock).not.toHaveBeenCalled();
   });
 
+  test("origin header only (no partnerOrigin body field) is still enforced", async () => {
+    prisma.tenant.findUnique.mockResolvedValueOnce({
+      vertical: "wellness",
+      callifiedAutoCampaignId: null,
+      embedAllowlistJson: JSON.stringify(["https://allowed.example.com"]),
+    });
+    classifyLeadMock.mockResolvedValueOnce({
+      isJunk: false,
+      score: 61,
+      reasons: [],
+    });
+    pickAssigneeMock.mockResolvedValueOnce({
+      userId: 11,
+      reason: "matched cat=website",
+    });
+    computeFirstResponseDueAtMock.mockResolvedValueOnce({
+      dueAt: new Date("2026-06-01T10:05:00Z"),
+      tier: "medium",
+      minutes: 30,
+    });
+    prisma.contact.findFirst.mockResolvedValueOnce(null);
+    prisma.contact.create.mockResolvedValueOnce({
+      id: 777,
+      name: "Allowed Header Lead",
+      email: "allowed-header@example.com",
+      phone: "+919900112299",
+      status: "Lead",
+      source: "website-form",
+      aiScore: 61,
+      assignedToId: 11,
+      tenantId: 7,
+      createdAt: new Date(),
+    });
+
+    const app = makeApp();
+    const res = await request(app)
+      .post("/api/v1/external/leads")
+      .set("Origin", "https://allowed.example.com")
+      .send({
+        name: "Allowed Header Lead",
+        phone: "+919900112299",
+        email: "allowed-header@example.com",
+        source: "website-form",
+      });
+
+    expect(res.status).toBe(201);
+    expect(notifyAdminsOfBlockedLeadOriginMock).not.toHaveBeenCalled();
+    expect(notifyAdminsOfNewLeadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("configured allowlist with no origin evidence returns ORIGIN_REQUIRED", async () => {
+    prisma.tenant.findUnique.mockResolvedValueOnce({
+      vertical: "wellness",
+      callifiedAutoCampaignId: null,
+      embedAllowlistJson: JSON.stringify(["https://allowed.example.com"]),
+    });
+
+    const app = makeApp();
+    const res = await request(app).post("/api/v1/external/leads").send({
+      name: "Missing Origin Lead",
+      phone: "+919900112233",
+      email: "missing-origin@example.com",
+      source: "website-form",
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Partner origin is required",
+      code: "ORIGIN_REQUIRED",
+    });
+    expect(classifyLeadMock).not.toHaveBeenCalled();
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+    expect(notifyAdminsOfBlockedLeadOriginMock).not.toHaveBeenCalled();
+  });
+
   test("soft-deleted same email is restored so re-registered external lead is visible", async () => {
     classifyLeadMock.mockResolvedValueOnce({
       isJunk: false,

--- a/backend/test/routes/external.test.js
+++ b/backend/test/routes/external.test.js
@@ -129,6 +129,7 @@ Module._cache[leadSlaPath] = {
 };
 
 const notifyAdminsOfNewLeadMock = vi.fn().mockResolvedValue([]);
+const notifyAdminsOfBlockedLeadOriginMock = vi.fn().mockResolvedValue([]);
 const leadNotificationsPath = requireCJS.resolve("../../lib/leadNotifications.js");
 Module._cache[leadNotificationsPath] = {
   id: leadNotificationsPath,
@@ -136,6 +137,26 @@ Module._cache[leadNotificationsPath] = {
   loaded: true,
   exports: {
     notifyAdminsOfNewLead: notifyAdminsOfNewLeadMock,
+    notifyAdminsOfBlockedLeadOrigin: notifyAdminsOfBlockedLeadOriginMock,
+    isEmbedOriginAllowed: (origin, allowlistJson) => {
+      if (!allowlistJson) return true;
+      try {
+        const list = typeof allowlistJson === "string" ? JSON.parse(allowlistJson) : allowlistJson;
+        if (!Array.isArray(list) || list.length === 0) return true;
+        return list.includes(origin);
+      } catch (_err) {
+        return true;
+      }
+    },
+    normalizeEmbedOrigin: (origin) => {
+      if (!origin) return null;
+      try {
+        const parsed = new URL(origin);
+        return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+      } catch (_err) {
+        return null;
+      }
+    },
   },
 };
 
@@ -259,7 +280,7 @@ beforeEach(() => {
   prisma.visit.create.mockReset();
   prisma.tenant.findUnique
     .mockReset()
-    .mockResolvedValue({ callifiedAutoCampaignId: null });
+    .mockResolvedValue({ callifiedAutoCampaignId: null, embedAllowlistJson: null });
 
   classifyLeadMock.mockReset().mockResolvedValue({
     isJunk: false,
@@ -299,6 +320,7 @@ beforeEach(() => {
     userId: 4,
     tenantId: 7,
   };
+  notifyAdminsOfBlockedLeadOriginMock.mockReset().mockResolvedValue([]);
 });
 
 describe("GET /api/v1/external/health — public reachability", () => {
@@ -593,6 +615,38 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     }));
   });
 
+  test("blocked partner origin → 403 ORIGIN_NOT_ALLOWED and admin notification", async () => {
+    prisma.tenant.findUnique.mockResolvedValueOnce({
+      vertical: "wellness",
+      callifiedAutoCampaignId: null,
+      embedAllowlistJson: JSON.stringify(["https://allowed.example.com"]),
+    });
+
+    const app = makeApp();
+    const res = await request(app).post("/api/v1/external/leads").send({
+      name: "Blocked Origin Lead",
+      phone: "+919900112233",
+      email: "blocked@example.com",
+      source: "website-form",
+      partnerOrigin: "https://blocked.example.com",
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Partner origin is not allowed",
+      code: "ORIGIN_NOT_ALLOWED",
+    });
+    expect(classifyLeadMock).not.toHaveBeenCalled();
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+    expect(notifyAdminsOfBlockedLeadOriginMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 7,
+        origin: "https://blocked.example.com",
+      }),
+    );
+    expect(notifyAdminsOfNewLeadMock).not.toHaveBeenCalled();
+  });
+
   test("soft-deleted same email is restored so re-registered external lead is visible", async () => {
     classifyLeadMock.mockResolvedValueOnce({
       isJunk: false,
@@ -686,7 +740,7 @@ describe("POST /api/v1/external/leads — create pipeline", () => {
     expect(res.status).toBe(201);
     expect(prisma.tenant.findUnique).toHaveBeenCalledWith({
       where: { id: 7 },
-      select: { vertical: true, callifiedAutoCampaignId: true },
+      select: { vertical: true, callifiedAutoCampaignId: true, embedAllowlistJson: true },
     });
     const cArgs = prisma.contact.create.mock.calls[0][0].data;
     expect(cArgs.status).toBe("Lead");

--- a/frontend/public/embed/lead-form.html
+++ b/frontend/public/embed/lead-form.html
@@ -42,6 +42,7 @@
       var apiBase = cfg.apiBase || params.get('api') || 'https://crm.globusdemos.com';
       var slug    = cfg.slug    || params.get('slug') || '';
       var apiKey  = cfg.apiKey  || params.get('key') || '';
+      var partnerOrigin = cfg.partnerOrigin || params.get('partner_origin') || '';
       var title   = cfg.title   || params.get('title') || 'Book your appointment';
       var subtitle = cfg.subtitle || params.get('sub') || 'We\u2019ll call you within 30 minutes to confirm.';
       var accent  = cfg.accent  || params.get('color') || '#0ea5e9';
@@ -106,6 +107,9 @@
           source: 'website-form',
           note: [fd.get('service') ? 'Service: ' + fd.get('service') : null, fd.get('note')].filter(Boolean).join(' | '),
         };
+        if (partnerOrigin) {
+          payload.partnerOrigin = partnerOrigin;
+        }
 
         // Two delivery modes:
         //   (a) public booking page if `slug` is set (creates Patient + Visit, no key)

--- a/frontend/public/embed/widget.js
+++ b/frontend/public/embed/widget.js
@@ -69,6 +69,12 @@
       // the page's legacy data-color chrome instead of breaking outright.
       subBrand = '';
     }
+    var partnerOrigin = '';
+    try {
+      partnerOrigin = window.location && window.location.origin ? window.location.origin : '';
+    } catch (e) {
+      partnerOrigin = '';
+    }
 
     var qs = new URLSearchParams();
     if (key) qs.set('key', key);
@@ -78,6 +84,7 @@
     if (subtitle) qs.set('sub', subtitle);
     if (color) qs.set('color', color);
     if (services) qs.set('services', services);
+    if (partnerOrigin) qs.set('partner_origin', partnerOrigin);
     qs.set('api', apiBase);
 
     var iframe = document.createElement('iframe');

--- a/frontend/src/__tests__/EmbedWidget.test.jsx
+++ b/frontend/src/__tests__/EmbedWidget.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WIDGET_PATH = path.resolve(process.cwd(), 'public', 'embed', 'widget.js');
+const WIDGET_SOURCE = readFileSync(WIDGET_PATH, 'utf8');
+
+function mountWidgetFixture() {
+  document.body.innerHTML = '';
+  window.__gbsFormLoaded = undefined;
+  window.MutationObserver = undefined;
+
+  const target = document.createElement('div');
+  target.setAttribute('data-gbs-form', '');
+  target.setAttribute('data-key', 'glbs_testkey');
+  target.setAttribute('data-title', 'Hello');
+  document.body.appendChild(target);
+
+  const script = document.createElement('script');
+  script.src = 'https://crm.globusdemos.com/embed/widget.js';
+  document.body.appendChild(script);
+
+  window.eval(WIDGET_SOURCE);
+  return target;
+}
+
+describe('embed/widget.js', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.__gbsFormLoaded = undefined;
+    window.MutationObserver = undefined;
+  });
+
+  it('mounts an iframe and forwards the current page origin as partner_origin', () => {
+    const target = mountWidgetFixture();
+    const iframe = target.querySelector('iframe');
+
+    expect(iframe).toBeTruthy();
+    const iframeUrl = new URL(iframe.src);
+    expect(iframeUrl.origin).toBe('https://crm.globusdemos.com');
+    expect(iframeUrl.pathname).toBe('/embed/lead-form.html');
+    expect(iframeUrl.searchParams.get('key')).toBe('glbs_testkey');
+    expect(iframeUrl.searchParams.get('partner_origin')).toBe(window.location.origin);
+    expect(iframeUrl.searchParams.get('api')).toBe('https://crm.globusdemos.com');
+  });
+
+  it('keeps the lead form src stable when multiple mounts happen', () => {
+    const target = mountWidgetFixture();
+    const firstIframe = target.querySelector('iframe');
+    const firstSrc = firstIframe?.src;
+
+    window.eval(WIDGET_SOURCE);
+
+    const secondIframe = target.querySelector('iframe');
+    expect(secondIframe).toBe(firstIframe);
+    expect(secondIframe?.src).toBe(firstSrc);
+  });
+});

--- a/frontend/src/__tests__/Layout.test.jsx
+++ b/frontend/src/__tests__/Layout.test.jsx
@@ -11,6 +11,14 @@ vi.mock('../components/Omnibar', () => ({ default: () => <div data-testid="omnib
 vi.mock('../components/Presence', () => ({ default: () => <div data-testid="presence-stub" /> }));
 vi.mock('../components/Softphone', () => ({ default: () => <div data-testid="softphone-stub" /> }));
 vi.mock('../components/NotificationBell', () => ({ default: () => <div data-testid="bell-stub" /> }));
+const notifyMock = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  confirm: vi.fn(),
+  prompt: vi.fn(),
+};
+vi.mock('../utils/notify', () => ({ useNotify: () => notifyMock }));
 
 // #555: mock fetchApi (Layout no longer pings /api/auth/tenants under
 // lock-per-session — the chip reads from AuthContext.tenant — but
@@ -57,6 +65,12 @@ describe('Layout', () => {
     setupPushMock.mockClear();
     fetchApiMock.mockReset();
     fetchApiMock.mockResolvedValue({});
+    notifyMock.success.mockReset();
+    notifyMock.error.mockReset();
+    notifyMock.info.mockReset();
+    notifyMock.confirm.mockReset();
+    notifyMock.prompt.mockReset();
+    notifyMock.confirm.mockResolvedValue(true);
   });
 
   it('renders Sidebar + Omnibar + Presence + NotificationBell + outlet', () => {
@@ -93,7 +107,7 @@ describe('Layout', () => {
     expect(setupPushMock).toHaveBeenCalledWith('t-abc');
   });
 
-  it('logout button has aria-label + is clickable', () => {
+  it('logout button has aria-label + opens the in-app confirm dialog', () => {
     renderLayout();
     const btn = screen.getByLabelText(/Log out/i);
     expect(btn).toBeInTheDocument();
@@ -260,6 +274,19 @@ describe('Layout', () => {
     );
     expect(logoutCalls.length).toBeGreaterThanOrEqual(1);
     expect(logoutCalls[0][1]).toMatchObject({ method: 'POST', silent: true });
+  });
+
+  it('does not call logout APIs when the user cancels the confirm dialog', async () => {
+    notifyMock.confirm.mockResolvedValueOnce(false);
+
+    renderLayout();
+    fireEvent.click(screen.getByLabelText(/Log out/i));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const logoutCalls = fetchApiMock.mock.calls.filter(
+      (c) => c[0] === '/api/auth/logout',
+    );
+    expect(logoutCalls).toHaveLength(0);
   });
 
   // #862 -- theme toggle button is gated on ThemeContext.toggleTheme. With

--- a/frontend/src/__tests__/LeadSourceAllowlistCard.test.jsx
+++ b/frontend/src/__tests__/LeadSourceAllowlistCard.test.jsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const fetchApiMock = vi.fn();
+vi.mock("../utils/api", () => ({
+  fetchApi: (...args) => fetchApiMock(...args),
+}));
+
+const notifyObj = {
+  success: vi.fn(),
+  error: vi.fn(),
+};
+vi.mock("../utils/notify", () => ({
+  useNotify: () => notifyObj,
+}));
+
+vi.mock("../App", () => {
+  const React = require("react");
+  return {
+    AuthContext: React.createContext({
+      user: { tenant: { id: 1 } },
+    }),
+  };
+});
+
+import LeadSourceAllowlistCard from "../components/LeadSourceAllowlistCard";
+
+function renderCard() {
+  return render(<LeadSourceAllowlistCard tenantId={1} />);
+}
+
+describe("<LeadSourceAllowlistCard />", () => {
+  beforeEach(() => {
+    fetchApiMock.mockReset();
+    notifyObj.success.mockReset();
+    notifyObj.error.mockReset();
+  });
+
+  it("lists allowed origins and lets an admin deny one before saving", async () => {
+    const user = userEvent.setup();
+    fetchApiMock.mockImplementation((url, opts) => {
+      const method = opts?.method || "GET";
+      if (url === "/api/admin/tenants/1/embed-allowlist" && method === "GET") {
+        return Promise.resolve({
+          tenantId: 1,
+          origins: ["https://mysite.com", "https://*.mysite.com"],
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      if (url === "/api/admin/tenants/1/embed-allowlist" && method === "PATCH") {
+        const body = JSON.parse(opts.body);
+        return Promise.resolve({
+          tenantId: 1,
+          origins: body.origins,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    renderCard();
+    await waitFor(() =>
+      expect(screen.getByText("https://mysite.com")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("/api/v1/external/leads")).toBeInTheDocument();
+    expect(screen.getAllByText("https://*.mysite.com").length).toBeGreaterThan(0);
+
+    await user.click(
+      screen.getByRole("button", { name: /Deny https:\/\/mysite\.com/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /Save domains/i }));
+
+    await waitFor(() => {
+      const patchCalls = fetchApiMock.mock.calls.filter(
+        ([url, opts]) =>
+          url === "/api/admin/tenants/1/embed-allowlist" &&
+          opts?.method === "PATCH",
+      );
+      expect(patchCalls).toHaveLength(1);
+      expect(JSON.parse(patchCalls[0][1].body).origins).toEqual([
+        "https://*.mysite.com",
+      ]);
+    });
+    expect(notifyObj.success).toHaveBeenCalledWith(
+      expect.stringMatching(/allowlist updated/i),
+    );
+  });
+
+  it("falls back to the authenticated tenant object when no tenantId prop is passed", async () => {
+    fetchApiMock.mockResolvedValue({
+      tenantId: 1,
+      origins: ["https://fallback.example.com"],
+      updatedAt: new Date().toISOString(),
+    });
+
+    render(<LeadSourceAllowlistCard />);
+
+    await waitFor(() =>
+      expect(screen.getByText("https://fallback.example.com")).toBeInTheDocument(),
+    );
+
+    expect(fetchApiMock).toHaveBeenCalledWith(
+      "/api/admin/tenants/1/embed-allowlist",
+      { silent: true },
+    );
+  });
+});

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -22,6 +22,7 @@ import TrialBanner from "./TrialBanner";
 // user cannot dismiss it until they pay (or sign out).
 import SubscriptionGate from "./SubscriptionGate";
 import { AuthContext, ThemeContext } from "../App";
+import { useNotify } from "../utils/notify";
 import { fetchApi } from "../utils/api";
 import { setupPush } from "../utils/pushSetup";
 
@@ -145,6 +146,7 @@ const Layout = () => {
   // in the app, addressing the QA observation that the only theme control
   // was buried in /settings.
   const { theme, toggleTheme } = useContext(ThemeContext) || {};
+  const notify = useNotify();
   const navigate = useNavigate();
   const location = useLocation();
   // Wellness tenants use Callified.ai for voice — hide the built-in softphone
@@ -237,6 +239,16 @@ const Layout = () => {
   }, [user]);
 
   const handleLogout = async () => {
+    const confirmed = await notify.confirm({
+      title: "Sign out?",
+      message: "Are you sure you want to sign out of your account?",
+      confirmText: "Sign out",
+      cancelText: "Cancel",
+      destructive: true,
+    });
+
+    if (!confirmed) return;
+
     // #528 (CRIT-03 fix): revoke the JWT SERVER-SIDE before clearing local
     // state. POST /api/auth/logout reads req.user.jti and adds it to the
     // RevokedToken denylist (verifyToken middleware checks it on every

--- a/frontend/src/components/LeadSourceAllowlistCard.jsx
+++ b/frontend/src/components/LeadSourceAllowlistCard.jsx
@@ -1,0 +1,392 @@
+import { useContext, useEffect, useMemo, useState } from "react";
+import { AlertCircle, Globe, Plus, Save, Shield, X } from "lucide-react";
+import { fetchApi } from "../utils/api";
+import { useNotify } from "../utils/notify";
+import { AuthContext } from "../App";
+
+const HTTPS_ORIGIN_RE_V2 = /^https:\/\/(\*\.)?[^\s/*]+(:\d+)?(\/.*)?$/;
+
+function isValidOrigin(origin) {
+  return typeof origin === "string" && HTTPS_ORIGIN_RE_V2.test(origin.trim());
+}
+
+export default function LeadSourceAllowlistCard({ tenantId }) {
+  const notify = useNotify();
+  const { user } = useContext(AuthContext) || {};
+  const activeTenantId = tenantId ?? user?.tenant?.id ?? null;
+
+  const [loading, setLoading] = useState(true);
+  const [accessible, setAccessible] = useState(true);
+  const [origins, setOrigins] = useState([]);
+  const [inputValue, setInputValue] = useState("");
+  const [loadError, setLoadError] = useState("");
+  const [inputError, setInputError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [lastSavedJson, setLastSavedJson] = useState("[]");
+
+  const originCount = useMemo(() => origins.length, [origins]);
+
+  const syncDirty = (nextOrigins) => {
+    setDirty(JSON.stringify(nextOrigins) !== lastSavedJson);
+  };
+
+  const load = async () => {
+    if (!activeTenantId) {
+      setAccessible(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setLoadError("");
+    try {
+      const data = await fetchApi(
+        `/api/admin/tenants/${activeTenantId}/embed-allowlist`,
+        { silent: true },
+      );
+      const next = Array.isArray(data?.origins) ? data.origins : [];
+      setOrigins(next);
+      setLastSavedJson(JSON.stringify(next));
+      setDirty(false);
+      setAccessible(true);
+    } catch (err) {
+      if (err?.status === 401 || err?.status === 403) {
+        setAccessible(false);
+      } else {
+        setLoadError(err?.message || "Failed to load lead-source allowlist");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTenantId]);
+
+  const handleAdd = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      setInputError("Origin cannot be empty");
+      return;
+    }
+    if (!isValidOrigin(trimmed)) {
+      setInputError("Origin must be a valid HTTPS URL (e.g. https://mysite.com)");
+      return;
+    }
+    if (origins.includes(trimmed)) {
+      setInputError("This origin is already in the allowlist");
+      return;
+    }
+    if (origins.length >= 100) {
+      setInputError("Allowlist is at the 100-entry cap - remove an entry first");
+      return;
+    }
+
+    const next = [...origins, trimmed];
+    setOrigins(next);
+    setInputValue("");
+    setInputError("");
+    syncDirty(next);
+  };
+
+  const handleRemove = (origin) => {
+    const next = origins.filter((item) => item !== origin);
+    setOrigins(next);
+    syncDirty(next);
+  };
+
+  const handleSave = async () => {
+    if (!activeTenantId) return;
+    setSaving(true);
+    setInputError("");
+    try {
+      const data = await fetchApi(
+        `/api/admin/tenants/${activeTenantId}/embed-allowlist`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ origins }),
+        },
+      );
+      const next = Array.isArray(data?.origins) ? data.origins : [];
+      setOrigins(next);
+      setLastSavedJson(JSON.stringify(next));
+      setDirty(false);
+      notify.success(
+        next.length === 0
+          ? "Lead-source allowlist cleared"
+          : `Lead-source allowlist updated (${next.length} origin${next.length === 1 ? "" : "s"})`,
+      );
+    } catch (err) {
+      if (err?.status === 401 || err?.status === 403) {
+        setAccessible(false);
+        return;
+      }
+      notify.error(err?.body?.error || err?.message || "Failed to save allowlist");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputIsValid = useMemo(
+    () => inputValue.trim() === "" || isValidOrigin(inputValue.trim()),
+    [inputValue],
+  );
+
+  if (!accessible) return null;
+
+  return (
+    <div className="card" style={{ padding: "clamp(1.25rem, 3vw, 2rem)" }}>
+      <h3
+        style={{
+          fontSize: "1.25rem",
+          fontWeight: "600",
+          marginBottom: "0.5rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <Shield size={20} color="var(--primary-color, var(--accent-color))" />
+        External Lead Domains
+      </h3>
+      <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem", marginBottom: "1rem" }}>
+        Allow partner websites to embed CRM lead capture surfaces for this tenant.
+        This applies across travel, wellness, and generic tenants. Use one HTTPS
+        origin per line, for example <code>https://globussoft.com</code> and{" "}
+        <code>https://*.globussoft.com</code>.
+      </p>
+
+      <div
+        style={{
+          marginBottom: "1rem",
+          padding: "0.85rem 1rem",
+          borderRadius: "8px",
+          border: "1px solid rgba(59, 130, 246, 0.25)",
+          background: "rgba(59, 130, 246, 0.08)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <div style={{ fontSize: "0.78rem", color: "var(--text-secondary)", fontWeight: 600 }}>
+          Use this API
+        </div>
+        <div style={{ marginTop: "0.25rem", fontSize: "0.92rem" }}>
+          <code>/api/v1/external/leads</code> is used for lead submission.
+          Allow the domains that should be able to submit leads through this API.
+        </div>
+        <div style={{ marginTop: "0.35rem", fontSize: "0.8rem", color: "var(--text-secondary)" }}>
+          If a blocked origin tries to submit, admin notifications will appear in the bell.
+        </div>
+      </div>
+
+      {loading ? (
+        <div style={{ padding: "0.9rem 0", color: "var(--text-secondary)" }}>
+          Loading external lead domains...
+        </div>
+      ) : loadError ? (
+        <div
+          style={{
+            padding: "0.9rem 1rem",
+            borderRadius: "8px",
+            border: "1px solid rgba(239,68,68,0.35)",
+            background: "rgba(239,68,68,0.08)",
+            color: "var(--text-primary)",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.6rem",
+          }}
+        >
+          <AlertCircle size={16} color="#ef4444" />
+          <div style={{ flex: 1 }}>{loadError}</div>
+          <button type="button" className="btn-primary" onClick={load}>
+            Retry
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.9rem" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "0.75rem",
+              padding: "0.85rem 1rem",
+              borderRadius: "8px",
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid var(--border-color, rgba(255,255,255,0.08))",
+            }}
+          >
+            <div>
+              <div style={{ fontSize: "0.82rem", color: "var(--text-secondary)" }}>
+                Allowed origins
+              </div>
+              <div style={{ fontSize: "1rem", fontWeight: 700 }}>{originCount}</div>
+            </div>
+          </div>
+
+          <div>
+            <div
+              style={{
+                fontSize: "0.82rem",
+                color: "var(--text-secondary)",
+                fontWeight: 600,
+                marginBottom: "0.5rem",
+              }}
+            >
+              Origins
+            </div>
+            {origins.length === 0 ? (
+              <div
+                style={{
+                  padding: "1rem",
+                  border: "1px dashed var(--border-color, rgba(255,255,255,0.18))",
+                  borderRadius: "8px",
+                  color: "var(--text-secondary)",
+                  fontSize: "0.88rem",
+                  fontStyle: "italic",
+                }}
+              >
+                No allowlist set - partner sites can embed the lead form without restrictions.
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+                {origins.map((origin) => (
+                  <span
+                    key={origin}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "0.4rem",
+                      padding: "0.35rem 0.6rem 0.35rem 0.8rem",
+                      borderRadius: "999px",
+                      background: "rgba(59, 130, 246, 0.10)",
+                      border: "1px solid rgba(59, 130, 246, 0.35)",
+                      color: "var(--text-primary)",
+                      fontSize: "0.82rem",
+                      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                    }}
+                  >
+                    <Globe size={12} />
+                    <span>{origin}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(origin)}
+                      aria-label={`Deny ${origin}`}
+                      style={{
+                        background: "transparent",
+                        border: "none",
+                        color: "var(--text-secondary)",
+                        cursor: "pointer",
+                        padding: "0.1rem",
+                        display: "inline-flex",
+                        alignItems: "center",
+                      }}
+                    >
+                      <X size={13} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="lead-source-allowlist-input"
+              style={{ fontSize: "0.82rem", color: "var(--text-secondary)", fontWeight: 600 }}
+            >
+              Allow origin
+            </label>
+            <div style={{ display: "flex", gap: "0.6rem", marginTop: "0.4rem" }}>
+              <input
+                id="lead-source-allowlist-input"
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  if (inputError) setInputError("");
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAdd();
+                  }
+                }}
+                placeholder="https://mysite.com"
+                spellCheck={false}
+                style={{
+                  flex: 1,
+                  padding: "0.8rem 0.9rem",
+                  borderRadius: "8px",
+                  border: inputError
+                    ? "1px solid #ef4444"
+                    : "1px solid var(--border-color, rgba(255,255,255,0.12))",
+                  background: "var(--surface-color, rgba(255,255,255,0.04))",
+                  color: "var(--text-primary)",
+                  fontSize: "0.9rem",
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                  outline: "none",
+                }}
+              />
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handleAdd}
+                disabled={!inputValue.trim() || !inputIsValid}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.4rem",
+                  opacity: !inputValue.trim() || !inputIsValid ? 0.6 : 1,
+                  cursor: !inputValue.trim() || !inputIsValid ? "not-allowed" : "pointer",
+                }}
+              >
+                <Plus size={14} />
+                Allow
+              </button>
+            </div>
+            {inputError && (
+              <div style={{ color: "#ef4444", fontSize: "0.82rem", marginTop: "0.35rem" }}>
+                {inputError}
+              </div>
+            )}
+          </div>
+
+          <div
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--text-secondary)",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "0.75rem",
+            }}
+          >
+            <span>HTTPS only.</span>
+            <span>Up to 100 origins.</span>
+            <span>An empty list means unrestricted embedding.</span>
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.4rem",
+                opacity: !dirty || saving ? 0.6 : 1,
+                cursor: !dirty || saving ? "not-allowed" : "pointer",
+              }}
+            >
+              <Save size={14} />
+              {saving ? "Saving..." : "Save domains"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -34,6 +34,7 @@ import { useNotify } from "../utils/notify";
 import { usePermissions } from "../hooks/usePermissions";
 import { ThemeContext, AuthContext } from "../App";
 import PasswordInput from "../components/PasswordInput";
+import LeadSourceAllowlistCard from "../components/LeadSourceAllowlistCard";
 import WebhookSigningCredential from "../components/WebhookSigningCredential";
 import RoleHistoryDialog from "../components/RoleHistoryDialog";
 import { SUB_BRAND_IDS, subBrandShortLabel, subBrandBackground } from "../utils/travelSubBrand";
@@ -172,6 +173,7 @@ export default function Settings() {
   const [callifiedDirty, setCallifiedDirty] = useState(false);
   const MASKED_CALLIFIED_KEY = "••••••••••••••••";
   const isCallifiedKeyMasked = callifiedApiKey === MASKED_CALLIFIED_KEY;
+  const leadSourceTenantId = tenant?.id ?? ctxTenant?.id ?? null;
 
   useEffect(() => {
     fetchApi("/api/tenant-settings/travel.externalReviewUrl")
@@ -2230,6 +2232,12 @@ export default function Settings() {
               webhooks (GlobusPhone lead-sync). Self-contained admin component;
               ADMIN-only + subscription-gated server-side. */}
           <WebhookSigningCredential />
+
+          {/* External Lead Domains — partner origins allowed to embed lead
+              capture surfaces. Shared across travel, wellness, and generic. */}
+          {hasPermission("settings", "manage") && (
+            <LeadSourceAllowlistCard tenantId={leadSourceTenantId} />
+          )}
 
           {/* Notification Preferences Card */}
           <NotificationPreferencesCard notify={notify} />


### PR DESCRIPTION
1. Added tenant-scoped external lead domain allowlist support across travel, wellness, and generic CRM tenants.
2. Restored the settings page section for managing external lead domains in `/settings`.
3. Kept the flow focused on domain-based access control, not API-key authorization.
4. Added admin notifications when a lead submission comes from a blocked origin.
5. Updated the widget to forward the partner origin into the lead form flow.
6. Updated the lead form to pass the origin through on submission.
7. Improved the settings UI copy to explain the `/api/v1/external/leads` submission flow.
8. Allowed admins to add, deny, and remove allowed origins from the allowlist.
9. Updated matching logic so `https://*.globussoft.com` also covers `https://globussoft.com`.
10. Added backend and frontend tests to cover the new external lead-domain behavior.
11. Added logout functionality to securely sign out the user from the application.