### PR TITLE
Feat/dynamicquery

### DIFF
--- a/backend/middleware/originCheck.js
+++ b/backend/middleware/originCheck.js
@@ -67,6 +67,11 @@
 
 const URL_TOKEN_RE = /^https?:\/\/[^/]+/i;
 
+// Loopback origin with any (or no) port — http://localhost:5174,
+// http://127.0.0.1:5173, etc. Used for the non-production dev bypass in
+// originCheck(); see the comment at that call site.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/i;
+
 /**
  * Build the allowlist of origins permitted to make state-changing requests.
  * Mirrors the CORS allowlist build in server.js — same env vars, same fail-safes.
@@ -222,6 +227,17 @@ function originCheck(req, res, next) {
   // chrome-extension: page is not a web origin an attacker's site can
   // forge (extension pages don't load third-party HTML into this context).
   if (claimedOrigin.startsWith("chrome-extension://")) {
+    return next();
+  }
+
+  // Local dev, any port. Vite claims the next free port when its default is
+  // taken (5173 → 5174 → 5175 …), so the moment a second dev server runs the
+  // app's own frontend starts failing the app's own CSRF check — a hardcoded
+  // dev-port list can't keep up with that. Loopback is not an origin a remote
+  // attacker's page can present, so accepting it costs nothing here.
+  // Deliberately gated on NODE_ENV: in production the allowlist stays exact,
+  // and a literal localhost Origin there is not a case we want to wave through.
+  if (process.env.NODE_ENV !== "production" && LOOPBACK_ORIGIN_RE.test(claimedOrigin)) {
     return next();
   }
 

--- a/backend/routes/contacts.js
+++ b/backend/routes/contacts.js
@@ -118,6 +118,243 @@ function canViewAllLeads(req) {
   return !!(req && req.user && ['ADMIN', 'MANAGER'].includes(req.user.role));
 }
 
+// Freshsales-style "Filter by" panel — field allowlist. Each entry maps a
+// UI-facing field key to a real Contact column (or the two joined columns,
+// owner/territory, which resolve to a User/Territory row for their label).
+// `kind: "text"` fields support contains/does not contain/is empty/is not
+// empty. `kind: "id"` fields (owner, territory) are equality-only against a
+// resolved id, since "contains" has no meaning on a foreign key — the UI
+// still presents them as a checkbox list of distinct values, just sourced
+// from the User/Territory table instead of DISTINCT on Contact.
+// `required: true` marks the one column (Contact.status) that is a
+// non-nullable `String` in the schema — Prisma rejects `{ not: null }` on a
+// required-string field ("Argument `not` is missing", since `null` isn't a
+// valid value for that field's type at all), so the /filter-fields
+// has-any-data presence check below only checks "not empty string" for it,
+// skipping the not-null half other (nullable) fields need.
+//
+// `verticals: [...]` restricts a field to specific Tenant.vertical values
+// (see the `vertical` column on Tenant — "generic" | "wellness" | "travel").
+// Two fields on Contact are travel-specific per their own schema.prisma
+// comments — `subBrand` ("Travel vertical sub-brand tag... nullable so
+// generic + wellness Contacts ignore it") and `kycStatus` ("Travel CRM —
+// customer-portal DigiLocker / Aadhaar verification... nullable so
+// non-travel + non-customer Contacts ignore them"). The has-data presence
+// check alone isn't enough to keep these off a generic tenant's picker:
+// `kycStatus` has a schema `@default("unverified")` that Prisma writes to
+// EVERY new Contact regardless of vertical — so has-data is trivially true
+// everywhere, even though no generic tenant ever intentionally sets it —
+// and `subBrand` can leak in from a single stray/seed/imported row even on
+// a tenant that has never used the travel feature. A field with no
+// `verticals` key is available to every vertical (the common case).
+// SOURCE OF TRUTH: this list is deliberately kept in lockstep with
+// BUILTIN_COLUMNS in table_column_preferences.js ("Customize table") — the
+// same union of Leads + Contacts built-in columns (name, email, phone,
+// company, aiScore, source, status, assignedTo, createdAt), mapped to
+// their real Contact column + comparison kind. Two lists existed briefly
+// during development (this one grew to ~30 fields including title,
+// linkedin, gst, birthDate, callifiedCampaignId, etc.) and drifted out of
+// sync with what "Customize table" actually shows as columns — a field a
+// user could filter by but never see rendered anywhere. Reusing the same
+// authoritative set both UIs already agree on avoids that drift by
+// construction. Territory (territoryId) is the one addition beyond
+// BUILTIN_COLUMNS — it has no visible table column today, but is kept
+// because it's a real, already-shipped Freshsales-parity filter (see the
+// original screenshots this feature was built from) with its own User/
+// Territory-backed value resolution, not a hand-added guess.
+//
+// `kind` drives BOTH the operator set the value-panel offers per field AND
+// how buildFilterClause turns a checkbox selection into a Prisma clause:
+//   "text"   — contains/not_contains via substring `contains` match.
+//   "id"     — contains/not_contains via `in`/`notIn` on a parsed int,
+//              values resolved against a local table (User/Territory) for
+//              a human label.
+//   "number" — contains/not_contains via `in`/`notIn` on a parsed float.
+//   "date"   — contains/not_contains via `in`/`notIn` matching the exact
+//              calendar day (values are day-boundary ranges under the
+//              hood — see buildFilterClause).
+//   "range"  — a bounded numeric column offered as fixed BUCKETS rather
+//              than one checkbox per distinct value. Lead Score is 0-100,
+//              so a DISTINCT scan lists every individual score a tenant
+//              happens to have (5, 36, 49, 64, 66, 68, 72, ...) — useless
+//              to pick from and unbounded as data grows. The buckets
+//              mirror the Lead Score dropdown Contacts.jsx already ships
+//              (SCORE_BUCKETS), so both surfaces offer the same choices.
+const FILTERABLE_FIELDS = {
+  name: { column: 'name', kind: 'text', label: 'Name', required: true },
+  email: { column: 'email', kind: 'text', label: 'Email' },
+  phone: { column: 'phone', kind: 'text', label: 'Phone' },
+  company: { column: 'company', kind: 'text', label: 'Company' },
+  status: { column: 'status', kind: 'text', label: 'Status', required: true },
+  source: { column: 'source', kind: 'text', label: 'Source' },
+  kycStatus: { column: 'kycStatus', kind: 'text', label: 'KYC Status', verticals: ['travel'] },
+  subBrand: { column: 'subBrand', kind: 'text', label: 'Sub-brand', verticals: ['travel'] },
+  aiScore: {
+    column: 'aiScore',
+    kind: 'range',
+    label: 'Lead Score',
+    required: true,
+    // Mirrors SCORE_BUCKETS in frontend/src/pages/Contacts.jsx.
+    buckets: [
+      { value: '0-25', label: '0 - 25', min: 0, max: 25 },
+      { value: '26-50', label: '26 - 50', min: 26, max: 50 },
+      { value: '51-75', label: '51 - 75', min: 51, max: 75 },
+      { value: '76-100', label: '76 - 100', min: 76, max: 100 },
+    ],
+  },
+  createdAt: { column: 'createdAt', kind: 'date', label: 'Created', required: true },
+  assignedToId: { column: 'assignedToId', kind: 'id', label: 'Sales Owner' },
+};
+
+const FILTER_OPERATORS = ['contains', 'not_contains', 'is_empty', 'is_not_empty'];
+
+// NOTE: there is deliberately NO "has-data" gate on the field list.
+//
+// A field is offered because the ORG HAS IT — i.e. it's one of the
+// Leads/Contacts table columns (BUILTIN_COLUMNS) or a custom field an
+// admin created in Settings > Lead Fields. Whether any row has a value
+// yet is irrelevant to whether the field exists: a freshly-added "UTM
+// Source" custom field with zero values filled in is still a field this
+// org has, and hiding it from the picker just makes the panel look broken
+// next to a table that clearly renders that column.
+//
+// Earlier revisions gated on row counts (≥1, then ≥2) to suppress
+// "First Touch Source", which appeared off the back of a single
+// system-generated Sample row. That was the wrong lever — firstTouchSource
+// is not a table column or a custom field, so it simply doesn't belong in
+// FILTERABLE_FIELDS at all, and removing it there fixed the real problem.
+//
+// "Show only what exists" still applies one level down, to VALUES: each
+// field's checkbox list is a DISTINCT scan of values actually present, so
+// an empty field just yields an empty value list.
+
+// Admin-defined Lead custom fields (Settings > Lead Fields,
+// LeadCustomFieldDefinition/LeadCustomFieldValue) are dynamic per tenant —
+// unlike FILTERABLE_FIELDS above they can't be a static allowlist. The
+// panel addresses them as "custom_<definitionId>" and this always resolves
+// against `valueText`: every fieldType stores its display value there
+// too (dropdown/radio store the selected option string, multiselect a JSON
+// array string, checkbox "true"/"false" — see the model comment in
+// schema.prisma), so a single `contains`-style match works uniformly
+// without needing per-type clause branches.
+const CUSTOM_FIELD_PREFIX = 'custom_';
+
+function isCustomField(field) {
+  return typeof field === 'string' && field.startsWith(CUSTOM_FIELD_PREFIX);
+}
+
+function customFieldDefIdFromKey(field) {
+  const id = parseInt(field.slice(CUSTOM_FIELD_PREFIX.length), 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+// Builds a single Prisma where-clause fragment for one filter field.
+// `values` is always an array (checkbox multi-select) — for `kind: "text"`
+// with "contains"/"not_contains" this becomes an OR/AND-NOT of `contains`
+// matches; `kind: "id"` uses `in`/`notIn` on the raw id since exact-match
+// is the only sensible comparison for a foreign key.
+//
+// Converts a "YYYY-MM-DD" (or any Date-parseable) checkbox value into a
+// [start-of-day, start-of-next-day) range — the DISTINCT scan in
+// /filter-values/:field returns whole calendar days for date-kind fields
+// (see that route), so a "contains" match here means "occurred on this
+// day", not an exact-to-the-millisecond DateTime equality that would never
+// match a real timestamp.
+function dayRange(value) {
+  const start = new Date(value);
+  if (Number.isNaN(start.getTime())) return null;
+  start.setUTCHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { gte: start, lt: end };
+}
+
+// is_empty/is_not_empty on a `required` (non-nullable) column — Contact.
+// name/status/aiScore/createdAt today — must NOT reference `{ not: null }`
+// / `{ [column]: null }` at all: Prisma rejects null as a value for a
+// required field's comparison ("Argument `not` must not be null" /
+// equivalent), since null can never legally appear in that column. A
+// required TEXT field's "empty" can only mean the empty string; a required
+// NUMBER/DATE field (aiScore, createdAt) has no such "empty" representation
+// at all — every row always has a value — so is_empty matches nothing and
+// is_not_empty matches everything for those two kinds.
+function buildFilterClause(fieldDef, operator, values) {
+  const { column, kind, required } = fieldDef;
+  if (operator === 'is_empty') {
+    if (kind === 'id' || kind === 'external') return { [column]: null };
+    if (required && (kind === 'number' || kind === 'date' || kind === 'range')) return { id: { in: [] } }; // matches nothing — see comment above
+    return required ? { [column]: '' } : { OR: [{ [column]: null }, { [column]: '' }] };
+  }
+  if (operator === 'is_not_empty') {
+    if (kind === 'id' || kind === 'external') return { [column]: { not: null } };
+    if (required && (kind === 'number' || kind === 'date' || kind === 'range')) return {}; // matches everything — see comment above
+    return required
+      ? { [column]: { not: '' } }
+      : { AND: [{ [column]: { not: null } }, { [column]: { not: '' } }] };
+  }
+  const list = (values || []).filter((v) => v !== undefined && v !== null && v !== '');
+  if (list.length === 0) return null;
+  if (kind === 'id' || kind === 'external') {
+    const ids = list.map((v) => parseInt(v, 10)).filter((n) => !Number.isNaN(n));
+    if (ids.length === 0) return null;
+    return operator === 'not_contains' ? { [column]: { notIn: ids } } : { [column]: { in: ids } };
+  }
+  if (kind === 'number') {
+    const nums = list.map((v) => Number(v)).filter((n) => Number.isFinite(n));
+    if (nums.length === 0) return null;
+    return operator === 'not_contains' ? { [column]: { notIn: nums } } : { [column]: { in: nums } };
+  }
+  if (kind === 'range') {
+    // Values are bucket keys ("26-50"), resolved back to their {min,max}
+    // via the field's own `buckets` definition rather than parsed from the
+    // string — an unknown key is dropped instead of being coerced into a
+    // bogus range.
+    const picked = list
+      .map((v) => (fieldDef.buckets || []).find((b) => b.value === String(v)))
+      .filter(Boolean);
+    if (picked.length === 0) return null;
+    return operator === 'not_contains'
+      ? { AND: picked.map((b) => ({ NOT: { [column]: { gte: b.min, lte: b.max } } })) }
+      : { OR: picked.map((b) => ({ [column]: { gte: b.min, lte: b.max } })) };
+  }
+  if (kind === 'date') {
+    const ranges = list.map(dayRange).filter(Boolean);
+    if (ranges.length === 0) return null;
+    return operator === 'not_contains'
+      ? { AND: ranges.map((r) => ({ NOT: { [column]: r } })) }
+      : { OR: ranges.map((r) => ({ [column]: r })) };
+  }
+  if (operator === 'not_contains') {
+    return { AND: list.map((v) => ({ [column]: { not: { contains: String(v) } } })) };
+  }
+  return { OR: list.map((v) => ({ [column]: { contains: String(v) } })) };
+}
+
+// Same operator semantics as buildFilterClause, but against the related
+// LeadCustomFieldValue rows for one definition id (via
+// Contact.leadCustomFieldValues — see the relation field of that name on
+// both Contact and LeadCustomFieldDefinition in schema.prisma). is_empty
+// means "no LeadCustomFieldValue row for this field at all, OR a row
+// exists with an empty valueText" — an admin can add a field after leads
+// already exist, leaving old rows with no value row for it.
+function buildCustomFieldClause(defId, operator, values) {
+  if (operator === 'is_empty') {
+    return { OR: [
+      { leadCustomFieldValues: { none: { fieldId: defId } } },
+      { leadCustomFieldValues: { some: { fieldId: defId, OR: [{ valueText: null }, { valueText: '' }] } } },
+    ] };
+  }
+  if (operator === 'is_not_empty') {
+    return { leadCustomFieldValues: { some: { fieldId: defId, valueText: { not: null }, NOT: { valueText: '' } } } };
+  }
+  const list = (values || []).filter((v) => v !== undefined && v !== null && v !== '');
+  if (list.length === 0) return null;
+  if (operator === 'not_contains') {
+    return { NOT: { leadCustomFieldValues: { some: { fieldId: defId, OR: list.map((v) => ({ valueText: { contains: String(v) } })) } } } };
+  }
+  return { leadCustomFieldValues: { some: { fieldId: defId, OR: list.map((v) => ({ valueText: { contains: String(v) } })) } } };
+}
+
 function canAccessLead(req, contact) {
   if (!req || !req.user || !contact) return false;
   if (canViewAllLeads(req)) return true;
@@ -443,6 +680,69 @@ router.get('/', async (req, res) => {
       }
       where.source = { startsWith: prefix };
     }
+    // Freshsales-style "Filter by" panel — ?filters=<JSON array>, each entry
+    // {field, operator, values}. `field` is either a FILTERABLE_FIELDS key
+    // (never trust a raw column name from the client into a Prisma
+    // where-clause) or "custom_<id>" for an admin-defined Lead custom field
+    // (Settings > Lead Fields — dynamic per tenant, so it can't be a static
+    // allowlist like FILTERABLE_FIELDS). operator must be one of
+    // FILTER_OPERATORS. Invalid entries are skipped rather than erroring —
+    // the panel only ever sends known field/operator pairs, so a mismatch
+    // here means stale client cache, not attacker input.
+    if (req.query.filters) {
+      let parsed;
+      try {
+        parsed = JSON.parse(req.query.filters);
+      } catch {
+        return res.status(400).json({ error: 'filters must be a JSON array', code: 'INVALID_FILTERS' });
+      }
+      if (!Array.isArray(parsed)) {
+        return res.status(400).json({ error: 'filters must be a JSON array', code: 'INVALID_FILTERS' });
+      }
+      // Custom-field entries need their definition id checked against this
+      // tenant before it's trusted in a query — otherwise a crafted
+      // "custom_<id>" from another tenant's field would leak whether a
+      // row exists there. Fetched once, only when the payload actually
+      // references one, to avoid an extra round-trip on the common case.
+      let tenantCustomFieldIds = null;
+      if (parsed.some((f) => f && isCustomField(f.field))) {
+        const defs = await prisma.leadCustomFieldDefinition.findMany({
+          where: { tenantId: req.user.tenantId },
+          select: { id: true },
+        });
+        tenantCustomFieldIds = new Set(defs.map((d) => d.id));
+      }
+      // Vertical gate — same rule as /filter-fields and /filter-values (see
+      // the big comment above FILTERABLE_FIELDS): a field restricted to
+      // e.g. `verticals: ['travel']` must be rejected here too, not just
+      // hidden from the picker, or a crafted request could still filter a
+      // generic tenant's contacts by a travel-only column. Only resolved
+      // when the payload actually references a `verticals`-gated field, to
+      // avoid the extra round-trip on the common (ungated-fields-only) case.
+      let vertical = null;
+      if (parsed.some((f) => f && FILTERABLE_FIELDS[f.field]?.verticals)) {
+        const tenant = await prisma.tenant.findUnique({ where: { id: req.user.tenantId }, select: { vertical: true } });
+        vertical = tenant?.vertical || 'generic';
+      }
+      const clauses = [];
+      for (const f of parsed) {
+        if (!f || typeof f !== 'object' || !FILTER_OPERATORS.includes(f.operator)) continue;
+        const rawValues = Array.isArray(f.values) ? f.values : [];
+        if (isCustomField(f.field)) {
+          const defId = customFieldDefIdFromKey(f.field);
+          if (defId === null || !tenantCustomFieldIds.has(defId)) continue;
+          const clause = buildCustomFieldClause(defId, f.operator, rawValues);
+          if (clause) clauses.push(clause);
+          continue;
+        }
+        const fieldDef = FILTERABLE_FIELDS[f.field];
+        if (!fieldDef) continue;
+        if (fieldDef.verticals && !fieldDef.verticals.includes(vertical)) continue;
+        const clause = buildFilterClause(fieldDef, f.operator, rawValues);
+        if (clause) clauses.push(clause);
+      }
+      if (clauses.length > 0) where.AND = [...(where.AND || []), ...clauses];
+    }
     // #167: hide soft-deleted rows by default; admin views can opt in.
     applyDeletedAtFilter(where, req.query.includeDeleted === 'true');
     // #588: USER role sees only contacts assigned to them; ADMIN/MANAGER see
@@ -500,6 +800,200 @@ router.get('/', async (req, res) => {
     res.json(withCustomFields);
   } catch (_err) {
     res.status(500).json({ error: 'Failed to fetch contacts' });
+  }
+});
+
+// GET /api/contacts/filter-fields — the field list a "Filter by" panel
+// offers, mirroring Freshsales' field picker. Merges the static
+// FILTERABLE_FIELDS allowlist (kept in lockstep with BUILTIN_COLUMNS in
+// table_column_preferences.js — the same columns "Customize table" shows)
+// with this tenant's admin-defined Lead custom fields (Settings > Lead
+// Fields), so a field an admin adds today shows up in the filter panel
+// immediately with no code change. Every field the org HAS is listed;
+// there is no has-data gate (see the NOTE above FILTERABLE_FIELDS for why
+// row-count gating was removed). The frontend renders these as the
+// left-hand field-picker list, then calls /filter-values/:field once a
+// field is chosen.
+//
+// Optional ?status=<value> scopes the VALUE lists (via /filter-values) to
+// the same subset the calling page filters over — Leads.jsx passes
+// ?status=Lead (leads ARE Contact rows with status="Lead"; there is no
+// separate Lead model), Contacts.jsx passes nothing and sees every status.
+// It's accepted here too so both endpoints take the same query shape.
+//
+// Registered BEFORE /:id — Express matches in order, so a literal path
+// must precede the /:id param route or it would be read as :id.
+router.get('/filter-fields', async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    // Vertical gate — see the comment above FILTERABLE_FIELDS. Travel-only
+    // columns (subBrand, kycStatus) never reach a generic/wellness tenant's
+    // picker, regardless of what stray or schema-default data exists.
+    const tenant = await prisma.tenant.findUnique({ where: { id: tenantId }, select: { vertical: true } });
+    const vertical = tenant?.vertical || 'generic';
+    const staticFields = Object.entries(FILTERABLE_FIELDS)
+      .filter(([, def]) => !def.verticals || def.verticals.includes(vertical))
+      .map(([key, def]) => ({
+        field: key,
+        label: def.label,
+        kind: def.kind,
+      }));
+    const customDefs = await prisma.leadCustomFieldDefinition.findMany({
+      where: { tenantId },
+      orderBy: [{ displayOrder: 'asc' }, { id: 'asc' }],
+      select: { id: true, label: true, fieldType: true },
+    });
+    const customFields = customDefs.map((d) => ({
+      field: `${CUSTOM_FIELD_PREFIX}${d.id}`,
+      label: d.label,
+      kind: 'text',
+      custom: true,
+      fieldType: d.fieldType,
+    }));
+    res.json({ fields: [...staticFields, ...customFields] });
+  } catch (_err) {
+    res.status(500).json({ error: 'Failed to fetch filter fields' });
+  }
+});
+
+// GET /api/contacts/filter-values/:field — distinct values for one field,
+// scoped to the caller's tenant, for the panel's checkbox list. `id`-kind
+// fields (owner/territory) resolve against User/Territory rows rather than
+// DISTINCT Contact.assignedToId, since the panel needs a human label
+// ("Jane Doe"), not a bare foreign-key integer. "custom_<id>" fields with a
+// fixed choice list (dropdown/radio/multiselect) return the field
+// definition's own `options` — this is deliberately NOT a DISTINCT scan
+// over stored values, so a choice nobody has picked yet still appears as a
+// filterable option (mirrors how the Lead create/edit form itself sources
+// its dropdown). Free-text custom field types (text/textarea/url/number/
+// date/checkbox) fall back to a DISTINCT scan since there's no fixed list.
+router.get('/filter-values/:field', async (req, res) => {
+  try {
+    const tenantId = req.user.tenantId;
+    // Same ?status scoping as /filter-fields (see that route's comment) —
+    // Leads.jsx passes ?status=Lead so the value list only shows values
+    // that actually occur among Lead-status rows, matching what /filter-
+    // fields already gated the field's very presence on. Without this, a
+    // field could correctly appear in the Leads picker (gated on Lead-scoped
+    // presence) but its value list would still include values that only
+    // ever occur on Customer/Prospect rows — same mismatch, one level down.
+    const statusScope = typeof req.query.status === 'string' && req.query.status ? req.query.status : null;
+    const scopeWhere = statusScope ? { status: statusScope } : {};
+    if (isCustomField(req.params.field)) {
+      const defId = customFieldDefIdFromKey(req.params.field);
+      if (defId === null) return res.status(404).json({ error: 'Unknown filter field', code: 'UNKNOWN_FIELD' });
+      const def = await prisma.leadCustomFieldDefinition.findFirst({ where: { id: defId, tenantId } });
+      if (!def) return res.status(404).json({ error: 'Unknown filter field', code: 'UNKNOWN_FIELD' });
+      if (['dropdown', 'radio', 'multiselect'].includes(def.fieldType) && def.options) {
+        const options = JSON.parse(def.options);
+        return res.json({ values: options.map((o) => ({ value: o, label: o })) });
+      }
+      // Custom field values live on LeadCustomFieldValue, joined via its
+      // `contact` relation — status scoping has to filter through that
+      // relation since the value row itself has no status column.
+      const rows = await prisma.leadCustomFieldValue.findMany({
+        where: {
+          fieldId: defId,
+          tenantId,
+          valueText: { not: null },
+          ...(statusScope ? { contact: { status: statusScope, deletedAt: null } } : {}),
+        },
+        select: { valueText: true },
+        distinct: ['valueText'],
+        orderBy: { valueText: 'asc' },
+        take: 200,
+      });
+      const values = rows
+        .map((r) => r.valueText)
+        .filter((v) => v !== null && v !== '')
+        .map((v) => ({ value: v, label: v }));
+      return res.json({ values });
+    }
+    const fieldDef = FILTERABLE_FIELDS[req.params.field];
+    if (!fieldDef) return res.status(404).json({ error: 'Unknown filter field', code: 'UNKNOWN_FIELD' });
+    // Vertical gate — mirrors /filter-fields' eligibility check (see the
+    // big comment above FILTERABLE_FIELDS). A vertical-restricted field
+    // (subBrand, kycStatus) is rejected here too, not just hidden from the
+    // picker — otherwise a stale client-side filter chip, or someone
+    // hitting this endpoint directly, could still pull values for a
+    // feature this tenant's vertical doesn't have.
+    if (fieldDef.verticals) {
+      const tenant = await prisma.tenant.findUnique({ where: { id: tenantId }, select: { vertical: true } });
+      const vertical = tenant?.vertical || 'generic';
+      if (!fieldDef.verticals.includes(vertical)) {
+        return res.status(404).json({ error: 'Unknown filter field', code: 'UNKNOWN_FIELD' });
+      }
+    }
+    if (req.params.field === 'assignedToId') {
+      const users = await prisma.user.findMany({
+        where: { tenantId },
+        select: { id: true, name: true, email: true },
+        orderBy: { name: 'asc' },
+      });
+      return res.json({ values: users.map((u) => ({ value: String(u.id), label: u.name || u.email })) });
+    }
+    if (req.params.field === 'territoryId') {
+      const territories = await prisma.territory.findMany({
+        where: { tenantId },
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+      });
+      return res.json({ values: territories.map((t) => ({ value: String(t.id), label: t.name })) });
+    }
+    // range-kind fields offer their fixed buckets, not a DISTINCT scan of
+    // every individual value present (see the "range" note above
+    // FILTERABLE_FIELDS — Lead Score would otherwise list 5, 36, 49, 64…).
+    if (fieldDef.kind === 'range') {
+      return res.json({ values: (fieldDef.buckets || []).map((b) => ({ value: b.value, label: b.label })) });
+    }
+    // `required` (non-nullable) columns — Contact.name/status/aiScore/
+    // createdAt — can't be filtered with `{ not: null }`; Prisma rejects
+    // null as a comparison value for a field whose type never permits it.
+    // Text ones only need the empty-string exclusion; number/date ones
+    // have no "empty" representation at all (every row has a real value),
+    // so no not-null/not-empty filter is needed on the DISTINCT scan itself.
+    let notNullFilter;
+    if (fieldDef.required && (fieldDef.kind === 'number' || fieldDef.kind === 'date')) {
+      notNullFilter = undefined;
+    } else if (fieldDef.required) {
+      notNullFilter = { not: '' };
+    } else {
+      notNullFilter = { not: null };
+    }
+    // Same status/column key-collision risk as /filter-fields' presence
+    // check above (querying /filter-values/status?status=Lead would spread
+    // `status: 'Lead'` then `status: {not: ''}`, silently dropping one) —
+    // AND-combine instead of a flat spread so both always apply.
+    const columnPredicate = notNullFilter ? { [fieldDef.column]: notNullFilter } : {};
+    const rows = await prisma.contact.findMany({
+      where: { tenantId, deletedAt: null, AND: [scopeWhere, columnPredicate] },
+      select: { [fieldDef.column]: true },
+      distinct: [fieldDef.column],
+      orderBy: { [fieldDef.column]: 'asc' },
+      take: 200,
+    });
+    // date-kind values are DateTime objects — normalize to a "YYYY-MM-DD"
+    // day label both for the checkbox list's display AND as the `value`
+    // sent back in ?filters=, since buildFilterClause's dayRange() parses
+    // that same string into a [start, end) range. Time-of-day is dropped
+    // deliberately — the panel filters by "occurred on this day", matching
+    // how a human reads a date column in a table, not exact timestamps.
+    if (fieldDef.kind === 'date') {
+      const days = [...new Set(
+        rows
+          .map((r) => r[fieldDef.column])
+          .filter((v) => v !== null)
+          .map((v) => new Date(v).toISOString().slice(0, 10)),
+      )].sort();
+      return res.json({ values: days.map((d) => ({ value: d, label: d })) });
+    }
+    const values = rows
+      .map((r) => r[fieldDef.column])
+      .filter((v) => v !== null && v !== '')
+      .map((v) => ({ value: String(v), label: String(v) }));
+    res.json({ values });
+  } catch (_err) {
+    res.status(500).json({ error: 'Failed to fetch filter values' });
   }
 });
 

--- a/backend/routes/contacts.js
+++ b/backend/routes/contacts.js
@@ -206,7 +206,10 @@ const FILTERABLE_FIELDS = {
   assignedToId: { column: 'assignedToId', kind: 'id', label: 'Sales Owner' },
 };
 
-const FILTER_OPERATORS = ['contains', 'not_contains', 'is_empty', 'is_not_empty'];
+// `between` is date-only: it takes [from, to] (either side omittable for an
+// open-ended range) and is what a date field offers instead of the
+// checkbox-of-every-stored-day list the other kinds use.
+const FILTER_OPERATORS = ['contains', 'not_contains', 'is_empty', 'is_not_empty', 'between'];
 
 // NOTE: there is deliberately NO "has-data" gate on the field list.
 //
@@ -239,6 +242,18 @@ const FILTER_OPERATORS = ['contains', 'not_contains', 'is_empty', 'is_not_empty'
 // without needing per-type clause branches.
 const CUSTOM_FIELD_PREFIX = 'custom_';
 
+// Maps a LeadCustomFieldDefinition.fieldType to the filter `kind` that
+// drives its operator set and value UI. Mirrors the typed-column split in
+// LeadCustomFieldValue: date → valueDate, number → valueNumber, checkbox →
+// valueBool, and everything else → valueText. Types not listed fall back to
+// "text" (textarea / url / dropdown / radio / multiselect all live in
+// valueText and are matched as strings).
+const CUSTOM_FIELD_TYPE_TO_KIND = {
+  date: 'date',
+  number: 'number',
+  checkbox: 'boolean',
+};
+
 function isCustomField(field) {
   return typeof field === 'string' && field.startsWith(CUSTOM_FIELD_PREFIX);
 }
@@ -269,6 +284,32 @@ function dayRange(value) {
   return { gte: start, lt: end };
 }
 
+// [from, to] "YYYY-MM-DD" pair → an inclusive-of-both-days Prisma range.
+// `to` becomes the START of the following day and is compared with `lt`, so
+// a stored timestamp anywhere inside the end day still matches — comparing
+// `lte` against the end day's midnight would drop everything after 00:00 on
+// that day. Either side may be blank for an open-ended range; both blank
+// (or both unparseable) yields null so the caller drops the clause.
+function betweenRange(fromValue, toValue) {
+  const range = {};
+  if (fromValue) {
+    const from = new Date(fromValue);
+    if (!Number.isNaN(from.getTime())) {
+      from.setUTCHours(0, 0, 0, 0);
+      range.gte = from;
+    }
+  }
+  if (toValue) {
+    const to = new Date(toValue);
+    if (!Number.isNaN(to.getTime())) {
+      to.setUTCHours(0, 0, 0, 0);
+      to.setUTCDate(to.getUTCDate() + 1);
+      range.lt = to;
+    }
+  }
+  return Object.keys(range).length ? range : null;
+}
+
 // is_empty/is_not_empty on a `required` (non-nullable) column — Contact.
 // name/status/aiScore/createdAt today — must NOT reference `{ not: null }`
 // / `{ [column]: null }` at all: Prisma rejects null as a value for a
@@ -280,17 +321,31 @@ function dayRange(value) {
 // is_not_empty matches everything for those two kinds.
 function buildFilterClause(fieldDef, operator, values) {
   const { column, kind, required } = fieldDef;
+  // A DateTime / Int column has no empty-string state, and Prisma rejects
+  // '' as a value for one outright ("Invalid value for argument: Expected
+  // ISO-8601 DateTime"). Only NULL means empty for these.
+  const nonTextual = kind === 'number' || kind === 'date' || kind === 'range';
   if (operator === 'is_empty') {
     if (kind === 'id' || kind === 'external') return { [column]: null };
-    if (required && (kind === 'number' || kind === 'date' || kind === 'range')) return { id: { in: [] } }; // matches nothing — see comment above
+    if (required && nonTextual) return { id: { in: [] } }; // matches nothing — see comment above
+    if (nonTextual) return { [column]: null };
     return required ? { [column]: '' } : { OR: [{ [column]: null }, { [column]: '' }] };
   }
   if (operator === 'is_not_empty') {
     if (kind === 'id' || kind === 'external') return { [column]: { not: null } };
-    if (required && (kind === 'number' || kind === 'date' || kind === 'range')) return {}; // matches everything — see comment above
+    if (required && nonTextual) return {}; // matches everything — see comment above
+    if (nonTextual) return { [column]: { not: null } };
     return required
       ? { [column]: { not: '' } }
       : { AND: [{ [column]: { not: null } }, { [column]: { not: '' } }] };
+  }
+  // Handled before the empty-string strip below: `between` carries
+  // [from, to] positionally, and either end may legitimately be blank for
+  // an open-ended range — compacting the array would shift `to` into `from`.
+  if (operator === 'between') {
+    if (kind !== 'date') return null;
+    const range = betweenRange((values || [])[0], (values || [])[1]);
+    return range ? { [column]: range } : null;
   }
   const list = (values || []).filter((v) => v !== undefined && v !== null && v !== '');
   if (list.length === 0) return null;
@@ -337,15 +392,36 @@ function buildFilterClause(fieldDef, operator, values) {
 // means "no LeadCustomFieldValue row for this field at all, OR a row
 // exists with an empty valueText" — an admin can add a field after leads
 // already exist, leaving old rows with no value row for it.
-function buildCustomFieldClause(defId, operator, values) {
+function buildCustomFieldClause(defId, operator, values, kind = 'text') {
+  // Which typed column on LeadCustomFieldValue actually holds this field's
+  // data — see CUSTOM_FIELD_TYPE_TO_KIND. A Date-picker field's values live
+  // in valueDate and are always NULL in valueText, so probing valueText for
+  // one returns nothing no matter what the user picked.
+  const isDate = kind === 'date';
   if (operator === 'is_empty') {
+    if (isDate) {
+      return { OR: [
+        { leadCustomFieldValues: { none: { fieldId: defId } } },
+        { leadCustomFieldValues: { some: { fieldId: defId, valueDate: null } } },
+      ] };
+    }
     return { OR: [
       { leadCustomFieldValues: { none: { fieldId: defId } } },
       { leadCustomFieldValues: { some: { fieldId: defId, OR: [{ valueText: null }, { valueText: '' }] } } },
     ] };
   }
   if (operator === 'is_not_empty') {
+    if (isDate) {
+      return { leadCustomFieldValues: { some: { fieldId: defId, valueDate: { not: null } } } };
+    }
     return { leadCustomFieldValues: { some: { fieldId: defId, valueText: { not: null }, NOT: { valueText: '' } } } };
+  }
+  // See buildFilterClause: handled before the empty-string strip so an
+  // open-ended [from, ""] range keeps its positions.
+  if (operator === 'between') {
+    if (!isDate) return null;
+    const range = betweenRange((values || [])[0], (values || [])[1]);
+    return range ? { leadCustomFieldValues: { some: { fieldId: defId, valueDate: range } } } : null;
   }
   const list = (values || []).filter((v) => v !== undefined && v !== null && v !== '');
   if (list.length === 0) return null;
@@ -705,12 +781,22 @@ router.get('/', async (req, res) => {
       // row exists there. Fetched once, only when the payload actually
       // references one, to avoid an extra round-trip on the common case.
       let tenantCustomFieldIds = null;
+      let tenantCustomFieldKinds = null;
       if (parsed.some((f) => f && isCustomField(f.field))) {
         const defs = await prisma.leadCustomFieldDefinition.findMany({
           where: { tenantId: req.user.tenantId },
-          select: { id: true },
+          select: { id: true, fieldType: true },
         });
         tenantCustomFieldIds = new Set(defs.map((d) => d.id));
+        // fieldType decides WHICH typed column on LeadCustomFieldValue holds
+        // the data (valueDate for a Date-picker field, valueText otherwise),
+        // so buildCustomFieldClause needs it to probe the right one. Without
+        // it every custom field was treated as text and a date `between`
+        // silently produced no clause at all — the filter then returned the
+        // whole unfiltered list rather than the matching rows.
+        tenantCustomFieldKinds = new Map(
+          defs.map((d) => [d.id, CUSTOM_FIELD_TYPE_TO_KIND[d.fieldType] || 'text']),
+        );
       }
       // Vertical gate — same rule as /filter-fields and /filter-values (see
       // the big comment above FILTERABLE_FIELDS): a field restricted to
@@ -731,7 +817,7 @@ router.get('/', async (req, res) => {
         if (isCustomField(f.field)) {
           const defId = customFieldDefIdFromKey(f.field);
           if (defId === null || !tenantCustomFieldIds.has(defId)) continue;
-          const clause = buildCustomFieldClause(defId, f.operator, rawValues);
+          const clause = buildCustomFieldClause(defId, f.operator, rawValues, tenantCustomFieldKinds.get(defId) || 'text');
           if (clause) clauses.push(clause);
           continue;
         }
@@ -843,10 +929,16 @@ router.get('/filter-fields', async (req, res) => {
       orderBy: [{ displayOrder: 'asc' }, { id: 'asc' }],
       select: { id: true, label: true, fieldType: true },
     });
+    // A custom field's admin-chosen fieldType decides how it can be
+    // filtered, exactly as it decides which typed column stores its values
+    // (valueText / valueNumber / valueDate / valueBool — see
+    // attachLeadCustomFieldsBatch). Handing every custom field back as
+    // "text" made a Date-picker field offer a substring match over a list
+    // of stored days instead of a calendar.
     const customFields = customDefs.map((d) => ({
       field: `${CUSTOM_FIELD_PREFIX}${d.id}`,
       label: d.label,
-      kind: 'text',
+      kind: CUSTOM_FIELD_TYPE_TO_KIND[d.fieldType] || 'text',
       custom: true,
       fieldType: d.fieldType,
     }));

--- a/backend/routes/portal.js
+++ b/backend/routes/portal.js
@@ -727,6 +727,9 @@ router.post("/travel/itineraries/:id/request-cancellation", verifyPortalToken, r
     if (itin.cancellationStatus === "requested" || itin.cancellationStatus === "cancelled") {
       return res.status(409).json({ error: "A cancellation is already in progress for this booking.", code: "ALREADY_REQUESTED" });
     }
+    if (itin.cancellationStatus === "refunded") {
+      return res.status(409).json({ error: "This booking has already been cancelled and refunded.", code: "ALREADY_REFUNDED" });
+    }
     // A trip that has already departed (or ended) can't be cancelled online —
     // there's nothing left to cancel and the cancellation policy keys off
     // days-before-departure (which is now negative). The customer must contact

--- a/backend/routes/travel_school_terms.js
+++ b/backend/routes/travel_school_terms.js
@@ -206,6 +206,19 @@ router.get("/check", verifyToken, async (req, res) => {
     if (!date) {
       return res.status(400).json({ error: "date is required (YYYY-MM-DD)", code: "INVALID_DATE" });
     }
+    // Trips can only be scheduled forward, so a past date is a data-entry
+    // slip rather than a question worth answering. Compared in UTC against
+    // UTC midnight because parseDateOrNull turns "YYYY-MM-DD" into UTC
+    // midnight — mixing in local time here would misjudge the boundary by
+    // a day for anyone east or west of the server. Today itself is allowed.
+    const todayUtc = new Date();
+    todayUtc.setUTCHours(0, 0, 0, 0);
+    if (date.getTime() < todayUtc.getTime()) {
+      return res.status(400).json({
+        error: "Pick today or a future date — past dates can't be scheduled.",
+        code: "PAST_DATE",
+      });
+    }
     const where = {
       tenantId: req.user.tenantId,
       isActive: true,
@@ -217,10 +230,23 @@ router.get("/check", verifyToken, async (req, res) => {
     }
     const matches = await prisma.travelSchoolTerm.findMany({ where, orderBy: { startDate: "asc" } });
     const blocking = matches.filter((m) => m.kind === "term" || m.kind === "exam-blackout");
+    // Three distinct outcomes, not two. `ok` alone can't tell "this date is
+    // inside a holiday window, go ahead" apart from "no window covers this
+    // date at all" — both leave `blocking` empty, so a date with no calendar
+    // data was reading as a confirmed green light. `status` separates them:
+    //   blocked — a term / exam-blackout window covers the date
+    //   clear   — a window covers it and none of them block (i.e. a holiday)
+    //   unknown — nothing on file for this date; we can't vouch for it
+    // `ok` and `inWindow` keep their original meaning for existing callers.
+    let status;
+    if (blocking.length > 0) status = "blocked";
+    else if (matches.length > 0) status = "clear";
+    else status = "unknown";
     res.json({
       date: req.query.date,
       inWindow: matches.length > 0,
       ok: blocking.length === 0,
+      status,
       blocking: blocking.map((m) => ({ kind: m.kind, label: m.label, schoolName: m.schoolName })),
       matches: matches.map((m) => ({
         id: m.id,

--- a/backend/test/middleware/originCheck.test.js
+++ b/backend/test/middleware/originCheck.test.js
@@ -310,6 +310,41 @@ describe('originCheck — browser callers with allowed Origin', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  test('localhost on a port NOT in the allowlist passes outside production', () => {
+    // Regression: Vite takes the next free port when 5173 is busy (a second
+    // dev server, a stale process), so the app's own frontend served from
+    // :5174 was failing the app's own CSRF origin check with
+    // ORIGIN_NOT_ALLOWED. Any loopback port is accepted in dev.
+    delete process.env.NODE_ENV;
+    for (const origin of ['http://localhost:5174', 'http://localhost:3000', 'http://127.0.0.1:4321']) {
+      const { req, res, next } = makeReqRes({ headers: { origin } });
+      originCheck(req, res, next);
+      expect(next, `expected ${origin} to pass in dev`).toHaveBeenCalledOnce();
+    }
+  });
+
+  test('localhost on an unlisted port is REJECTED in production', () => {
+    // The dev bypass is gated on NODE_ENV — production keeps the exact
+    // allowlist, so a literal localhost Origin there is still a 403.
+    process.env.NODE_ENV = 'production';
+    const { req, res, next } = makeReqRes({
+      headers: { origin: 'http://localhost:5174' },
+    });
+    originCheck(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('a non-loopback origin is still rejected in dev (bypass is loopback-only)', () => {
+    delete process.env.NODE_ENV;
+    const { req, res, next } = makeReqRes({
+      headers: { origin: 'http://localhost.evil.com' },
+    });
+    originCheck(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
   test('127.0.0.1:5000 passes', () => {
     const { req, res, next } = makeReqRes({
       headers: { origin: 'http://127.0.0.1:5000' },

--- a/backend/test/routes/contacts-filter-panel.test.js
+++ b/backend/test/routes/contacts-filter-panel.test.js
@@ -595,7 +595,9 @@ describe('GET /api/contacts?filters=<JSON> — generic where-clause builder', ()
     expect(res.status).toBe(200);
     expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith({
       where: { tenantId: 1 },
-      select: { id: true },
+      // fieldType comes back too — it decides which typed column on
+      // LeadCustomFieldValue the clause probes (valueDate vs valueText).
+      select: { id: true, fieldType: true },
     });
     const call = prisma.contact.findMany.mock.calls[0][0];
     expect(call.where.AND).toEqual([
@@ -727,6 +729,107 @@ describe('GET /api/contacts?filters=<JSON> — generic where-clause builder', ()
 
       const call = prisma.contact.findMany.mock.calls[0][0];
       expect(call.where.AND).toEqual([{ id: { in: [] } }]);
+    });
+  });
+
+  describe('"between" operator — the calendar range a date field is picked with', () => {
+    const andOf = () => prisma.contact.findMany.mock.calls[0][0].where.AND;
+
+    test('[from, to] → one inclusive-of-both-days range', async () => {
+      const filters = [{ field: 'createdAt', operator: 'between', values: ['2026-08-01', '2026-08-31'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const r = andOf()[0].createdAt;
+      expect(r.gte.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+      // End day is exclusive-of-the-NEXT-day, so a timestamp at any hour on
+      // Aug 31 still matches. `lte` against Aug 31 midnight would drop them.
+      expect(r.lt.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    test('same date on both ends → that single day', async () => {
+      const filters = [{ field: 'createdAt', operator: 'between', values: ['2026-08-03', '2026-08-03'] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const r = andOf()[0].createdAt;
+      expect(r.gte.toISOString()).toBe('2026-08-03T00:00:00.000Z');
+      expect(r.lt.toISOString()).toBe('2026-08-04T00:00:00.000Z');
+    });
+
+    test('open-ended [from, ""] → only a lower bound; the blank end is not shifted into `from`', async () => {
+      const filters = [{ field: 'createdAt', operator: 'between', values: ['2026-05-01', ''] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const r = andOf()[0].createdAt;
+      expect(r.gte.toISOString()).toBe('2026-05-01T00:00:00.000Z');
+      expect(r.lt).toBeUndefined();
+    });
+
+    test('open-ended ["", to] → only an upper bound', async () => {
+      const filters = [{ field: 'createdAt', operator: 'between', values: ['', '2026-05-01'] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const r = andOf()[0].createdAt;
+      expect(r.gte).toBeUndefined();
+      expect(r.lt.toISOString()).toBe('2026-05-02T00:00:00.000Z');
+    });
+
+    test('both ends blank / unparseable → clause dropped, not an empty range', async () => {
+      const filters = [{ field: 'createdAt', operator: 'between', values: ['', 'not-a-date'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      expect(prisma.contact.findMany.mock.calls[0][0].where.AND).toBeUndefined();
+    });
+
+    test('"between" on a non-date field is ignored', async () => {
+      const filters = [{ field: 'source', operator: 'between', values: ['2026-01-01', '2026-12-31'] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(prisma.contact.findMany.mock.calls[0][0].where.AND).toBeUndefined();
+    });
+  });
+
+  describe('custom DATE fields query valueDate, not valueText', () => {
+    // Regression: every custom field was handed to the clause builder as
+    // "text", so a Date-picker field probed valueText — always NULL for a
+    // date field, since its values live in valueDate. `between` then built
+    // no clause at all and the request came back completely UNFILTERED,
+    // which reads as "the filter did nothing" rather than as an error.
+    beforeEach(() => {
+      prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+        { id: 7, fieldType: 'date' },
+        { id: 9, fieldType: 'dropdown' },
+      ]);
+    });
+
+    test('between on a custom date field → valueDate range on the relation', async () => {
+      const filters = [{ field: 'custom_7', operator: 'between', values: ['2026-08-01', '2026-08-31'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const some = prisma.contact.findMany.mock.calls[0][0].where.AND[0].leadCustomFieldValues.some;
+      expect(some.fieldId).toBe(7);
+      expect(some.valueDate.gte.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+      expect(some.valueDate.lt.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+      expect(some.valueText).toBeUndefined();
+    });
+
+    test('is_not_empty on a custom date field checks valueDate', async () => {
+      const filters = [{ field: 'custom_7', operator: 'is_not_empty', values: [] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const some = prisma.contact.findMany.mock.calls[0][0].where.AND[0].leadCustomFieldValues.some;
+      expect(some).toEqual({ fieldId: 7, valueDate: { not: null } });
+    });
+
+    test('a non-date custom field still matches on valueText', async () => {
+      const filters = [{ field: 'custom_9', operator: 'contains', values: ['Google'] }];
+      await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const some = prisma.contact.findMany.mock.calls[0][0].where.AND[0].leadCustomFieldValues.some;
+      expect(some.fieldId).toBe(9);
+      expect(some.OR).toEqual([{ valueText: { contains: 'Google' } }]);
     });
   });
 

--- a/backend/test/routes/contacts-filter-panel.test.js
+++ b/backend/test/routes/contacts-filter-panel.test.js
@@ -1,0 +1,733 @@
+// @ts-check
+/**
+ * Freshsales-style "Filter by" panel — pins the new contract added to
+ * backend/routes/contacts.js:
+ *
+ *   - GET  /api/contacts/filter-fields         — static FILTERABLE_FIELDS
+ *     merged with this tenant's LeadCustomFieldDefinition rows.
+ *   - GET  /api/contacts/filter-values/:field  — distinct values for a
+ *     field: text-kind columns (DISTINCT scan), id-kind columns (User /
+ *     Territory join for a human label), and "custom_<id>" fields (fixed
+ *     `options` for dropdown/radio/multiselect, DISTINCT scan otherwise).
+ *   - GET  /api/contacts?filters=<JSON>        — generic where-clause
+ *     builder (buildFilterClause / buildCustomFieldClause) for
+ *     contains / not_contains / is_empty / is_not_empty, composed into
+ *     where.AND alongside the existing status/source/tenant filters.
+ *
+ * Both new routes are registered BEFORE the existing GET /:id route (see
+ * comment in contacts.js) — a regression there would make Express treat
+ * "filter-fields" as an :id value instead, which the "does not collide
+ * with /:id" tests below would catch as a 400 INVALID_SOURCE-shaped or
+ * id-parsing response instead of the expected filter-panel response.
+ *
+ * Pattern reference: contacts-source-filter.test.js (prisma singleton
+ * monkey-patch + supertest against the mounted router, auth middleware
+ * pass-through). Per repo convention, JWT key is userId not id.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+import prisma from '../../lib/prisma.js';
+import { createRequire } from 'node:module';
+const requireCJS = createRequire(import.meta.url);
+
+const authMw = requireCJS('../../middleware/auth');
+authMw.verifyToken = (_req, _res, next) => next();
+authMw.verifyRole = () => (_req, _res, next) => next();
+
+prisma.contact = prisma.contact || {};
+prisma.contact.findMany = vi.fn();
+prisma.contact.findFirst = vi.fn();
+prisma.contact.count = vi.fn();
+prisma.fieldPermission = prisma.fieldPermission || {};
+prisma.fieldPermission.findMany = vi.fn().mockResolvedValue([]);
+prisma.user = prisma.user || {};
+prisma.user.findMany = vi.fn();
+prisma.territory = prisma.territory || {};
+prisma.territory.findMany = vi.fn();
+prisma.leadCustomFieldDefinition = prisma.leadCustomFieldDefinition || {};
+prisma.leadCustomFieldDefinition.findMany = vi.fn();
+prisma.leadCustomFieldDefinition.findFirst = vi.fn();
+prisma.leadCustomFieldValue = prisma.leadCustomFieldValue || {};
+prisma.leadCustomFieldValue.findMany = vi.fn();
+prisma.tenant = prisma.tenant || {};
+prisma.tenant.findUnique = vi.fn();
+
+import express from 'express';
+import request from 'supertest';
+const contactsRouter = requireCJS('../../routes/contacts');
+
+const SAMPLE_CONTACT = {
+  id: 9001,
+  name: 'Amita Rao',
+  email: 'amita@example.com',
+  status: 'Lead',
+  source: 'Organic',
+  tenantId: 1,
+  assignedToId: 7,
+  deletedAt: null,
+  activities: [],
+  tasks: [],
+  assignedTo: null,
+};
+
+function makeApp({ tenantId = 1, userId = 7, role = 'ADMIN' } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { userId, tenantId, role };
+    next();
+  });
+  app.use('/api/contacts', contactsRouter);
+  return app;
+}
+
+beforeEach(() => {
+  prisma.contact.findMany.mockReset().mockResolvedValue([SAMPLE_CONTACT]);
+  prisma.contact.findFirst.mockReset().mockResolvedValue({ id: 1 });
+  // /filter-fields no longer probes row counts at all (see the NOTE above
+  // FILTERABLE_FIELDS) — this mock only backstops the ?count=1 branch on
+  // the list route and keeps an accidental reintroduction visible.
+  prisma.contact.count.mockReset().mockResolvedValue(2);
+  prisma.user.findMany.mockReset().mockResolvedValue([]);
+  prisma.territory.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldDefinition.findMany.mockReset().mockResolvedValue([]);
+  prisma.leadCustomFieldDefinition.findFirst.mockReset().mockResolvedValue(null);
+  // Default to a generic tenant — most tests aren't about vertical gating.
+  // Tests that ARE about it (subBrand/kycStatus visibility) override this.
+  prisma.tenant.findUnique.mockReset().mockResolvedValue({ vertical: 'generic' });
+  prisma.leadCustomFieldValue.findMany.mockReset().mockResolvedValue([]);
+});
+
+describe('GET /api/contacts/filter-fields', () => {
+  // The field list is "every field this org HAS" — the Leads/Contacts
+  // built-in columns (kept in lockstep with BUILTIN_COLUMNS in
+  // table_column_preferences.js) plus every custom field the tenant's
+  // admin created. There is deliberately no row-count / has-data gate;
+  // see the NOTE above FILTERABLE_FIELDS in routes/contacts.js.
+
+  test('returns every built-in field for a generic tenant with no custom fields', async () => {
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+    expect(res.status).toBe(200);
+    expect(res.body.fields.map((f) => f.field)).toEqual([
+      'name', 'email', 'phone', 'company', 'status', 'source', 'aiScore', 'createdAt', 'assignedToId',
+    ]);
+  });
+
+  test('field kinds drive the operator + value UI: text / range / date / id', async () => {
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+    const byKey = Object.fromEntries(res.body.fields.map((f) => [f.field, f]));
+    expect(byKey.name.kind).toBe('text');
+    expect(byKey.status.kind).toBe('text');
+    expect(byKey.aiScore.kind).toBe('range');
+    expect(byKey.createdAt.kind).toBe('date');
+    expect(byKey.assignedToId.kind).toBe('id');
+    expect(byKey.assignedToId.label).toBe('Sales Owner');
+  });
+
+  test('every column the Leads/Contacts table renders is filterable (BUILTIN_COLUMNS parity)', async () => {
+    // Regression for the live report "table has columns the filter panel
+    // doesn't offer". BUILTIN_COLUMNS (table_column_preferences.js) is the
+    // org-facing definition of "what columns exist"; this pins that the
+    // filter picker covers the same set.
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+    const fieldKeys = res.body.fields.map((f) => f.field);
+    for (const key of ['name', 'email', 'phone', 'company', 'aiScore', 'source', 'status', 'assignedToId', 'createdAt']) {
+      expect(fieldKeys).toContain(key);
+    }
+  });
+
+  test('a field with ZERO stored values is STILL offered — the org has the field either way', async () => {
+    // Regression: an earlier revision gated fields on row counts, which hid
+    // freshly-created custom fields (date / JOB TITLE / UTM Source / Drop
+    // down / Select a Product on the live generic tenant) even though the
+    // table renders a column for each. Field existence and value presence
+    // are separate questions; only the VALUE list is data-driven.
+    prisma.contact.count.mockResolvedValue(0);
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 7, label: 'date', fieldType: 'date' },
+      { id: 8, label: 'UTM Source', fieldType: 'text' },
+    ]);
+
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+    const fieldKeys = res.body.fields.map((f) => f.field);
+    expect(fieldKeys).toContain('custom_7');
+    expect(fieldKeys).toContain('custom_8');
+    expect(fieldKeys).toContain('phone');
+  });
+
+  test('no per-field probe queries are issued — the list is pure metadata', async () => {
+    await request(makeApp()).get('/api/contacts/filter-fields');
+
+    expect(prisma.contact.count).not.toHaveBeenCalled();
+    expect(prisma.contact.findMany).not.toHaveBeenCalled();
+  });
+
+  test("merges in this tenant's admin-defined Lead custom fields, tagged custom:true", async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([
+      { id: 55, label: 'Referral Source', fieldType: 'dropdown' },
+      { id: 56, label: 'Budget', fieldType: 'number' },
+    ]);
+
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+    expect(res.status).toBe(200);
+    expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { tenantId: 1 } }),
+    );
+    const custom = res.body.fields.filter((f) => f.custom);
+    expect(custom).toHaveLength(2);
+    expect(custom[0]).toMatchObject({ field: 'custom_55', label: 'Referral Source', kind: 'text', fieldType: 'dropdown' });
+    expect(custom[1]).toMatchObject({ field: 'custom_56', label: 'Budget', fieldType: 'number' });
+  });
+
+  test('custom fields are scoped to the caller tenant — another org never sees them', async () => {
+    await request(makeApp({ tenantId: 42 })).get('/api/contacts/filter-fields');
+
+    expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { tenantId: 42 } }),
+    );
+  });
+
+  test('does not collide with /:id — "filter-fields" is not parsed as a contact id', async () => {
+    const res = await request(makeApp()).get('/api/contacts/filter-fields');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('fields');
+  });
+
+  describe('vertical gate (subBrand / kycStatus are travel-only)', () => {
+    // REGRESSION — the live bug report: a generic tenant (NovaCrest) had a
+    // single stray/seed Contact row with subBrand:"tmc", and EVERY row
+    // carries kycStatus:"unverified" from the schema's own @default, so
+    // both leaked "travel feature" fields into a generic org's picker.
+    // Gating on Tenant.vertical is what keeps them out.
+
+    test('generic tenant never sees subBrand or kycStatus', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'generic' });
+
+      const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+      const fieldKeys = res.body.fields.map((f) => f.field);
+      expect(fieldKeys).not.toContain('subBrand');
+      expect(fieldKeys).not.toContain('kycStatus');
+    });
+
+    test('wellness tenant never sees subBrand or kycStatus either', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'wellness' });
+
+      const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+      const fieldKeys = res.body.fields.map((f) => f.field);
+      expect(fieldKeys).not.toContain('subBrand');
+      expect(fieldKeys).not.toContain('kycStatus');
+    });
+
+    test('travel tenant DOES see subBrand/kycStatus', async () => {
+      prisma.tenant.findUnique.mockResolvedValue({ vertical: 'travel' });
+
+      const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+      const fieldKeys = res.body.fields.map((f) => f.field);
+      expect(fieldKeys).toContain('subBrand');
+      expect(fieldKeys).toContain('kycStatus');
+    });
+
+    test('a tenant row with no vertical falls back to generic (no travel fields)', async () => {
+      prisma.tenant.findUnique.mockResolvedValue(null);
+
+      const res = await request(makeApp()).get('/api/contacts/filter-fields');
+
+      expect(res.status).toBe(200);
+      expect(res.body.fields.map((f) => f.field)).not.toContain('subBrand');
+    });
+  });
+});
+
+describe('GET /api/contacts/filter-values/:field', () => {
+  test('unknown field → 404 UNKNOWN_FIELD', async () => {
+    const res = await request(makeApp()).get('/api/contacts/filter-values/notAField');
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ code: 'UNKNOWN_FIELD' });
+  });
+
+  test('text-kind REQUIRED field (status) → DISTINCT scan filters not-empty-string, NOT not-null', async () => {
+    // Regression test for a real production bug: Contact.status is
+    // `String @default(...)` — non-nullable — and Prisma's real client
+    // rejects `{ not: null }` on it ("Argument `not` must not be null",
+    // confirmed against a live Prisma client/DB, not just this mock) since
+    // null is not a legal value for that field's type at all. The mock
+    // here can't catch that class of error (it accepts any where-shape),
+    // which is exactly how this bug shipped once already — the assertion
+    // on the exact where-clause shape is what pins the fix.
+    prisma.contact.findMany.mockResolvedValue([{ status: 'Lead' }, { status: 'Customer' }]);
+
+    const res = await request(makeApp({ tenantId: 3 })).get('/api/contacts/filter-values/status');
+
+    expect(res.status).toBe(200);
+    expect(prisma.contact.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      // scopeWhere (empty here, unscoped) is AND-combined as AND[0] rather
+      // than flat-spread — see the collision-avoidance comment in
+      // contacts.js above this query.
+      where: { tenantId: 3, deletedAt: null, AND: [{}, { status: { not: '' } }] },
+      distinct: ['status'],
+    }));
+    expect(res.body.values).toEqual([
+      { value: 'Lead', label: 'Lead' },
+      { value: 'Customer', label: 'Customer' },
+    ]);
+  });
+
+  test('id-kind field assignedToId → resolves User rows, not a DISTINCT scan on Contact', async () => {
+    prisma.user.findMany.mockResolvedValue([
+      { id: 7, name: 'Jane Doe', email: 'jane@x.com' },
+      { id: 8, name: null, email: 'noname@x.com' },
+    ]);
+
+    const res = await request(makeApp()).get('/api/contacts/filter-values/assignedToId');
+
+    expect(res.status).toBe(200);
+    expect(prisma.contact.findMany).not.toHaveBeenCalled();
+    expect(res.body.values).toEqual([
+      { value: '7', label: 'Jane Doe' },
+      { value: '8', label: 'noname@x.com' }, // falls back to email when name is null
+    ]);
+  });
+
+  test('a field not in FILTERABLE_FIELDS → 404 (territoryId is not a table column, so not offered)', async () => {
+    const res = await request(makeApp()).get('/api/contacts/filter-values/territoryId');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ code: 'UNKNOWN_FIELD' });
+  });
+
+  test('custom_<id> not owned by this tenant → 404 UNKNOWN_FIELD (no cross-tenant leak)', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue(null);
+
+    const res = await request(makeApp({ tenantId: 1 })).get('/api/contacts/filter-values/custom_999');
+
+    expect(res.status).toBe(404);
+    expect(prisma.leadCustomFieldDefinition.findFirst).toHaveBeenCalledWith({ where: { id: 999, tenantId: 1 } });
+  });
+
+  test('custom_<id> dropdown field → returns the field\'s own `options`, not a DB value scan', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({
+      id: 55, tenantId: 1, fieldType: 'dropdown', options: JSON.stringify(['Referral', 'Ad', 'Organic']),
+    });
+
+    const res = await request(makeApp()).get('/api/contacts/filter-values/custom_55');
+
+    expect(res.status).toBe(200);
+    expect(prisma.leadCustomFieldValue.findMany).not.toHaveBeenCalled();
+    expect(res.body.values).toEqual([
+      { value: 'Referral', label: 'Referral' },
+      { value: 'Ad', label: 'Ad' },
+      { value: 'Organic', label: 'Organic' },
+    ]);
+  });
+
+  test('custom_<id> text field → DISTINCT scan on LeadCustomFieldValue.valueText', async () => {
+    prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({ id: 56, tenantId: 1, fieldType: 'text', options: null });
+    prisma.leadCustomFieldValue.findMany.mockResolvedValue([{ valueText: '5000' }, { valueText: '10000' }]);
+
+    const res = await request(makeApp()).get('/api/contacts/filter-values/custom_56');
+
+    expect(res.status).toBe(200);
+    expect(prisma.leadCustomFieldValue.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { fieldId: 56, tenantId: 1, valueText: { not: null } },
+      distinct: ['valueText'],
+    }));
+    expect(res.body.values).toEqual([
+      { value: '5000', label: '5000' },
+      { value: '10000', label: '10000' },
+    ]);
+  });
+
+  describe('?status=<value> scoping (Leads page passes status=Lead)', () => {
+    // Uses the `email` field (not `status`) — querying /filter-values/
+    // status would legitimately put a `status` key in the where-clause as
+    // the DISTINCT column filter itself, colliding with the ?status scoping
+    // key this block is testing.
+    test('without ?status, the static-field DISTINCT scan is not scoped by status', async () => {
+      prisma.contact.findMany.mockResolvedValue([{ email: 'a@x.com' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/email');
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      // scopeWhere is AND-combined (AND[0]) alongside the column filter
+      // (AND[1]) rather than flat-spread — see the collision-avoidance
+      // comment above this query in contacts.js. Unscoped → AND[0] is {}.
+      expect(call.where.AND[0]).toEqual({});
+    });
+
+    test('?status=Lead scopes the static-field DISTINCT scan to status:"Lead"', async () => {
+      prisma.contact.findMany.mockResolvedValue([{ email: 'a@x.com' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/email?status=Lead');
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({ tenantId: 1, deletedAt: null });
+      expect(call.where.AND).toEqual([{ status: 'Lead' }, { email: { not: null } }]);
+    });
+
+    test('REGRESSION: ?status=Lead scoping /filter-values/status itself does not get clobbered by the column filter', async () => {
+      // The exact bug found live: /filter-values/status?status=Lead returned
+      // ALL statuses instead of just "Lead", because a flat spread let the
+      // column filter's `status` key silently overwrite the scope's
+      // `status` key (both targeted the same object property). Confirmed
+      // fixed against the live dev DB — this pins the where-clause shape
+      // that makes it work.
+      prisma.contact.findMany.mockResolvedValue([{ status: 'Lead' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/status?status=Lead');
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{ status: 'Lead' }, { status: { not: '' } }]);
+    });
+
+    test('?status=Lead scopes the custom-field value scan through the contact relation', async () => {
+      prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({ id: 56, tenantId: 1, fieldType: 'text', options: null });
+      prisma.leadCustomFieldValue.findMany.mockResolvedValue([{ valueText: 'x' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/custom_56?status=Lead');
+
+      const call = prisma.leadCustomFieldValue.findMany.mock.calls[0][0];
+      expect(call.where.contact).toEqual({ status: 'Lead', deletedAt: null });
+    });
+
+    test('without ?status, the custom-field value scan does not join through `contact` at all', async () => {
+      prisma.leadCustomFieldDefinition.findFirst.mockResolvedValue({ id: 56, tenantId: 1, fieldType: 'text', options: null });
+      prisma.leadCustomFieldValue.findMany.mockResolvedValue([{ valueText: 'x' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/custom_56');
+
+      const call = prisma.leadCustomFieldValue.findMany.mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('contact');
+    });
+
+    test('owner (assignedToId) values are NOT status-scoped — the User list is org-wide regardless of view', async () => {
+      prisma.user.findMany.mockResolvedValue([{ id: 7, name: 'Jane Doe', email: 'jane@x.com' }]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/assignedToId?status=Lead');
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { tenantId: 1 } }));
+    });
+  });
+
+  describe('"date" kind — values are day-labels (YYYY-MM-DD), time-of-day dropped', () => {
+    test('createdAt DISTINCT scan is deduped + normalized to calendar-day strings', async () => {
+      prisma.contact.findMany.mockResolvedValue([
+        { createdAt: new Date('2026-01-15T08:30:00Z') },
+        { createdAt: new Date('2026-01-15T21:00:00Z') }, // same day, different time — dedupes to one value
+        { createdAt: new Date('2026-02-01T00:00:00Z') },
+      ]);
+
+      const res = await request(makeApp()).get('/api/contacts/filter-values/createdAt');
+
+      expect(res.status).toBe(200);
+      expect(res.body.values).toEqual([
+        { value: '2026-01-15', label: '2026-01-15' },
+        { value: '2026-02-01', label: '2026-02-01' },
+      ]);
+    });
+
+    test('required date field (createdAt) DISTINCT scan has no not-null/not-empty predicate — every row already has a value', async () => {
+      prisma.contact.findMany.mockResolvedValue([]);
+
+      await request(makeApp()).get('/api/contacts/filter-values/createdAt');
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{}, {}]);
+    });
+  });
+
+  describe('"range" kind — aiScore offers fixed buckets, never a DISTINCT scan of individual scores', () => {
+    test('returns the four Lead Score buckets and never queries Contact', async () => {
+      // Regression: a DISTINCT scan listed every individual score present
+      // (5, 36, 49, 64, 66, 68, 72…) — an unusable checkbox list that grows
+      // with the data. Buckets mirror Contacts.jsx's SCORE_BUCKETS.
+      const res = await request(makeApp()).get('/api/contacts/filter-values/aiScore');
+
+      expect(res.status).toBe(200);
+      expect(res.body.values).toEqual([
+        { value: '0-25', label: '0 - 25' },
+        { value: '26-50', label: '26 - 50' },
+        { value: '51-75', label: '51 - 75' },
+        { value: '76-100', label: '76 - 100' },
+      ]);
+      expect(prisma.contact.findMany).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('GET /api/contacts?filters=<JSON> — generic where-clause builder', () => {
+  test('absent ?filters → no where.AND key added', async () => {
+    const res = await request(makeApp()).get('/api/contacts');
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toBeUndefined();
+  });
+
+  test('invalid JSON → 400 INVALID_FILTERS; findMany not called', async () => {
+    const res = await request(makeApp()).get('/api/contacts?filters=not-json');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'INVALID_FILTERS' });
+    expect(prisma.contact.findMany).not.toHaveBeenCalled();
+  });
+
+  test('non-array JSON → 400 INVALID_FILTERS', async () => {
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify({ field: 'status' }))}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'INVALID_FILTERS' });
+  });
+
+  test('text field "contains" → OR of `contains` matches inside where.AND', async () => {
+    const filters = [{ field: 'source', operator: 'contains', values: ['Referral', 'Web'] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([
+      { OR: [{ source: { contains: 'Referral' } }, { source: { contains: 'Web' } }] },
+    ]);
+  });
+
+  test('text field "not_contains" → AND of negated `contains` matches', async () => {
+    const filters = [{ field: 'source', operator: 'not_contains', values: ['Referral'] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([
+      { AND: [{ source: { not: { contains: 'Referral' } } }] },
+    ]);
+  });
+
+  test('"is_empty" on a text field → OR[null, ""]; values array ignored', async () => {
+    const filters = [{ field: 'email', operator: 'is_empty', values: [] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ OR: [{ email: null }, { email: '' }] }]);
+  });
+
+  test('"is_not_empty" on a text field → AND[not null, not ""]', async () => {
+    const filters = [{ field: 'email', operator: 'is_not_empty', values: [] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ AND: [{ email: { not: null } }, { email: { not: '' } }] }]);
+  });
+
+  test('"is_empty" on the REQUIRED text field (status) → equality "" only, no `null` reference at all', async () => {
+    // Regression test: Contact.status is non-nullable — a where-clause
+    // that mentions `{ status: null }` (even inside an OR) is what a real
+    // Prisma client rejects for this column. Pins that the required-field
+    // branch never produces a null literal for `status`.
+    const filters = [{ field: 'status', operator: 'is_empty', values: [] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ status: '' }]);
+  });
+
+  test('"is_not_empty" on the REQUIRED text field (status) → not-empty-string only, no `not: null`', async () => {
+    // Regression test for the exact bug that shipped: this used to be
+    // `{ AND: [{ status: { not: null } }, ...] }`, which a real (unmocked)
+    // Prisma client throws on for a non-nullable column ("Argument `not`
+    // must not be null") — confirmed against the live dev DB. This mock
+    // alone can't catch that error class, which is why the wrong shape
+    // shipped once already; the exact-shape assertion is what pins it.
+    const filters = [{ field: 'status', operator: 'is_not_empty', values: [] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ status: { not: '' } }]);
+  });
+
+  test('id-kind field (assignedToId) "contains" → { in: [...] } on the raw ids, non-numeric values dropped', async () => {
+    const filters = [{ field: 'assignedToId', operator: 'contains', values: ['7', '8', 'not-a-number'] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ assignedToId: { in: [7, 8] } }]);
+  });
+
+  test('id-kind field "is_empty" → equality null (no OR[""], integers have no empty string)', async () => {
+    const filters = [{ field: 'assignedToId', operator: 'is_empty', values: [] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{ assignedToId: null }]);
+  });
+
+  test('unknown field is skipped silently (stale client cache, not an error)', async () => {
+    const filters = [{ field: 'notAField', operator: 'contains', values: ['x'] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toBeUndefined();
+  });
+
+  test('unknown operator is skipped silently', async () => {
+    const filters = [{ field: 'status', operator: 'greater_than', values: ['x'] }];
+    const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toBeUndefined();
+  });
+
+  test('custom_<id> field owned by this tenant → relational `some` clause on leadCustomFieldValues', async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([{ id: 55 }]);
+    const filters = [{ field: 'custom_55', operator: 'contains', values: ['Referral'] }];
+    const res = await request(makeApp({ tenantId: 1 })).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    expect(prisma.leadCustomFieldDefinition.findMany).toHaveBeenCalledWith({
+      where: { tenantId: 1 },
+      select: { id: true },
+    });
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([
+      { leadCustomFieldValues: { some: { fieldId: 55, OR: [{ valueText: { contains: 'Referral' } }] } } },
+    ]);
+  });
+
+  test('custom_<id> field NOT belonging to this tenant → silently dropped (no cross-tenant filter leak)', async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([{ id: 55 }]); // tenant only owns 55
+    const filters = [{ field: 'custom_999', operator: 'contains', values: ['x'] }]; // probing a foreign id
+    const res = await request(makeApp({ tenantId: 1 })).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toBeUndefined();
+  });
+
+  test('custom_<id> "is_empty" → OR[no value row at all, OR row exists with empty valueText]', async () => {
+    prisma.leadCustomFieldDefinition.findMany.mockResolvedValue([{ id: 55 }]);
+    const filters = [{ field: 'custom_55', operator: 'is_empty', values: [] }];
+    const res = await request(makeApp({ tenantId: 1 })).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.AND).toEqual([{
+      OR: [
+        { leadCustomFieldValues: { none: { fieldId: 55 } } },
+        { leadCustomFieldValues: { some: { fieldId: 55, OR: [{ valueText: null }, { valueText: '' }] } } },
+      ],
+    }]);
+  });
+
+  test('combined with existing ?status= param — both compose in the same where', async () => {
+    const filters = [{ field: 'source', operator: 'contains', values: ['Referral'] }];
+    const res = await request(makeApp()).get(`/api/contacts?status=Lead&filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.status).toBe('Lead');
+    expect(call.where.AND).toEqual([{ OR: [{ source: { contains: 'Referral' } }] }]);
+  });
+
+  test('tenant scope preserved alongside filters', async () => {
+    const filters = [{ field: 'status', operator: 'is_not_empty', values: [] }];
+    const res = await request(makeApp({ tenantId: 42 })).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+    expect(res.status).toBe(200);
+    const call = prisma.contact.findMany.mock.calls[0][0];
+    expect(call.where.tenantId).toBe(42);
+  });
+
+  describe('"range" kind (aiScore) — bucket keys resolve to gte/lte ranges', () => {
+    test('"contains" → OR of {gte,lte} per picked bucket; unknown bucket keys dropped', async () => {
+      const filters = [{ field: 'aiScore', operator: 'contains', values: ['26-50', '76-100', 'not-a-bucket'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{
+        OR: [
+          { aiScore: { gte: 26, lte: 50 } },
+          { aiScore: { gte: 76, lte: 100 } },
+        ],
+      }]);
+    });
+
+    test('"not_contains" → AND of NOT{gte,lte}', async () => {
+      const filters = [{ field: 'aiScore', operator: 'not_contains', values: ['0-25'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{ AND: [{ NOT: { aiScore: { gte: 0, lte: 25 } } }] }]);
+    });
+
+    test('only unknown bucket keys → clause dropped entirely (no bogus range)', async () => {
+      const filters = [{ field: 'aiScore', operator: 'contains', values: ['999-1000'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toBeUndefined();
+    });
+
+    test('"is_empty" on required number field (aiScore) → matches nothing (every row already has a value)', async () => {
+      const filters = [{ field: 'aiScore', operator: 'is_empty', values: [] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{ id: { in: [] } }]);
+    });
+
+    test('"is_not_empty" on required number field (aiScore) → matches everything (no-op predicate)', async () => {
+      const filters = [{ field: 'aiScore', operator: 'is_not_empty', values: [] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{}]);
+    });
+  });
+
+  describe('"date" kind (createdAt) — exact calendar-day match via [start,end) ranges', () => {
+    test('"contains" with one date → OR[{gte,lt}] spanning that UTC day', async () => {
+      const filters = [{ field: 'createdAt', operator: 'contains', values: ['2026-01-15'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      expect(res.status).toBe(200);
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toHaveLength(1);
+      const clause = call.where.AND[0];
+      expect(clause.OR).toHaveLength(1);
+      expect(clause.OR[0].createdAt.gte.toISOString()).toBe('2026-01-15T00:00:00.000Z');
+      expect(clause.OR[0].createdAt.lt.toISOString()).toBe('2026-01-16T00:00:00.000Z');
+    });
+
+    test('"not_contains" → AND[NOT{range}], unparseable date values are dropped', async () => {
+      const filters = [{ field: 'createdAt', operator: 'not_contains', values: ['2026-01-15', 'not-a-date'] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      const clause = call.where.AND[0];
+      expect(clause.AND).toHaveLength(1); // "not-a-date" dropped, not a second AND entry
+      expect(clause.AND[0].NOT.createdAt.gte.toISOString()).toBe('2026-01-15T00:00:00.000Z');
+    });
+
+    test('"is_empty" on required date field (createdAt) → matches nothing', async () => {
+      const filters = [{ field: 'createdAt', operator: 'is_empty', values: [] }];
+      const res = await request(makeApp()).get(`/api/contacts?filters=${encodeURIComponent(JSON.stringify(filters))}`);
+
+      const call = prisma.contact.findMany.mock.calls[0][0];
+      expect(call.where.AND).toEqual([{ id: { in: [] } }]);
+    });
+  });
+
+});

--- a/backend/test/routes/portal-travel-cancellation.test.js
+++ b/backend/test/routes/portal-travel-cancellation.test.js
@@ -95,3 +95,38 @@ describe('request-cancellation — departure guard', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('request-cancellation — lifecycle guard (no re-request once resolved)', () => {
+  test('cancellationStatus=requested → 409 ALREADY_REQUESTED, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'requested' }));
+    const res = await request(makeApp())
+      .post('/api/portal/travel/itineraries/9/request-cancellation')
+      .set('Authorization', portalBearer())
+      .send({ reason: 'changed plans again' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('ALREADY_REQUESTED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
+  test('cancellationStatus=cancelled → 409 ALREADY_REQUESTED, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'cancelled' }));
+    const res = await request(makeApp())
+      .post('/api/portal/travel/itineraries/9/request-cancellation')
+      .set('Authorization', portalBearer())
+      .send({ reason: 'still want out' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('ALREADY_REQUESTED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
+  test('cancellationStatus=refunded → 409 ALREADY_REFUNDED, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'refunded' }));
+    const res = await request(makeApp())
+      .post('/api/portal/travel/itineraries/9/request-cancellation')
+      .set('Authorization', portalBearer())
+      .send({ reason: 'want to cancel again' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('ALREADY_REFUNDED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/routes/travel-itineraries-cancellation.test.js
+++ b/backend/test/routes/travel-itineraries-cancellation.test.js
@@ -240,6 +240,28 @@ describe('PATCH /api/travel/itineraries/:id/cancellation — lifecycle guards', 
     expect(prisma.itinerary.update).not.toHaveBeenCalled();
   });
 
+  test('approve after already refunded → 409 NO_PENDING_REQUEST, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'refunded' }));
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'approve' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('NO_PENDING_REQUEST');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
+  test('refund again after already refunded → 409 NOT_CANCELLED, no write', async () => {
+    prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'refunded' }));
+    const res = await request(makeApp())
+      .patch('/api/travel/itineraries/55/cancellation')
+      .set('Authorization', `Bearer ${tokenFor()}`)
+      .send({ decision: 'refunded' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('NOT_CANCELLED');
+    expect(prisma.itinerary.update).not.toHaveBeenCalled();
+  });
+
   test('invalid decision → 400 INVALID_DECISION', async () => {
     prisma.itinerary.findFirst.mockResolvedValue(itin({ cancellationStatus: 'requested' }));
     const res = await request(makeApp())

--- a/backend/test/routes/travel-school-terms.test.js
+++ b/backend/test/routes/travel-school-terms.test.js
@@ -61,11 +61,18 @@ describe('GET /api/travel-school-terms/check', () => {
   });
 
   test('a holiday window → ok:true; an exam window → ok:false + blocking', async () => {
+    // Dates are generated relative to now, not hardcoded — the route rejects
+    // past dates, so a literal like '2026-05-01' silently rots into a 400 the
+    // day it falls behind the clock.
+    const soon = new Date();
+    soon.setUTCDate(soon.getUTCDate() + 30);
+    const soonIso = soon.toISOString().slice(0, 10);
+
     // Holiday match → trips are fine.
     prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([
       { id: 1, kind: 'holiday', label: 'Summer Break', schoolName: null, startDate: new Date(), endDate: new Date() },
     ]);
-    let res = await request(makeApp()).get('/api/travel-school-terms/check?date=2026-05-01');
+    let res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${soonIso}`);
     expect(res.status).toBe(200);
     expect(res.body.inWindow).toBe(true);
     expect(res.body.ok).toBe(true);
@@ -75,12 +82,69 @@ describe('GET /api/travel-school-terms/check', () => {
     prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([
       { id: 2, kind: 'exam-blackout', label: 'Half-yearly Exams', schoolName: 'DPS', startDate: new Date(), endDate: new Date() },
     ]);
-    res = await request(makeApp()).get('/api/travel-school-terms/check?date=2026-09-25&schoolName=DPS');
+    res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${soonIso}&schoolName=DPS`);
     expect(res.body.ok).toBe(false);
     expect(res.body.blocking[0]).toMatchObject({ kind: 'exam-blackout' });
     // The school's own AND baseline (null) windows are queried.
     const where = prisma.travelSchoolTerm.findMany.mock.calls[1][0].where;
     expect(where.OR).toEqual([{ schoolName: 'DPS' }, { schoolName: null }]);
+  });
+
+  // A future date, built at call time so these never age into the past.
+  const futureDate = () => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + 30);
+    return d.toISOString().slice(0, 10);
+  };
+
+  test('a date with NO window on file → status "unknown", not a green light', async () => {
+    // Regression: `ok` is true whenever nothing BLOCKS the date, which is
+    // also true when no window covers it at all — so a date the calendar
+    // knows nothing about rendered identically to a confirmed holiday.
+    prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([]);
+
+    const res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${futureDate()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('unknown');
+    expect(res.body.inWindow).toBe(false);
+    expect(res.body.matches).toHaveLength(0);
+    expect(res.body.blocking).toHaveLength(0);
+  });
+
+  test('a holiday window → status "clear"; a term window → status "blocked"', async () => {
+    prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([
+      { id: 1, kind: 'holiday', label: 'Summer Break', schoolName: null, startDate: new Date(), endDate: new Date() },
+    ]);
+    let res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${futureDate()}`);
+    expect(res.body.status).toBe('clear');
+
+    // `term` blocks just like `exam-blackout` — trips must avoid term-time.
+    prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([
+      { id: 2, kind: 'term', label: 'Autumn Term', schoolName: null, startDate: new Date(), endDate: new Date() },
+    ]);
+    res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${futureDate()}`);
+    expect(res.body.status).toBe('blocked');
+    expect(res.body.ok).toBe(false);
+    expect(res.body.blocking[0]).toMatchObject({ kind: 'term', label: 'Autumn Term' });
+  });
+
+  test('a past date → 400 PAST_DATE, no query issued', async () => {
+    const res = await request(makeApp()).get('/api/travel-school-terms/check?date=2020-01-01');
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PAST_DATE');
+    expect(prisma.travelSchoolTerm.findMany).not.toHaveBeenCalled();
+  });
+
+  test("today itself is allowed — it's not a past date", async () => {
+    prisma.travelSchoolTerm.findMany.mockResolvedValueOnce([]);
+    const today = new Date().toISOString().slice(0, 10);
+
+    const res = await request(makeApp()).get(`/api/travel-school-terms/check?date=${today}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('unknown');
   });
 });
 

--- a/frontend/src/components/CalendarRangePicker.jsx
+++ b/frontend/src/components/CalendarRangePicker.jsx
@@ -187,9 +187,14 @@ export default function CalendarRangePicker({ value, onChange, label = 'Date ran
           aria-label="Select date range"
           style={{
             position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 50,
-            background: 'var(--card-bg, #1a1a1a)', color: 'var(--text-primary)',
+            // --card-bg is not defined by either theme, so this always fell
+            // through to the hardcoded dark #1a1a1a. Under the light theme
+            // that put --text-primary (near-black there) on a near-black
+            // panel and the month name and dates went invisible. --bg-color
+            // is defined by both themes and is opaque in both.
+            background: 'var(--bg-color)', color: 'var(--text-primary)',
             border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
-            borderRadius: 12, boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+            borderRadius: 12, boxShadow: 'var(--shadow-lg, 0 12px 32px rgba(0,0,0,0.4))',
             padding: '0.85rem', width: 300,
           }}
         >

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Filter, X, ChevronLeft, Plus, Search } from "lucide-react";
 import { fetchApi } from "../utils/api";
+import CalendarRangePicker from "./CalendarRangePicker";
 
 // ── FilterPanel — Freshsales-style "Filter by" panel ───────────────────
 // Trigger button opens a panel DOCKED TO THE RIGHT EDGE OF THE VIEWPORT
@@ -30,6 +31,7 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
   const [valuesLoading, setValuesLoading] = useState(false);
   const [fieldSearch, setFieldSearch] = useState(""); // filters the field-picker list
   const [valueSearch, setValueSearch] = useState(""); // filters the checkbox-value list
+  const [dateRange, setDateRange] = useState({ from: "", to: "" }); // date-kind fields only
   const wrapRef = useRef(null);
   const triggerRef = useRef(null);
   const panelRef = useRef(null);
@@ -72,11 +74,20 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
 
   const openFieldPicker = () => { setActiveField(null); setFieldSearch(""); setOpen(true); };
 
+  const kindOf = (field) => fields.find((f) => f.field === field)?.kind || "text";
+  const activeKind = activeField ? kindOf(activeField) : "text";
+  const isDateField = activeKind === "date";
+
   const chooseField = async (field) => {
     setActiveField(field);
-    setOperator("contains");
+    // A date field is picked on a calendar, so it opens on `between` rather
+    // than the substring/checkbox operators the other kinds default to.
+    setOperator(kindOf(field) === "date" ? "between" : "contains");
     setChecked([]);
     setValueSearch("");
+    setDateRange({ from: "", to: "" });
+    // Date fields never show a value list — there is nothing to fetch.
+    if (kindOf(field) === "date") return;
     if (valuesByField[field]) return;
     setValuesLoading(true);
     try {
@@ -93,22 +104,42 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
     setChecked((prev) => (prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]));
   };
 
-  const needsValues = operator === "contains" || operator === "not_contains";
+  const needsValues = !isDateField && (operator === "contains" || operator === "not_contains");
+  const needsRange = operator === "between";
+
+  // Apply stays disabled until the chosen operator actually has an input:
+  // checkbox operators need a tick, `between` needs at least one end of the
+  // range. The empty/not-empty operators need neither.
+  const applyDisabled = (needsValues && checked.length === 0)
+    || (needsRange && !dateRange.from && !dateRange.to);
 
   const applyFilter = () => {
     if (!activeField) return;
     if (needsValues && checked.length === 0) return;
+    if (needsRange && !dateRange.from && !dateRange.to) return;
     const fieldMeta = fields.find((f) => f.field === activeField);
     const options = valuesByField[activeField] || [];
     const valueLabels = checked.map((v) => options.find((o) => o.value === v)?.label || v);
     const next = filters.filter((f) => f.field !== activeField);
+    // `between` carries [from, to] POSITIONALLY — an omitted end stays as an
+    // empty string rather than being dropped, so an open-ended range ("from
+    // 1 Aug onwards") doesn't slide its `to` into the `from` slot.
+    let values = [];
+    let labels = [];
+    if (needsRange) {
+      values = [dateRange.from || "", dateRange.to || ""];
+      labels = [[dateRange.from, dateRange.to].filter(Boolean).join(" → ")];
+    } else if (needsValues) {
+      values = checked;
+      labels = valueLabels;
+    }
     next.push({
       field: activeField,
       label: fieldMeta?.label || activeField,
       kind: fieldMeta?.kind || "text",
       operator,
-      values: needsValues ? checked : [],
-      valueLabels: needsValues ? valueLabels : [],
+      values,
+      valueLabels: labels,
     });
     onChange(next);
     setOpen(false);
@@ -264,7 +295,6 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
                     {fields.find((f) => f.field === activeField)?.label || activeField}
                   </strong>
                   {(() => {
-                    const activeKind = fields.find((f) => f.field === activeField)?.kind;
                     const labels = operatorLabelsFor(activeKind);
                     return (
                       <select
@@ -275,14 +305,34 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
                           background: "var(--surface-color, #fff)", color: "var(--accent-color)", fontSize: "0.82rem",
                         }}
                       >
-                        <option value="contains">{labels.contains}</option>
-                        <option value="not_contains">{labels.not_contains}</option>
+                        {/* A date is picked on a calendar, so substring
+                            operators make no sense for it — it gets a range
+                            instead, plus the empty/not-empty pair. */}
+                        {isDateField ? (
+                          <option value="between">is between</option>
+                        ) : (
+                          <>
+                            <option value="contains">{labels.contains}</option>
+                            <option value="not_contains">{labels.not_contains}</option>
+                          </>
+                        )}
                         <option value="is_not_empty">{labels.is_not_empty} (has any value)</option>
                         <option value="is_empty">{labels.is_empty}</option>
                       </select>
                     );
                   })()}
                 </div>
+                {needsRange && (
+                  <div style={{ padding: "0.9rem", display: "grid", gap: "0.6rem" }}>
+                    <CalendarRangePicker
+                      value={dateRange}
+                      onChange={(next) => setDateRange({ from: next?.from || "", to: next?.to || "" })}
+                    />
+                    <span style={{ fontSize: "0.78rem", color: "var(--text-secondary)", lineHeight: 1.5 }}>
+                      Pick one date for a single day, or two to cover a range. Both ends are included.
+                    </span>
+                  </div>
+                )}
                 {needsValues && (
                   <>
                     <div style={{ padding: "0.6rem 0.9rem", borderBottom: "1px solid var(--border-color, rgba(0,0,0,0.08))", position: "relative" }}>
@@ -335,8 +385,8 @@ export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange })
                     type="button"
                     className="btn-primary"
                     onClick={applyFilter}
-                    disabled={needsValues && checked.length === 0}
-                    style={{ fontSize: "0.85rem", padding: "0.4rem 0.9rem", opacity: needsValues && checked.length === 0 ? 0.5 : 1 }}
+                    disabled={applyDisabled}
+                    style={{ fontSize: "0.85rem", padding: "0.4rem 0.9rem", opacity: applyDisabled ? 0.5 : 1 }}
                   >
                     Apply
                   </button>

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -1,0 +1,387 @@
+import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { Filter, X, ChevronLeft, Plus, Search } from "lucide-react";
+import { fetchApi } from "../utils/api";
+
+// ── FilterPanel — Freshsales-style "Filter by" panel ───────────────────
+// Trigger button opens a panel DOCKED TO THE RIGHT EDGE OF THE VIEWPORT
+// (fixed top/right/bottom, not anchored under the trigger) — this mirrors
+// the Freshsales reference UI, where "Filter by" always slides out as a
+// tall right-hand drawer regardless of where the button sits on the page.
+// First screen lists the filterable fields (fetched once from
+// `fieldsUrl`); picking one shows a second screen with an operator
+// dropdown (contains / does not contain / is empty / is not empty) and —
+// for the two "contains"-family operators — a checkbox list of that
+// field's distinct values (fetched lazily from `valuesUrl(field)` and
+// cached per field for the life of the panel).
+//
+// Active filters are chips under the trigger button, each removable on its
+// own; "Add filter" re-opens the field-picker screen. `onChange` receives
+// the full filters array — `[{field, operator, values, label, valueLabels}]`
+// — on every add/remove so the host page can refetch immediately.
+export default function FilterPanel({ fieldsUrl, valuesUrl, filters, onChange }) {
+  const [open, setOpen] = useState(false);
+  const [fields, setFields] = useState([]);
+  const [fieldsLoading, setFieldsLoading] = useState(false);
+  const [activeField, setActiveField] = useState(null); // field key while on the operator/values screen
+  const [operator, setOperator] = useState("contains");
+  const [checked, setChecked] = useState([]); // selected values for activeField, string[]
+  const [valuesByField, setValuesByField] = useState({}); // cache: { [field]: [{value,label}] }
+  const [valuesLoading, setValuesLoading] = useState(false);
+  const [fieldSearch, setFieldSearch] = useState(""); // filters the field-picker list
+  const [valueSearch, setValueSearch] = useState(""); // filters the checkbox-value list
+  const wrapRef = useRef(null);
+  const triggerRef = useRef(null);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDoc = (e) => {
+      const insideWrap = wrapRef.current && wrapRef.current.contains(e.target);
+      const insidePanel = panelRef.current && panelRef.current.contains(e.target);
+      if (!insideWrap && !insidePanel) { setOpen(false); setActiveField(null); }
+    };
+    const onKey = (e) => { if (e.key === "Escape") { setOpen(false); setActiveField(null); } };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Refetches on EVERY open — not just once per component lifetime. Both
+  // the field list (has-data / has-custom-field gating) and each field's
+  // value list are live snapshots of current data: a new Lead can arrive
+  // with a value for a field that had none a minute ago, an admin can add
+  // a custom field, or another user's edit can add a brand-new value.
+  // Caching across opens showed a real stale-data bug — a field the
+  // backend now correctly includes stayed invisible in an already-open
+  // browser tab because the panel had cached its first (pre-fix) fetch
+  // for the rest of the session. `valuesByField` is cleared on every open
+  // for the same reason, so a stale per-field value list can't linger.
+  useEffect(() => {
+    if (!open) return;
+    setFieldsLoading(true);
+    setValuesByField({});
+    fetchApi(fieldsUrl, { silent: true })
+      .then((data) => setFields(data.fields || []))
+      .catch(() => setFields([]))
+      .finally(() => setFieldsLoading(false));
+  }, [open, fieldsUrl]);
+
+  const openFieldPicker = () => { setActiveField(null); setFieldSearch(""); setOpen(true); };
+
+  const chooseField = async (field) => {
+    setActiveField(field);
+    setOperator("contains");
+    setChecked([]);
+    setValueSearch("");
+    if (valuesByField[field]) return;
+    setValuesLoading(true);
+    try {
+      const data = await fetchApi(valuesUrl(field), { silent: true });
+      setValuesByField((prev) => ({ ...prev, [field]: data.values || [] }));
+    } catch {
+      setValuesByField((prev) => ({ ...prev, [field]: [] }));
+    } finally {
+      setValuesLoading(false);
+    }
+  };
+
+  const toggleValue = (value) => {
+    setChecked((prev) => (prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]));
+  };
+
+  const needsValues = operator === "contains" || operator === "not_contains";
+
+  const applyFilter = () => {
+    if (!activeField) return;
+    if (needsValues && checked.length === 0) return;
+    const fieldMeta = fields.find((f) => f.field === activeField);
+    const options = valuesByField[activeField] || [];
+    const valueLabels = checked.map((v) => options.find((o) => o.value === v)?.label || v);
+    const next = filters.filter((f) => f.field !== activeField);
+    next.push({
+      field: activeField,
+      label: fieldMeta?.label || activeField,
+      kind: fieldMeta?.kind || "text",
+      operator,
+      values: needsValues ? checked : [],
+      valueLabels: needsValues ? valueLabels : [],
+    });
+    onChange(next);
+    setOpen(false);
+    setActiveField(null);
+  };
+
+  const removeFilter = (field) => onChange(filters.filter((f) => f.field !== field));
+
+  const backToFieldList = () => setActiveField(null);
+
+  // "contains" reads naturally for free-text fields (a substring match),
+  // but is misleading for a checkbox-pick-exact-values field like Sales
+  // Owner, Callified Campaign, Lead Score, or Created (a date) — those are
+  // always exact-match against the selected checkboxes, never substring.
+  // Labels are picked per the active field's `kind` (from /filter-fields).
+  const TEXT_OPERATOR_LABELS = {
+    contains: "contains",
+    not_contains: "does not contain",
+    is_empty: "is empty",
+    is_not_empty: "is not empty",
+  };
+  const EXACT_OPERATOR_LABELS = {
+    contains: "is any of",
+    not_contains: "is none of",
+    is_empty: "is empty",
+    is_not_empty: "is not empty",
+  };
+  const operatorLabelsFor = (kind) => (kind === "text" ? TEXT_OPERATOR_LABELS : EXACT_OPERATOR_LABELS);
+
+  return (
+    <div style={{ display: "inline-flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap" }}>
+      <div ref={wrapRef} style={{ position: "relative" }}>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => (open ? setOpen(false) : openFieldPicker())}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
+            padding: "0.5rem 0.85rem",
+            background: "var(--surface-color, #fff)",
+            border: "1px solid var(--border-color, rgba(0,0,0,0.12))",
+            borderRadius: 8,
+            color: "var(--text-primary)",
+            fontSize: "0.85rem",
+            cursor: "pointer",
+          }}
+        >
+          <Filter size={14} /> Filter by
+          {filters.length > 0 && (
+            <span style={{
+              display: "inline-flex", alignItems: "center", justifyContent: "center",
+              minWidth: 18, height: 18, padding: "0 4px", borderRadius: 999,
+              background: "var(--accent-color)", color: "#fff", fontSize: "0.7rem", fontWeight: 600,
+            }}>
+              {filters.length}
+            </span>
+          )}
+        </button>
+
+        {open && createPortal(
+          <>
+            {/* Dim backdrop — click-through to the outside-click handler above,
+                but visually grounds the drawer as an overlay the way the
+                Freshsales reference UI dims the page behind the panel. */}
+            <div
+              style={{
+                position: "fixed", inset: 0, zIndex: 1099,
+                background: "rgba(0,0,0,0.15)",
+              }}
+            />
+            <div
+              ref={panelRef}
+              style={{
+                position: "fixed",
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: 360,
+                maxWidth: "90vw",
+                zIndex: 1100,
+                background: "var(--bg-color, #fff)",
+                borderLeft: "1px solid var(--border-color, rgba(0,0,0,0.18))",
+                boxShadow: "var(--shadow-lg, -12px 0 32px rgba(0,0,0,0.25))",
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+              }}
+            >
+            {activeField === null ? (
+              <>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0.9rem 1rem", borderBottom: "1px solid var(--border-color, rgba(0,0,0,0.1))" }}>
+                  <strong style={{ fontSize: "1rem" }}>Filters</strong>
+                  <button type="button" onClick={() => setOpen(false)} aria-label="Close filters" style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-secondary)", display: "flex" }}>
+                    <X size={18} />
+                  </button>
+                </div>
+                <div style={{ padding: "0.6rem 0.9rem", borderBottom: "1px solid var(--border-color, rgba(0,0,0,0.08))", position: "relative" }}>
+                  <Search size={14} style={{ position: "absolute", left: "1.4rem", top: "50%", transform: "translateY(-50%)", color: "var(--text-secondary)" }} />
+                  <input
+                    value={fieldSearch}
+                    onChange={(e) => setFieldSearch(e.target.value)}
+                    placeholder="Search fields…"
+                    aria-label="Search fields"
+                    style={{
+                      width: "100%", padding: "0.45rem 0.6rem 0.45rem 2rem", boxSizing: "border-box",
+                      border: "1px solid var(--border-color, rgba(0,0,0,0.12))", borderRadius: 6,
+                      background: "var(--surface-color, #fff)", color: "var(--text-primary)", fontSize: "0.85rem", outline: "none",
+                    }}
+                  />
+                </div>
+                <div style={{ overflowY: "auto", padding: "0.3rem 0", flex: 1 }}>
+                  {fieldsLoading && (
+                    <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>Loading fields…</div>
+                  )}
+                  {!fieldsLoading && fields.length === 0 && (
+                    <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>No filterable fields.</div>
+                  )}
+                  {(() => {
+                    const term = fieldSearch.trim().toLowerCase();
+                    const visibleFields = term ? fields.filter((f) => f.label.toLowerCase().includes(term)) : fields;
+                    if (!fieldsLoading && fields.length > 0 && visibleFields.length === 0) {
+                      return <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>No matching fields.</div>;
+                    }
+                    return visibleFields.map((f) => {
+                      const active = filters.some((flt) => flt.field === f.field);
+                      return (
+                        <button
+                          key={f.field}
+                          type="button"
+                          onClick={() => chooseField(f.field)}
+                          style={{
+                            display: "block", width: "100%", textAlign: "left",
+                            padding: "0.55rem 0.9rem", background: active ? "var(--subtle-bg, rgba(0,0,0,0.04))" : "transparent",
+                            border: "none", cursor: "pointer", fontSize: "0.87rem", color: "var(--text-primary)",
+                          }}
+                        >
+                          {f.label}
+                        </button>
+                      );
+                    });
+                  })()}
+                </div>
+              </>
+            ) : (
+              <>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", padding: "0.7rem 0.9rem", borderBottom: "1px solid var(--border-color, rgba(0,0,0,0.1))" }}>
+                  <button type="button" onClick={backToFieldList} aria-label="Back to field list" style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-secondary)", display: "flex" }}>
+                    <ChevronLeft size={16} />
+                  </button>
+                  <strong style={{ fontSize: "0.9rem", flex: 1 }}>
+                    {fields.find((f) => f.field === activeField)?.label || activeField}
+                  </strong>
+                  {(() => {
+                    const activeKind = fields.find((f) => f.field === activeField)?.kind;
+                    const labels = operatorLabelsFor(activeKind);
+                    return (
+                      <select
+                        value={operator}
+                        onChange={(e) => setOperator(e.target.value)}
+                        style={{
+                          padding: "0.3rem 0.5rem", borderRadius: 6, border: "1px solid var(--border-color, rgba(0,0,0,0.12))",
+                          background: "var(--surface-color, #fff)", color: "var(--accent-color)", fontSize: "0.82rem",
+                        }}
+                      >
+                        <option value="contains">{labels.contains}</option>
+                        <option value="not_contains">{labels.not_contains}</option>
+                        <option value="is_not_empty">{labels.is_not_empty} (has any value)</option>
+                        <option value="is_empty">{labels.is_empty}</option>
+                      </select>
+                    );
+                  })()}
+                </div>
+                {needsValues && (
+                  <>
+                    <div style={{ padding: "0.6rem 0.9rem", borderBottom: "1px solid var(--border-color, rgba(0,0,0,0.08))", position: "relative" }}>
+                      <Search size={14} style={{ position: "absolute", left: "1.4rem", top: "50%", transform: "translateY(-50%)", color: "var(--text-secondary)" }} />
+                      <input
+                        value={valueSearch}
+                        onChange={(e) => setValueSearch(e.target.value)}
+                        placeholder="Search values…"
+                        aria-label="Search values"
+                        style={{
+                          width: "100%", padding: "0.45rem 0.6rem 0.45rem 2rem", boxSizing: "border-box",
+                          border: "1px solid var(--border-color, rgba(0,0,0,0.12))", borderRadius: 6,
+                          background: "var(--surface-color, #fff)", color: "var(--text-primary)", fontSize: "0.85rem", outline: "none",
+                        }}
+                      />
+                    </div>
+                    <div style={{ overflowY: "auto", padding: "0.3rem 0", flex: 1, minHeight: 0 }}>
+                      {valuesLoading && (
+                        <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>Loading values…</div>
+                      )}
+                      {!valuesLoading && (valuesByField[activeField] || []).length === 0 && (
+                        <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>No values found.</div>
+                      )}
+                      {!valuesLoading && (() => {
+                        const term = valueSearch.trim().toLowerCase();
+                        const options = valuesByField[activeField] || [];
+                        const visibleOptions = term ? options.filter((o) => o.label.toLowerCase().includes(term)) : options;
+                        if (options.length > 0 && visibleOptions.length === 0) {
+                          return <div style={{ padding: "0.6rem 0.9rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>No matching values.</div>;
+                        }
+                        return visibleOptions.map((opt) => (
+                          <label
+                            key={opt.value}
+                            style={{
+                              display: "flex", alignItems: "center", gap: "0.55rem",
+                              padding: "0.45rem 0.9rem", cursor: "pointer", fontSize: "0.87rem", color: "var(--text-primary)",
+                              background: checked.includes(opt.value) ? "var(--subtle-bg, rgba(0,0,0,0.04))" : "transparent",
+                            }}
+                          >
+                            <input type="checkbox" checked={checked.includes(opt.value)} onChange={() => toggleValue(opt.value)} />
+                            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{opt.label}</span>
+                          </label>
+                        ));
+                      })()}
+                    </div>
+                  </>
+                )}
+                <div style={{ padding: "0.6rem 0.9rem", borderTop: "1px solid var(--border-color, rgba(0,0,0,0.1))", display: "flex", justifyContent: "flex-end" }}>
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={applyFilter}
+                    disabled={needsValues && checked.length === 0}
+                    style={{ fontSize: "0.85rem", padding: "0.4rem 0.9rem", opacity: needsValues && checked.length === 0 ? 0.5 : 1 }}
+                  >
+                    Apply
+                  </button>
+                </div>
+              </>
+            )}
+            </div>
+          </>,
+          document.body,
+        )}
+      </div>
+
+      {filters.map((f) => (
+        <span
+          key={f.field}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: "0.35rem",
+            padding: "0.35rem 0.6rem", borderRadius: 999,
+            background: "var(--subtle-bg, rgba(0,0,0,0.05))", border: "1px solid var(--border-color, rgba(0,0,0,0.1))",
+            fontSize: "0.8rem", color: "var(--text-primary)",
+          }}
+        >
+          <strong>{f.label}</strong>{" "}
+          {operatorLabelsFor(f.kind)[f.operator]}
+          {f.valueLabels && f.valueLabels.length > 0 ? ` ${f.valueLabels.join(", ")}` : ""}
+          <button
+            type="button"
+            onClick={() => removeFilter(f.field)}
+            aria-label={`Remove ${f.label} filter`}
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-secondary)", display: "flex", padding: 0 }}
+          >
+            <X size={12} />
+          </button>
+        </span>
+      ))}
+
+      {filters.length > 0 && (
+        <button
+          type="button"
+          onClick={openFieldPicker}
+          style={{ display: "inline-flex", alignItems: "center", gap: "0.25rem", background: "none", border: "none", color: "var(--accent-color)", cursor: "pointer", fontSize: "0.8rem" }}
+        >
+          <Plus size={13} /> Add filter
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Contacts.jsx
+++ b/frontend/src/pages/Contacts.jsx
@@ -1,11 +1,12 @@
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
 import { formatDateMedium as formatDate } from '../utils/date';
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import { Search, Plus, Trash2, Pencil, RefreshCw, TrendingUp, Upload, X, FileSpreadsheet, UserCheck, Users, GitMerge, EyeOff } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import DuplicateContactModal from '../components/DuplicateContactModal';
 import ColumnPicker from '../components/ColumnPicker';
+import FilterPanel from '../components/FilterPanel';
 import TopScrollSync from '../components/TopScrollSync';
 import SavedViewsBar from '../components/SavedViewsBar';
 import ScrollableSelect from '../components/ScrollableSelect';
@@ -191,6 +192,12 @@ const Contacts = () => {
   // '' = all, else "min-max" bucket key parsed at filter time.
   const [assignedToFilter, setAssignedToFilter] = useState('');
   const [scoreFilter, setScoreFilter] = useState('');
+  // Freshsales-style "Filter by" panel (components/FilterPanel.jsx) — a
+  // dynamic field-picker + operator + checkbox-values panel, separate from
+  // the fixed dropdowns above. Applied server-side via ?filters=<JSON>
+  // (backend/routes/contacts.js FILTERABLE_FIELDS) so it isn't bounded by
+  // the same-page 500-row client cap the way the dropdowns above are.
+  const [advancedFilters, setAdvancedFilters] = useState([]);
   const SCORE_BUCKETS = [
     { value: '0-25', label: '0 - 25', min: 0, max: 25 },
     { value: '26-50', label: '26 - 50', min: 26, max: 50 },
@@ -253,7 +260,10 @@ const Contacts = () => {
   };
 
   const fetchContacts = () => {
-    fetchApi('/api/contacts').then(data => {
+    const qs = advancedFilters.length > 0
+      ? `?filters=${encodeURIComponent(JSON.stringify(advancedFilters.map(({ field, operator, values }) => ({ field, operator, values }))))}`
+      : '';
+    fetchApi(`/api/contacts${qs}`).then(data => {
         setContacts(Array.isArray(data) ? data : []);
         setLoading(false);
       }).catch(() => { setContacts([]); setLoading(false); });
@@ -275,6 +285,15 @@ const Contacts = () => {
     fetchContacts();
     fetchApi('/api/staff').then(data => setStaff(data)).catch(() => {});
   }, []);
+
+  // Refetch (server-side) whenever the FilterPanel's filter set changes.
+  // Skips the very first render — the mount effect above already fetched
+  // once with the (empty) initial advancedFilters.
+  const isFirstFiltersRender = useRef(true);
+  useEffect(() => {
+    if (isFirstFiltersRender.current) { isFirstFiltersRender.current = false; return; }
+    fetchContacts();
+  }, [advancedFilters]);
 
   // Generic-vertical-only Lead custom fields (Settings > Lead Fields).
   // Own effect keyed on [isWellness, isTravel] (not the mount-only effect
@@ -559,7 +578,7 @@ const Contacts = () => {
       )}
 
       <div className="card" style={{ overflow: 'hidden' }}>
-        <div style={{ padding: '1rem', borderBottom: '1px solid var(--border-color)', display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <div style={{ padding: '1rem', borderBottom: '1px solid var(--border-color)', display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
           <div style={{ position: 'relative', flex: 1, maxWidth: '300px' }}>
             <Search size={18} style={{ position: 'absolute', left: '1rem', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-secondary)' }} />
             <input
@@ -610,13 +629,19 @@ const Contacts = () => {
               <option key={b.value} value={b.value}>{b.label}</option>
             ))}
           </select>
-          {(searchTerm || statusFilter !== 'All' || assignedToFilter || scoreFilter || activeViewId != null) && (
+          <FilterPanel
+            fieldsUrl="/api/contacts/filter-fields"
+            valuesUrl={(field) => `/api/contacts/filter-values/${field}`}
+            filters={advancedFilters}
+            onChange={setAdvancedFilters}
+          />
+          {(searchTerm || statusFilter !== 'All' || assignedToFilter || scoreFilter || activeViewId != null || advancedFilters.length > 0) && (
             <>
               <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
                 Showing {visibleContacts.length} of {contacts.length}
               </span>
               <button
-                onClick={() => { setSearchTerm(''); setStatusFilter('All'); setAssignedToFilter(''); setScoreFilter(''); }}
+                onClick={() => { setSearchTerm(''); setStatusFilter('All'); setAssignedToFilter(''); setScoreFilter(''); setAdvancedFilters([]); }}
                 style={{ background: 'none', border: 'none', color: 'var(--accent-color)', cursor: 'pointer', fontSize: '0.8rem' }}
               >
                 Clear filters

--- a/frontend/src/pages/Leads.jsx
+++ b/frontend/src/pages/Leads.jsx
@@ -1,7 +1,7 @@
 import { fetchApi } from '../utils/api';
 import { useNotify } from '../utils/notify';
 import { formatDateMedium as formatDate } from '../utils/date';
-import { useState, useEffect, useContext, useCallback } from 'react';
+import { useState, useEffect, useContext, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   UserPlus, Search, ArrowRightCircle, Plus, X, Pencil, Trash2, RefreshCw,
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { AuthContext } from '../App';
 import ColumnPicker from '../components/ColumnPicker';
+import FilterPanel from '../components/FilterPanel';
 import InlineCellEditor from '../components/InlineCellEditor';
 import TopScrollSync from '../components/TopScrollSync';
 import { SUB_BRAND_IDS, subBrandShortLabel } from '../utils/travelSubBrand';
@@ -173,6 +174,13 @@ const Leads = () => {
   const [campaignFilter, setCampaignFilter] = useState('');
   const [leadStatusFilter, setLeadStatusFilter] = useState('');
   const [assigneeFilter, setAssigneeFilter] = useState('');
+  // Freshsales-style "Filter by" panel (components/FilterPanel.jsx) — a
+  // dynamic field-picker + operator + checkbox-values panel that also
+  // surfaces admin-defined Lead custom fields (Settings > Lead Fields),
+  // separate from the fixed dropdowns above. Applied server-side via
+  // ?filters=<JSON> (backend/routes/contacts.js FILTERABLE_FIELDS) so it
+  // isn't bounded by the same ?limit=500 cap fetchLeads already applies.
+  const [advancedFilters, setAdvancedFilters] = useState([]);
   // Sequential one-by-one call queue
   const [callQueue, setCallQueue] = useState([]);
   const [callQueueActive, setCallQueueActive] = useState(false);
@@ -240,7 +248,10 @@ const Leads = () => {
   const fetchLeads = async ({ background = false } = {}) => {
     if (!background) setLoading(true);
     try {
-      const data = await fetchApi('/api/contacts?status=Lead&limit=500');
+      const filtersQs = advancedFilters.length > 0
+        ? `&filters=${encodeURIComponent(JSON.stringify(advancedFilters.map(({ field, operator, values }) => ({ field, operator, values }))))}`
+        : '';
+      const data = await fetchApi(`/api/contacts?status=Lead&limit=500${filtersQs}`);
       const rows = Array.isArray(data) ? data : [];
       setLeads(rows);
       return rows;
@@ -514,6 +525,15 @@ const Leads = () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Refetch (server-side) whenever the FilterPanel's filter set changes.
+  // Skips the very first render — the mount effect above already fetched
+  // once with the (empty) initial advancedFilters.
+  const isFirstFiltersRender = useRef(true);
+  useEffect(() => {
+    if (isFirstFiltersRender.current) { isFirstFiltersRender.current = false; return; }
+    fetchLeads();
+  }, [advancedFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // #600  load wellness service catalogue + clinic locations only when the
   // current tenant is the wellness vertical. Avoids 401 / empty-response
@@ -1055,6 +1075,7 @@ const Leads = () => {
     setLeadStatusFilter('');
     setAssigneeFilter('');
     setSearchTerm('');
+    setAdvancedFilters([]);
     setLeadsPage(0);
   };
 
@@ -1572,6 +1593,12 @@ const Leads = () => {
               <option key={s.id} value={String(s.id)}>{s.name || s.email}</option>
             ))}
           </select>
+          <FilterPanel
+            fieldsUrl="/api/contacts/filter-fields?status=Lead"
+            valuesUrl={(field) => `/api/contacts/filter-values/${field}?status=Lead`}
+            filters={advancedFilters}
+            onChange={setAdvancedFilters}
+          />
           <button
             type="button"
             onClick={resetFilters}

--- a/frontend/src/pages/settings/LeadFields.jsx
+++ b/frontend/src/pages/settings/LeadFields.jsx
@@ -55,7 +55,13 @@ const th = {
   letterSpacing: "0.04em",
   color: "var(--text-secondary)",
   fontWeight: 600,
-  background: "#23262d",
+  // Theme-driven, not a fixed dark hex. --subtle-bg composites over the
+  // table body's --bg-color to sit a shade apart from the rows in BOTH
+  // themes (white 5% over near-black in dark, black 4% over #f0f2f5 in
+  // light). A hardcoded #23262d kept the header dark under the light
+  // theme while the text colours followed the theme and went dark too,
+  // leaving the labels unreadable.
+  background: "var(--subtle-bg)",
   boxShadow: "inset 0 -1px 0 var(--border-color)",
 };
 const td = { padding: "0.75rem 1rem", fontSize: "0.9rem" };
@@ -248,7 +254,7 @@ function renderFieldPreview(field, optionsText) {
             style={{
               padding: "0.3rem 0.6rem",
               borderRadius: 999,
-              background: "#23262d",
+              background: "var(--subtle-bg)",
               border: "1px solid var(--border-color)",
               color: "var(--text-secondary)",
               fontSize: "0.85rem",
@@ -528,11 +534,11 @@ export default function LeadFields() {
         ) : (
           <div style={{ marginTop: "0.75rem", paddingBottom: "0.5rem" }}>
             <TopScrollSync>
-              <div style={{ background: "#14161b" }}>
+              <div style={{ background: "var(--bg-color)" }}>
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                   <table className="stable-table" style={{ borderCollapse: "separate", borderSpacing: 0, width: "100%", tableLayout: "fixed" }}>
                     <thead>
-                      <tr style={{ background: "#23262d", display: "table", width: "100%", tableLayout: "fixed" }}>
+                      <tr style={{ background: "var(--subtle-bg)", display: "table", width: "100%", tableLayout: "fixed" }}>
                         <th style={{ ...th, width: "88px" }}>Order</th>
                         <th style={th}>Label</th>
                         <th style={th}>Type</th>

--- a/frontend/src/pages/travel/SchoolTermCalendar.jsx
+++ b/frontend/src/pages/travel/SchoolTermCalendar.jsx
@@ -105,9 +105,23 @@ export default function SchoolTermCalendar() {
     }
   };
 
+  // Local calendar day as YYYY-MM-DD — drives the date input's `min` so past
+  // days aren't offerable in the picker. Built from local parts rather than
+  // toISOString(), which converts to UTC first and would hand back yesterday
+  // for anyone sitting east of UTC late in the day.
+  const todayIso = (() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  })();
+
   const runCheck = async () => {
     if (!checkDate) {
       notify.error("Pick a date to check");
+      return;
+    }
+    // `min` on the input stops the picker, but a typed date bypasses it.
+    if (checkDate < todayIso) {
+      notify.error("Pick today or a future date - past dates can't be scheduled.");
       return;
     }
     try {
@@ -225,18 +239,41 @@ export default function SchoolTermCalendar() {
 
       <div className="glass" style={{ padding: 12, marginBottom: 16, display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
         <Search size={16} aria-hidden style={{ color: "var(--text-secondary)" }} />
-        <input type="date" value={checkDate} onChange={(e) => setCheckDate(e.target.value)} style={inp} aria-label="Date to check" />
+        <input type="date" value={checkDate} min={todayIso} onChange={(e) => setCheckDate(e.target.value)} style={inp} aria-label="Date to check" />
         <input type="text" placeholder="School (optional)" value={checkSchool} onChange={(e) => setCheckSchool(e.target.value)} style={inp} />
         <button type="button" onClick={runCheck} style={btn}>Check date</button>
-        {checkResult && (
-          <span style={{
-            padding: "4px 12px", borderRadius: 999, fontWeight: 700, fontSize: 13,
-            background: checkResult.ok ? "rgba(16,185,129,0.12)" : "rgba(239,68,68,0.12)",
-            color: checkResult.ok ? "#059669" : "#ef4444",
-          }}>
-            {checkResult.ok ? "OK to schedule" : `Avoid - ${checkResult.blocking.map((b) => b.label).join(", ")}`}
-          </span>
-        )}
+        {checkResult && (() => {
+          // Three outcomes, not two — see the /check route. A date with no
+          // window on file used to render the same green "OK to schedule"
+          // as a real holiday, which read as a confirmation the calendar
+          // could not actually give.
+          const tone = {
+            clear: { bg: "rgba(16,185,129,0.12)", fg: "#059669" },
+            blocked: { bg: "rgba(239,68,68,0.12)", fg: "#ef4444" },
+            unknown: { bg: "rgba(245,158,11,0.12)", fg: "#b45309" },
+          }[checkResult.status] || { bg: "rgba(245,158,11,0.12)", fg: "#b45309" };
+          let text;
+          if (checkResult.status === "blocked") {
+            text = `Avoid - ${checkResult.blocking.map((b) => b.label).join(", ")}`;
+          } else if (checkResult.status === "clear") {
+            text = `OK to schedule - ${checkResult.matches.map((m) => m.label).join(", ")}`;
+          } else {
+            text = "No calendar data for this date";
+          }
+          return (
+            <span
+              title={checkResult.status === "unknown"
+                ? "No term, holiday or exam window on file covers this date, so this is not a confirmation - add the school's windows below to get a definite answer."
+                : undefined}
+              style={{
+                padding: "4px 12px", borderRadius: 999, fontWeight: 700, fontSize: 13,
+                background: tone.bg, color: tone.fg,
+              }}
+            >
+              {text}
+            </span>
+          );
+        })()}
       </div>
 
       <div className="glass" style={{ padding: 14, marginBottom: 16, display: "grid", gap: 12 }}>

--- a/frontend/src/pages/travel/TravelCustomerPortal.jsx
+++ b/frontend/src/pages/travel/TravelCustomerPortal.jsx
@@ -2412,7 +2412,7 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
       {/* Customer-editable travel dates (collect-at-accept). Shown while the
           offer is live so the customer can set/adjust dates; saving notifies
           the advisor to confirm fares/availability. */}
-      {!isDeclined && status !== "expired" && cancellationStatus !== "cancelled" && (
+      {!isDeclined && status !== "expired" && cancellationStatus !== "cancelled" && cancellationStatus !== "refunded" && (
         <section style={cardStyle} aria-labelledby="dates-edit-heading">
           <h3 id="dates-edit-heading" style={{ margin: 0, fontSize: 16, display: "flex", alignItems: "center", gap: 8 }}>
             <Calendar size={18} aria-hidden /> Your travel dates
@@ -2497,7 +2497,7 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
           <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <Star size={18} aria-hidden fill="#F5B301" color="#F5B301" />
-              <span style={{ fontSize: 14, color: "var(--text-secondary)" }}>Thanks for reviewing your trip � we appreciate your feedback!</span>
+              <span style={{ fontSize: 14, color: "var(--text-secondary)" }}>Thanks for reviewing your trip — we appreciate your feedback!</span>
             </div>
             {reviewDone && reviewFollowUp?.enabled && (
               <div style={{ padding: 16, borderRadius: 12, border: "1px solid var(--border-color, rgba(255,255,255,0.08))", background: "rgba(255,255,255,0.03)" }}>
@@ -2534,13 +2534,15 @@ function BookingDetail({ itinerary, token, onChanged, onBack }) {
 
       {/* Cancellation — a committed booking can be cancelled; the advisor is
           flagged + processes any refund per the cancellation policy. */}
-      {(cancellationStatus === "requested" || cancellationStatus === "cancelled") ? (
-        <section style={{ ...cardStyle, background: "rgba(168, 50, 63, 0.06)", border: "1px solid rgba(168, 50, 63, 0.22)" }} role="status">
+      {(cancellationStatus === "requested" || cancellationStatus === "cancelled" || cancellationStatus === "refunded") ? (
+        <section style={{ ...cardStyle, background: cancellationStatus === "refunded" ? "rgba(22, 163, 74, 0.06)" : "rgba(168, 50, 63, 0.06)", border: cancellationStatus === "refunded" ? "1px solid rgba(22, 163, 74, 0.22)" : "1px solid rgba(168, 50, 63, 0.22)" }} role="status">
           <h3 style={{ margin: 0, fontSize: 16, display: "flex", alignItems: "center", gap: 8 }}>
-            <AlertCircle size={18} aria-hidden /> {cancellationStatus === "cancelled" ? "Booking cancelled" : "Cancellation requested"}
+            <AlertCircle size={18} aria-hidden /> {cancellationStatus === "refunded" ? "Booking cancelled & refunded" : cancellationStatus === "cancelled" ? "Booking cancelled" : "Cancellation requested"}
           </h3>
           <p style={{ color: "var(--text-secondary)", margin: "8px 0 0", fontSize: 14 }}>
-            {cancellationStatus === "cancelled"
+            {cancellationStatus === "refunded"
+              ? "This booking has been cancelled and your refund has been processed."
+              : cancellationStatus === "cancelled"
               ? "This booking has been cancelled. Your advisor will confirm any refund due per the cancellation policy."
               : "We've received your cancellation request. Your advisor will review it and process any refund due per the cancellation policy."}
           </p>


### PR DESCRIPTION

1. **Dynamic "Filter by" panel** on Leads + Contacts (generic vertical) — a Freshsales-style
   filter driven by the fields an org actually has, replacing reliance on the fixed dropdowns.
2. **Refunded-cancellation guard** in the travel customer portal — a refunded booking is now
   a proper terminal state instead of still being cancellable.