### PR TITLE
travel pagination fixed

### DIFF
--- a/frontend/src/__tests__/Itineraries.test.jsx
+++ b/frontend/src/__tests__/Itineraries.test.jsx
@@ -427,6 +427,14 @@ describe('<Itineraries /> — load + render lifecycle', () => {
     expect(screen.getByText('Schengen visa')).toBeInTheDocument();
   });
 
+  it('keeps the table inside the vertical infinite-scroll pane without the extra top scrollbar wrapper', async () => {
+    renderPage();
+    await screen.findByText('Andaman Islands');
+    const scrollArea = screen.getByTestId('itineraries-scroll-area');
+    expect(scrollArea.querySelector('.top-scroll-sync')).toBeNull();
+    expect(scrollArea.querySelector('table.stable-table')).toBeTruthy();
+  });
+
   it('scrolling the list pane near the bottom requests the second page with offset=10', async () => {
     const firstPage = Array.from({ length: 10 }, (_, i) =>
       makeItin({

--- a/frontend/src/pages/travel/Diagnostics.jsx
+++ b/frontend/src/pages/travel/Diagnostics.jsx
@@ -236,10 +236,19 @@ export default function Diagnostics() {
               height: 'calc(100vh - 300px)',
               minHeight: 620,
               maxHeight: 780,
-              overflow: 'auto',
+              overflowY: 'auto',
+              overflowX: 'hidden',
             }}
           >
-          <table aria-label="Diagnostics results" style={{ width: '100%', minWidth: 1600, borderCollapse: 'collapse' }}>
+          <table
+            aria-label="Diagnostics results"
+            style={{
+              width: '100%',
+              minWidth: 0,
+              tableLayout: 'fixed',
+              borderCollapse: 'collapse',
+            }}
+          >
             <thead>
               <tr>
                 <th style={th}>Submitted</th>
@@ -361,6 +370,9 @@ const th = {
 const td = {
   padding: '10px 12px', fontSize: 14,
   color: 'var(--text-primary)',
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
+  verticalAlign: 'top',
 };
 
 const brandBadge = {

--- a/frontend/src/pages/travel/Itineraries.jsx
+++ b/frontend/src/pages/travel/Itineraries.jsx
@@ -328,7 +328,6 @@ export default function Itineraries() {
   const loadingMoreRef = useRef(false);
   const offsetRef = useRef(0);
   const hasMoreRef = useRef(true);
-  const pendingScrollRestoreRef = useRef(null);
   const selectedItinerary = useMemo(
     () => (selectedItineraryId
       ? items.find((it) => it.id === selectedItineraryId)
@@ -366,18 +365,6 @@ export default function Itineraries() {
   useEffect(() => {
     hasMoreRef.current = hasMore;
   }, [hasMore]);
-
-  useEffect(() => {
-    const el = tableScrollRef.current;
-    const snapshot = pendingScrollRestoreRef.current;
-    if (!el || !snapshot || loadingMore) return;
-
-    el.scrollTop = Math.max(
-      0,
-      el.scrollHeight - el.clientHeight - snapshot.distanceFromBottom,
-    );
-    pendingScrollRestoreRef.current = null;
-  }, [items, loadingMore]);
   // Items array passed to MapPreview. When the itinerary has geocoded items
   // those are used directly. When there are none we geocode the destination
   // city names via Nominatim (same OSM data used for tiles) and show those
@@ -677,7 +664,6 @@ export default function Itineraries() {
       setHasMore(true);
       offsetRef.current = 0;
       hasMoreRef.current = true;
-      pendingScrollRestoreRef.current = null;
       if (tableScrollRef.current) {
         tableScrollRef.current.scrollTop = 0;
       }
@@ -735,11 +721,8 @@ export default function Itineraries() {
   const handleTableScroll = useCallback((e) => {
     const el = e.currentTarget;
     if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
-    const threshold = 72;
+    const threshold = 24;
     if (el.scrollTop + el.clientHeight >= el.scrollHeight - threshold) {
-      pendingScrollRestoreRef.current = {
-        distanceFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
-      };
       load({ reset: false });
     }
   }, [load]);
@@ -923,12 +906,12 @@ export default function Itineraries() {
             onScroll={handleTableScroll}
             style={{
               overflow: "auto",
-              height: "calc(100vh - 340px)",
-              minHeight: 520,
-              maxHeight: 760,
+              height: "calc(100vh - 300px)",
+              minHeight: 620,
+              maxHeight: 720,
             }}
           >
-            <table style={{ width: "100%", minWidth: ITINERARY_TABLE_WIDTH, borderCollapse: "collapse" }}>
+            <table className="stable-table" style={{ width: "100%", minWidth: ITINERARY_TABLE_WIDTH, borderCollapse: "collapse" }}>
             <thead>
               <tr>
                 <th style={th}>Destination</th>
@@ -1085,12 +1068,12 @@ export default function Itineraries() {
                 );
               })}
             </tbody>
-          </table>
-            {loadingMore && (
-              <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-color)" }}>
-                Loading more&hellip;
-              </div>
-            )}
+            </table>
+          {loadingMore && (
+            <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-color)" }}>
+              Loading more&hellip;
+            </div>
+          )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/travel/Trips.jsx
+++ b/frontend/src/pages/travel/Trips.jsx
@@ -219,6 +219,15 @@ export default function Trips() {
     load({ reset: true });
   }, [load]);
 
+  useEffect(() => {
+    if (loading || loadingMore || !hasMore || !listRef.current) return;
+    const el = listRef.current;
+    const threshold = 72;
+    if (el.scrollHeight <= el.clientHeight + threshold) {
+      load({ reset: false });
+    }
+  }, [trips, hasMore, loading, loadingMore, load]);
+
   const handleListScroll = useCallback((e) => {
     const el = e.currentTarget;
     if (!el || loadingRef.current || loadingMoreRef.current || !hasMoreRef.current) return;
@@ -293,7 +302,7 @@ export default function Trips() {
   };
 
   return (
-    <div style={{ padding: 24, maxWidth: 1200, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 1480, margin: "0 auto" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
         <div>
           {fromReports && (
@@ -347,7 +356,7 @@ export default function Trips() {
           overflow: "auto",
           height: "calc(100vh - 300px)",
           minHeight: 620,
-          maxHeight: 780,
+          maxHeight: 720,
         }}
       >
         {loading ? (
@@ -362,18 +371,23 @@ export default function Trips() {
           <>
             <table
               className="stable-table"
-              style={{ width: "100%", minWidth: 1520, borderCollapse: "collapse", tableLayout: "fixed" }}
+              style={{
+                width: "100%",
+                minWidth: 1560,
+                borderCollapse: "collapse",
+                tableLayout: "fixed",
+              }}
             >
               <colgroup>
-                <col style={{ width: 170 }} />
-                <col style={{ width: 260 }} />
-                <col style={{ width: 120 }} />
-                <col style={{ width: 140 }} />
-                <col style={{ width: 220 }} />
+                <col style={{ width: 160 }} />
                 <col style={{ width: 240 }} />
-                <col style={{ width: 130 }} />
-                <col style={{ width: 150 }} />
+                <col style={{ width: 90 }} />
                 <col style={{ width: 120 }} />
+                <col style={{ width: 190 }} />
+                <col style={{ width: 230 }} />
+                <col style={{ width: 120 }} />
+                <col style={{ width: 130 }} />
+                <col style={{ width: 110 }} />
                 <col style={{ width: 90 }} />
               </colgroup>
               <thead>
@@ -387,7 +401,7 @@ export default function Trips() {
                   <th style={th}>Participants</th>
                   <th style={th}>Per-student</th>
                   <th style={th}>Status</th>
-                  <th style={{ ...th, width: 60, textAlign: "right" }} aria-label="Actions"></th>
+                  <th style={{ ...th, width: 90, textAlign: "right" }} aria-label="Actions">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -456,7 +470,7 @@ export default function Trips() {
                   );
                 })}
               </tbody>
-            </table>
+              </table>
             {loadingMore && (
               <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-secondary)", borderTop: "1px solid var(--border-color)" }}>
                 Loading more&hellip;
@@ -640,11 +654,15 @@ const th = {
   color: "var(--text-secondary)", borderBottom: "1px solid var(--border-color)",
   position: "sticky",
   top: 0,
-  zIndex: 10,
+  zIndex: 3,
   background: "var(--modal-bg, var(--bg-color))",
   backgroundColor: "var(--modal-bg, var(--bg-color))",
   backgroundClip: "padding-box",
   boxShadow: "inset 0 -1px 0 var(--border-color)",
+  opacity: 1,
+  backgroundImage: "none",
+  isolation: "isolate",
+  backdropFilter: "none",
   whiteSpace: "nowrap",
 };
 const td = {

--- a/frontend/src/pages/travel/WebCheckinQueue.jsx
+++ b/frontend/src/pages/travel/WebCheckinQueue.jsx
@@ -24,7 +24,7 @@
 
 import { useEffect, useMemo, useState, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { ArrowLeft, Filter, Ticket, Calendar as CalendarIcon, Upload, Send, UserCheck, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowLeft, Filter, Ticket, Calendar as CalendarIcon, Upload, Send, UserCheck, RefreshCw } from "lucide-react";
 import { fetchApi, getAuthToken } from "../../utils/api";
 import { useNotify } from "../../utils/notify";
 
@@ -109,7 +109,14 @@ export default function WebCheckinQueue() {
     fetchApi(url)
       .then((res) => {
         const list = Array.isArray(res?.webcheckins) ? res.webcheckins : [];
-        setRows(list);
+        setRows((prev) => {
+          if (upcomingOnly || offset === 0) return list;
+          const merged = [...prev];
+          for (let i = 0; i < list.length; i += 1) {
+            merged[offset + i] = list[i];
+          }
+          return merged;
+        });
         setTotal(Number.isFinite(res?.total) ? res.total : list.length);
       })
       .catch((e) => {
@@ -119,7 +126,10 @@ export default function WebCheckinQueue() {
           setTotal(0);
         }
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+        scrolledPage.current = false;
+      });
   };
 
   // Staff list for the reassign dropdown — loaded once. /api/staff is
@@ -136,10 +146,16 @@ export default function WebCheckinQueue() {
   // on a smaller filtered result-set.
   const onStatusChange = (v) => {
     setStatus(v);
+    setRows([]);
+    setTotal(0);
+    scrolledPage.current = false;
     setOffset(0);
   };
   const onUpcomingToggle = (e) => {
     setUpcomingOnly(e.target.checked);
+    setRows([]);
+    setTotal(0);
+    scrolledPage.current = false;
     setOffset(0);
   };
 
@@ -238,10 +254,6 @@ export default function WebCheckinQueue() {
 
   // ─── Render ──────────────────────────────────────────────────────
 
-  const showingPagination = !upcomingOnly && total > PAGE_SIZE;
-  const fromIdx = total === 0 ? 0 : offset + 1;
-  const toIdx = Math.min(offset + rows.length, total);
-
   return (
     <div style={{ padding: 24, width: "100%", maxWidth: 1440, margin: "0 auto", boxSizing: "border-box" }}>
       {openedFromReports ? (
@@ -294,11 +306,6 @@ export default function WebCheckinQueue() {
         >
           <RefreshCw size={14} aria-hidden style={{ marginRight: 4 }} /> Refresh
         </button>
-        {showingPagination && (
-          <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-secondary)" }}>
-            {fromIdx}&ndash;{toIdx} of {total}
-          </span>
-        )}
       </div>
 
       {/* Table */}
@@ -307,7 +314,8 @@ export default function WebCheckinQueue() {
         onScroll={handleTableScroll}
         style={{
           background: "var(--surface-color)", borderRadius: 8,
-          border: "1px solid var(--border-color)", overflow: "auto",
+          border: "1px solid var(--border-color)", overflowY: "auto",
+          overflowX: "hidden",
           height: "calc(100vh - 300px)",
           minHeight: 620,
           maxHeight: 780,
@@ -321,17 +329,17 @@ export default function WebCheckinQueue() {
             flights are accepted.
           </div>
         ) : (
-          <table className="stable-table webcheckins-table" style={{ width: "100%", minWidth: 1700, borderCollapse: "collapse", tableLayout: "fixed" }}>
+          <table className="stable-table webcheckins-table" style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
             <colgroup>
-              <col style={{ width: "130px" }} />
-              <col style={{ width: "96px" }} />
-              <col style={{ width: "100px" }} />
-              <col style={{ width: "95px" }} />
+              <col style={{ width: "116px" }} />
+              <col style={{ width: "88px" }} />
+              <col style={{ width: "90px" }} />
+              <col style={{ width: "78px" }} />
+              <col style={{ width: "138px" }} />
               <col style={{ width: "150px" }} />
-              <col style={{ width: "170px" }} />
-              <col style={{ width: "98px" }} />
-              <col style={{ width: "132px" }} />
-              <col />
+              <col style={{ width: "92px" }} />
+              <col style={{ width: "118px" }} />
+              <col style={{ width: "320px" }} />
             </colgroup>
             <thead>
               <tr>
@@ -418,7 +426,7 @@ export default function WebCheckinQueue() {
                       )}
                     </td>
                     <td style={td}>
-                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center", minWidth: 0 }}>
+                      <div style={{ display: "flex", gap: 6, flexWrap: "nowrap", alignItems: "center", minWidth: 0 }}>
                         <button
                           type="button"
                           onClick={() => onUploadClick(r.id)}
@@ -475,32 +483,6 @@ export default function WebCheckinQueue() {
         )}
       </div>
 
-      {/* Pagination — only when not in upcoming mode and total exceeds page. */}
-      {showingPagination && (
-        <div style={{
-          display: "flex", justifyContent: "flex-end", alignItems: "center",
-          gap: 8, marginTop: 12,
-        }}>
-          <button
-            type="button"
-            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-            disabled={offset === 0}
-            style={pagerBtn}
-            aria-label="Previous page"
-          >
-            <ChevronLeft size={14} aria-hidden /> Prev
-          </button>
-          <button
-            type="button"
-            onClick={() => setOffset(offset + PAGE_SIZE)}
-            disabled={offset + rows.length >= total}
-            style={pagerBtn}
-            aria-label="Next page"
-          >
-            Next <ChevronRight size={14} aria-hidden />
-          </button>
-        </div>
-      )}
     </div>
   );
 }
@@ -522,7 +504,7 @@ const miniSelectStyle = {
   padding: "3px 6px", borderRadius: 4,
   border: "1px solid var(--border-color)",
   background: "var(--surface-color)", color: "var(--text-primary)",
-  fontSize: 12, minWidth: 110, height: 28, flexShrink: 0,
+  fontSize: 12, minWidth: 104, height: 28, flexShrink: 0,
 };
 const refreshBtn = {
   display: "inline-flex", alignItems: "center",
@@ -533,17 +515,10 @@ const refreshBtn = {
 };
 const actionBtn = {
   display: "inline-flex", alignItems: "center", justifyContent: "center",
-  padding: "4px 10px", borderRadius: 4,
+  padding: "4px 8px", borderRadius: 4,
   border: "1px solid var(--border-color)",
   background: "var(--surface-color)", color: "var(--text-primary)",
-  fontSize: 12, cursor: "pointer", height: 28, minWidth: 75, whiteSpace: "nowrap", flexShrink: 0,
-};
-const pagerBtn = {
-  display: "inline-flex", alignItems: "center", gap: 2,
-  padding: "6px 12px", borderRadius: 6,
-  border: "1px solid var(--border-color)",
-  background: "var(--surface-color)", color: "var(--text-primary)",
-  fontSize: 13, cursor: "pointer",
+  fontSize: 12, cursor: "pointer", height: 28, minWidth: 72, whiteSpace: "nowrap", flexShrink: 0,
 };
 const empty = {
   padding: 32, textAlign: "center",


### PR DESCRIPTION
1. `travel-pagi` focuses on fixing and testing travel list pagination.
2. It adds more seeded Cost Master rows across travel sub-brands.
3. It adds demo itineraries so the itineraries table has enough rows to scroll.
4. It adds extra web check-ins so the web check-in queue can paginate properly.
5. It adds extra TMC trips for a fuller trips list in pagination tests.
6. It helps reproduce real deployed behavior instead of only small local datasets.
7. It makes infinite scroll and table loading easier to validate.
8. It improves UI testing for travel pages that depend on large row counts.
9. Overall, the branch is about making travel tables behave consistently with pagination in deploy.